### PR TITLE
feat(runtime): add inspectable execution skeleton

### DIFF
--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -1,0 +1,94 @@
+use crate::model::CommandSpec;
+
+pub struct CommandCatalog {
+  commands: Vec<CommandSpec>,
+}
+
+impl CommandCatalog {
+  pub fn new(commands: Vec<CommandSpec>) -> Self {
+    Self { commands }
+  }
+
+  pub fn resolve(&self, command_id: &str) -> Option<&CommandSpec> {
+    self
+      .commands
+      .iter()
+      .find(|command| command.id == command_id)
+  }
+
+  pub fn all(&self) -> &[CommandSpec] {
+    &self.commands
+  }
+}
+
+pub fn default_command_catalog() -> CommandCatalog {
+  let commands = vec![CommandSpec {
+    id: "debug.fixtureObserve",
+    summary: "Emit a deterministic observation result without touching the host UI.",
+    driver_id: "fixture.observe",
+    operation: "observe_fixture_scene",
+  }];
+
+  CommandCatalog::new(commands)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn command_catalog_resolves_existing_command() {
+    let catalog = CommandCatalog::new(vec![CommandSpec {
+      id: "test.cmd",
+      summary: "Test command",
+      driver_id: "test.driver",
+      operation: "test_op",
+    }]);
+
+    let resolved = catalog.resolve("test.cmd").expect("should resolve");
+    assert_eq!(resolved.id, "test.cmd");
+    assert_eq!(resolved.operation, "test_op");
+  }
+
+  #[test]
+  fn command_catalog_returns_none_for_missing_command() {
+    let catalog = CommandCatalog::new(vec![]);
+    assert!(catalog.resolve("missing").is_none());
+  }
+
+  #[test]
+  fn command_catalog_returns_all_commands() {
+    let commands = vec![
+      CommandSpec {
+        id: "cmd1",
+        summary: "sum1",
+        driver_id: "d1",
+        operation: "op1",
+      },
+      CommandSpec {
+        id: "cmd2",
+        summary: "sum2",
+        driver_id: "d2",
+        operation: "op2",
+      },
+    ];
+    let catalog = CommandCatalog::new(commands.clone());
+    let all = catalog.all();
+    assert_eq!(all.len(), 2);
+    assert_eq!(all[0].id, "cmd1");
+    assert_eq!(all[1].id, "cmd2");
+  }
+
+  #[test]
+  fn default_catalog_exposes_runtime_validation_command() {
+    let catalog = default_command_catalog();
+    assert!(catalog.resolve("debug.fixtureObserve").is_some());
+  }
+
+  #[test]
+  fn default_catalog_does_not_expose_platform_commands_yet() {
+    let catalog = default_command_catalog();
+    assert!(catalog.resolve("debug.captureScreen").is_none());
+    assert!(catalog.resolve("debug.probePermissions").is_none());
+  }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,102 @@
+use std::collections::BTreeMap;
+
+use auv_cli::model::{AuvResult, ExecutionTarget, InvokeRequest};
+
+pub enum CliCommand {
+  Help,
+  ListCommands,
+  ListDrivers,
+  Invoke(InvokeRequest),
+  Inspect { run_id: String },
+}
+
+pub fn parse_cli(arguments: &[String]) -> AuvResult<CliCommand> {
+  if arguments.is_empty() {
+    return Ok(CliCommand::Help);
+  }
+
+  match arguments[0].as_str() {
+    "help" | "--help" | "-h" => Ok(CliCommand::Help),
+    "list-commands" => Ok(CliCommand::ListCommands),
+    "list-drivers" => Ok(CliCommand::ListDrivers),
+    "inspect" => parse_inspect(arguments),
+    "invoke" => parse_invoke(arguments),
+    other => Err(format!(
+      "unknown subcommand {other}; use `help` to see supported commands"
+    )),
+  }
+}
+
+pub fn help_text() -> String {
+  String::from(
+    "\
+auv-cli prototype
+
+USAGE
+  auv-cli list-commands
+  auv-cli list-drivers
+  auv-cli invoke <command-id> [--target <application-id>] [--label <text>]
+  auv-cli inspect <run-id>
+
+NOTES
+  - Names are provisional and reflect the current phase-0/1 runtime skeleton.
+  - The CLI is a thin frontend over the library runtime in src/lib.rs.
+  - `debug.fixtureObserve` is the current runtime-validation entrypoint.
+",
+  )
+}
+
+fn parse_inspect(arguments: &[String]) -> AuvResult<CliCommand> {
+  if arguments.len() != 2 {
+    return Err("usage: auv-cli inspect <run-id>".to_string());
+  }
+
+  Ok(CliCommand::Inspect {
+    run_id: arguments[1].clone(),
+  })
+}
+
+fn parse_invoke(arguments: &[String]) -> AuvResult<CliCommand> {
+  if arguments.len() < 2 {
+    return Err(
+      "usage: auv-cli invoke <command-id> [--target <application-id>] [--label <text>]".to_string(),
+    );
+  }
+
+  let command_id = arguments[1].clone();
+  let mut target = ExecutionTarget::default();
+  let mut inputs = BTreeMap::new();
+  let mut index = 2;
+
+  while index < arguments.len() {
+    let argument = &arguments[index];
+    if !argument.starts_with("--") {
+      return Err(format!("unexpected positional argument {argument}"));
+    }
+    if index + 1 >= arguments.len() {
+      return Err(format!("flag {argument} requires a value"));
+    }
+
+    let value = arguments[index + 1].clone();
+    match argument.as_str() {
+      "--target" => {
+        target.application_id = Some(value);
+      }
+      "--label" => {
+        inputs.insert("label".to_string(), value);
+      }
+      other => {
+        let key = other.trim_start_matches("--");
+        inputs.insert(key.to_string(), value);
+      }
+    }
+
+    index += 2;
+  }
+
+  Ok(CliCommand::Invoke(InvokeRequest {
+    command_id,
+    target,
+    inputs,
+  }))
+}

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -1,0 +1,189 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
+use crate::model::{AuvResult, DriverCall, DriverDescriptor, DriverResponse};
+
+pub trait Driver {
+  fn descriptor(&self) -> DriverDescriptor;
+  fn invoke(&self, call: &DriverCall) -> AuvResult<DriverResponse>;
+}
+
+pub struct DriverRegistry {
+  drivers: HashMap<String, Box<dyn Driver>>,
+}
+
+impl DriverRegistry {
+  pub fn new(drivers: Vec<Box<dyn Driver>>) -> Self {
+    let mut registry = HashMap::new();
+    for driver in drivers {
+      let descriptor = driver.descriptor();
+      registry.insert(descriptor.id.to_string(), driver);
+    }
+    Self { drivers: registry }
+  }
+
+  pub fn get(&self, driver_id: &str) -> Option<&dyn Driver> {
+    self.drivers.get(driver_id).map(Box::as_ref)
+  }
+
+  pub fn descriptors(&self) -> Vec<DriverDescriptor> {
+    let mut descriptors = self
+      .drivers
+      .values()
+      .map(|driver| driver.descriptor())
+      .collect::<Vec<_>>();
+    descriptors.sort_by(|left, right| left.id.cmp(right.id));
+    descriptors
+  }
+}
+
+pub fn default_driver_registry() -> DriverRegistry {
+  DriverRegistry::new(vec![Box::new(FixtureObserveDriver)])
+}
+
+struct FixtureObserveDriver;
+
+impl Driver for FixtureObserveDriver {
+  fn descriptor(&self) -> DriverDescriptor {
+    DriverDescriptor {
+      id: "fixture.observe",
+      summary: "Non-UI fixture driver that proves invoke -> run -> inspect without platform side effects.",
+      capabilities: &["observe.fixture"],
+      donor_boundary: "AUV-native fixture driver; validate the shared execution substrate before platform drivers land.",
+    }
+  }
+
+  fn invoke(&self, call: &DriverCall) -> AuvResult<DriverResponse> {
+    if call.operation != "observe_fixture_scene" {
+      return Err(format!(
+        "driver fixture.observe does not support operation {}",
+        call.operation
+      ));
+    }
+
+    let target = call
+      .target
+      .application_id
+      .clone()
+      .unwrap_or_else(|| "fixture://default".to_string());
+    let label = call
+      .inputs
+      .get("label")
+      .cloned()
+      .unwrap_or_else(|| "fixture-observation".to_string());
+
+    Ok(DriverResponse {
+      summary: format!(
+        "Observed deterministic fixture scene for target {} with label {}.",
+        target, label
+      ),
+      backend: Some("fixture.static".to_string()),
+      notes: vec![
+        "This command does not touch the real desktop.".to_string(),
+        "Use it to validate implicit run creation, artifact plumbing, and inspect output."
+          .to_string(),
+      ],
+      artifacts: Vec::new(),
+    })
+  }
+}
+
+pub fn copy_file(source: &PathBuf, destination: &PathBuf) -> AuvResult<()> {
+  if let Some(parent) = destination.parent() {
+    fs::create_dir_all(parent).map_err(|error| {
+      format!(
+        "failed to create artifact directory {}: {error}",
+        parent.display()
+      )
+    })?;
+  }
+
+  fs::copy(source, destination).map_err(|error| {
+    format!(
+      "failed to copy artifact from {} to {}: {error}",
+      source.display(),
+      destination.display()
+    )
+  })?;
+
+  Ok(())
+}
+
+pub fn sanitized_artifact_name(raw: &str) -> String {
+  let sanitized = raw
+    .chars()
+    .map(|character| match character {
+      'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' => character,
+      _ => '-',
+    })
+    .collect::<String>()
+    .trim_matches('-')
+    .to_string();
+
+  if sanitized.is_empty() {
+    "artifact".to_string()
+  } else {
+    sanitized
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::collections::BTreeMap;
+  use std::path::PathBuf;
+
+  use super::{Driver, DriverRegistry, FixtureObserveDriver, sanitized_artifact_name};
+  use crate::model::{DriverCall, ExecutionTarget, now_millis};
+
+  #[test]
+  fn sanitize_file_component_removes_invalid_characters() {
+    assert_eq!(sanitized_artifact_name("My App!"), "My-App");
+    assert_eq!(sanitized_artifact_name("../../etc/passwd"), "etc-passwd");
+    assert_eq!(sanitized_artifact_name(""), "artifact");
+  }
+
+  #[test]
+  fn driver_registry_stores_and_retrieves_drivers() {
+    let registry = DriverRegistry::new(vec![Box::new(FixtureObserveDriver)]);
+    assert!(registry.get("fixture.observe").is_some());
+    assert!(registry.get("missing").is_none());
+    assert_eq!(registry.descriptors().len(), 1);
+    assert_eq!(registry.descriptors()[0].id, "fixture.observe");
+  }
+
+  #[test]
+  fn fixture_driver_rejects_unknown_operations() {
+    let driver = FixtureObserveDriver;
+    let error = driver
+      .invoke(&DriverCall {
+        operation: "unknown".to_string(),
+        target: ExecutionTarget::default(),
+        inputs: BTreeMap::new(),
+        working_directory: PathBuf::from("."),
+      })
+      .expect_err("unknown operation should fail");
+    assert!(error.contains("does not support operation"));
+  }
+
+  #[test]
+  fn fixture_driver_produces_deterministic_summary() {
+    let driver = FixtureObserveDriver;
+    let mut inputs = BTreeMap::new();
+    inputs.insert("label".to_string(), format!("fixture-{}", now_millis()));
+    let response = driver
+      .invoke(&DriverCall {
+        operation: "observe_fixture_scene".to_string(),
+        target: ExecutionTarget {
+          application_id: Some("fixture://example".to_string()),
+        },
+        inputs,
+        working_directory: PathBuf::from("."),
+      })
+      .expect("fixture call should succeed");
+
+    assert!(response.summary.contains("fixture://example"));
+    assert_eq!(response.backend.as_deref(), Some("fixture.static"));
+    assert!(response.artifacts.is_empty());
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,20 @@
+pub mod catalog;
+pub mod driver;
+pub mod model;
+pub mod runtime;
+pub mod store;
+
+use std::path::PathBuf;
+
+use catalog::default_command_catalog;
+use driver::default_driver_registry;
+use model::AuvResult;
+use runtime::Runtime;
+use store::LocalStore;
+
+pub fn build_default_runtime(project_root: PathBuf) -> AuvResult<Runtime> {
+  let store = LocalStore::new(project_root.join(".auv"))?;
+  let commands = default_command_catalog();
+  let drivers = default_driver_registry();
+  Ok(Runtime::new(project_root, commands, drivers, store))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,71 @@
+mod cli;
+
+use std::env;
+use std::process;
+
+use auv_cli::build_default_runtime;
+use auv_cli::model::RunStatus;
+use cli::{CliCommand, help_text, parse_cli};
+
 fn main() {
-  println!("Hello, world!");
+  if let Err(error) = run() {
+    eprintln!("error: {error}");
+    process::exit(1);
+  }
+}
+
+fn run() -> Result<(), String> {
+  let arguments = env::args().skip(1).collect::<Vec<_>>();
+  let command = parse_cli(&arguments)?;
+  let project_root =
+    env::current_dir().map_err(|error| format!("failed to resolve current directory: {error}"))?;
+  let runtime = build_default_runtime(project_root)?;
+
+  match command {
+    CliCommand::Help => {
+      print!("{}", help_text());
+    }
+    CliCommand::ListCommands => {
+      for command in runtime.list_commands() {
+        println!(
+          "{} -> {}.{}",
+          command.id, command.driver_id, command.operation
+        );
+        println!("  {}", command.summary);
+      }
+    }
+    CliCommand::ListDrivers => {
+      for driver in runtime.list_drivers() {
+        println!("{}", driver.id);
+        println!("  {}", driver.summary);
+        println!("  capabilities: {}", driver.capabilities.join(", "));
+        println!("  donor boundary: {}", driver.donor_boundary);
+      }
+    }
+    CliCommand::Invoke(request) => {
+      let result = runtime.invoke(request)?;
+      println!("runId: {}", result.run_id);
+      println!("status: {}", result.status.as_str());
+      println!("output: {}", result.output_summary);
+      for artifact in &result.artifact_paths {
+        println!("artifact: {}", artifact.display());
+      }
+
+      if let Some(failure) = &result.failure_message {
+        return Err(format!(
+          "{} (inspect with `auv-cli inspect {}`)",
+          failure, result.run_id
+        ));
+      }
+
+      if result.status == RunStatus::Failed {
+        return Err(format!("run {} finished in failed state", result.run_id));
+      }
+    }
+    CliCommand::Inspect { run_id } => {
+      print!("{}", runtime.inspect(&run_id)?);
+    }
+  }
+
+  Ok(())
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,0 +1,276 @@
+use std::collections::BTreeMap;
+use std::fmt::{self, Display, Formatter};
+use std::path::PathBuf;
+use std::process;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub type AuvResult<T> = Result<T, String>;
+
+static RUN_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Clone, Debug)]
+pub struct CommandSpec {
+  pub id: &'static str,
+  pub summary: &'static str,
+  pub driver_id: &'static str,
+  pub operation: &'static str,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ExecutionTarget {
+  pub application_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct InvokeRequest {
+  pub command_id: String,
+  pub target: ExecutionTarget,
+  pub inputs: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RunStatus {
+  Completed,
+  Failed,
+}
+
+impl RunStatus {
+  pub fn as_str(&self) -> &'static str {
+    match self {
+      Self::Completed => "completed",
+      Self::Failed => "failed",
+    }
+  }
+}
+
+#[derive(Clone, Debug)]
+pub struct InvokeResult {
+  pub run_id: String,
+  pub status: RunStatus,
+  pub output_summary: String,
+  pub artifact_paths: Vec<PathBuf>,
+  pub failure_message: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct EventRecord {
+  pub at_millis: u128,
+  pub kind: String,
+  pub message: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct ArtifactRecord {
+  pub id: String,
+  pub kind: String,
+  pub path: PathBuf,
+  pub note: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct RunRecord {
+  pub run_id: String,
+  pub command_id: String,
+  pub driver_id: String,
+  pub operation: String,
+  pub target_application_id: Option<String>,
+  pub runtime_version: String,
+  pub started_at_millis: u128,
+  pub finished_at_millis: Option<u128>,
+  pub status: RunStatus,
+  pub inputs: BTreeMap<String, String>,
+  pub output_summary: String,
+  pub events: Vec<EventRecord>,
+  pub artifacts: Vec<ArtifactRecord>,
+}
+
+impl EventRecord {
+  pub fn render_log_line(&self) -> String {
+    format!("{} {} {}", self.at_millis, self.kind, self.message)
+  }
+}
+
+impl ArtifactRecord {
+  pub fn render_manifest_line(&self) -> String {
+    let note = self.note.clone().unwrap_or_else(|| "n/a".to_string());
+    format!(
+      "{} kind={} path={} note={}",
+      self.id,
+      self.kind,
+      self.path.display(),
+      note
+    )
+  }
+}
+
+impl RunRecord {
+  pub fn render_meta(&self) -> String {
+    let target = self
+      .target_application_id
+      .clone()
+      .unwrap_or_else(|| "n/a".to_string());
+    let finished = self
+      .finished_at_millis
+      .map(|value| value.to_string())
+      .unwrap_or_else(|| "n/a".to_string());
+
+    [
+      format!("runId: {}", self.run_id),
+      format!("status: {}", self.status.as_str()),
+      format!("command: {}", self.command_id),
+      format!("driver: {}", self.driver_id),
+      format!("operation: {}", self.operation),
+      format!("targetApplicationId: {target}"),
+      format!("runtimeVersion: {}", self.runtime_version),
+      format!("startedAtMillis: {}", self.started_at_millis),
+      format!("finishedAtMillis: {finished}"),
+    ]
+    .join("\n")
+      + "\n"
+  }
+
+  pub fn render_inputs(&self) -> String {
+    if self.inputs.is_empty() {
+      return "none\n".to_string();
+    }
+
+    let mut lines = Vec::new();
+    for (key, value) in &self.inputs {
+      lines.push(format!("{key}={value}"));
+    }
+    lines.join("\n") + "\n"
+  }
+
+  pub fn render_events(&self) -> String {
+    if self.events.is_empty() {
+      return "none\n".to_string();
+    }
+
+    self
+      .events
+      .iter()
+      .map(EventRecord::render_log_line)
+      .collect::<Vec<_>>()
+      .join("\n")
+      + "\n"
+  }
+
+  pub fn render_artifacts(&self) -> String {
+    if self.artifacts.is_empty() {
+      return "none\n".to_string();
+    }
+
+    self
+      .artifacts
+      .iter()
+      .map(ArtifactRecord::render_manifest_line)
+      .collect::<Vec<_>>()
+      .join("\n")
+      + "\n"
+  }
+
+  pub fn render_inspection(&self) -> String {
+    let target = self
+      .target_application_id
+      .clone()
+      .unwrap_or_else(|| "n/a".to_string());
+    let finished = self
+      .finished_at_millis
+      .map(|value| value.to_string())
+      .unwrap_or_else(|| "n/a".to_string());
+    let sections = vec![
+      format!("Run {}", self.run_id),
+      format!("Status: {}", self.status.as_str()),
+      format!("Command: {}", self.command_id),
+      format!("Driver: {}", self.driver_id),
+      format!("Operation: {}", self.operation),
+      format!("Target: {target}"),
+      format!("Runtime Version: {}", self.runtime_version),
+      format!("Started At (ms): {}", self.started_at_millis),
+      format!("Finished At (ms): {finished}"),
+      String::new(),
+      "Inputs".to_string(),
+      render_block(&self.render_inputs()),
+      "Output".to_string(),
+      render_block(&format!("{}\n", self.output_summary)),
+      "Artifacts".to_string(),
+      render_block(&self.render_artifacts()),
+      "Events".to_string(),
+      render_block(&self.render_events()),
+    ];
+
+    sections.join("\n")
+  }
+}
+
+impl Display for RunRecord {
+  fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+    formatter.write_str(&self.render_inspection())
+  }
+}
+
+#[derive(Clone, Debug)]
+pub struct DriverDescriptor {
+  pub id: &'static str,
+  pub summary: &'static str,
+  pub capabilities: &'static [&'static str],
+  pub donor_boundary: &'static str,
+}
+
+#[derive(Clone, Debug)]
+pub struct DriverCall {
+  pub operation: String,
+  pub target: ExecutionTarget,
+  pub inputs: BTreeMap<String, String>,
+  pub working_directory: PathBuf,
+}
+
+#[derive(Clone, Debug)]
+pub struct ProducedArtifact {
+  pub kind: String,
+  pub source_path: PathBuf,
+  pub preferred_name: String,
+  pub note: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct DriverResponse {
+  pub summary: String,
+  pub backend: Option<String>,
+  pub notes: Vec<String>,
+  pub artifacts: Vec<ProducedArtifact>,
+}
+
+pub fn now_millis() -> u128 {
+  SystemTime::now()
+    .duration_since(UNIX_EPOCH)
+    .unwrap_or_default()
+    .as_millis()
+}
+
+pub fn new_run_id() -> String {
+  let sequence = RUN_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
+  format!("run_{}_{}_{}", now_millis(), process::id(), sequence)
+}
+
+fn render_block(raw: &str) -> String {
+  raw
+    .lines()
+    .map(|line| format!("  {line}"))
+    .collect::<Vec<_>>()
+    .join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+  use super::new_run_id;
+
+  #[test]
+  fn new_run_id_is_unique_within_process() {
+    let first = new_run_id();
+    let second = new_run_id();
+
+    assert_ne!(first, second);
+  }
+}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,0 +1,300 @@
+use std::path::PathBuf;
+
+use crate::catalog::CommandCatalog;
+use crate::driver::DriverRegistry;
+use crate::model::{
+  ArtifactRecord, AuvResult, DriverCall, DriverDescriptor, EventRecord, InvokeRequest,
+  InvokeResult, RunRecord, RunStatus, new_run_id, now_millis,
+};
+use crate::store::LocalStore;
+
+pub struct Runtime {
+  project_root: PathBuf,
+  commands: CommandCatalog,
+  drivers: DriverRegistry,
+  store: LocalStore,
+}
+
+impl Runtime {
+  pub fn new(
+    project_root: PathBuf,
+    commands: CommandCatalog,
+    drivers: DriverRegistry,
+    store: LocalStore,
+  ) -> Self {
+    Self {
+      project_root,
+      commands,
+      drivers,
+      store,
+    }
+  }
+
+  pub fn list_commands(&self) -> &[crate::model::CommandSpec] {
+    self.commands.all()
+  }
+
+  pub fn list_drivers(&self) -> Vec<DriverDescriptor> {
+    self.drivers.descriptors()
+  }
+
+  pub fn inspect(&self, run_id: &str) -> AuvResult<String> {
+    self.store.render_inspection(run_id)
+  }
+
+  pub fn invoke(&self, request: InvokeRequest) -> AuvResult<InvokeResult> {
+    let command = self.commands.resolve(&request.command_id).ok_or_else(|| {
+      format!(
+        "unknown command {}; use `list-commands` to see available entries",
+        request.command_id
+      )
+    })?;
+    let driver = self.drivers.get(command.driver_id).ok_or_else(|| {
+      format!(
+        "command {} resolved to missing driver {}",
+        command.id, command.driver_id
+      )
+    })?;
+
+    let run_id = new_run_id();
+    let mut run = RunRecord {
+      run_id: run_id.clone(),
+      command_id: command.id.to_string(),
+      driver_id: command.driver_id.to_string(),
+      operation: command.operation.to_string(),
+      target_application_id: request.target.application_id.clone(),
+      runtime_version: env!("CARGO_PKG_VERSION").to_string(),
+      started_at_millis: now_millis(),
+      finished_at_millis: None,
+      status: RunStatus::Failed,
+      inputs: request.inputs.clone(),
+      output_summary: String::new(),
+      events: Vec::new(),
+      artifacts: Vec::new(),
+    };
+
+    push_event(
+      &mut run.events,
+      "run.created",
+      format!("implicit run created for command {}", command.id),
+    );
+    push_event(
+      &mut run.events,
+      "command.resolved",
+      format!(
+        "resolved {} -> {}.{}",
+        command.id, command.driver_id, command.operation
+      ),
+    );
+
+    let call = DriverCall {
+      operation: command.operation.to_string(),
+      target: request.target,
+      inputs: request.inputs,
+      working_directory: self.project_root.clone(),
+    };
+
+    push_event(
+      &mut run.events,
+      "driver.invoke",
+      format!("invoking {}.{}", command.driver_id, command.operation),
+    );
+
+    let mut failure_message = None;
+
+    match driver.invoke(&call) {
+      Ok(response) => {
+        if let Some(backend) = &response.backend {
+          push_event(
+            &mut run.events,
+            "driver.backend",
+            format!("backend={backend}"),
+          );
+        }
+
+        for note in &response.notes {
+          push_event(&mut run.events, "driver.note", note.clone());
+        }
+
+        let mut persisted_artifacts = Vec::new();
+        let mut artifact_failure = None;
+        for (index, artifact) in response.artifacts.into_iter().enumerate() {
+          match self.store.stage_artifact(&run.run_id, index, artifact) {
+            Ok(stored_artifact) => {
+              push_event(
+                &mut run.events,
+                "artifact.captured",
+                render_artifact_event(&stored_artifact),
+              );
+              persisted_artifacts.push(stored_artifact);
+            }
+            Err(error) => {
+              push_event(
+                &mut run.events,
+                "artifact.failed",
+                format!("artifact staging failed: {error}"),
+              );
+              artifact_failure = Some(error);
+              break;
+            }
+          }
+        }
+
+        run.artifacts = persisted_artifacts;
+        if let Some(error) = artifact_failure {
+          run.status = RunStatus::Failed;
+          run.output_summary = format!(
+            "Artifact staging failed after run creation. Inspect {} for the recorded trace.",
+            run.run_id
+          );
+          failure_message = Some(error.clone());
+          push_event(
+            &mut run.events,
+            "run.failed",
+            format!("artifact staging failed after driver success: {error}"),
+          );
+        } else {
+          run.status = RunStatus::Completed;
+          run.output_summary = response.summary.clone();
+          push_event(&mut run.events, "run.completed", response.summary);
+        }
+      }
+      Err(error) => {
+        run.status = RunStatus::Failed;
+        run.output_summary = format!(
+          "Driver invocation failed after run creation. Inspect {} for the recorded trace.",
+          run.run_id
+        );
+        failure_message = Some(error.clone());
+        push_event(&mut run.events, "driver.failed", error);
+      }
+    }
+
+    run.finished_at_millis = Some(now_millis());
+    self.store.persist_run(&run)?;
+
+    let artifact_paths = run
+      .artifacts
+      .iter()
+      .map(|artifact| artifact.path.clone())
+      .collect::<Vec<_>>();
+    let run_id = run.run_id.clone();
+    let status = run.status.clone();
+    let output_summary = run.output_summary.clone();
+
+    Ok(InvokeResult {
+      run_id,
+      status,
+      output_summary,
+      artifact_paths,
+      failure_message,
+    })
+  }
+}
+
+fn push_event(events: &mut Vec<EventRecord>, kind: &str, message: String) {
+  events.push(EventRecord {
+    at_millis: now_millis(),
+    kind: kind.to_string(),
+    message,
+  });
+}
+
+fn render_artifact_event(artifact: &ArtifactRecord) -> String {
+  let note = artifact.note.clone().unwrap_or_else(|| "n/a".to_string());
+  format!(
+    "{} kind={} path={} note={}",
+    artifact.id,
+    artifact.kind,
+    artifact.path.display(),
+    note
+  )
+}
+
+#[cfg(test)]
+mod tests {
+  use std::collections::BTreeMap;
+  use std::env;
+  use std::fs;
+  use std::path::PathBuf;
+
+  use super::Runtime;
+  use crate::catalog::CommandCatalog;
+  use crate::driver::{Driver, DriverRegistry};
+  use crate::model::{
+    AuvResult, CommandSpec, DriverCall, DriverDescriptor, DriverResponse, ExecutionTarget,
+    InvokeRequest, ProducedArtifact, RunStatus, now_millis,
+  };
+  use crate::store::LocalStore;
+
+  struct ArtifactFailureDriver;
+
+  impl Driver for ArtifactFailureDriver {
+    fn descriptor(&self) -> DriverDescriptor {
+      DriverDescriptor {
+        id: "test.driver",
+        summary: "Test driver",
+        capabilities: &["test.artifact-failure"],
+        donor_boundary: "test-only",
+      }
+    }
+
+    fn invoke(&self, _call: &DriverCall) -> AuvResult<DriverResponse> {
+      Ok(DriverResponse {
+        summary: "driver succeeded before artifact staging".to_string(),
+        backend: Some("test.backend".to_string()),
+        notes: vec!["note".to_string()],
+        artifacts: vec![ProducedArtifact {
+          kind: "text".to_string(),
+          source_path: PathBuf::from("/definitely/missing/artifact.txt"),
+          preferred_name: "artifact.txt".to_string(),
+          note: Some("missing".to_string()),
+        }],
+      })
+    }
+  }
+
+  #[test]
+  fn invoke_persists_failed_run_when_artifact_staging_breaks() {
+    let project_root = temp_dir("runtime-tests-project");
+    let store_root = temp_dir("runtime-tests-store");
+    let runtime = Runtime::new(
+      project_root.clone(),
+      CommandCatalog::new(vec![CommandSpec {
+        id: "test.invoke",
+        summary: "Test invoke",
+        driver_id: "test.driver",
+        operation: "test_operation",
+      }]),
+      DriverRegistry::new(vec![Box::new(ArtifactFailureDriver)]),
+      LocalStore::new(store_root.clone()).expect("store should initialize"),
+    );
+
+    let result = runtime
+      .invoke(InvokeRequest {
+        command_id: "test.invoke".to_string(),
+        target: ExecutionTarget::default(),
+        inputs: BTreeMap::new(),
+      })
+      .expect("artifact staging failures should still return an inspectable run");
+
+    assert_eq!(result.status, RunStatus::Failed);
+    assert!(result.failure_message.is_some());
+
+    let inspection = runtime
+      .inspect(&result.run_id)
+      .expect("failed run should still be inspectable");
+    assert!(inspection.contains("Status: failed"));
+    assert!(inspection.contains("artifact staging failed"));
+
+    let _ = fs::remove_dir_all(project_root);
+    let _ = fs::remove_dir_all(store_root);
+  }
+
+  fn temp_dir(label: &str) -> PathBuf {
+    let path = env::temp_dir().join(format!("auv-{}-{}", label, now_millis()));
+    let _ = fs::remove_dir_all(&path);
+    fs::create_dir_all(&path).expect("temp dir should be creatable");
+    path
+  }
+}

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,0 +1,230 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::driver::{copy_file, sanitized_artifact_name};
+use crate::model::{ArtifactRecord, AuvResult, ProducedArtifact, RunRecord, now_millis};
+
+pub struct LocalStore {
+  root: PathBuf,
+}
+
+impl LocalStore {
+  pub fn new(root: PathBuf) -> AuvResult<Self> {
+    fs::create_dir_all(root.join("runs"))
+      .map_err(|error| format!("failed to create run store root: {error}"))?;
+    fs::create_dir_all(root.join("artifacts"))
+      .map_err(|error| format!("failed to create artifact store root: {error}"))?;
+    Ok(Self { root })
+  }
+
+  pub fn stage_artifact(
+    &self,
+    run_id: &str,
+    index: usize,
+    artifact: ProducedArtifact,
+  ) -> AuvResult<ArtifactRecord> {
+    let artifact_id = format!("artifact_{:02}", index + 1);
+    let extension = artifact
+      .source_path
+      .extension()
+      .and_then(|extension| extension.to_str())
+      .unwrap_or("bin");
+    let base_name = sanitized_artifact_name(
+      artifact
+        .preferred_name
+        .trim_end_matches(&format!(".{extension}")),
+    );
+    let destination = self
+      .root
+      .join("artifacts")
+      .join(run_id)
+      .join(format!("{artifact_id}_{base_name}.{extension}"));
+
+    copy_file(&artifact.source_path, &destination)?;
+    if artifact.source_path != destination {
+      let _ = fs::remove_file(&artifact.source_path);
+    }
+
+    Ok(ArtifactRecord {
+      id: artifact_id,
+      kind: artifact.kind,
+      path: destination,
+      note: artifact.note,
+    })
+  }
+
+  pub fn persist_run(&self, run: &RunRecord) -> AuvResult<()> {
+    let runs_root = self.root.join("runs");
+    let run_directory = runs_root.join(&run.run_id);
+    if run_directory.exists() {
+      return Err(format!(
+        "run directory {} already exists",
+        run_directory.display()
+      ));
+    }
+
+    let staging_directory = runs_root.join(format!(".{}-tmp-{}", run.run_id, now_millis()));
+    fs::create_dir_all(&staging_directory).map_err(|error| {
+      format!(
+        "failed to create staging run directory {}: {error}",
+        staging_directory.display()
+      )
+    })?;
+
+    let write_result = write_run_snapshot(run, &staging_directory);
+    if let Err(error) = write_result {
+      let _ = fs::remove_dir_all(&staging_directory);
+      return Err(error);
+    }
+
+    fs::rename(&staging_directory, &run_directory).map_err(|error| {
+      let _ = fs::remove_dir_all(&staging_directory);
+      format!(
+        "failed to publish run directory {} from {}: {error}",
+        run_directory.display(),
+        staging_directory.display()
+      )
+    })?;
+
+    Ok(())
+  }
+
+  pub fn render_inspection(&self, run_id: &str) -> AuvResult<String> {
+    let inspection_path = self.root.join("runs").join(run_id).join("inspect.txt");
+
+    fs::read_to_string(&inspection_path).map_err(|error| {
+      format!(
+        "failed to read inspect snapshot {}: {error}",
+        inspection_path.display()
+      )
+    })
+  }
+}
+
+fn write_run_snapshot(run: &RunRecord, directory: &Path) -> AuvResult<()> {
+  write_snapshot_file(
+    &directory.join("meta.txt"),
+    run.render_meta(),
+    "run metadata",
+  )?;
+  write_snapshot_file(
+    &directory.join("inputs.txt"),
+    run.render_inputs(),
+    "run inputs",
+  )?;
+  write_snapshot_file(
+    &directory.join("events.log"),
+    run.render_events(),
+    "run events",
+  )?;
+  write_snapshot_file(
+    &directory.join("artifacts.txt"),
+    run.render_artifacts(),
+    "artifact manifest",
+  )?;
+  write_snapshot_file(
+    &directory.join("output.txt"),
+    format!("{}\n", run.output_summary),
+    "run output",
+  )?;
+  write_snapshot_file(
+    &directory.join("inspect.txt"),
+    run.to_string(),
+    "inspect snapshot",
+  )?;
+  Ok(())
+}
+
+fn write_snapshot_file(path: &Path, content: String, label: &str) -> AuvResult<()> {
+  fs::write(path, content)
+    .map_err(|error| format!("failed to write {} {}: {error}", label, path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::model::RunStatus;
+  use std::collections::BTreeMap;
+  use std::env;
+
+  #[test]
+  fn local_store_creates_root_directories() {
+    let root = temp_dir("store-init");
+    LocalStore::new(root.clone()).expect("should initialize");
+    assert!(root.join("runs").exists());
+    assert!(root.join("artifacts").exists());
+    let _ = fs::remove_dir_all(root);
+  }
+
+  #[test]
+  fn local_store_persists_and_renders_run() {
+    let root = temp_dir("store-persist");
+    let store = LocalStore::new(root.clone()).expect("should initialize");
+    let run = RunRecord {
+      run_id: "test_run".to_string(),
+      command_id: "test.cmd".to_string(),
+      driver_id: "test.driver".to_string(),
+      operation: "test_op".to_string(),
+      target_application_id: None,
+      runtime_version: "0.0.1".to_string(),
+      started_at_millis: 1000,
+      finished_at_millis: Some(1100),
+      status: RunStatus::Completed,
+      inputs: BTreeMap::new(),
+      output_summary: "success".to_string(),
+      events: Vec::new(),
+      artifacts: Vec::new(),
+    };
+
+    store.persist_run(&run).expect("should persist");
+    let inspection = store.render_inspection("test_run").expect("should render");
+
+    assert!(inspection.contains("Run test_run"));
+    assert!(inspection.contains("Status: completed"));
+    assert!(inspection.contains("Command: test.cmd"));
+
+    let _ = fs::remove_dir_all(root);
+  }
+
+  #[test]
+  fn local_store_fails_if_run_already_exists() {
+    let root = temp_dir("store-conflict");
+    let store = LocalStore::new(root.clone()).expect("should initialize");
+    let run = dummy_run("conflict_run");
+
+    store
+      .persist_run(&run)
+      .expect("first persist should succeed");
+    let error = store
+      .persist_run(&run)
+      .expect_err("second persist should fail");
+    assert!(error.contains("already exists"));
+
+    let _ = fs::remove_dir_all(root);
+  }
+
+  fn temp_dir(label: &str) -> PathBuf {
+    let path = env::temp_dir().join(format!("auv-{}-{}", label, now_millis()));
+    let _ = fs::remove_dir_all(&path);
+    fs::create_dir_all(&path).expect("temp dir should be creatable");
+    path
+  }
+
+  fn dummy_run(run_id: &str) -> RunRecord {
+    RunRecord {
+      run_id: run_id.to_string(),
+      command_id: "test.cmd".to_string(),
+      driver_id: "test.driver".to_string(),
+      operation: "test_op".to_string(),
+      target_application_id: None,
+      runtime_version: "0.0.1".to_string(),
+      started_at_millis: now_millis(),
+      finished_at_millis: None,
+      status: RunStatus::Failed,
+      inputs: BTreeMap::new(),
+      output_summary: String::new(),
+      events: Vec::new(),
+      artifacts: Vec::new(),
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds the first inspectable AUV runtime skeleton without any platform desktop driver.

Included here:
- library-first runtime entrypoint
- command catalog and driver registry boundaries
- deterministic `fixture.observe` driver for runtime validation
- implicit run creation for every invoke
- local `.auv/` run and artifact storage
- inspect output over persisted run snapshots
- thin CLI frontend over the shared runtime

## Why this shape

This is intentionally split away from macOS capability validation. The goal here is only to establish the reusable runtime path that later CLI, MCP, library, and UI frontends can share.

Platform-specific desktop capabilities will be reviewed in a follow-up PR built on top of this one.

## Included command

- `debug.fixtureObserve`

## Verification

- `cargo fmt`
- `cargo check`
- `cargo test`
- `git diff --check`
- `cargo run --quiet -- list-commands`
- `cargo run --quiet -- invoke debug.fixtureObserve --label runtime-only`
