### PR TITLE
feat(runtime): add initial execution skeleton

### DIFF
--- a/docs/ai/references/2026-05-13-auv-airi-desktop-reuse.md
+++ b/docs/ai/references/2026-05-13-auv-airi-desktop-reuse.md
@@ -1,0 +1,81 @@
+# AUV AIRI Desktop Reuse Notes
+
+Date: 2026-05-13
+
+Status: working implementation note
+
+## Purpose
+
+This note exists separately from `2026-05-12-auv-setup.md` so the design
+brainstorming document can stay focused on product and architecture direction.
+
+This file records the narrower implementation decision for current work:
+
+- what AUV may reuse from AIRI desktop work
+- what AUV must not import from AIRI
+- what the current prototype actually implements
+
+## Reuse Boundary
+
+AUV may reuse selected implementation ideas or low-level primitives from AIRI
+desktop work, but only at the driver layer.
+
+Good donor candidates include:
+
+- screenshot capture primitives
+- platform input primitives such as Quartz, Swift, or AppleScript-backed calls
+- CDP bridge patterns
+- capability declaration and verification habits
+- artifact capture habits around driver operations
+
+These are not acceptable donor layers for AUV core:
+
+- MCP tool descriptors
+- server-side action executors
+- approval queues
+- chat, workflow, or policy orchestration shells
+- AIRI-specific result shaping or provider-facing abstractions
+
+The practical rule is:
+
+> Borrow drivers and evidence capture, not the AIRI server wrapper.
+
+This matters because AUV must keep its own runtime invocation, implicit run
+creation, artifact retention, inspection, and replay semantics. If the project
+imports AIRI's outer server shell too early, it will collapse back into another
+computer-use service instead of an application command runtime.
+
+## Current Prototype Snapshot
+
+The current repository prototype implements the shared execution skeleton and
+the first observable desktop primitive, but it does so without importing AIRI's
+outer server shell.
+
+Implemented in the current prototype:
+
+- library-first runtime core in `src/lib.rs`
+- provisional file-backed local `.auv/` run store
+- provisional file-backed local `.auv/` artifact store
+- implicit run creation for every `invoke`
+- minimal `inspect` CLI path over stored run snapshots
+- fixture driver for non-destructive runtime validation
+- macOS screenshot driver using `/usr/sbin/screencapture`
+
+Intentionally not implemented yet:
+
+- OCR driver
+- mouse and keyboard input driver
+- trace replay
+- inspect UI
+- AIRI-style action executor, approval queue, or MCP tool registration shell
+
+This prototype is deliberately narrow. It proves the execution substrate and
+the driver boundary before stronger desktop or browser drivers land.
+
+## Immediate Follow-Up
+
+The next implementation steps should continue to respect the same boundary:
+
+1. add stronger first-party drivers through the shared runtime path
+2. keep run and artifact inspection as the source of truth for driver behavior
+3. avoid introducing AIRI server semantics into AUV core just to move faster

--- a/docs/ai/references/2026-05-13-auv-airi-desktop-reuse.md
+++ b/docs/ai/references/2026-05-13-auv-airi-desktop-reuse.md
@@ -60,11 +60,14 @@ Implemented in the current prototype:
 - minimal `inspect` CLI path over stored run snapshots
 - fixture driver for non-destructive runtime validation
 - macOS screenshot driver using `/usr/sbin/screencapture`
+- macOS window observation report via Swift + `CGWindowList`
+- macOS permission probe for screen recording, accessibility, and automation
+- macOS app launch and focus via `open` + `osascript`
+- macOS click, type, press-keys, scroll, and wait primitives via Swift + Quartz
 
 Intentionally not implemented yet:
 
 - OCR driver
-- mouse and keyboard input driver
 - trace replay
 - inspect UI
 - AIRI-style action executor, approval queue, or MCP tool registration shell

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -23,8 +23,62 @@ pub fn default_command_catalog() -> CommandCatalog {
     CommandSpec {
       id: "debug.captureScreen",
       summary: "Capture one desktop screenshot through the shared runtime path.",
-      driver_id: "macos.screenshot",
+      driver_id: "macos.desktop",
       operation: "capture_screen",
+    },
+    CommandSpec {
+      id: "debug.observeWindows",
+      summary: "Observe visible macOS windows and capture a text report artifact.",
+      driver_id: "macos.desktop",
+      operation: "observe_windows",
+    },
+    CommandSpec {
+      id: "debug.probePermissions",
+      summary: "Probe macOS screen recording, accessibility, and automation permissions.",
+      driver_id: "macos.desktop",
+      operation: "probe_permissions",
+    },
+    CommandSpec {
+      id: "debug.openApp",
+      summary: "Open an application on the local macOS host.",
+      driver_id: "macos.desktop",
+      operation: "open_app",
+    },
+    CommandSpec {
+      id: "debug.focusApp",
+      summary: "Open and activate an application on the local macOS host.",
+      driver_id: "macos.desktop",
+      operation: "focus_app",
+    },
+    CommandSpec {
+      id: "debug.click",
+      summary: "Move the pointer and click on the local macOS desktop.",
+      driver_id: "macos.desktop",
+      operation: "click",
+    },
+    CommandSpec {
+      id: "debug.typeText",
+      summary: "Type text through Quartz keyboard events on the local macOS host.",
+      driver_id: "macos.desktop",
+      operation: "type_text",
+    },
+    CommandSpec {
+      id: "debug.pressKeys",
+      summary: "Press a macOS key combination through Quartz keyboard events.",
+      driver_id: "macos.desktop",
+      operation: "press_keys",
+    },
+    CommandSpec {
+      id: "debug.scroll",
+      summary: "Scroll on the local macOS desktop with optional pointer positioning.",
+      driver_id: "macos.desktop",
+      operation: "scroll",
+    },
+    CommandSpec {
+      id: "debug.wait",
+      summary: "Sleep inside the shared runtime path for a bounded duration.",
+      driver_id: "macos.desktop",
+      operation: "wait",
     },
     CommandSpec {
       id: "debug.fixtureObserve",

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -10,7 +10,10 @@ impl CommandCatalog {
   }
 
   pub fn resolve(&self, command_id: &str) -> Option<&CommandSpec> {
-    self.commands.iter().find(|command| command.id == command_id)
+    self
+      .commands
+      .iter()
+      .find(|command| command.id == command_id)
   }
 
   pub fn all(&self) -> &[CommandSpec] {

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -1,0 +1,36 @@
+use crate::model::CommandSpec;
+
+pub struct CommandCatalog {
+  commands: Vec<CommandSpec>,
+}
+
+impl CommandCatalog {
+  pub fn new(commands: Vec<CommandSpec>) -> Self {
+    Self { commands }
+  }
+
+  pub fn resolve(&self, command_id: &str) -> Option<&CommandSpec> {
+    self.commands.iter().find(|command| command.id == command_id)
+  }
+
+  pub fn all(&self) -> &[CommandSpec] {
+    &self.commands
+  }
+}
+
+pub fn default_command_catalog() -> CommandCatalog {
+  CommandCatalog::new(vec![
+    CommandSpec {
+      id: "debug.captureScreen",
+      summary: "Capture one desktop screenshot through the shared runtime path.",
+      driver_id: "macos.screenshot",
+      operation: "capture_screen",
+    },
+    CommandSpec {
+      id: "debug.fixtureObserve",
+      summary: "Emit a deterministic observation result without touching the real UI.",
+      driver_id: "fixture.observe",
+      operation: "observe_fixture_scene",
+    },
+  ])
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,100 @@
+use std::collections::BTreeMap;
+
+use auv_cli::model::{AuvResult, ExecutionTarget, InvokeRequest};
+
+pub enum CliCommand {
+  Help,
+  ListCommands,
+  ListDrivers,
+  Invoke(InvokeRequest),
+  Inspect { run_id: String },
+}
+
+pub fn parse_cli(arguments: &[String]) -> AuvResult<CliCommand> {
+  if arguments.is_empty() {
+    return Ok(CliCommand::Help);
+  }
+
+  match arguments[0].as_str() {
+    "help" | "--help" | "-h" => Ok(CliCommand::Help),
+    "list-commands" => Ok(CliCommand::ListCommands),
+    "list-drivers" => Ok(CliCommand::ListDrivers),
+    "inspect" => parse_inspect(arguments),
+    "invoke" => parse_invoke(arguments),
+    other => Err(format!(
+      "unknown subcommand {other}; use `help` to see supported commands"
+    )),
+  }
+}
+
+pub fn help_text() -> &'static str {
+  "\
+auv-cli prototype
+
+USAGE
+  auv-cli list-commands
+  auv-cli list-drivers
+  auv-cli invoke <command-id> [--target <application-id>] [--label <text>]
+  auv-cli inspect <run-id>
+
+NOTES
+  - Names are provisional and reflect the current phase-0/1 runtime skeleton.
+  - The CLI is a thin frontend over the library runtime in src/lib.rs.
+  - `debug.captureScreen` proves driver-level desktop reuse without importing AIRI server tooling.
+"
+}
+
+fn parse_inspect(arguments: &[String]) -> AuvResult<CliCommand> {
+  if arguments.len() != 2 {
+    return Err("usage: auv-cli inspect <run-id>".to_string());
+  }
+
+  Ok(CliCommand::Inspect {
+    run_id: arguments[1].clone(),
+  })
+}
+
+fn parse_invoke(arguments: &[String]) -> AuvResult<CliCommand> {
+  if arguments.len() < 2 {
+    return Err(
+      "usage: auv-cli invoke <command-id> [--target <application-id>] [--label <text>]".to_string(),
+    );
+  }
+
+  let command_id = arguments[1].clone();
+  let mut target = ExecutionTarget::default();
+  let mut inputs = BTreeMap::new();
+  let mut index = 2;
+
+  while index < arguments.len() {
+    let argument = &arguments[index];
+    if !argument.starts_with("--") {
+      return Err(format!("unexpected positional argument {argument}"));
+    }
+    if index + 1 >= arguments.len() {
+      return Err(format!("flag {argument} requires a value"));
+    }
+
+    let value = arguments[index + 1].clone();
+    match argument.as_str() {
+      "--target" => {
+        target.application_id = Some(value);
+      }
+      "--label" => {
+        inputs.insert("label".to_string(), value);
+      }
+      other => {
+        let key = other.trim_start_matches("--");
+        inputs.insert(key.to_string(), value);
+      }
+    }
+
+    index += 2;
+  }
+
+  Ok(CliCommand::Invoke(InvokeRequest {
+    command_id,
+    target,
+    inputs,
+  }))
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -40,7 +40,11 @@ USAGE
 NOTES
   - Names are provisional and reflect the current phase-0/1 runtime skeleton.
   - The CLI is a thin frontend over the library runtime in src/lib.rs.
-  - `debug.captureScreen` proves driver-level desktop reuse without importing AIRI server tooling.
+  - `debug.captureScreen`, `debug.observeWindows`, and `debug.probePermissions` are the current desktop donor entrypoints.
+  - Operation-specific flags are forwarded as string inputs, for example:
+    `auv-cli invoke debug.click --x 640 --y 480 --button left`
+    `auv-cli invoke debug.pressKeys --keys cmd+k`
+    `auv-cli invoke debug.focusApp --app Music`
 "
 }
 

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -8,12 +8,7 @@ use std::thread;
 use std::time::Duration;
 
 use crate::model::{
-  AuvResult,
-  DriverCall,
-  DriverDescriptor,
-  DriverResponse,
-  ProducedArtifact,
-  now_millis,
+  AuvResult, DriverCall, DriverDescriptor, DriverResponse, ProducedArtifact, now_millis,
 };
 
 const PROBE_ACCESSIBILITY_SCRIPT: &str = r#"
@@ -390,10 +385,7 @@ impl Driver for MacOsDesktopDriver {
 fn capture_screen(call: &DriverCall) -> AuvResult<DriverResponse> {
   let label = optional_string(call, "label").unwrap_or_else(|| "desktop".to_string());
   let temporary_path = screenshot_temp_path(&label);
-  let args = vec![
-    "-x".to_string(),
-    temporary_path.display().to_string(),
-  ];
+  let args = vec!["-x".to_string(), temporary_path.display().to_string()];
   run_command(SCREEN_CAPTURE_BINARY, &args)?;
 
   if !temporary_path.exists() {
@@ -411,13 +403,16 @@ fn capture_screen(call: &DriverCall) -> AuvResult<DriverResponse> {
         "Temporary screenshot created at {} before artifact ingestion.",
         temporary_path.display()
       ),
-      "This remains a driver-level primitive instead of an AIRI-style desktop tool wrapper.".to_string(),
+      "This remains a driver-level primitive instead of an AIRI-style desktop tool wrapper."
+        .to_string(),
     ],
     artifacts: vec![ProducedArtifact {
       kind: "screenshot".to_string(),
       source_path: temporary_path,
       preferred_name: format!("{}.png", sanitize_file_component(&label)),
-      note: Some("Phase-1 screenshot artifact captured through the macOS desktop driver.".to_string()),
+      note: Some(
+        "Phase-1 screenshot artifact captured through the macOS desktop driver.".to_string(),
+      ),
     }],
   })
 }
@@ -430,31 +425,42 @@ fn observe_windows(call: &DriverCall) -> AuvResult<DriverResponse> {
     .unwrap_or("0")
     .parse::<usize>()
     .unwrap_or(0);
-  let frontmost_app = report_value(&report, "frontmostAppName=").unwrap_or("").to_string();
-  let frontmost_window = report_value(&report, "frontmostWindowTitle=").unwrap_or("").to_string();
-  let observed_at = report_value(&report, "observedAt=").unwrap_or("").to_string();
+  let frontmost_app = report_value(&report, "frontmostAppName=")
+    .unwrap_or("")
+    .to_string();
+  let frontmost_window = report_value(&report, "frontmostWindowTitle=")
+    .unwrap_or("")
+    .to_string();
+  let observed_at = report_value(&report, "observedAt=")
+    .unwrap_or("")
+    .to_string();
   let artifact = build_text_artifact(
     "observe-windows",
     "txt",
-    &format!("observe-windows-{}", sanitize_file_component(&frontmost_app)),
+    &format!(
+      "observe-windows-{}",
+      sanitize_file_component(&frontmost_app)
+    ),
     report.clone(),
     "Captured window observation report from the macOS desktop driver.",
   )?;
   let mut notes = vec![format!("observedAt={observed_at}")];
-  for line in report.lines().filter(|line| line.starts_with("window\t")).take(5) {
+  for line in report
+    .lines()
+    .filter(|line| line.starts_with("window\t"))
+    .take(5)
+  {
     notes.push(line.to_string());
   }
 
   let summary = if frontmost_app.is_empty() {
     format!("Observed {} visible macOS window(s).", window_count)
-  }
-  else if frontmost_window.is_empty() {
+  } else if frontmost_window.is_empty() {
     format!(
       "Observed {} visible macOS window(s); frontmost app is {}.",
       window_count, frontmost_app
     )
-  }
-  else {
+  } else {
     format!(
       "Observed {} visible macOS window(s); frontmost app is {} ({})",
       window_count, frontmost_app, frontmost_window
@@ -470,8 +476,12 @@ fn observe_windows(call: &DriverCall) -> AuvResult<DriverResponse> {
 }
 
 fn probe_permissions(_call: &DriverCall) -> AuvResult<DriverResponse> {
-  let screen_recording = run_swift_script(PROBE_SCREEN_RECORDING_SCRIPT)?.trim().to_string();
-  let accessibility = run_swift_script(PROBE_ACCESSIBILITY_SCRIPT)?.trim().to_string();
+  let screen_recording = run_swift_script(PROBE_SCREEN_RECORDING_SCRIPT)?
+    .trim()
+    .to_string();
+  let accessibility = run_swift_script(PROBE_ACCESSIBILITY_SCRIPT)?
+    .trim()
+    .to_string();
   let automation = probe_automation_to_system_events();
   let launch_host = launch_host_process();
 
@@ -524,7 +534,10 @@ fn focus_app(call: &DriverCall) -> AuvResult<DriverResponse> {
   run_command(OPEN_BINARY, &open_args)?;
   let activate_args = vec![
     "-e".to_string(),
-    format!("tell application {} to activate", apple_script_string(&resolved)),
+    format!(
+      "tell application {} to activate",
+      apple_script_string(&resolved)
+    ),
   ];
   run_command(OSASCRIPT_BINARY, &activate_args)?;
 
@@ -567,7 +580,10 @@ fn type_text(call: &DriverCall) -> AuvResult<DriverResponse> {
   run_swift_script(
     &TYPE_TEXT_SCRIPT_TEMPLATE
       .replace("__TEXT__", &swift_string_literal(&text))
-      .replace("__PRESS_ENTER__", if press_enter { "true" } else { "false" }),
+      .replace(
+        "__PRESS_ENTER__",
+        if press_enter { "true" } else { "false" },
+      ),
   )?;
 
   Ok(DriverResponse {
@@ -595,13 +611,11 @@ fn press_keys(call: &DriverCall) -> AuvResult<DriverResponse> {
     normalized[..normalized.len() - 1]
       .iter()
       .map(|modifier| {
-        modifier_flag(modifier)
-          .ok_or_else(|| format!("unsupported modifier key: {}", modifier))
+        modifier_flag(modifier).ok_or_else(|| format!("unsupported modifier key: {}", modifier))
       })
       .collect::<AuvResult<Vec<_>>>()?
       .join(" | ")
-  }
-  else {
+  } else {
     "[]".to_string()
   };
 
@@ -635,7 +649,10 @@ fn scroll(call: &DriverCall) -> AuvResult<DriverResponse> {
   )?;
 
   Ok(DriverResponse {
-    summary: format!("Scrolled on the local macOS desktop with deltaX={}, deltaY={}.", delta_x, delta_y),
+    summary: format!(
+      "Scrolled on the local macOS desktop with deltaX={}, deltaY={}.",
+      delta_x, delta_y
+    ),
     backend: Some("macos.swift.quartz-scroll".to_string()),
     notes: vec![format!("hasPoint={has_point}")],
     artifacts: Vec::new(),
@@ -678,8 +695,12 @@ fn probe_automation_to_system_events() -> String {
 
 fn run_swift_script(source: &str) -> AuvResult<String> {
   let script_path = temp_file_path("swift-script", "swift");
-  fs::write(&script_path, source)
-    .map_err(|error| format!("failed to write Swift script {}: {error}", script_path.display()))?;
+  fs::write(&script_path, source).map_err(|error| {
+    format!(
+      "failed to write Swift script {}: {error}",
+      script_path.display()
+    )
+  })?;
 
   let result = run_swift_script_with_fallback(&script_path);
   let _ = fs::remove_file(&script_path);
@@ -687,10 +708,7 @@ fn run_swift_script(source: &str) -> AuvResult<String> {
 }
 
 fn run_swift_script_with_fallback(script_path: &PathBuf) -> AuvResult<String> {
-  let xcrun_args = vec![
-    "swift".to_string(),
-    script_path.display().to_string(),
-  ];
+  let xcrun_args = vec!["swift".to_string(), script_path.display().to_string()];
 
   match run_command(XCRUN_BINARY, &xcrun_args) {
     Ok(output) => Ok(output.stdout),
@@ -722,8 +740,7 @@ fn run_command(binary: &str, args: &[String]) -> AuvResult<CommandOutput> {
       output.status,
       if trimmed_stderr.is_empty() {
         "no stderr output"
-      }
-      else {
+      } else {
         trimmed_stderr
       }
     ));
@@ -750,8 +767,12 @@ fn build_text_artifact(
   note: &str,
 ) -> AuvResult<ProducedArtifact> {
   let source_path = temp_file_path(label, extension);
-  fs::write(&source_path, content)
-    .map_err(|error| format!("failed to write artifact source {}: {error}", source_path.display()))?;
+  fs::write(&source_path, content).map_err(|error| {
+    format!(
+      "failed to write artifact source {}: {error}",
+      source_path.display()
+    )
+  })?;
 
   Ok(ProducedArtifact {
     kind: kind.to_string(),
@@ -776,12 +797,18 @@ fn require_macos() -> AuvResult<()> {
 fn required_app(call: &DriverCall) -> AuvResult<String> {
   app_identifier(call)
     .filter(|value| !value.trim().is_empty())
-    .ok_or_else(|| "operation requires --app <Application Name> or --target <Application Name>".to_string())
+    .ok_or_else(|| {
+      "operation requires --app <Application Name> or --target <Application Name>".to_string()
+    })
 }
 
 fn app_identifier(call: &DriverCall) -> Option<String> {
   optional_string(call, "app").or_else(|| {
-    call.target.application_id.clone().filter(|value| !value.trim().is_empty())
+    call
+      .target
+      .application_id
+      .clone()
+      .filter(|value| !value.trim().is_empty())
   })
 }
 
@@ -796,16 +823,23 @@ fn optional_string(call: &DriverCall, key: &str) -> Option<String> {
 }
 
 fn required_f64(call: &DriverCall, key: &str) -> AuvResult<f64> {
-  optional_f64(call, key)?
-    .ok_or_else(|| format!("operation requires --{} <number>", key))
+  optional_f64(call, key)?.ok_or_else(|| format!("operation requires --{} <number>", key))
 }
 
 fn optional_f64(call: &DriverCall, key: &str) -> AuvResult<Option<f64>> {
   match call.inputs.get(key) {
-    Some(value) => value
-      .parse::<f64>()
-      .map(Some)
-      .map_err(|error| format!("invalid --{} value {}: {}", key, value, error)),
+    Some(value) => {
+      let parsed = value
+        .parse::<f64>()
+        .map_err(|error| format!("invalid --{} value {}: {}", key, value, error))?;
+      if !parsed.is_finite() {
+        return Err(format!(
+          "invalid --{} value {}: expected a finite number",
+          key, value
+        ));
+      }
+      Ok(Some(parsed))
+    }
     None => Ok(None),
   }
 }
@@ -822,7 +856,10 @@ fn optional_i64(call: &DriverCall, key: &str) -> AuvResult<Option<i64>> {
 
 fn optional_bool(call: &DriverCall, key: &str) -> Option<bool> {
   call.inputs.get(key).map(|value| {
-    matches!(value.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on")
+    matches!(
+      value.trim().to_ascii_lowercase().as_str(),
+      "1" | "true" | "yes" | "on"
+    )
   })
 }
 
@@ -912,6 +949,15 @@ fn modifier_flag(key: &str) -> Option<String> {
 }
 
 fn resolve_installed_app_name(app: &str) -> String {
+  let trimmed = app.trim();
+  if trimmed.is_empty() {
+    return app.to_string();
+  }
+
+  if trimmed.ends_with(".app") || trimmed.contains('/') {
+    return trimmed.to_string();
+  }
+
   let mut roots = vec![PathBuf::from("/Applications")];
   if let Some(home) = env::var_os("HOME") {
     roots.push(PathBuf::from(home).join("Applications"));
@@ -937,7 +983,7 @@ fn resolve_installed_app_name(app: &str) -> String {
     }
   }
 
-  app.to_string()
+  trimmed.to_string()
 }
 
 fn launch_host_process() -> String {
@@ -984,16 +1030,19 @@ fn sanitize_file_component(raw: &str) -> String {
 
   if sanitized.is_empty() {
     "artifact".to_string()
-  }
-  else {
+  } else {
     sanitized
   }
 }
 
 pub fn copy_file(source: &PathBuf, destination: &PathBuf) -> AuvResult<()> {
   if let Some(parent) = destination.parent() {
-    fs::create_dir_all(parent)
-      .map_err(|error| format!("failed to create artifact directory {}: {error}", parent.display()))?;
+    fs::create_dir_all(parent).map_err(|error| {
+      format!(
+        "failed to create artifact directory {}: {error}",
+        parent.display()
+      )
+    })?;
   }
 
   fs::copy(source, destination).map_err(|error| {
@@ -1013,4 +1062,43 @@ pub fn sanitized_artifact_name(raw: &str) -> String {
 
 struct CommandOutput {
   stdout: String,
+}
+
+#[cfg(test)]
+mod tests {
+  use std::collections::BTreeMap;
+  use std::path::PathBuf;
+
+  use super::{optional_f64, resolve_installed_app_name};
+  use crate::model::{DriverCall, ExecutionTarget};
+
+  #[test]
+  fn optional_f64_rejects_non_finite_numbers() {
+    let call = build_call([("x", "NaN")]);
+    let error = optional_f64(&call, "x").expect_err("NaN should be rejected");
+    assert!(error.contains("finite number"));
+  }
+
+  #[test]
+  fn resolve_installed_app_name_keeps_bundle_paths_without_scanning() {
+    assert_eq!(
+      resolve_installed_app_name("/Applications/Preview.app"),
+      "/Applications/Preview.app"
+    );
+    assert_eq!(resolve_installed_app_name("Preview.app"), "Preview.app");
+  }
+
+  fn build_call<const N: usize>(entries: [(&str, &str); N]) -> DriverCall {
+    let mut inputs = BTreeMap::new();
+    for (key, value) in entries {
+      inputs.insert(key.to_string(), value.to_string());
+    }
+
+    DriverCall {
+      operation: "test".to_string(),
+      target: ExecutionTarget::default(),
+      inputs,
+      working_directory: PathBuf::from("."),
+    }
+  }
 }

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -1,0 +1,218 @@
+use std::collections::HashMap;
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+use crate::model::{
+  AuvResult,
+  DriverCall,
+  DriverDescriptor,
+  DriverResponse,
+  ProducedArtifact,
+  now_millis,
+};
+
+pub trait Driver {
+  fn descriptor(&self) -> DriverDescriptor;
+  fn invoke(&self, call: &DriverCall) -> AuvResult<DriverResponse>;
+}
+
+pub struct DriverRegistry {
+  drivers: HashMap<String, Box<dyn Driver>>,
+}
+
+impl DriverRegistry {
+  pub fn new(drivers: Vec<Box<dyn Driver>>) -> Self {
+    let mut registry = HashMap::new();
+    for driver in drivers {
+      let descriptor = driver.descriptor();
+      registry.insert(descriptor.id.to_string(), driver);
+    }
+    Self { drivers: registry }
+  }
+
+  pub fn get(&self, driver_id: &str) -> Option<&dyn Driver> {
+    self.drivers.get(driver_id).map(Box::as_ref)
+  }
+
+  pub fn descriptors(&self) -> Vec<DriverDescriptor> {
+    let mut descriptors = self
+      .drivers
+      .values()
+      .map(|driver| driver.descriptor())
+      .collect::<Vec<_>>();
+    descriptors.sort_by(|left, right| left.id.cmp(right.id));
+    descriptors
+  }
+}
+
+pub fn default_driver_registry() -> DriverRegistry {
+  DriverRegistry::new(vec![
+    Box::new(FixtureObserveDriver),
+    Box::new(MacOsScreenshotDriver),
+  ])
+}
+
+struct FixtureObserveDriver;
+
+impl Driver for FixtureObserveDriver {
+  fn descriptor(&self) -> DriverDescriptor {
+    DriverDescriptor {
+      id: "fixture.observe",
+      summary: "Non-UI fixture driver that proves invoke -> run -> inspect without platform side effects.",
+      capabilities: &["observe.fixture"],
+      donor_boundary: "AUV-native fixture driver; useful for validating the shared execution substrate before real app drivers land.",
+    }
+  }
+
+  fn invoke(&self, call: &DriverCall) -> AuvResult<DriverResponse> {
+    if call.operation != "observe_fixture_scene" {
+      return Err(format!(
+        "driver fixture.observe does not support operation {}",
+        call.operation
+      ));
+    }
+
+    let target = call
+      .target
+      .application_id
+      .clone()
+      .unwrap_or_else(|| "fixture://default".to_string());
+    let label = call
+      .inputs
+      .get("label")
+      .cloned()
+      .unwrap_or_else(|| "fixture-observation".to_string());
+
+    Ok(DriverResponse {
+      summary: format!(
+        "Observed deterministic fixture scene for target {} with label {}.",
+        target, label
+      ),
+      backend: Some("fixture.static".to_string()),
+      notes: vec![
+        "This command does not touch the real desktop.".to_string(),
+        "Use it to verify that implicit run creation and inspect output stay stable.".to_string(),
+      ],
+      artifacts: Vec::new(),
+    })
+  }
+}
+
+struct MacOsScreenshotDriver;
+
+impl Driver for MacOsScreenshotDriver {
+  fn descriptor(&self) -> DriverDescriptor {
+    DriverDescriptor {
+      id: "macos.screenshot",
+      summary: "Capture screenshots on macOS through the shared driver protocol.",
+      capabilities: &["observe.screenshot", "artifact.image"],
+      donor_boundary: "Borrow the driver layer idea from AIRI desktop, but keep MCP/server orchestration, approval, and workflow shells out of AUV core.",
+    }
+  }
+
+  fn invoke(&self, call: &DriverCall) -> AuvResult<DriverResponse> {
+    if call.operation != "capture_screen" {
+      return Err(format!(
+        "driver macos.screenshot does not support operation {}",
+        call.operation
+      ));
+    }
+
+    if env::consts::OS != "macos" {
+      return Err("macos.screenshot is only available on macOS".to_string());
+    }
+
+    let label = sanitize_file_component(
+      call.inputs
+        .get("label")
+        .map(String::as_str)
+        .unwrap_or("desktop"),
+    );
+    let temporary_path = screenshot_temp_path(&label);
+    let output = Command::new("screencapture")
+      .arg("-x")
+      .arg(&temporary_path)
+      .output()
+      .map_err(|error| format!("failed to spawn screencapture: {error}"))?;
+
+    if !output.status.success() {
+      let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+      return Err(format!(
+        "screencapture exited with status {}: {}",
+        output.status,
+        if stderr.is_empty() { "no stderr output" } else { &stderr }
+      ));
+    }
+
+    if !temporary_path.exists() {
+      return Err(format!(
+        "screencapture reported success but no image was created at {}",
+        temporary_path.display()
+      ));
+    }
+
+    Ok(DriverResponse {
+      summary: "Captured one desktop screenshot through the shared AUV runtime.".to_string(),
+      backend: Some("macos.screencapture".to_string()),
+      notes: vec![
+        format!(
+          "Temporary screenshot created at {} before artifact ingestion.",
+          temporary_path.display()
+        ),
+        "This is intentionally a driver-level primitive; it does not pull in AIRI MCP tools, action executors, or approval queues.".to_string(),
+      ],
+      artifacts: vec![ProducedArtifact {
+        kind: "screenshot".to_string(),
+        source_path: temporary_path,
+        preferred_name: format!("{label}.png"),
+        note: Some("Phase-1 screenshot artifact captured through the macOS first-party driver.".to_string()),
+      }],
+    })
+  }
+}
+
+fn screenshot_temp_path(label: &str) -> PathBuf {
+  env::temp_dir().join(format!("auv-{}-{}.png", label, now_millis()))
+}
+
+fn sanitize_file_component(raw: &str) -> String {
+  let sanitized = raw
+    .chars()
+    .map(|character| match character {
+      'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' => character,
+      _ => '-',
+    })
+    .collect::<String>()
+    .trim_matches('-')
+    .to_string();
+
+  if sanitized.is_empty() {
+    "artifact".to_string()
+  }
+  else {
+    sanitized
+  }
+}
+
+pub fn copy_file(source: &PathBuf, destination: &PathBuf) -> AuvResult<()> {
+  if let Some(parent) = destination.parent() {
+    fs::create_dir_all(parent)
+      .map_err(|error| format!("failed to create artifact directory {}: {error}", parent.display()))?;
+  }
+
+  fs::copy(source, destination).map_err(|error| {
+    format!(
+      "failed to copy artifact from {} to {}: {error}",
+      source.display(),
+      destination.display()
+    )
+  })?;
+
+  Ok(())
+}
+
+pub fn sanitized_artifact_name(raw: &str) -> String {
+  sanitize_file_component(raw)
+}

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -1,8 +1,11 @@
 use std::collections::HashMap;
 use std::env;
 use std::fs;
+use std::io::ErrorKind;
 use std::path::PathBuf;
 use std::process::Command;
+use std::thread;
+use std::time::Duration;
 
 use crate::model::{
   AuvResult,
@@ -12,6 +15,245 @@ use crate::model::{
   ProducedArtifact,
   now_millis,
 };
+
+const PROBE_ACCESSIBILITY_SCRIPT: &str = r#"
+import ApplicationServices
+print(AXIsProcessTrusted() ? "granted" : "missing")
+"#;
+
+const PROBE_SCREEN_RECORDING_SCRIPT: &str = r#"
+import CoreGraphics
+import Foundation
+print(CGPreflightScreenCaptureAccess() ? "granted" : "missing")
+"#;
+
+const OBSERVE_WINDOWS_SCRIPT_TEMPLATE: &str = r#"
+import AppKit
+import CoreGraphics
+import Foundation
+
+func boundsDict(_ value: NSDictionary?) -> [String: Int]? {
+  guard let value else { return nil }
+  var rect = CGRect.zero
+  guard CGRectMakeWithDictionaryRepresentation(value, &rect) else { return nil }
+  return [
+    "x": Int(rect.origin.x.rounded()),
+    "y": Int(rect.origin.y.rounded()),
+    "width": Int(rect.size.width.rounded()),
+    "height": Int(rect.size.height.rounded())
+  ]
+}
+
+let limit = __LIMIT__
+let appFilter = __APP_FILTER__.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+let frontmostAppName = NSWorkspace.shared.frontmostApplication?.localizedName ?? ""
+
+let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
+let rawWindowInfo = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] ?? []
+var windows: [[String: Any]] = []
+for window in rawWindowInfo {
+  let ownerName = (window[kCGWindowOwnerName as String] as? String) ?? "Unknown"
+  if !appFilter.isEmpty && !ownerName.lowercased().contains(appFilter) {
+    continue
+  }
+
+  let alpha = window[kCGWindowAlpha as String] as? Double ?? 1.0
+  let layer = window[kCGWindowLayer as String] as? Int ?? 0
+  let bounds = boundsDict(window[kCGWindowBounds as String] as? NSDictionary)
+  let title = (window[kCGWindowName as String] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+  let ownerPid = window[kCGWindowOwnerPID as String] as? Int ?? 0
+
+  if alpha <= 0 || (bounds?["width"] ?? 0) <= 1 || (bounds?["height"] ?? 0) <= 1 {
+    continue
+  }
+
+  windows.append([
+    "appName": ownerName,
+    "title": title,
+    "ownerPid": ownerPid,
+    "layer": layer,
+    "x": bounds?["x"] ?? 0,
+    "y": bounds?["y"] ?? 0,
+    "width": bounds?["width"] ?? 0,
+    "height": bounds?["height"] ?? 0
+  ])
+
+  if windows.count >= limit {
+    break
+  }
+}
+
+let frontmostWindowTitle = windows.first(where: { ($0["appName"] as? String) == frontmostAppName })?["title"] as? String ?? ""
+
+print("frontmostAppName=\(frontmostAppName)")
+print("frontmostWindowTitle=\(frontmostWindowTitle)")
+print("observedAt=\(ISO8601DateFormatter().string(from: Date()))")
+print("windowCount=\(windows.count)")
+for window in windows {
+  let appName = window["appName"] as? String ?? "Unknown"
+  let title = window["title"] as? String ?? ""
+  let ownerPid = window["ownerPid"] as? Int ?? 0
+  let layer = window["layer"] as? Int ?? 0
+  let x = window["x"] as? Int ?? 0
+  let y = window["y"] as? Int ?? 0
+  let width = window["width"] as? Int ?? 0
+  let height = window["height"] as? Int ?? 0
+  print("window\t\(appName)\t\(ownerPid)\t\(layer)\t\(title)\t\(x)\t\(y)\t\(width)\t\(height)")
+}
+"#;
+
+const CLICK_SCRIPT_TEMPLATE: &str = r#"
+import CoreGraphics
+import Foundation
+
+func mouseButton(_ value: Int) -> CGMouseButton {
+  switch value {
+  case 1: return .right
+  case 2: return .center
+  default: return .left
+  }
+}
+
+func mouseDownType(_ button: CGMouseButton) -> CGEventType {
+  switch button {
+  case .right: return .rightMouseDown
+  case .center: return .otherMouseDown
+  default: return .leftMouseDown
+  }
+}
+
+func mouseUpType(_ button: CGMouseButton) -> CGEventType {
+  switch button {
+  case .right: return .rightMouseUp
+  case .center: return .otherMouseUp
+  default: return .leftMouseUp
+  }
+}
+
+let original = CGEvent(source: nil)?.location ?? CGPoint.zero
+defer {
+  CGWarpMouseCursorPosition(original)
+}
+
+let x = __X__
+let y = __Y__
+let clickCount = __CLICK_COUNT__
+let button = mouseButton(__BUTTON__)
+let location = CGPoint(x: x, y: y)
+
+if let moveEvent = CGEvent(mouseEventSource: nil, mouseType: .mouseMoved, mouseCursorPosition: location, mouseButton: .left) {
+  moveEvent.post(tap: .cghidEventTap)
+}
+
+for _ in 0..<max(clickCount, 1) {
+  if let down = CGEvent(mouseEventSource: nil, mouseType: mouseDownType(button), mouseCursorPosition: location, mouseButton: button),
+     let up = CGEvent(mouseEventSource: nil, mouseType: mouseUpType(button), mouseCursorPosition: location, mouseButton: button) {
+    down.setIntegerValueField(.mouseEventClickState, value: Int64(clickCount))
+    up.setIntegerValueField(.mouseEventClickState, value: Int64(clickCount))
+    down.post(tap: .cghidEventTap)
+    up.post(tap: .cghidEventTap)
+  }
+}
+
+print("clicked")
+"#;
+
+const TYPE_TEXT_SCRIPT_TEMPLATE: &str = r#"
+import CoreGraphics
+import Foundation
+
+let text = __TEXT__
+let pressEnter = __PRESS_ENTER__
+let characterDelayMicros: useconds_t = 12_000
+let settleDelayMicros: useconds_t = 80_000
+
+func postText(_ chunk: String) {
+  let chars = Array(chunk.utf16)
+  let length = chars.count
+  guard length > 0 else { return }
+  chars.withUnsafeBufferPointer { buffer in
+    if let keyDown = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: true),
+       let keyUp = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: false) {
+      keyDown.keyboardSetUnicodeString(stringLength: length, unicodeString: buffer.baseAddress!)
+      keyUp.keyboardSetUnicodeString(stringLength: length, unicodeString: buffer.baseAddress!)
+      keyDown.post(tap: .cghidEventTap)
+      keyUp.post(tap: .cghidEventTap)
+    }
+  }
+
+  usleep(characterDelayMicros)
+}
+
+for character in text {
+  postText(String(character))
+}
+
+if !text.isEmpty {
+  usleep(settleDelayMicros)
+}
+
+if pressEnter {
+  if let down = CGEvent(keyboardEventSource: nil, virtualKey: 36, keyDown: true),
+     let up = CGEvent(keyboardEventSource: nil, virtualKey: 36, keyDown: false) {
+    down.post(tap: .cghidEventTap)
+    up.post(tap: .cghidEventTap)
+  }
+}
+
+print("typed")
+"#;
+
+const PRESS_KEYS_SCRIPT_TEMPLATE: &str = r#"
+import CoreGraphics
+import Foundation
+
+let keyCode: CGKeyCode = __KEY_CODE__
+let modifierFlags: CGEventFlags = __MODIFIER_FLAGS__
+
+if let keyDown = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: true),
+   let keyUp = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: false) {
+  keyDown.flags = modifierFlags
+  keyUp.flags = modifierFlags
+  keyDown.post(tap: .cghidEventTap)
+  keyUp.post(tap: .cghidEventTap)
+}
+
+print("pressed")
+"#;
+
+const SCROLL_SCRIPT_TEMPLATE: &str = r#"
+import CoreGraphics
+import Foundation
+
+let original = CGEvent(source: nil)?.location ?? CGPoint.zero
+defer {
+  CGWarpMouseCursorPosition(original)
+}
+
+let hasPoint = __HAS_POINT__
+let x = __X__
+let y = __Y__
+let deltaX = Int32(__DELTA_X__)
+let deltaY = Int32(__DELTA_Y__)
+
+if hasPoint {
+  let location = CGPoint(x: x, y: y)
+  if let moveEvent = CGEvent(mouseEventSource: nil, mouseType: .mouseMoved, mouseCursorPosition: location, mouseButton: .left) {
+    moveEvent.post(tap: .cghidEventTap)
+  }
+}
+
+if let scrollEvent = CGEvent(scrollWheelEvent2Source: nil, units: .pixel, wheelCount: 2, wheel1: deltaY, wheel2: deltaX, wheel3: 0) {
+  scrollEvent.post(tap: .cghidEventTap)
+}
+
+print("scrolled")
+"#;
+
+const XCRUN_BINARY: &str = "/usr/bin/xcrun";
+const OSASCRIPT_BINARY: &str = "/usr/bin/osascript";
+const OPEN_BINARY: &str = "/usr/bin/open";
+const SCREEN_CAPTURE_BINARY: &str = "/usr/sbin/screencapture";
 
 pub trait Driver {
   fn descriptor(&self) -> DriverDescriptor;
@@ -50,7 +292,7 @@ impl DriverRegistry {
 pub fn default_driver_registry() -> DriverRegistry {
   DriverRegistry::new(vec![
     Box::new(FixtureObserveDriver),
-    Box::new(MacOsScreenshotDriver),
+    Box::new(MacOsDesktopDriver),
   ])
 }
 
@@ -100,81 +342,633 @@ impl Driver for FixtureObserveDriver {
   }
 }
 
-struct MacOsScreenshotDriver;
+struct MacOsDesktopDriver;
 
-impl Driver for MacOsScreenshotDriver {
+impl Driver for MacOsDesktopDriver {
   fn descriptor(&self) -> DriverDescriptor {
     DriverDescriptor {
-      id: "macos.screenshot",
-      summary: "Capture screenshots on macOS through the shared driver protocol.",
-      capabilities: &["observe.screenshot", "artifact.image"],
-      donor_boundary: "Borrow the driver layer idea from AIRI desktop, but keep MCP/server orchestration, approval, and workflow shells out of AUV core.",
+      id: "macos.desktop",
+      summary: "Desktop donor primitives extracted into the shared AUV driver protocol.",
+      capabilities: &[
+        "observe.screenshot",
+        "observe.windows",
+        "observe.permissions",
+        "control.open-app",
+        "control.focus-app",
+        "control.click",
+        "control.type-text",
+        "control.press-keys",
+        "control.scroll",
+        "control.wait",
+      ],
+      donor_boundary: "Borrow Swift/Quartz desktop primitives from AIRI, but keep MCP tools, action executors, approval queues, and workflow shells out of AUV core.",
     }
   }
 
   fn invoke(&self, call: &DriverCall) -> AuvResult<DriverResponse> {
-    if call.operation != "capture_screen" {
-      return Err(format!(
-        "driver macos.screenshot does not support operation {}",
-        call.operation
-      ));
+    require_macos()?;
+
+    match call.operation.as_str() {
+      "capture_screen" => capture_screen(call),
+      "observe_windows" => observe_windows(call),
+      "probe_permissions" => probe_permissions(call),
+      "open_app" => open_app(call),
+      "focus_app" => focus_app(call),
+      "click" => click(call),
+      "type_text" => type_text(call),
+      "press_keys" => press_keys(call),
+      "scroll" => scroll(call),
+      "wait" => wait(call),
+      other => Err(format!(
+        "driver macos.desktop does not support operation {}",
+        other
+      )),
     }
-
-    if env::consts::OS != "macos" {
-      return Err("macos.screenshot is only available on macOS".to_string());
-    }
-
-    let label = sanitize_file_component(
-      call.inputs
-        .get("label")
-        .map(String::as_str)
-        .unwrap_or("desktop"),
-    );
-    let temporary_path = screenshot_temp_path(&label);
-    let output = Command::new("screencapture")
-      .arg("-x")
-      .arg(&temporary_path)
-      .output()
-      .map_err(|error| format!("failed to spawn screencapture: {error}"))?;
-
-    if !output.status.success() {
-      let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-      return Err(format!(
-        "screencapture exited with status {}: {}",
-        output.status,
-        if stderr.is_empty() { "no stderr output" } else { &stderr }
-      ));
-    }
-
-    if !temporary_path.exists() {
-      return Err(format!(
-        "screencapture reported success but no image was created at {}",
-        temporary_path.display()
-      ));
-    }
-
-    Ok(DriverResponse {
-      summary: "Captured one desktop screenshot through the shared AUV runtime.".to_string(),
-      backend: Some("macos.screencapture".to_string()),
-      notes: vec![
-        format!(
-          "Temporary screenshot created at {} before artifact ingestion.",
-          temporary_path.display()
-        ),
-        "This is intentionally a driver-level primitive; it does not pull in AIRI MCP tools, action executors, or approval queues.".to_string(),
-      ],
-      artifacts: vec![ProducedArtifact {
-        kind: "screenshot".to_string(),
-        source_path: temporary_path,
-        preferred_name: format!("{label}.png"),
-        note: Some("Phase-1 screenshot artifact captured through the macOS first-party driver.".to_string()),
-      }],
-    })
   }
 }
 
+fn capture_screen(call: &DriverCall) -> AuvResult<DriverResponse> {
+  let label = optional_string(call, "label").unwrap_or_else(|| "desktop".to_string());
+  let temporary_path = screenshot_temp_path(&label);
+  let args = vec![
+    "-x".to_string(),
+    temporary_path.display().to_string(),
+  ];
+  run_command(SCREEN_CAPTURE_BINARY, &args)?;
+
+  if !temporary_path.exists() {
+    return Err(format!(
+      "screencapture reported success but no image was created at {}",
+      temporary_path.display()
+    ));
+  }
+
+  Ok(DriverResponse {
+    summary: "Captured one desktop screenshot through the shared AUV runtime.".to_string(),
+    backend: Some("macos.screencapture".to_string()),
+    notes: vec![
+      format!(
+        "Temporary screenshot created at {} before artifact ingestion.",
+        temporary_path.display()
+      ),
+      "This remains a driver-level primitive instead of an AIRI-style desktop tool wrapper.".to_string(),
+    ],
+    artifacts: vec![ProducedArtifact {
+      kind: "screenshot".to_string(),
+      source_path: temporary_path,
+      preferred_name: format!("{}.png", sanitize_file_component(&label)),
+      note: Some("Phase-1 screenshot artifact captured through the macOS desktop driver.".to_string()),
+    }],
+  })
+}
+
+fn observe_windows(call: &DriverCall) -> AuvResult<DriverResponse> {
+  let limit = optional_i64(call, "limit")?.unwrap_or(12).max(1);
+  let app_filter = app_identifier(call).unwrap_or_default();
+  let report = run_swift_script(&build_observe_windows_script(limit, &app_filter))?;
+  let window_count = report_value(&report, "windowCount=")
+    .unwrap_or("0")
+    .parse::<usize>()
+    .unwrap_or(0);
+  let frontmost_app = report_value(&report, "frontmostAppName=").unwrap_or("").to_string();
+  let frontmost_window = report_value(&report, "frontmostWindowTitle=").unwrap_or("").to_string();
+  let observed_at = report_value(&report, "observedAt=").unwrap_or("").to_string();
+  let artifact = build_text_artifact(
+    "observe-windows",
+    "txt",
+    &format!("observe-windows-{}", sanitize_file_component(&frontmost_app)),
+    report.clone(),
+    "Captured window observation report from the macOS desktop driver.",
+  )?;
+  let mut notes = vec![format!("observedAt={observed_at}")];
+  for line in report.lines().filter(|line| line.starts_with("window\t")).take(5) {
+    notes.push(line.to_string());
+  }
+
+  let summary = if frontmost_app.is_empty() {
+    format!("Observed {} visible macOS window(s).", window_count)
+  }
+  else if frontmost_window.is_empty() {
+    format!(
+      "Observed {} visible macOS window(s); frontmost app is {}.",
+      window_count, frontmost_app
+    )
+  }
+  else {
+    format!(
+      "Observed {} visible macOS window(s); frontmost app is {} ({})",
+      window_count, frontmost_app, frontmost_window
+    )
+  };
+
+  Ok(DriverResponse {
+    summary,
+    backend: Some("macos.swift.cgwindowlist".to_string()),
+    notes,
+    artifacts: vec![artifact],
+  })
+}
+
+fn probe_permissions(_call: &DriverCall) -> AuvResult<DriverResponse> {
+  let screen_recording = run_swift_script(PROBE_SCREEN_RECORDING_SCRIPT)?.trim().to_string();
+  let accessibility = run_swift_script(PROBE_ACCESSIBILITY_SCRIPT)?.trim().to_string();
+  let automation = probe_automation_to_system_events();
+  let launch_host = launch_host_process();
+
+  let report = [
+    format!("screenRecording={screen_recording}"),
+    format!("accessibility={accessibility}"),
+    format!("automationToSystemEvents={automation}"),
+    format!("launchHostProcess={launch_host}"),
+  ]
+  .join("\n")
+    + "\n";
+
+  let artifact = build_text_artifact(
+    "probe-permissions",
+    "txt",
+    "permission-report",
+    report.clone(),
+    "Captured macOS permission probe report from the desktop driver.",
+  )?;
+
+  Ok(DriverResponse {
+    summary: format!(
+      "Permission probe: screenRecording={}, accessibility={}, automationToSystemEvents={}.",
+      screen_recording, accessibility, automation
+    ),
+    backend: Some("macos.swift-and-osascript".to_string()),
+    notes: report.lines().map(str::to_string).collect(),
+    artifacts: vec![artifact],
+  })
+}
+
+fn open_app(call: &DriverCall) -> AuvResult<DriverResponse> {
+  let app = required_app(call)?;
+  let resolved = resolve_installed_app_name(&app);
+  let args = vec!["-a".to_string(), resolved.clone()];
+  run_command(OPEN_BINARY, &args)?;
+
+  Ok(DriverResponse {
+    summary: format!("Opened app {}.", resolved),
+    backend: Some("macos.open".to_string()),
+    notes: vec![format!("requestedApp={app}")],
+    artifacts: Vec::new(),
+  })
+}
+
+fn focus_app(call: &DriverCall) -> AuvResult<DriverResponse> {
+  let app = required_app(call)?;
+  let resolved = resolve_installed_app_name(&app);
+  let open_args = vec!["-a".to_string(), resolved.clone()];
+  run_command(OPEN_BINARY, &open_args)?;
+  let activate_args = vec![
+    "-e".to_string(),
+    format!("tell application {} to activate", apple_script_string(&resolved)),
+  ];
+  run_command(OSASCRIPT_BINARY, &activate_args)?;
+
+  Ok(DriverResponse {
+    summary: format!("Focused app {}.", resolved),
+    backend: Some("macos.open-and-osascript".to_string()),
+    notes: vec![format!("requestedApp={app}")],
+    artifacts: Vec::new(),
+  })
+}
+
+fn click(call: &DriverCall) -> AuvResult<DriverResponse> {
+  let x = required_f64(call, "x")?;
+  let y = required_f64(call, "y")?;
+  let button_name = optional_string(call, "button").unwrap_or_else(|| "left".to_string());
+  let button = button_code(&button_name)?;
+  let click_count = optional_i64(call, "clickCount")?.unwrap_or(1).max(1);
+  run_swift_script(
+    &CLICK_SCRIPT_TEMPLATE
+      .replace("__X__", &format!("{x}"))
+      .replace("__Y__", &format!("{y}"))
+      .replace("__CLICK_COUNT__", &click_count.to_string())
+      .replace("__BUTTON__", &button.to_string()),
+  )?;
+
+  Ok(DriverResponse {
+    summary: format!("Clicked at ({x}, {y}) on the local macOS desktop."),
+    backend: Some("macos.swift.quartz-click".to_string()),
+    notes: vec![
+      format!("button={button_name}"),
+      format!("clickCount={click_count}"),
+    ],
+    artifacts: Vec::new(),
+  })
+}
+
+fn type_text(call: &DriverCall) -> AuvResult<DriverResponse> {
+  let text = required_string(call, "text")?;
+  let press_enter = optional_bool(call, "pressEnter").unwrap_or(false);
+  run_swift_script(
+    &TYPE_TEXT_SCRIPT_TEMPLATE
+      .replace("__TEXT__", &swift_string_literal(&text))
+      .replace("__PRESS_ENTER__", if press_enter { "true" } else { "false" }),
+  )?;
+
+  Ok(DriverResponse {
+    summary: format!(
+      "Typed {} character(s) on the local macOS desktop.",
+      text.chars().count()
+    ),
+    backend: Some("macos.swift.quartz-type".to_string()),
+    notes: vec![format!("pressEnter={press_enter}")],
+    artifacts: Vec::new(),
+  })
+}
+
+fn press_keys(call: &DriverCall) -> AuvResult<DriverResponse> {
+  let keys = required_string(call, "keys")?;
+  let normalized = split_keys(&keys);
+  if normalized.is_empty() {
+    return Err("press_keys requires at least one key".to_string());
+  }
+
+  let main_key = normalized.last().cloned().unwrap_or_default();
+  let key_code = key_code(&main_key)
+    .ok_or_else(|| format!("unsupported macOS key for press_keys: {}", main_key))?;
+  let modifier_expression = if normalized.len() > 1 {
+    normalized[..normalized.len() - 1]
+      .iter()
+      .map(|modifier| {
+        modifier_flag(modifier)
+          .ok_or_else(|| format!("unsupported modifier key: {}", modifier))
+      })
+      .collect::<AuvResult<Vec<_>>>()?
+      .join(" | ")
+  }
+  else {
+    "[]".to_string()
+  };
+
+  run_swift_script(
+    &PRESS_KEYS_SCRIPT_TEMPLATE
+      .replace("__KEY_CODE__", &key_code.to_string())
+      .replace("__MODIFIER_FLAGS__", &modifier_expression),
+  )?;
+
+  Ok(DriverResponse {
+    summary: format!("Pressed keys {}.", normalized.join("+")),
+    backend: Some("macos.swift.quartz-keys".to_string()),
+    notes: vec![format!("rawKeys={keys}")],
+    artifacts: Vec::new(),
+  })
+}
+
+fn scroll(call: &DriverCall) -> AuvResult<DriverResponse> {
+  let x = optional_f64(call, "x")?.unwrap_or(0.0);
+  let y = optional_f64(call, "y")?.unwrap_or(0.0);
+  let has_point = call.inputs.contains_key("x") && call.inputs.contains_key("y");
+  let delta_x = optional_i64(call, "deltaX")?.unwrap_or(0);
+  let delta_y = optional_i64(call, "deltaY")?.unwrap_or(0);
+  run_swift_script(
+    &SCROLL_SCRIPT_TEMPLATE
+      .replace("__HAS_POINT__", if has_point { "true" } else { "false" })
+      .replace("__X__", &format!("{x}"))
+      .replace("__Y__", &format!("{y}"))
+      .replace("__DELTA_X__", &delta_x.to_string())
+      .replace("__DELTA_Y__", &delta_y.to_string()),
+  )?;
+
+  Ok(DriverResponse {
+    summary: format!("Scrolled on the local macOS desktop with deltaX={}, deltaY={}.", delta_x, delta_y),
+    backend: Some("macos.swift.quartz-scroll".to_string()),
+    notes: vec![format!("hasPoint={has_point}")],
+    artifacts: Vec::new(),
+  })
+}
+
+fn wait(call: &DriverCall) -> AuvResult<DriverResponse> {
+  let duration_ms = optional_i64(call, "durationMs")?.unwrap_or(0).max(0) as u64;
+  thread::sleep(Duration::from_millis(duration_ms));
+
+  Ok(DriverResponse {
+    summary: format!("Waited {}ms inside the shared runtime path.", duration_ms),
+    backend: Some("std.thread.sleep".to_string()),
+    notes: Vec::new(),
+    artifacts: Vec::new(),
+  })
+}
+
+fn build_observe_windows_script(limit: i64, app_filter: &str) -> String {
+  OBSERVE_WINDOWS_SCRIPT_TEMPLATE
+    .replace("__LIMIT__", &limit.to_string())
+    .replace("__APP_FILTER__", &swift_string_literal(app_filter))
+}
+
+fn probe_automation_to_system_events() -> String {
+  let args = vec![
+    "-e".to_string(),
+    "tell application \"System Events\"".to_string(),
+    "-e".to_string(),
+    "return name of first application process whose frontmost is true".to_string(),
+    "-e".to_string(),
+    "end tell".to_string(),
+  ];
+
+  match run_command(OSASCRIPT_BINARY, &args) {
+    Ok(_) => "granted".to_string(),
+    Err(_) => "missing".to_string(),
+  }
+}
+
+fn run_swift_script(source: &str) -> AuvResult<String> {
+  let script_path = temp_file_path("swift-script", "swift");
+  fs::write(&script_path, source)
+    .map_err(|error| format!("failed to write Swift script {}: {error}", script_path.display()))?;
+
+  let result = run_swift_script_with_fallback(&script_path);
+  let _ = fs::remove_file(&script_path);
+  result
+}
+
+fn run_swift_script_with_fallback(script_path: &PathBuf) -> AuvResult<String> {
+  let xcrun_args = vec![
+    "swift".to_string(),
+    script_path.display().to_string(),
+  ];
+
+  match run_command(XCRUN_BINARY, &xcrun_args) {
+    Ok(output) => Ok(output.stdout),
+    Err(error) if error.contains("failed to spawn xcrun") => {
+      let swift_args = vec![script_path.display().to_string()];
+      Ok(run_command("swift", &swift_args)?.stdout)
+    }
+    Err(error) => Err(error),
+  }
+}
+
+fn run_command(binary: &str, args: &[String]) -> AuvResult<CommandOutput> {
+  let output = Command::new(binary)
+    .args(args)
+    .output()
+    .map_err(|error| match error.kind() {
+      ErrorKind::NotFound => format!("failed to spawn {}: command not found", binary),
+      _ => format!("failed to spawn {}: {}", binary, error),
+    })?;
+
+  let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+  let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+  if !output.status.success() {
+    let trimmed_stderr = stderr.trim();
+    return Err(format!(
+      "{} exited with status {}: {}",
+      binary,
+      output.status,
+      if trimmed_stderr.is_empty() {
+        "no stderr output"
+      }
+      else {
+        trimmed_stderr
+      }
+    ));
+  }
+
+  Ok(CommandOutput { stdout })
+}
+
+fn temp_file_path(label: &str, extension: &str) -> PathBuf {
+  env::temp_dir().join(format!(
+    "auv-{}-{}-{}.{}",
+    sanitize_file_component(label),
+    now_millis(),
+    std::process::id(),
+    extension
+  ))
+}
+
+fn build_text_artifact(
+  kind: &str,
+  extension: &str,
+  label: &str,
+  content: String,
+  note: &str,
+) -> AuvResult<ProducedArtifact> {
+  let source_path = temp_file_path(label, extension);
+  fs::write(&source_path, content)
+    .map_err(|error| format!("failed to write artifact source {}: {error}", source_path.display()))?;
+
+  Ok(ProducedArtifact {
+    kind: kind.to_string(),
+    source_path,
+    preferred_name: format!("{}.{}", sanitize_file_component(label), extension),
+    note: Some(note.to_string()),
+  })
+}
+
 fn screenshot_temp_path(label: &str) -> PathBuf {
-  env::temp_dir().join(format!("auv-{}-{}.png", label, now_millis()))
+  temp_file_path(label, "png")
+}
+
+fn require_macos() -> AuvResult<()> {
+  if env::consts::OS != "macos" {
+    return Err("macos.desktop is only available on macOS".to_string());
+  }
+
+  Ok(())
+}
+
+fn required_app(call: &DriverCall) -> AuvResult<String> {
+  app_identifier(call)
+    .filter(|value| !value.trim().is_empty())
+    .ok_or_else(|| "operation requires --app <Application Name> or --target <Application Name>".to_string())
+}
+
+fn app_identifier(call: &DriverCall) -> Option<String> {
+  optional_string(call, "app").or_else(|| {
+    call.target.application_id.clone().filter(|value| !value.trim().is_empty())
+  })
+}
+
+fn required_string(call: &DriverCall, key: &str) -> AuvResult<String> {
+  optional_string(call, key)
+    .filter(|value| !value.trim().is_empty())
+    .ok_or_else(|| format!("operation requires --{} <value>", key))
+}
+
+fn optional_string(call: &DriverCall, key: &str) -> Option<String> {
+  call.inputs.get(key).cloned()
+}
+
+fn required_f64(call: &DriverCall, key: &str) -> AuvResult<f64> {
+  optional_f64(call, key)?
+    .ok_or_else(|| format!("operation requires --{} <number>", key))
+}
+
+fn optional_f64(call: &DriverCall, key: &str) -> AuvResult<Option<f64>> {
+  match call.inputs.get(key) {
+    Some(value) => value
+      .parse::<f64>()
+      .map(Some)
+      .map_err(|error| format!("invalid --{} value {}: {}", key, value, error)),
+    None => Ok(None),
+  }
+}
+
+fn optional_i64(call: &DriverCall, key: &str) -> AuvResult<Option<i64>> {
+  match call.inputs.get(key) {
+    Some(value) => value
+      .parse::<i64>()
+      .map(Some)
+      .map_err(|error| format!("invalid --{} value {}: {}", key, value, error)),
+    None => Ok(None),
+  }
+}
+
+fn optional_bool(call: &DriverCall, key: &str) -> Option<bool> {
+  call.inputs.get(key).map(|value| {
+    matches!(value.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on")
+  })
+}
+
+fn report_value<'a>(report: &'a str, prefix: &str) -> Option<&'a str> {
+  report
+    .lines()
+    .find_map(|line| line.strip_prefix(prefix))
+    .map(str::trim)
+}
+
+fn split_keys(raw: &str) -> Vec<String> {
+  raw
+    .split(|character| character == '+' || character == ',')
+    .map(|key| key.trim().to_ascii_lowercase())
+    .filter(|key| !key.is_empty())
+    .collect()
+}
+
+fn button_code(button: &str) -> AuvResult<i64> {
+  match button.trim().to_ascii_lowercase().as_str() {
+    "left" => Ok(0),
+    "right" => Ok(1),
+    "middle" => Ok(2),
+    other => Err(format!("unsupported mouse button: {}", other)),
+  }
+}
+
+fn key_code(key: &str) -> Option<i64> {
+  match key {
+    "a" => Some(0),
+    "b" => Some(11),
+    "c" => Some(8),
+    "d" => Some(2),
+    "e" => Some(14),
+    "f" => Some(3),
+    "g" => Some(5),
+    "h" => Some(4),
+    "i" => Some(34),
+    "j" => Some(38),
+    "k" => Some(40),
+    "l" => Some(37),
+    "m" => Some(46),
+    "n" => Some(45),
+    "o" => Some(31),
+    "p" => Some(35),
+    "q" => Some(12),
+    "r" => Some(15),
+    "s" => Some(1),
+    "t" => Some(17),
+    "u" => Some(32),
+    "v" => Some(9),
+    "w" => Some(13),
+    "x" => Some(7),
+    "y" => Some(16),
+    "z" => Some(6),
+    "0" => Some(29),
+    "1" => Some(18),
+    "2" => Some(19),
+    "3" => Some(20),
+    "4" => Some(21),
+    "5" => Some(23),
+    "6" => Some(22),
+    "7" => Some(26),
+    "8" => Some(28),
+    "9" => Some(25),
+    "enter" | "return" => Some(36),
+    "tab" => Some(48),
+    "space" => Some(49),
+    "escape" | "esc" => Some(53),
+    "delete" | "backspace" => Some(51),
+    "up" => Some(126),
+    "down" => Some(125),
+    "left" => Some(123),
+    "right" => Some(124),
+    _ => None,
+  }
+}
+
+fn modifier_flag(key: &str) -> Option<String> {
+  match key {
+    "command" | "cmd" => Some(".maskCommand".to_string()),
+    "shift" => Some(".maskShift".to_string()),
+    "control" | "ctrl" => Some(".maskControl".to_string()),
+    "option" | "alt" => Some(".maskAlternate".to_string()),
+    _ => None,
+  }
+}
+
+fn resolve_installed_app_name(app: &str) -> String {
+  let mut roots = vec![PathBuf::from("/Applications")];
+  if let Some(home) = env::var_os("HOME") {
+    roots.push(PathBuf::from(home).join("Applications"));
+  }
+
+  for root in roots {
+    let entries = match fs::read_dir(&root) {
+      Ok(entries) => entries,
+      Err(_) => continue,
+    };
+
+    for entry in entries.flatten() {
+      let file_name = entry.file_name();
+      let bundle_name = file_name.to_string_lossy();
+      if !bundle_name.ends_with(".app") {
+        continue;
+      }
+
+      let trimmed = bundle_name.trim_end_matches(".app");
+      if trimmed.eq_ignore_ascii_case(app) {
+        return trimmed.to_string();
+      }
+    }
+  }
+
+  app.to_string()
+}
+
+fn launch_host_process() -> String {
+  env::args()
+    .next()
+    .map(PathBuf::from)
+    .as_ref()
+    .and_then(|value| value.file_name())
+    .and_then(|value| value.to_str())
+    .unwrap_or("auv-cli")
+    .to_string()
+}
+
+fn apple_script_string(raw: &str) -> String {
+  format!("\"{}\"", raw.replace('\\', "\\\\").replace('"', "\\\""))
+}
+
+fn swift_string_literal(raw: &str) -> String {
+  let mut escaped = String::from("\"");
+  for character in raw.chars() {
+    match character {
+      '\\' => escaped.push_str("\\\\"),
+      '"' => escaped.push_str("\\\""),
+      '\n' => escaped.push_str("\\n"),
+      '\r' => escaped.push_str("\\r"),
+      '\t' => escaped.push_str("\\t"),
+      _ => escaped.push(character),
+    }
+  }
+  escaped.push('"');
+  escaped
 }
 
 fn sanitize_file_component(raw: &str) -> String {
@@ -215,4 +1009,8 @@ pub fn copy_file(source: &PathBuf, destination: &PathBuf) -> AuvResult<()> {
 
 pub fn sanitized_artifact_name(raw: &str) -> String {
   sanitize_file_component(raw)
+}
+
+struct CommandOutput {
+  stdout: String,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,20 @@
+pub mod catalog;
+pub mod driver;
+pub mod model;
+pub mod runtime;
+pub mod store;
+
+use std::path::PathBuf;
+
+use catalog::default_command_catalog;
+use driver::default_driver_registry;
+use model::AuvResult;
+use runtime::Runtime;
+use store::LocalStore;
+
+pub fn build_default_runtime(project_root: PathBuf) -> AuvResult<Runtime> {
+  let store = LocalStore::new(project_root.join(".auv"))?;
+  let commands = default_command_catalog();
+  let drivers = default_driver_registry();
+  Ok(Runtime::new(project_root, commands, drivers, store))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,8 +17,8 @@ fn main() {
 fn run() -> Result<(), String> {
   let arguments = env::args().skip(1).collect::<Vec<_>>();
   let command = parse_cli(&arguments)?;
-  let project_root = env::current_dir()
-    .map_err(|error| format!("failed to resolve current directory: {error}"))?;
+  let project_root =
+    env::current_dir().map_err(|error| format!("failed to resolve current directory: {error}"))?;
   let runtime = build_default_runtime(project_root)?;
 
   match command {
@@ -59,10 +59,7 @@ fn run() -> Result<(), String> {
       }
 
       if result.status == RunStatus::Failed {
-        return Err(format!(
-          "run {} finished in failed state",
-          result.run_id
-        ));
+        return Err(format!("run {} finished in failed state", result.run_id));
       }
     }
     CliCommand::Inspect { run_id } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,74 @@
+mod cli;
+
+use std::env;
+use std::process;
+
+use auv_cli::build_default_runtime;
+use auv_cli::model::RunStatus;
+use cli::{CliCommand, help_text, parse_cli};
+
 fn main() {
-  println!("Hello, world!");
+  if let Err(error) = run() {
+    eprintln!("error: {error}");
+    process::exit(1);
+  }
+}
+
+fn run() -> Result<(), String> {
+  let arguments = env::args().skip(1).collect::<Vec<_>>();
+  let command = parse_cli(&arguments)?;
+  let project_root = env::current_dir()
+    .map_err(|error| format!("failed to resolve current directory: {error}"))?;
+  let runtime = build_default_runtime(project_root)?;
+
+  match command {
+    CliCommand::Help => {
+      print!("{}", help_text());
+    }
+    CliCommand::ListCommands => {
+      for command in runtime.list_commands() {
+        println!(
+          "{} -> {}.{}",
+          command.id, command.driver_id, command.operation
+        );
+        println!("  {}", command.summary);
+      }
+    }
+    CliCommand::ListDrivers => {
+      for driver in runtime.list_drivers() {
+        println!("{}", driver.id);
+        println!("  {}", driver.summary);
+        println!("  capabilities: {}", driver.capabilities.join(", "));
+        println!("  donor boundary: {}", driver.donor_boundary);
+      }
+    }
+    CliCommand::Invoke(request) => {
+      let result = runtime.invoke(request)?;
+      println!("runId: {}", result.run_id);
+      println!("status: {}", result.status.as_str());
+      println!("output: {}", result.output_summary);
+      for artifact in &result.artifact_paths {
+        println!("artifact: {}", artifact.display());
+      }
+
+      if let Some(failure) = &result.failure_message {
+        return Err(format!(
+          "{} (inspect with `auv-cli inspect {}`)",
+          failure, result.run_id
+        ));
+      }
+
+      if result.status == RunStatus::Failed {
+        return Err(format!(
+          "run {} finished in failed state",
+          result.run_id
+        ));
+      }
+    }
+    CliCommand::Inspect { run_id } => {
+      print!("{}", runtime.inspect(&run_id)?);
+    }
+  }
+
+  Ok(())
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,0 +1,125 @@
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::process;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub type AuvResult<T> = Result<T, String>;
+
+#[derive(Clone, Debug)]
+pub struct CommandSpec {
+  pub id: &'static str,
+  pub summary: &'static str,
+  pub driver_id: &'static str,
+  pub operation: &'static str,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ExecutionTarget {
+  pub application_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct InvokeRequest {
+  pub command_id: String,
+  pub target: ExecutionTarget,
+  pub inputs: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RunStatus {
+  Completed,
+  Failed,
+}
+
+impl RunStatus {
+  pub fn as_str(&self) -> &'static str {
+    match self {
+      Self::Completed => "completed",
+      Self::Failed => "failed",
+    }
+  }
+}
+
+#[derive(Clone, Debug)]
+pub struct InvokeResult {
+  pub run_id: String,
+  pub status: RunStatus,
+  pub output_summary: String,
+  pub artifact_paths: Vec<PathBuf>,
+  pub failure_message: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct EventRecord {
+  pub at_millis: u128,
+  pub kind: String,
+  pub message: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct ArtifactRecord {
+  pub id: String,
+  pub kind: String,
+  pub path: PathBuf,
+  pub note: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct RunRecord {
+  pub run_id: String,
+  pub command_id: String,
+  pub driver_id: String,
+  pub operation: String,
+  pub target_application_id: Option<String>,
+  pub runtime_version: String,
+  pub started_at_millis: u128,
+  pub finished_at_millis: Option<u128>,
+  pub status: RunStatus,
+  pub inputs: BTreeMap<String, String>,
+  pub output_summary: String,
+  pub events: Vec<EventRecord>,
+  pub artifacts: Vec<ArtifactRecord>,
+}
+
+#[derive(Clone, Debug)]
+pub struct DriverDescriptor {
+  pub id: &'static str,
+  pub summary: &'static str,
+  pub capabilities: &'static [&'static str],
+  pub donor_boundary: &'static str,
+}
+
+#[derive(Clone, Debug)]
+pub struct DriverCall {
+  pub operation: String,
+  pub target: ExecutionTarget,
+  pub inputs: BTreeMap<String, String>,
+  pub working_directory: PathBuf,
+}
+
+#[derive(Clone, Debug)]
+pub struct ProducedArtifact {
+  pub kind: String,
+  pub source_path: PathBuf,
+  pub preferred_name: String,
+  pub note: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct DriverResponse {
+  pub summary: String,
+  pub backend: Option<String>,
+  pub notes: Vec<String>,
+  pub artifacts: Vec<ProducedArtifact>,
+}
+
+pub fn now_millis() -> u128 {
+  SystemTime::now()
+    .duration_since(UNIX_EPOCH)
+    .unwrap_or_default()
+    .as_millis()
+}
+
+pub fn new_run_id() -> String {
+  format!("run_{}_{}", now_millis(), process::id())
+}

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,9 +1,12 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::process;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 pub type AuvResult<T> = Result<T, String>;
+
+static RUN_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Clone, Debug)]
 pub struct CommandSpec {
@@ -121,5 +124,19 @@ pub fn now_millis() -> u128 {
 }
 
 pub fn new_run_id() -> String {
-  format!("run_{}_{}", now_millis(), process::id())
+  let sequence = RUN_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
+  format!("run_{}_{}_{}", now_millis(), process::id(), sequence)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::new_run_id;
+
+  #[test]
+  fn new_run_id_is_unique_within_process() {
+    let first = new_run_id();
+    let second = new_run_id();
+
+    assert_ne!(first, second);
+  }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,0 +1,198 @@
+use std::path::PathBuf;
+
+use crate::catalog::CommandCatalog;
+use crate::driver::DriverRegistry;
+use crate::model::{
+  ArtifactRecord,
+  AuvResult,
+  DriverCall,
+  DriverDescriptor,
+  EventRecord,
+  InvokeRequest,
+  InvokeResult,
+  RunRecord,
+  RunStatus,
+  new_run_id,
+  now_millis,
+};
+use crate::store::LocalStore;
+
+pub struct Runtime {
+  project_root: PathBuf,
+  commands: CommandCatalog,
+  drivers: DriverRegistry,
+  store: LocalStore,
+}
+
+impl Runtime {
+  pub fn new(
+    project_root: PathBuf,
+    commands: CommandCatalog,
+    drivers: DriverRegistry,
+    store: LocalStore,
+  ) -> Self {
+    Self {
+      project_root,
+      commands,
+      drivers,
+      store,
+    }
+  }
+
+  pub fn list_commands(&self) -> &[crate::model::CommandSpec] {
+    self.commands.all()
+  }
+
+  pub fn list_drivers(&self) -> Vec<DriverDescriptor> {
+    self.drivers.descriptors()
+  }
+
+  pub fn inspect(&self, run_id: &str) -> AuvResult<String> {
+    self.store.render_inspection(run_id)
+  }
+
+  pub fn invoke(&self, request: InvokeRequest) -> AuvResult<InvokeResult> {
+    let command = self.commands.resolve(&request.command_id).ok_or_else(|| {
+      format!(
+        "unknown command {}; use `list-commands` to see available entries",
+        request.command_id
+      )
+    })?;
+    let driver = self.drivers.get(command.driver_id).ok_or_else(|| {
+      format!(
+        "command {} resolved to missing driver {}",
+        command.id, command.driver_id
+      )
+    })?;
+
+    let run_id = new_run_id();
+    let mut run = RunRecord {
+      run_id: run_id.clone(),
+      command_id: command.id.to_string(),
+      driver_id: command.driver_id.to_string(),
+      operation: command.operation.to_string(),
+      target_application_id: request.target.application_id.clone(),
+      runtime_version: env!("CARGO_PKG_VERSION").to_string(),
+      started_at_millis: now_millis(),
+      finished_at_millis: None,
+      status: RunStatus::Failed,
+      inputs: request.inputs.clone(),
+      output_summary: String::new(),
+      events: Vec::new(),
+      artifacts: Vec::new(),
+    };
+
+    push_event(
+      &mut run.events,
+      "run.created",
+      format!("implicit run created for command {}", command.id),
+    );
+    push_event(
+      &mut run.events,
+      "command.resolved",
+      format!(
+        "resolved {} -> {}.{}",
+        command.id, command.driver_id, command.operation
+      ),
+    );
+
+    let call = DriverCall {
+      operation: command.operation.to_string(),
+      target: request.target,
+      inputs: request.inputs,
+      working_directory: self.project_root.clone(),
+    };
+
+    push_event(
+      &mut run.events,
+      "driver.invoke",
+      format!("invoking {}.{}", command.driver_id, command.operation),
+    );
+
+    let mut failure_message = None;
+
+    match driver.invoke(&call) {
+      Ok(response) => {
+        if let Some(backend) = &response.backend {
+          push_event(
+            &mut run.events,
+            "driver.backend",
+            format!("backend={backend}"),
+          );
+        }
+
+        for note in &response.notes {
+          push_event(&mut run.events, "driver.note", note.clone());
+        }
+
+        let mut persisted_artifacts = Vec::new();
+        for (index, artifact) in response.artifacts.into_iter().enumerate() {
+          let stored_artifact = self.store.stage_artifact(&run.run_id, index, artifact)?;
+          push_event(
+            &mut run.events,
+            "artifact.captured",
+            render_artifact_event(&stored_artifact),
+          );
+          persisted_artifacts.push(stored_artifact);
+        }
+
+        run.status = RunStatus::Completed;
+        run.output_summary = response.summary.clone();
+        run.artifacts = persisted_artifacts;
+        push_event(
+          &mut run.events,
+          "run.completed",
+          response.summary,
+        );
+      }
+      Err(error) => {
+        run.status = RunStatus::Failed;
+        run.output_summary = format!(
+          "Driver invocation failed after run creation. Inspect {} for the recorded trace.",
+          run.run_id
+        );
+        failure_message = Some(error.clone());
+        push_event(&mut run.events, "driver.failed", error);
+      }
+    }
+
+    run.finished_at_millis = Some(now_millis());
+    self.store.persist_run(&run)?;
+
+    let artifact_paths = run
+      .artifacts
+      .iter()
+      .map(|artifact| artifact.path.clone())
+      .collect::<Vec<_>>();
+    let run_id = run.run_id.clone();
+    let status = run.status.clone();
+    let output_summary = run.output_summary.clone();
+
+    Ok(InvokeResult {
+      run_id,
+      status,
+      output_summary,
+      artifact_paths,
+      failure_message,
+    })
+  }
+}
+
+fn push_event(events: &mut Vec<EventRecord>, kind: &str, message: String) {
+  events.push(EventRecord {
+    at_millis: now_millis(),
+    kind: kind.to_string(),
+    message,
+  });
+}
+
+fn render_artifact_event(artifact: &ArtifactRecord) -> String {
+  let note = artifact.note.clone().unwrap_or_else(|| "n/a".to_string());
+  format!(
+    "{} kind={} path={} note={}",
+    artifact.id,
+    artifact.kind,
+    artifact.path.display(),
+    note
+  )
+}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -3,17 +3,8 @@ use std::path::PathBuf;
 use crate::catalog::CommandCatalog;
 use crate::driver::DriverRegistry;
 use crate::model::{
-  ArtifactRecord,
-  AuvResult,
-  DriverCall,
-  DriverDescriptor,
-  EventRecord,
-  InvokeRequest,
-  InvokeResult,
-  RunRecord,
-  RunStatus,
-  new_run_id,
-  now_millis,
+  ArtifactRecord, AuvResult, DriverCall, DriverDescriptor, EventRecord, InvokeRequest,
+  InvokeResult, RunRecord, RunStatus, new_run_id, now_millis,
 };
 use crate::store::LocalStore;
 
@@ -126,24 +117,47 @@ impl Runtime {
         }
 
         let mut persisted_artifacts = Vec::new();
+        let mut artifact_failure = None;
         for (index, artifact) in response.artifacts.into_iter().enumerate() {
-          let stored_artifact = self.store.stage_artifact(&run.run_id, index, artifact)?;
-          push_event(
-            &mut run.events,
-            "artifact.captured",
-            render_artifact_event(&stored_artifact),
-          );
-          persisted_artifacts.push(stored_artifact);
+          match self.store.stage_artifact(&run.run_id, index, artifact) {
+            Ok(stored_artifact) => {
+              push_event(
+                &mut run.events,
+                "artifact.captured",
+                render_artifact_event(&stored_artifact),
+              );
+              persisted_artifacts.push(stored_artifact);
+            }
+            Err(error) => {
+              push_event(
+                &mut run.events,
+                "artifact.failed",
+                format!("artifact staging failed: {error}"),
+              );
+              artifact_failure = Some(error);
+              break;
+            }
+          }
         }
 
-        run.status = RunStatus::Completed;
-        run.output_summary = response.summary.clone();
         run.artifacts = persisted_artifacts;
-        push_event(
-          &mut run.events,
-          "run.completed",
-          response.summary,
-        );
+        if let Some(error) = artifact_failure {
+          run.status = RunStatus::Failed;
+          run.output_summary = format!(
+            "Artifact staging failed after run creation. Inspect {} for the recorded trace.",
+            run.run_id
+          );
+          failure_message = Some(error.clone());
+          push_event(
+            &mut run.events,
+            "run.failed",
+            format!("artifact staging failed after driver success: {error}"),
+          );
+        } else {
+          run.status = RunStatus::Completed;
+          run.output_summary = response.summary.clone();
+          push_event(&mut run.events, "run.completed", response.summary);
+        }
       }
       Err(error) => {
         run.status = RunStatus::Failed;
@@ -195,4 +209,92 @@ fn render_artifact_event(artifact: &ArtifactRecord) -> String {
     artifact.path.display(),
     note
   )
+}
+
+#[cfg(test)]
+mod tests {
+  use std::collections::BTreeMap;
+  use std::env;
+  use std::fs;
+  use std::path::PathBuf;
+
+  use super::Runtime;
+  use crate::catalog::CommandCatalog;
+  use crate::driver::{Driver, DriverRegistry};
+  use crate::model::{
+    AuvResult, CommandSpec, DriverCall, DriverDescriptor, DriverResponse, ExecutionTarget,
+    InvokeRequest, ProducedArtifact, RunStatus, now_millis,
+  };
+  use crate::store::LocalStore;
+
+  struct ArtifactFailureDriver;
+
+  impl Driver for ArtifactFailureDriver {
+    fn descriptor(&self) -> DriverDescriptor {
+      DriverDescriptor {
+        id: "test.driver",
+        summary: "Test driver",
+        capabilities: &["test.artifact-failure"],
+        donor_boundary: "test-only",
+      }
+    }
+
+    fn invoke(&self, _call: &DriverCall) -> AuvResult<DriverResponse> {
+      Ok(DriverResponse {
+        summary: "driver succeeded before artifact staging".to_string(),
+        backend: Some("test.backend".to_string()),
+        notes: vec!["note".to_string()],
+        artifacts: vec![ProducedArtifact {
+          kind: "text".to_string(),
+          source_path: PathBuf::from("/definitely/missing/artifact.txt"),
+          preferred_name: "artifact.txt".to_string(),
+          note: Some("missing".to_string()),
+        }],
+      })
+    }
+  }
+
+  #[test]
+  fn invoke_persists_failed_run_when_artifact_staging_breaks() {
+    let project_root = temp_dir("runtime-tests-project");
+    let store_root = temp_dir("runtime-tests-store");
+    let runtime = Runtime::new(
+      project_root.clone(),
+      CommandCatalog::new(vec![CommandSpec {
+        id: "test.invoke",
+        summary: "Test invoke",
+        driver_id: "test.driver",
+        operation: "test_operation",
+      }]),
+      DriverRegistry::new(vec![Box::new(ArtifactFailureDriver)]),
+      LocalStore::new(store_root.clone()).expect("store should initialize"),
+    );
+
+    let result = runtime
+      .invoke(InvokeRequest {
+        command_id: "test.invoke".to_string(),
+        target: ExecutionTarget::default(),
+        inputs: BTreeMap::new(),
+      })
+      .expect("artifact staging failures should still return an inspectable run");
+
+    assert_eq!(result.status, RunStatus::Failed);
+    assert!(result.failure_message.is_some());
+
+    let inspection = runtime
+      .inspect(&result.run_id)
+      .expect("failed run should still be inspectable");
+    assert!(inspection.contains("Status: failed"));
+    assert!(inspection.contains("artifact staging failed"));
+
+    let _ = fs::remove_dir_all(project_root);
+    let _ = fs::remove_dir_all(store_root);
+  }
+
+  fn temp_dir(label: &str) -> PathBuf {
+    let path = env::temp_dir().join(format!("auv-{}-{}", label, now_millis()));
+    let _ = fs::remove_dir_all(&path);
+    fs::create_dir_all(&path).expect("temp dir should be creatable");
+    path
+  }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,9 +1,9 @@
 use std::collections::BTreeMap;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::driver::{copy_file, sanitized_artifact_name};
-use crate::model::{ArtifactRecord, AuvResult, ProducedArtifact, RunRecord};
+use crate::model::{ArtifactRecord, AuvResult, ProducedArtifact, RunRecord, now_millis};
 
 pub struct LocalStore {
   root: PathBuf,
@@ -55,36 +55,43 @@ impl LocalStore {
   }
 
   pub fn persist_run(&self, run: &RunRecord) -> AuvResult<()> {
-    let run_directory = self.root.join("runs").join(&run.run_id);
-    fs::create_dir_all(&run_directory).map_err(|error| {
-      format!(
-        "failed to create run directory {}: {error}",
+    let runs_root = self.root.join("runs");
+    let run_directory = runs_root.join(&run.run_id);
+    if run_directory.exists() {
+      return Err(format!(
+        "run directory {} already exists",
         run_directory.display()
+      ));
+    }
+
+    let staging_directory = runs_root.join(format!(".{}-tmp-{}", run.run_id, now_millis()));
+    fs::create_dir_all(&staging_directory).map_err(|error| {
+      format!(
+        "failed to create staging run directory {}: {error}",
+        staging_directory.display()
       )
     })?;
 
-    fs::write(run_directory.join("meta.txt"), render_meta(run))
-      .map_err(|error| format!("failed to write run metadata: {error}"))?;
-    fs::write(run_directory.join("inputs.txt"), render_inputs(&run.inputs))
-      .map_err(|error| format!("failed to write run inputs: {error}"))?;
-    fs::write(run_directory.join("events.log"), render_events(run))
-      .map_err(|error| format!("failed to write run events: {error}"))?;
-    fs::write(run_directory.join("artifacts.txt"), render_artifacts(run))
-      .map_err(|error| format!("failed to write artifact manifest: {error}"))?;
-    fs::write(run_directory.join("output.txt"), format!("{}\n", run.output_summary))
-      .map_err(|error| format!("failed to write run output: {error}"))?;
-    fs::write(run_directory.join("inspect.txt"), render_inspection(run))
-      .map_err(|error| format!("failed to write inspect snapshot: {error}"))?;
+    let write_result = write_run_snapshot(run, &staging_directory);
+    if let Err(error) = write_result {
+      let _ = fs::remove_dir_all(&staging_directory);
+      return Err(error);
+    }
+
+    fs::rename(&staging_directory, &run_directory).map_err(|error| {
+      let _ = fs::remove_dir_all(&staging_directory);
+      format!(
+        "failed to publish run directory {} from {}: {error}",
+        run_directory.display(),
+        staging_directory.display()
+      )
+    })?;
 
     Ok(())
   }
 
   pub fn render_inspection(&self, run_id: &str) -> AuvResult<String> {
-    let inspection_path = self
-      .root
-      .join("runs")
-      .join(run_id)
-      .join("inspect.txt");
+    let inspection_path = self.root.join("runs").join(run_id).join("inspect.txt");
 
     fs::read_to_string(&inspection_path).map_err(|error| {
       format!(
@@ -93,6 +100,45 @@ impl LocalStore {
       )
     })
   }
+}
+
+fn write_run_snapshot(run: &RunRecord, directory: &Path) -> AuvResult<()> {
+  write_snapshot_file(
+    &directory.join("meta.txt"),
+    render_meta(run),
+    "run metadata",
+  )?;
+  write_snapshot_file(
+    &directory.join("inputs.txt"),
+    render_inputs(&run.inputs),
+    "run inputs",
+  )?;
+  write_snapshot_file(
+    &directory.join("events.log"),
+    render_events(run),
+    "run events",
+  )?;
+  write_snapshot_file(
+    &directory.join("artifacts.txt"),
+    render_artifacts(run),
+    "artifact manifest",
+  )?;
+  write_snapshot_file(
+    &directory.join("output.txt"),
+    format!("{}\n", run.output_summary),
+    "run output",
+  )?;
+  write_snapshot_file(
+    &directory.join("inspect.txt"),
+    render_inspection(run),
+    "inspect snapshot",
+  )?;
+  Ok(())
+}
+
+fn write_snapshot_file(path: &Path, content: String, label: &str) -> AuvResult<()> {
+  fs::write(path, content)
+    .map_err(|error| format!("failed to write {} {}: {error}", label, path.display()))
 }
 
 fn render_meta(run: &RunRecord) -> String {

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,0 +1,208 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::PathBuf;
+
+use crate::driver::{copy_file, sanitized_artifact_name};
+use crate::model::{ArtifactRecord, AuvResult, ProducedArtifact, RunRecord};
+
+pub struct LocalStore {
+  root: PathBuf,
+}
+
+impl LocalStore {
+  pub fn new(root: PathBuf) -> AuvResult<Self> {
+    fs::create_dir_all(root.join("runs"))
+      .map_err(|error| format!("failed to create run store root: {error}"))?;
+    fs::create_dir_all(root.join("artifacts"))
+      .map_err(|error| format!("failed to create artifact store root: {error}"))?;
+    Ok(Self { root })
+  }
+
+  pub fn stage_artifact(
+    &self,
+    run_id: &str,
+    index: usize,
+    artifact: ProducedArtifact,
+  ) -> AuvResult<ArtifactRecord> {
+    let artifact_id = format!("artifact_{:02}", index + 1);
+    let extension = artifact
+      .source_path
+      .extension()
+      .and_then(|extension| extension.to_str())
+      .unwrap_or("bin");
+    let base_name = sanitized_artifact_name(
+      artifact
+        .preferred_name
+        .trim_end_matches(&format!(".{extension}")),
+    );
+    let destination = self
+      .root
+      .join("artifacts")
+      .join(run_id)
+      .join(format!("{artifact_id}_{base_name}.{extension}"));
+
+    copy_file(&artifact.source_path, &destination)?;
+    if artifact.source_path != destination {
+      let _ = fs::remove_file(&artifact.source_path);
+    }
+
+    Ok(ArtifactRecord {
+      id: artifact_id,
+      kind: artifact.kind,
+      path: destination,
+      note: artifact.note,
+    })
+  }
+
+  pub fn persist_run(&self, run: &RunRecord) -> AuvResult<()> {
+    let run_directory = self.root.join("runs").join(&run.run_id);
+    fs::create_dir_all(&run_directory).map_err(|error| {
+      format!(
+        "failed to create run directory {}: {error}",
+        run_directory.display()
+      )
+    })?;
+
+    fs::write(run_directory.join("meta.txt"), render_meta(run))
+      .map_err(|error| format!("failed to write run metadata: {error}"))?;
+    fs::write(run_directory.join("inputs.txt"), render_inputs(&run.inputs))
+      .map_err(|error| format!("failed to write run inputs: {error}"))?;
+    fs::write(run_directory.join("events.log"), render_events(run))
+      .map_err(|error| format!("failed to write run events: {error}"))?;
+    fs::write(run_directory.join("artifacts.txt"), render_artifacts(run))
+      .map_err(|error| format!("failed to write artifact manifest: {error}"))?;
+    fs::write(run_directory.join("output.txt"), format!("{}\n", run.output_summary))
+      .map_err(|error| format!("failed to write run output: {error}"))?;
+    fs::write(run_directory.join("inspect.txt"), render_inspection(run))
+      .map_err(|error| format!("failed to write inspect snapshot: {error}"))?;
+
+    Ok(())
+  }
+
+  pub fn render_inspection(&self, run_id: &str) -> AuvResult<String> {
+    let inspection_path = self
+      .root
+      .join("runs")
+      .join(run_id)
+      .join("inspect.txt");
+
+    fs::read_to_string(&inspection_path).map_err(|error| {
+      format!(
+        "failed to read inspect snapshot {}: {error}",
+        inspection_path.display()
+      )
+    })
+  }
+}
+
+fn render_meta(run: &RunRecord) -> String {
+  let target = run
+    .target_application_id
+    .clone()
+    .unwrap_or_else(|| "n/a".to_string());
+  let finished = run
+    .finished_at_millis
+    .map(|value| value.to_string())
+    .unwrap_or_else(|| "n/a".to_string());
+
+  [
+    format!("runId: {}", run.run_id),
+    format!("status: {}", run.status.as_str()),
+    format!("command: {}", run.command_id),
+    format!("driver: {}", run.driver_id),
+    format!("operation: {}", run.operation),
+    format!("targetApplicationId: {target}"),
+    format!("runtimeVersion: {}", run.runtime_version),
+    format!("startedAtMillis: {}", run.started_at_millis),
+    format!("finishedAtMillis: {finished}"),
+  ]
+  .join("\n")
+    + "\n"
+}
+
+fn render_inputs(inputs: &BTreeMap<String, String>) -> String {
+  if inputs.is_empty() {
+    return "none\n".to_string();
+  }
+
+  let mut lines = Vec::new();
+  for (key, value) in inputs {
+    lines.push(format!("{key}={value}"));
+  }
+  lines.join("\n") + "\n"
+}
+
+fn render_events(run: &RunRecord) -> String {
+  if run.events.is_empty() {
+    return "none\n".to_string();
+  }
+
+  let mut lines = Vec::new();
+  for event in &run.events {
+    lines.push(format!(
+      "{} {} {}",
+      event.at_millis, event.kind, event.message
+    ));
+  }
+  lines.join("\n") + "\n"
+}
+
+fn render_artifacts(run: &RunRecord) -> String {
+  if run.artifacts.is_empty() {
+    return "none\n".to_string();
+  }
+
+  let mut lines = Vec::new();
+  for artifact in &run.artifacts {
+    let note = artifact.note.clone().unwrap_or_else(|| "n/a".to_string());
+    lines.push(format!(
+      "{} kind={} path={} note={}",
+      artifact.id,
+      artifact.kind,
+      artifact.path.display(),
+      note
+    ));
+  }
+  lines.join("\n") + "\n"
+}
+
+fn render_inspection(run: &RunRecord) -> String {
+  let target = run
+    .target_application_id
+    .clone()
+    .unwrap_or_else(|| "n/a".to_string());
+  let finished = run
+    .finished_at_millis
+    .map(|value| value.to_string())
+    .unwrap_or_else(|| "n/a".to_string());
+  let sections = vec![
+    format!("Run {}", run.run_id),
+    format!("Status: {}", run.status.as_str()),
+    format!("Command: {}", run.command_id),
+    format!("Driver: {}", run.driver_id),
+    format!("Operation: {}", run.operation),
+    format!("Target: {target}"),
+    format!("Runtime Version: {}", run.runtime_version),
+    format!("Started At (ms): {}", run.started_at_millis),
+    format!("Finished At (ms): {finished}"),
+    String::new(),
+    "Inputs".to_string(),
+    render_block(&render_inputs(&run.inputs)),
+    "Output".to_string(),
+    render_block(&format!("{}\n", run.output_summary)),
+    "Artifacts".to_string(),
+    render_block(&render_artifacts(run)),
+    "Events".to_string(),
+    render_block(&render_events(run)),
+  ];
+
+  sections.join("\n")
+}
+
+fn render_block(raw: &str) -> String {
+  raw
+    .lines()
+    .map(|line| format!("  {line}"))
+    .collect::<Vec<_>>()
+    .join("\n")
+}


### PR DESCRIPTION
## Summary
- establish a library-first AUV runtime with implicit run creation, driver dispatch, inspectable run records, and file-backed local `.auv/` persistence
- port the first AIRI desktop donor primitives into AUV at the driver layer only, without importing AIRI server shells, MCP tool descriptors, approval queues, or workflow orchestration
- harden the prototype after bot review so failed artifact staging still produces inspectable runs, run ids do not collide in-process, and run snapshots publish more safely

## What's included
- shared runtime core for `invoke`, event capture, artifact staging, and `inspect`
- provisional local `RunStore` / `ArtifactStore` under `.auv/`
- minimal CLI frontend for `list-commands`, `list-drivers`, `invoke`, and `inspect`
- fixture driver for non-destructive validation of the execution substrate
- `macos.desktop` driver with:
  - screenshot capture
  - visible window observation
  - permission probe
  - app open / focus
  - click / type text / press keys / scroll / wait

## Review Follow-Up Landed
- persist failed runs even when artifact staging breaks mid-run
- add a monotonic in-process component to generated run ids
- reject non-finite float inputs before emitting Swift literals
- publish run snapshots through a staging directory before final rename
- skip `/Applications` scanning when the user already provides a `.app` name or path
- add regression tests for the review-fixed behaviors

## Verification
- `cargo fmt`
- `cargo check`
- `cargo test`
- `git diff --check`

## Out of Scope in This PR
- AIRI-style action executor, approval queue, or MCP registration shell
- CDP/browser-dom bridge
- OCR driver
- trace replay
- inspect UI

## Notes
- this PR is still intentionally narrow: it establishes the execution substrate and first desktop donor boundary, not full AIRI desktop feature parity
