### PR TITLE
feat(scroll-scan): scroll scan over OCR with visual band analysis

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,28 @@ When an implementation is mostly complete, update durable reference material in
 `docs/ai/references/`. Add, merge, or revise reference docs so completed and
 partially completed work is discoverable outside the original plan or spec.
 
+### Documentation Placement
+
+Use `docs/ai/references/` only for durable project reference material: accepted
+design notes, implementation handoffs, evidence packs, coverage reports, and
+records that should be useful to reviewers after the original task context is
+gone. Content in this directory should describe the current project state or a
+clearly labeled historical decision.
+
+Use `docs/ai/explanations/` for committed explanatory material: tutorials,
+interactive explainers, conceptual walkthroughs, diagrams, and other documents
+whose purpose is to teach or clarify an idea rather than record project
+evidence. Prefer English for committed explanations unless the user explicitly
+asks for another language.
+
+Use `docs/notes/<owner>/` for personal, exploratory, or scratch material,
+including rough HTML demos, temporary investigation notes, local run logs, and
+drafts that are not ready to be shared as durable project references. Do not
+commit notes from `docs/notes/<owner>/` unless the user explicitly asks for
+that exact material to be committed. If a note becomes generally useful, move
+or rewrite it into `docs/ai/explanations/` or `docs/ai/references/` as
+appropriate before committing.
+
 ## Validation Commands
 
 - `cargo fmt --check`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,7 +131,9 @@ Use `docs/ai/explanations/` for committed explanatory material: tutorials,
 interactive explainers, conceptual walkthroughs, diagrams, and other documents
 whose purpose is to teach or clarify an idea rather than record project
 evidence. Prefer English for committed explanations unless the user explicitly
-asks for another language.
+asks for another language. For explanatory HTML files, name the file with the
+relevant module or feature name in kebab case as the prefix, followed by a
+short description, for example `scroll-scan-visual-row-band.html`.
 
 Use `docs/notes/<owner>/` for personal, exploratory, or scratch material,
 including rough HTML demos, temporary investigation notes, local run logs, and

--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ Useful CLI entrypoints:
 - `cargo run --quiet -- skill cases list`
 - `cargo run --quiet -- skill bundle list`
 - `cargo run --quiet -- skill bundle coverage native.app.skill-tree.v0`
+- `cargo run --quiet -- scan window-region --target <bundle-id> --region 0.0,0.0,1.0,1.0 --max-pages 3`
+
+`scan window-region` is the first scroll-scan workflow. It is OCR-first,
+region-scoped, conservative about duplicate text, and records why scanning
+stopped instead of unconditionally claiming a complete collection.
 
 ## License
 

--- a/docs/TERMS_AND_CONCEPTS.md
+++ b/docs/TERMS_AND_CONCEPTS.md
@@ -130,6 +130,70 @@ window image, while the same ratio on a display-scoped command is relative to
 the selected display capture. A region should not be used as a substitute for
 the scope itself.
 
+## Segmented Region
+
+A segmented region is a derived region produced by an observation or scan step.
+It is evidence about visible layout, not a user-authored target region.
+
+Segmented regions should carry their coordinate space, bounds, role,
+confidence, and evidence. For example, a list scanner may emit one segmented
+region with the role `list_region` after detecting a repeated row pattern.
+
+## Anchor
+
+An anchor is a visible or native UI signal used to locate another observation or
+action target. Anchors may come from OCR text, AX text, image features, stable
+window metadata, or previously recorded geometry.
+
+Anchors are evidence, not guarantees. Recipes should record which anchor was
+used and how it resolved to a region, row, item, or action point.
+
+## List Region
+
+A list region is a segmented region that appears to contain repeated list-like
+content. It is not tied to one domain such as playlists, tables, search results,
+or inboxes.
+
+A list region may contain section headers, partial rows, ads, dividers, and
+other non-item content. Those are filtered or interpreted by later stages.
+
+## List Row Candidate
+
+A list row candidate is a row-like visual or textual band observed inside a
+region. It is a candidate because row detection can include headers, tabs,
+partial rows, and other repeated or near-repeated layout elements.
+
+List row candidates should preserve source evidence such as OCR fragments,
+visual-band bounds, row index, and detection strategy.
+
+## Row Filter
+
+A row filter is a deterministic step that turns list row candidates into list
+item candidates by rejecting candidates that are clearly outside the expected
+row pattern.
+
+Row filters should be conservative. They should avoid semantic parsing and
+should preserve rejected candidates with reasons so a reviewer or later hook can
+inspect what was lost.
+
+## List Item Candidate
+
+A list item candidate is a list row candidate that survived row filtering and is
+ready for item-level observation or recipe handling.
+
+A list item candidate is still not a parsed domain object. It may have geometry
+and OCR fragments, but it does not become a semantic song, email, file, or table
+record until a recipe or parser interprets it.
+
+## List Item Observation
+
+A list item observation is recorded evidence extracted from a list item
+candidate on one scan page. It can include text fragments, geometry, source
+artifacts, row-filter metadata, and parser attributes.
+
+List item observations are the per-page entries that can later be merged into
+an observed collection.
+
 ## AX Tree
 
 An AX tree is a snapshot of accessibility elements exposed by a target
@@ -257,3 +321,25 @@ future scan behavior.
 
 Hooks are observation-only by default. Hooks that mutate UI must declare their
 disturbance explicitly.
+
+## Sub Recipe
+
+A sub recipe is a recipe manifest invoked by another runtime workflow instead
+of directly by a user-facing command. The host workflow supplies context from
+its own execution, such as a scan page, list item candidate, or stop candidate.
+
+Sub recipes should declare their invocation host and stage in the manifest so
+the caller can reject incompatible recipes before execution. Current scan sub
+recipes use a provisional scalar context; typed context artifacts should replace
+that once the hook contract stabilizes.
+
+## List Scan Hook
+
+A list scan hook is a scan hook that runs while scanning list-like content.
+Depending on where it is attached, it may inspect a segmented region, list row
+candidate, list item candidate, page observation, or stop candidate.
+
+List scan hooks should make their input stage explicit. A hook that runs after
+row filtering is not the same as a row filter, because it can run recipe logic
+and may produce annotations or decisions rather than only deterministic
+accept/reject results.

--- a/docs/ai/explanations/scroll-scan-visual-row-band.html
+++ b/docs/ai/explanations/scroll-scan-visual-row-band.html
@@ -1,0 +1,792 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>AUV Visual Row Bands Explainer</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f6f4ee;
+      --panel: #ffffff;
+      --ink: #20242b;
+      --muted: #6a707b;
+      --line: #d8d4c8;
+      --cyan: #00a9b8;
+      --cyan-soft: #d8f5f7;
+      --green: #68a815;
+      --yellow: #f0b400;
+      --red: #d64b4b;
+      --blue: #557ce1;
+      --shadow: 0 8px 24px rgba(32, 36, 43, 0.08);
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      font-size: 14px;
+      line-height: 1.45;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: var(--bg);
+      color: var(--ink);
+    }
+
+    header {
+      padding: 18px 24px 12px;
+      border-bottom: 1px solid var(--line);
+      background: rgba(255, 255, 255, 0.72);
+      position: sticky;
+      top: 0;
+      z-index: 10;
+      backdrop-filter: blur(10px);
+    }
+
+    h1 {
+      margin: 0;
+      font-size: 20px;
+      line-height: 1.2;
+      letter-spacing: 0;
+    }
+
+    .subtitle {
+      margin-top: 6px;
+      color: var(--muted);
+      max-width: 980px;
+    }
+
+    main {
+      display: grid;
+      grid-template-columns: 320px minmax(0, 1fr);
+      gap: 16px;
+      padding: 16px;
+      max-width: 1440px;
+      margin: 0 auto;
+    }
+
+    .controls,
+    .stage,
+    .explain {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      box-shadow: var(--shadow);
+    }
+
+    .controls {
+      border-radius: 8px;
+      padding: 14px;
+      align-self: start;
+      position: sticky;
+      top: 94px;
+    }
+
+    .stage {
+      border-radius: 8px;
+      padding: 14px;
+      min-width: 0;
+    }
+
+    .canvas-grid {
+      display: grid;
+      grid-template-columns: minmax(280px, 1.2fr) minmax(280px, 1fr) minmax(220px, 0.85fr);
+      gap: 12px;
+      align-items: stretch;
+    }
+
+    .pane {
+      min-width: 0;
+    }
+
+    .pane h2,
+    .controls h2,
+    .explain h2 {
+      margin: 0 0 10px;
+      font-size: 13px;
+      text-transform: uppercase;
+      color: var(--muted);
+      letter-spacing: 0.04em;
+    }
+
+    canvas {
+      display: block;
+      width: 100%;
+      height: auto;
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      background: #fbfaf7;
+    }
+
+    .metric-strip {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 8px;
+      margin-top: 12px;
+    }
+
+    .metric {
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      padding: 8px;
+      background: #fbfaf7;
+      min-width: 0;
+    }
+
+    .metric .label {
+      font-size: 11px;
+      color: var(--muted);
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+
+    .metric .value {
+      margin-top: 3px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 18px;
+    }
+
+    .control {
+      padding: 10px 0;
+      border-top: 1px solid var(--line);
+    }
+
+    .control:first-of-type { border-top: 0; }
+
+    .control label {
+      display: flex;
+      justify-content: space-between;
+      gap: 10px;
+      font-size: 13px;
+    }
+
+    .control .value {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      color: var(--cyan);
+      white-space: nowrap;
+    }
+
+    input[type="range"] {
+      width: 100%;
+      margin: 8px 0 0;
+      accent-color: var(--cyan);
+    }
+
+    .buttons {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 12px;
+    }
+
+    button {
+      border: 1px solid var(--line);
+      background: #fbfaf7;
+      color: var(--ink);
+      border-radius: 6px;
+      padding: 8px 10px;
+      cursor: pointer;
+      font: inherit;
+    }
+
+    button.active {
+      border-color: var(--cyan);
+      background: var(--cyan-soft);
+    }
+
+    .legend {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px 12px;
+      margin-top: 10px;
+      color: var(--muted);
+      font-size: 12px;
+    }
+
+    .key {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .swatch {
+      width: 12px;
+      height: 12px;
+      border-radius: 3px;
+      border: 1px solid rgba(0, 0, 0, 0.16);
+    }
+
+    .explain {
+      grid-column: 1 / -1;
+      border-radius: 8px;
+      padding: 16px;
+    }
+
+    .explain-grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 14px;
+    }
+
+    .note {
+      border-left: 3px solid var(--cyan);
+      padding-left: 10px;
+      color: var(--muted);
+    }
+
+    code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      background: #f0eee7;
+      padding: 1px 4px;
+      border-radius: 4px;
+    }
+
+    @media (max-width: 1080px) {
+      main {
+        grid-template-columns: 1fr;
+      }
+
+      .controls {
+        position: static;
+      }
+
+      .canvas-grid,
+      .explain-grid {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>AUV visual-bands row detection</h1>
+    <div class="subtitle">
+      This explainer mirrors the core idea behind the current visual row-band detector: sample an analysis strip on the left side of a list region, compute an active-pixel ratio for each y coordinate, smooth that into a row signal, and treat continuous spans above the threshold as candidate row bands.
+    </div>
+  </header>
+
+  <main>
+    <aside class="controls">
+      <h2>Controls</h2>
+      <div class="control">
+        <label>Scenario <span class="value" id="sceneLabel">Song list</span></label>
+        <div class="buttons">
+          <button type="button" class="active" data-scene="music">Song list</button>
+          <button type="button" data-scene="cards">Card list</button>
+          <button type="button" data-scene="sections">Multi-section</button>
+        </div>
+      </div>
+      <div class="control">
+        <label>Edge threshold <span class="value" data-value-for="edgeThreshold"></span></label>
+        <input id="edgeThreshold" type="range" min="0.02" max="0.24" step="0.01" value="0.10">
+      </div>
+      <div class="control">
+        <label>Saturation threshold <span class="value" data-value-for="satThreshold"></span></label>
+        <input id="satThreshold" type="range" min="0.08" max="0.50" step="0.01" value="0.24">
+      </div>
+      <div class="control">
+        <label>Row signal threshold <span class="value" data-value-for="rowThreshold"></span></label>
+        <input id="rowThreshold" type="range" min="0.002" max="0.080" step="0.001" value="0.018">
+      </div>
+      <div class="control">
+        <label>Allowed gap <span class="value" data-value-for="maxGap"></span></label>
+        <input id="maxGap" type="range" min="0" max="24" step="1" value="10">
+      </div>
+      <div class="control">
+        <label>Minimum band height <span class="value" data-value-for="minBandHeight"></span></label>
+        <input id="minBandHeight" type="range" min="4" max="80" step="1" value="28">
+      </div>
+      <div class="control">
+        <label>Maximum band height <span class="value" data-value-for="maxBandHeight"></span></label>
+        <input id="maxBandHeight" type="range" min="60" max="300" step="5" value="220">
+      </div>
+      <div class="control">
+        <label>Background noise <span class="value" data-value-for="noise"></span></label>
+        <input id="noise" type="range" min="0" max="40" step="1" value="4">
+      </div>
+      <div class="control">
+        <label>Row gap <span class="value" data-value-for="rowGap"></span></label>
+        <input id="rowGap" type="range" min="0" max="36" step="1" value="12">
+      </div>
+    </aside>
+
+    <section class="stage">
+      <div class="canvas-grid">
+        <div class="pane">
+          <h2>1. Synthetic screenshot</h2>
+          <canvas id="scene" width="520" height="620"></canvas>
+          <div class="legend">
+            <span class="key"><span class="swatch" style="background: rgba(0,169,184,.18)"></span>analysis strip, 2%-24% width</span>
+            <span class="key"><span class="swatch" style="background: rgba(104,168,21,.24)"></span>detected row bands</span>
+          </div>
+        </div>
+        <div class="pane">
+          <h2>2. Row signal per y</h2>
+          <canvas id="signal" width="420" height="620"></canvas>
+          <div class="legend">
+            <span class="key"><span class="swatch" style="background: var(--blue)"></span>raw active ratio</span>
+            <span class="key"><span class="swatch" style="background: var(--cyan)"></span>smoothed signal</span>
+            <span class="key"><span class="swatch" style="background: var(--red)"></span>threshold</span>
+          </div>
+        </div>
+        <div class="pane">
+          <h2>3. Bands</h2>
+          <canvas id="bands" width="300" height="620"></canvas>
+          <div class="legend">
+            <span class="key"><span class="swatch" style="background: var(--yellow)"></span>raw band</span>
+            <span class="key"><span class="swatch" style="background: var(--green)"></span>accepted row</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="metric-strip">
+        <div class="metric"><div class="label">active pixel</div><div class="value" id="activeRule">edge/sat</div></div>
+        <div class="metric"><div class="label">raw bands</div><div class="value" id="rawBands">0</div></div>
+        <div class="metric"><div class="label">accepted rows</div><div class="value" id="acceptedRows">0</div></div>
+        <div class="metric"><div class="label">hover y</div><div class="value" id="hoverReadout">-</div></div>
+      </div>
+    </section>
+
+    <section class="explain">
+      <h2>What the algorithm is assuming</h2>
+      <div class="explain-grid">
+        <div class="note">
+          <strong>Active-pixel ratio</strong><br>
+          For one horizontal line <code>y</code>, inspect only the left-side analysis strip. A pixel is active when it has enough local edge contrast or enough color saturation. <code>activeCount / stripWidth</code> is the active-pixel ratio for that y coordinate.
+        </div>
+        <div class="note">
+          <strong>row signal</strong><br>
+          Every <code>y</code> has an active ratio, so the screenshot becomes a one-dimensional curve from top to bottom. The current implementation averages it with a radius-2 window to produce <code>smoothedSignal</code>, which keeps single-pixel noise from splitting a row.
+        </div>
+        <div class="note">
+          <strong>Why continuous y spans become rows</strong><br>
+          The detector assumes list items appear as horizontal bands: covers, icons, text, and buttons usually share the same vertical range. A continuous high-signal span therefore often corresponds to one item row. This works for lists, but not for masonry layouts, dense tables, strong background textures, or tall cards that span multiple rows.
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    const width = 520;
+    const height = 620;
+    const sceneCanvas = document.getElementById("scene");
+    const signalCanvas = document.getElementById("signal");
+    const bandsCanvas = document.getElementById("bands");
+    const sceneCtx = sceneCanvas.getContext("2d", { willReadFrequently: true });
+    const signalCtx = signalCanvas.getContext("2d");
+    const bandsCtx = bandsCanvas.getContext("2d");
+
+    const controls = {
+      edgeThreshold: document.getElementById("edgeThreshold"),
+      satThreshold: document.getElementById("satThreshold"),
+      rowThreshold: document.getElementById("rowThreshold"),
+      maxGap: document.getElementById("maxGap"),
+      minBandHeight: document.getElementById("minBandHeight"),
+      maxBandHeight: document.getElementById("maxBandHeight"),
+      noise: document.getElementById("noise"),
+      rowGap: document.getElementById("rowGap")
+    };
+
+    let scene = "music";
+    let hoverY = null;
+    let latest = null;
+
+    function readSettings() {
+      return {
+        edgeThreshold: Number(controls.edgeThreshold.value),
+        satThreshold: Number(controls.satThreshold.value),
+        rowThreshold: Number(controls.rowThreshold.value),
+        maxGap: Number(controls.maxGap.value),
+        minBandHeight: Number(controls.minBandHeight.value),
+        maxBandHeight: Number(controls.maxBandHeight.value),
+        noise: Number(controls.noise.value),
+        rowGap: Number(controls.rowGap.value)
+      };
+    }
+
+    function updateValueLabels(settings) {
+      for (const [key, value] of Object.entries(settings)) {
+        const el = document.querySelector(`[data-value-for="${key}"]`);
+        if (!el) continue;
+        el.textContent = Number.isInteger(value) ? String(value) : value.toFixed(3);
+      }
+      document.getElementById("activeRule").textContent =
+        `edge>=${settings.edgeThreshold.toFixed(2)} or sat>${settings.satThreshold.toFixed(2)}`;
+    }
+
+    function seededNoise(x, y, amount) {
+      const value = Math.sin(x * 12.9898 + y * 78.233) * 43758.5453;
+      return (value - Math.floor(value) - 0.5) * amount;
+    }
+
+    function drawSyntheticScene(settings) {
+      sceneCtx.clearRect(0, 0, width, height);
+      sceneCtx.fillStyle = "#f9f8f4";
+      sceneCtx.fillRect(0, 0, width, height);
+
+      const imageData = sceneCtx.getImageData(0, 0, width, height);
+      const data = imageData.data;
+      for (let y = 0; y < height; y++) {
+        for (let x = 0; x < width; x++) {
+          const i = (y * width + x) * 4;
+          const n = seededNoise(x, y, settings.noise);
+          data[i] = clamp(249 + n, 0, 255);
+          data[i + 1] = clamp(248 + n, 0, 255);
+          data[i + 2] = clamp(244 + n, 0, 255);
+          data[i + 3] = 255;
+        }
+      }
+      sceneCtx.putImageData(imageData, 0, 0);
+
+      sceneCtx.fillStyle = "#ffffff";
+      sceneCtx.fillRect(34, 26, width - 68, height - 52);
+      sceneCtx.strokeStyle = "#d8d4c8";
+      sceneCtx.strokeRect(34.5, 26.5, width - 69, height - 53);
+
+      if (scene === "music") drawMusicList(settings);
+      if (scene === "cards") drawCardList(settings);
+      if (scene === "sections") drawSectionList(settings);
+    }
+
+    function drawMusicList(settings) {
+      const rowHeight = 52;
+      let y = 72;
+      for (let row = 0; row < 8; row++) {
+        drawListRow(y, rowHeight, row, settings.rowGap, row % 3 === 0);
+        y += rowHeight + settings.rowGap;
+      }
+    }
+
+    function drawCardList(settings) {
+      const rowHeight = 86;
+      let y = 56;
+      for (let row = 0; row < 5; row++) {
+        sceneCtx.fillStyle = row % 2 ? "#fbfbf8" : "#f3f8f9";
+        roundRect(sceneCtx, 64, y, 392, rowHeight, 8);
+        sceneCtx.fill();
+        sceneCtx.strokeStyle = "#d8d4c8";
+        sceneCtx.stroke();
+        drawListRow(y + 14, 52, row, settings.rowGap, true);
+        y += rowHeight + settings.rowGap;
+      }
+    }
+
+    function drawSectionList(settings) {
+      const rowHeight = 48;
+      let y = 54;
+      for (let section = 0; section < 3; section++) {
+        sceneCtx.fillStyle = "#eef0ea";
+        sceneCtx.fillRect(58, y, 390, 28);
+        sceneCtx.fillStyle = "#6a707b";
+        sceneCtx.font = "12px ui-monospace, monospace";
+        sceneCtx.fillText(`SECTION ${section + 1}`, 72, y + 18);
+        y += 36;
+        for (let row = 0; row < 3; row++) {
+          drawListRow(y, rowHeight, section * 3 + row, settings.rowGap, row === 1);
+          y += rowHeight + settings.rowGap;
+        }
+        y += 10;
+      }
+    }
+
+    function drawListRow(y, rowHeight, row, rowGap, accent) {
+      sceneCtx.fillStyle = row % 2 ? "#ffffff" : "#fbfaf7";
+      sceneCtx.fillRect(58, y, 390, rowHeight);
+      sceneCtx.strokeStyle = "#ece8dd";
+      sceneCtx.beginPath();
+      sceneCtx.moveTo(58, y + rowHeight + 0.5);
+      sceneCtx.lineTo(448, y + rowHeight + 0.5);
+      sceneCtx.stroke();
+
+      sceneCtx.fillStyle = accent ? "#00a9b8" : "#99a0aa";
+      roundRect(sceneCtx, 74, y + 9, 34, 34, 5);
+      sceneCtx.fill();
+      sceneCtx.fillStyle = "#20242b";
+      sceneCtx.fillRect(122, y + 13, 150 + (row % 3) * 18, 8);
+      sceneCtx.fillStyle = "#8b929d";
+      sceneCtx.fillRect(122, y + 31, 100 + (row % 4) * 22, 6);
+      sceneCtx.fillStyle = row % 2 ? "#68a815" : "#f0b400";
+      sceneCtx.fillRect(385, y + 20, 28, 12);
+    }
+
+    function analyze(settings) {
+      const imageData = sceneCtx.getImageData(0, 0, width, height);
+      const data = imageData.data;
+      const stripLeft = Math.max(0, Math.round(width * 0.02));
+      const stripRight = Math.min(width, Math.max(stripLeft + 1, Math.round(width * 0.24)));
+      const stripWidth = Math.max(1, stripRight - stripLeft);
+      const rowSignal = new Array(height).fill(0);
+
+      function pixel(x, y) {
+        const i = (y * width + x) * 4;
+        return {
+          r: data[i] / 255,
+          g: data[i + 1] / 255,
+          b: data[i + 2] / 255,
+          a: data[i + 3] / 255
+        };
+      }
+
+      function luminance(p) {
+        return 0.2126 * p.r + 0.7152 * p.g + 0.0722 * p.b;
+      }
+
+      function saturation(p) {
+        return Math.max(p.r, p.g, p.b) - Math.min(p.r, p.g, p.b);
+      }
+
+      function edgeStrength(x, y) {
+        const p = pixel(x, y);
+        const right = pixel(Math.min(width - 1, x + 1), y);
+        const down = pixel(x, Math.min(height - 1, y + 1));
+        return Math.abs(luminance(p) - luminance(right)) + Math.abs(luminance(p) - luminance(down));
+      }
+
+      function isActive(x, y) {
+        const p = pixel(x, y);
+        if (p.a <= 0.05) return false;
+        return edgeStrength(x, y) >= settings.edgeThreshold || saturation(p) > settings.satThreshold;
+      }
+
+      for (let y = 0; y < height; y++) {
+        let activeCount = 0;
+        for (let x = stripLeft; x < stripRight; x++) {
+          if (isActive(x, y)) activeCount++;
+        }
+        rowSignal[y] = activeCount / stripWidth;
+      }
+
+      const smoothingRadius = 2;
+      const smoothedSignal = new Array(height).fill(0);
+      for (let y = 0; y < height; y++) {
+        const lower = Math.max(0, y - smoothingRadius);
+        const upper = Math.min(height - 1, y + smoothingRadius);
+        let sum = 0;
+        for (let yy = lower; yy <= upper; yy++) sum += rowSignal[yy];
+        smoothedSignal[y] = sum / (upper - lower + 1);
+      }
+
+      const rawBands = [];
+      let bandStart = null;
+      let gap = 0;
+      for (let y = 0; y < height; y++) {
+        if (smoothedSignal[y] >= settings.rowThreshold) {
+          if (bandStart === null) bandStart = y;
+          gap = 0;
+        } else if (bandStart !== null) {
+          gap++;
+          if (gap > settings.maxGap) {
+            rawBands.push({ start: bandStart, end: y - gap });
+            bandStart = null;
+            gap = 0;
+          }
+        }
+      }
+      if (bandStart !== null) rawBands.push({ start: bandStart, end: height - 1 });
+
+      const acceptedBands = rawBands
+        .map((band, index) => ({ ...band, index, height: band.end - band.start + 1 }))
+        .filter(band => band.height >= settings.minBandHeight && band.height <= settings.maxBandHeight);
+
+      return {
+        stripLeft,
+        stripRight,
+        stripWidth,
+        rowSignal,
+        smoothedSignal,
+        rawBands,
+        acceptedBands
+      };
+    }
+
+    function render(settings, result) {
+      drawSceneOverlay(result);
+      drawSignal(settings, result);
+      drawBands(settings, result);
+      document.getElementById("rawBands").textContent = String(result.rawBands.length);
+      document.getElementById("acceptedRows").textContent = String(result.acceptedBands.length);
+      updateHoverReadout(result);
+    }
+
+    function drawSceneOverlay(result) {
+      sceneCtx.save();
+      sceneCtx.fillStyle = "rgba(0, 169, 184, 0.14)";
+      sceneCtx.fillRect(result.stripLeft, 0, result.stripRight - result.stripLeft, height);
+      sceneCtx.strokeStyle = "rgba(0, 169, 184, 0.9)";
+      sceneCtx.strokeRect(result.stripLeft + 0.5, 0.5, result.stripRight - result.stripLeft, height - 1);
+      for (const band of result.acceptedBands) {
+        sceneCtx.fillStyle = "rgba(104, 168, 21, 0.18)";
+        sceneCtx.fillRect(0, band.start, width, band.end - band.start + 1);
+        sceneCtx.strokeStyle = "rgba(104, 168, 21, 0.95)";
+        sceneCtx.strokeRect(0.5, band.start + 0.5, width - 1, band.end - band.start);
+      }
+      if (hoverY !== null) {
+        sceneCtx.strokeStyle = "rgba(214,75,75,.95)";
+        sceneCtx.beginPath();
+        sceneCtx.moveTo(0, hoverY + 0.5);
+        sceneCtx.lineTo(width, hoverY + 0.5);
+        sceneCtx.stroke();
+      }
+      sceneCtx.restore();
+    }
+
+    function drawSignal(settings, result) {
+      signalCtx.clearRect(0, 0, signalCanvas.width, signalCanvas.height);
+      signalCtx.fillStyle = "#fbfaf7";
+      signalCtx.fillRect(0, 0, signalCanvas.width, signalCanvas.height);
+      const leftPad = 46;
+      const plotWidth = signalCanvas.width - leftPad - 16;
+      const maxSignal = Math.max(0.08, ...result.smoothedSignal, ...result.rowSignal);
+
+      signalCtx.strokeStyle = "#ece8dd";
+      for (let y = 0; y <= height; y += 50) {
+        signalCtx.beginPath();
+        signalCtx.moveTo(leftPad, y + 0.5);
+        signalCtx.lineTo(signalCanvas.width - 16, y + 0.5);
+        signalCtx.stroke();
+      }
+
+      const thresholdX = leftPad + (settings.rowThreshold / maxSignal) * plotWidth;
+      signalCtx.strokeStyle = "#d64b4b";
+      signalCtx.beginPath();
+      signalCtx.moveTo(thresholdX, 0);
+      signalCtx.lineTo(thresholdX, height);
+      signalCtx.stroke();
+
+      drawSignalPath(result.rowSignal, leftPad, plotWidth, maxSignal, "#557ce1", 0.45);
+      drawSignalPath(result.smoothedSignal, leftPad, plotWidth, maxSignal, "#00a9b8", 1);
+
+      for (const band of result.acceptedBands) {
+        signalCtx.fillStyle = "rgba(104, 168, 21, 0.10)";
+        signalCtx.fillRect(leftPad, band.start, plotWidth, band.end - band.start + 1);
+      }
+
+      if (hoverY !== null) {
+        signalCtx.strokeStyle = "rgba(214,75,75,.95)";
+        signalCtx.beginPath();
+        signalCtx.moveTo(0, hoverY + 0.5);
+        signalCtx.lineTo(signalCanvas.width, hoverY + 0.5);
+        signalCtx.stroke();
+      }
+
+      signalCtx.fillStyle = "#6a707b";
+      signalCtx.font = "11px ui-monospace, monospace";
+      signalCtx.fillText("0", 18, 14);
+      signalCtx.fillText(maxSignal.toFixed(2), 8, 34);
+      signalCtx.fillText("threshold", thresholdX + 4, 14);
+    }
+
+    function drawSignalPath(values, leftPad, plotWidth, maxSignal, color, alpha) {
+      signalCtx.save();
+      signalCtx.globalAlpha = alpha;
+      signalCtx.strokeStyle = color;
+      signalCtx.lineWidth = 2;
+      signalCtx.beginPath();
+      for (let y = 0; y < values.length; y++) {
+        const x = leftPad + (values[y] / maxSignal) * plotWidth;
+        if (y === 0) signalCtx.moveTo(x, y);
+        else signalCtx.lineTo(x, y);
+      }
+      signalCtx.stroke();
+      signalCtx.restore();
+    }
+
+    function drawBands(settings, result) {
+      bandsCtx.clearRect(0, 0, bandsCanvas.width, bandsCanvas.height);
+      bandsCtx.fillStyle = "#fbfaf7";
+      bandsCtx.fillRect(0, 0, bandsCanvas.width, bandsCanvas.height);
+      bandsCtx.strokeStyle = "#ece8dd";
+      for (let y = 0; y <= height; y += 50) {
+        bandsCtx.beginPath();
+        bandsCtx.moveTo(0, y + 0.5);
+        bandsCtx.lineTo(bandsCanvas.width, y + 0.5);
+        bandsCtx.stroke();
+      }
+
+      for (const band of result.rawBands) {
+        bandsCtx.fillStyle = "rgba(240, 180, 0, 0.20)";
+        bandsCtx.fillRect(28, band.start, 110, band.end - band.start + 1);
+      }
+      for (const band of result.acceptedBands) {
+        bandsCtx.fillStyle = "rgba(104, 168, 21, 0.30)";
+        bandsCtx.fillRect(150, band.start, 118, band.end - band.start + 1);
+        bandsCtx.fillStyle = "#20242b";
+        bandsCtx.font = "11px ui-monospace, monospace";
+        bandsCtx.fillText(`#${band.index + 1} h=${band.height}`, 156, band.start + 14);
+      }
+
+      bandsCtx.fillStyle = "#6a707b";
+      bandsCtx.font = "12px ui-monospace, monospace";
+      bandsCtx.fillText("raw", 68, 18);
+      bandsCtx.fillText("accepted", 174, 18);
+
+      if (hoverY !== null) {
+        bandsCtx.strokeStyle = "rgba(214,75,75,.95)";
+        bandsCtx.beginPath();
+        bandsCtx.moveTo(0, hoverY + 0.5);
+        bandsCtx.lineTo(bandsCanvas.width, hoverY + 0.5);
+        bandsCtx.stroke();
+      }
+    }
+
+    function updateHoverReadout(result) {
+      const el = document.getElementById("hoverReadout");
+      if (hoverY === null || !result) {
+        el.textContent = "-";
+        return;
+      }
+      const y = Math.max(0, Math.min(height - 1, Math.round(hoverY)));
+      el.textContent = `y=${y} raw=${result.rowSignal[y].toFixed(3)} smooth=${result.smoothedSignal[y].toFixed(3)}`;
+    }
+
+    function rerender() {
+      const settings = readSettings();
+      updateValueLabels(settings);
+      drawSyntheticScene(settings);
+      latest = analyze(settings);
+      render(settings, latest);
+    }
+
+    function clamp(value, min, max) {
+      return Math.max(min, Math.min(max, value));
+    }
+
+    function roundRect(ctx, x, y, w, h, r) {
+      ctx.beginPath();
+      ctx.moveTo(x + r, y);
+      ctx.arcTo(x + w, y, x + w, y + h, r);
+      ctx.arcTo(x + w, y + h, x, y + h, r);
+      ctx.arcTo(x, y + h, x, y, r);
+      ctx.arcTo(x, y, x + w, y, r);
+      ctx.closePath();
+    }
+
+    for (const input of Object.values(controls)) {
+      input.addEventListener("input", rerender);
+    }
+
+    document.querySelectorAll("[data-scene]").forEach(button => {
+      button.addEventListener("click", () => {
+        document.querySelectorAll("[data-scene]").forEach(item => item.classList.remove("active"));
+        button.classList.add("active");
+        scene = button.dataset.scene;
+        document.getElementById("sceneLabel").textContent = button.textContent;
+        rerender();
+      });
+    });
+
+    for (const canvas of [sceneCanvas, signalCanvas, bandsCanvas]) {
+      canvas.addEventListener("mousemove", event => {
+        const rect = canvas.getBoundingClientRect();
+        hoverY = Math.round((event.clientY - rect.top) * (canvas.height / rect.height));
+        rerender();
+      });
+      canvas.addEventListener("mouseleave", () => {
+        hoverY = null;
+        rerender();
+      });
+    }
+
+    rerender();
+  </script>
+</body>
+</html>

--- a/recipes/scan/list-item-candidate-continue-hook.v0.json
+++ b/recipes/scan/list-item-candidate-continue-hook.v0.json
@@ -1,0 +1,82 @@
+{
+  "recipe_id": "scan.fixture.list_item_candidate_continue.v0",
+  "version": "0.1.0",
+  "status": "prototype-sub-recipe",
+  "platform": "AUV",
+  "target_app": {
+    "name": "AUV fixture",
+    "bundle_id": "fixture://scan-hook",
+    "display_mode": "fixture"
+  },
+  "strategy": {
+    "family": "native-text",
+    "grounding": "ax-text",
+    "activation": "pointer-focus-clipboard-paste",
+    "verificationContract": "verifyAxText"
+  },
+  "invocation": {
+    "kind": "sub_recipe",
+    "host": "scroll_scan",
+    "stage": "per_list_item_candidate",
+    "context_schema": "auv.scan.list_item_candidate.scalar_context.v0",
+    "return_schema": "auv.scan.hook_decision.v0"
+  },
+  "objective": "Prototype sub recipe used to prove scroll scan can call a per-list-item candidate recipe and consume its hook decision without touching the live desktop.",
+  "inputs": {
+    "hook_action": { "type": "string", "default": "continue" },
+    "hook_reason": {
+      "type": "string",
+      "default": "fixture list item candidate hook continued"
+    },
+    "context": {
+      "type": "string",
+      "default": "${scan.item.context_artifact}"
+    }
+  },
+  "preconditions": [
+    "This recipe is only intended to be invoked by scroll scan as a sub recipe."
+  ],
+  "disturbance_policy": {
+    "max_disturbance": "none",
+    "declared_classes": ["none"],
+    "notes": [
+      "Prototype hook uses debug.fixtureObserve and must not touch the live desktop."
+    ]
+  },
+  "steps": [
+    {
+      "id": "return-hook-decision",
+      "command_id": "debug.fixtureObserve",
+      "disturbance": {
+        "classes": ["none"],
+        "max": "none"
+      },
+      "args": {
+        "target": "fixture://scan-hook",
+        "label": "list-item-candidate-hook",
+        "hook_action": "${hook_action}",
+        "hook_reason": "${hook_reason}",
+        "context": "${context}"
+      },
+      "expect": {
+        "signal_equals": {
+          "last.scan.hook.action": "${hook_action}"
+        }
+      }
+    }
+  ],
+  "verification": {
+    "expected_signals": ["last.scan.hook.action"],
+    "success_criteria": [
+      "The fixture driver returns last.scan.hook.action from the recipe input."
+    ],
+    "non_goals": [
+      "This recipe does not parse item text or mutate the UI."
+    ]
+  },
+  "known_limits": {
+    "context": "Uses scalar scan.item.* variables as a prototype until typed hook context artifacts exist.",
+    "composition": "This hook is a standalone recipe manifest only because SkillCatalog cannot yet resolve inline hook/sub-recipe blocks from a parent manifest. MaaFW's Context::run_task/run_recognition/run_action plus JSON pipeline_override are the useful reference shape: /Users/neko/Git/github.com/MaaXYZ/MaaFramework/source/MaaFramework/Task/Context.cpp and /Users/neko/Git/github.com/MaaXYZ/MaaFramework/docs/zh_cn/3.1-任务流水线协议.md.",
+    "return_value": "Hook decisions are returned through exported scalar signals today. MaaFW's RecoResult detail/runtime cache pattern is the useful reference for structured details: /Users/neko/Git/github.com/MaaXYZ/MaaFramework/source/MaaFramework/Task/Component/Recognizer.cpp and /Users/neko/Git/github.com/MaaXYZ/MaaFramework/source/MaaFramework/Tasker/RuntimeCache.cpp."
+  }
+}

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -178,6 +178,24 @@ pub fn default_command_catalog() -> CommandCatalog {
       disturbance_classes: NONE,
       max_disturbance: DisturbanceClass::None,
     },
+    // REVIEW: Public names are explicit window-scoped variants for the first
+    // implementation. Revisit before introducing screen or generic region scans.
+    CommandSpec {
+      id: "debug.observeWindowRegion",
+      summary: "Observe OCR row-like content inside a resolved macOS window region without scrolling.",
+      driver_id: "macos.desktop",
+      operation: "observe_window_region",
+      disturbance_classes: NONE,
+      max_disturbance: DisturbanceClass::None,
+    },
+    CommandSpec {
+      id: "debug.scrollWindowRegion",
+      summary: "Scroll at the center of a resolved macOS window region and record scroll evidence.",
+      driver_id: "macos.desktop",
+      operation: "scroll_window_region",
+      disturbance_classes: POINTER_WITH_FOREGROUND,
+      max_disturbance: DisturbanceClass::Pointer,
+    },
     CommandSpec {
       id: "debug.verifyNowPlayingTitle",
       summary: "Verify the current now-playing title from the observed AX tree without relying on screenshot OCR.",
@@ -591,6 +609,14 @@ mod tests {
         "missing {command_id}"
       );
     }
+  }
+
+  #[test]
+  fn default_catalog_resolves_window_region_scan_primitives() {
+    let catalog = default_command_catalog();
+    assert!(catalog.resolve("debug.observeWindowRegion").is_some());
+    assert!(catalog.resolve("debug.scrollWindowRegion").is_some());
+    assert!(catalog.resolve("debug.scanWindowRegion").is_none());
   }
 
   #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -143,6 +143,7 @@ pub enum CliCommand {
     min_confidence: f64,
     max_observations: i64,
     per_page_after_observe_recipe: Option<String>,
+    per_list_item_candidate_recipe: Option<String>,
     on_stop_candidate_recipe: Option<String>,
   },
   XtaskGenerateSwiftBridge,
@@ -528,6 +529,7 @@ fn parse_scan(arguments: &[String]) -> AuvResult<CliCommand> {
   let mut min_confidence = 0.0;
   let mut max_observations = 128i64;
   let mut per_page_after_observe_recipe = None;
+  let mut per_list_item_candidate_recipe = None;
   let mut on_stop_candidate_recipe = None;
 
   let mut index = 2;
@@ -592,6 +594,14 @@ fn parse_scan(arguments: &[String]) -> AuvResult<CliCommand> {
         )?);
         index += 2;
       }
+      "--per-list-item-candidate-recipe" => {
+        per_list_item_candidate_recipe = Some(required_flag_value(
+          arguments,
+          index,
+          "--per-list-item-candidate-recipe",
+        )?);
+        index += 2;
+      }
       "--on-stop-candidate-recipe" => {
         on_stop_candidate_recipe = Some(required_flag_value(
           arguments,
@@ -615,6 +625,7 @@ fn parse_scan(arguments: &[String]) -> AuvResult<CliCommand> {
     min_confidence,
     max_observations,
     per_page_after_observe_recipe,
+    per_list_item_candidate_recipe,
     on_stop_candidate_recipe,
   })
 }
@@ -921,11 +932,41 @@ mod tests {
         target,
         region,
         max_pages,
+        per_list_item_candidate_recipe,
         ..
       } => {
         assert_eq!(target, "com.example.App");
         assert_eq!(region, "0.1,0.2,0.9,0.8");
         assert_eq!(max_pages, 3);
+        assert!(per_list_item_candidate_recipe.is_none());
+      }
+      other => panic!("unexpected command: {other:?}"),
+    }
+  }
+
+  #[test]
+  fn parse_scan_window_region_accepts_per_list_item_candidate_recipe() {
+    let command = parse_cli(&[
+      "scan".to_string(),
+      "window-region".to_string(),
+      "--target".to_string(),
+      "com.example.App".to_string(),
+      "--region".to_string(),
+      "0.1,0.2,0.9,0.8".to_string(),
+      "--per-list-item-candidate-recipe".to_string(),
+      "scan.fixture.list_item_candidate_continue.v0".to_string(),
+    ])
+    .expect("scan window-region command should parse");
+
+    match command {
+      CliCommand::ScanWindowRegion {
+        per_list_item_candidate_recipe,
+        ..
+      } => {
+        assert_eq!(
+          per_list_item_candidate_recipe.as_deref(),
+          Some("scan.fixture.list_item_candidate_continue.v0")
+        );
       }
       other => panic!("unexpected command: {other:?}"),
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -130,6 +130,21 @@ pub enum CliCommand {
     overrides: BTreeMap<String, String>,
     inspect: InspectClientOptions,
   },
+  // REVIEW: `scan window-region` is the first public scan CLI surface; keep
+  // the name easy to revisit before treating scan terminology as stable.
+  ScanWindowRegion {
+    target: String,
+    region: String,
+    max_pages: usize,
+    max_scrolls: usize,
+    direction: String,
+    scroll_amount: f64,
+    settle_ms: u64,
+    min_confidence: f64,
+    max_observations: i64,
+    per_page_after_observe_recipe: Option<String>,
+    on_stop_candidate_recipe: Option<String>,
+  },
   XtaskGenerateSwiftBridge,
 }
 
@@ -146,6 +161,7 @@ pub fn parse_cli(arguments: &[String]) -> AuvResult<CliCommand> {
     "app" => parse_app(arguments),
     "inspect" => parse_inspect(arguments),
     "invoke" => parse_invoke(arguments),
+    "scan" => parse_scan(arguments),
     "skill" => parse_skill(arguments),
     other => Err(format!(
       "unknown subcommand {other}; use `help` to see supported commands"
@@ -181,6 +197,7 @@ USAGE
   auv-cli invoke <command-id> [--target <application-id>] [--label <text>] [--store-root <path>] [--inspect-local-write true|false|default] [--inspect-server-write true|false|default] [--require-inspect-server-write] [--inspect-server-url <url>] [--inspect-server-token <token>] [--inspect-server-token-file <path>]
   auv-cli inspect <run-id>
   auv-cli inspect serve [--host <host>] [--port <port>] [--store-root <path>] [--enable-write] [--write-token <token>] [--write-token-file <path>] [--no-write-token]
+  auv-cli scan window-region --target <application-id> --region <left,top,right,bottom> [--max-pages <n>] [--max-scrolls <n>]
   auv-cli skill list
   auv-cli skill show <skill-id-or-path>
   auv-cli skill bundle list
@@ -496,6 +513,119 @@ fn parse_invoke(arguments: &[String]) -> AuvResult<CliCommand> {
   })
 }
 
+fn parse_scan(arguments: &[String]) -> AuvResult<CliCommand> {
+  if arguments.len() < 2 || arguments[1] != "window-region" {
+    return Err("usage: auv-cli scan window-region --target <application-id> --region <left,top,right,bottom> [--max-pages <n>]".to_string());
+  }
+
+  let mut target = None;
+  let mut region = None;
+  let mut max_pages = 5usize;
+  let mut max_scrolls = 4usize;
+  let mut direction = "down".to_string();
+  let mut scroll_amount = 6.0;
+  let mut settle_ms = 250u64;
+  let mut min_confidence = 0.0;
+  let mut max_observations = 128i64;
+  let mut per_page_after_observe_recipe = None;
+  let mut on_stop_candidate_recipe = None;
+
+  let mut index = 2;
+  while index < arguments.len() {
+    match arguments[index].as_str() {
+      "--target" => {
+        target = Some(required_flag_value(arguments, index, "--target")?);
+        index += 2;
+      }
+      "--region" => {
+        region = Some(required_flag_value(arguments, index, "--region")?);
+        index += 2;
+      }
+      "--max-pages" => {
+        max_pages = required_flag_value(arguments, index, "--max-pages")?
+          .parse::<usize>()
+          .map_err(|error| format!("invalid --max-pages: {error}"))?;
+        if max_pages == 0 {
+          return Err("--max-pages must be greater than 0".to_string());
+        }
+        index += 2;
+      }
+      "--max-scrolls" => {
+        max_scrolls = required_flag_value(arguments, index, "--max-scrolls")?
+          .parse::<usize>()
+          .map_err(|error| format!("invalid --max-scrolls: {error}"))?;
+        index += 2;
+      }
+      "--direction" => {
+        direction = required_flag_value(arguments, index, "--direction")?;
+        index += 2;
+      }
+      "--scroll-amount" => {
+        scroll_amount = required_flag_value(arguments, index, "--scroll-amount")?
+          .parse::<f64>()
+          .map_err(|error| format!("invalid --scroll-amount: {error}"))?;
+        index += 2;
+      }
+      "--settle-ms" => {
+        settle_ms = required_flag_value(arguments, index, "--settle-ms")?
+          .parse::<u64>()
+          .map_err(|error| format!("invalid --settle-ms: {error}"))?;
+        index += 2;
+      }
+      "--min-confidence" => {
+        min_confidence = required_flag_value(arguments, index, "--min-confidence")?
+          .parse::<f64>()
+          .map_err(|error| format!("invalid --min-confidence: {error}"))?;
+        index += 2;
+      }
+      "--max-observations" => {
+        max_observations = required_flag_value(arguments, index, "--max-observations")?
+          .parse::<i64>()
+          .map_err(|error| format!("invalid --max-observations: {error}"))?;
+        index += 2;
+      }
+      "--per-page-after-observe-recipe" => {
+        per_page_after_observe_recipe = Some(required_flag_value(
+          arguments,
+          index,
+          "--per-page-after-observe-recipe",
+        )?);
+        index += 2;
+      }
+      "--on-stop-candidate-recipe" => {
+        on_stop_candidate_recipe = Some(required_flag_value(
+          arguments,
+          index,
+          "--on-stop-candidate-recipe",
+        )?);
+        index += 2;
+      }
+      other => return Err(format!("unexpected scan window-region argument {other}")),
+    }
+  }
+
+  Ok(CliCommand::ScanWindowRegion {
+    target: target.ok_or_else(|| "--target is required".to_string())?,
+    region: region.ok_or_else(|| "--region is required".to_string())?,
+    max_pages,
+    max_scrolls,
+    direction,
+    scroll_amount,
+    settle_ms,
+    min_confidence,
+    max_observations,
+    per_page_after_observe_recipe,
+    on_stop_candidate_recipe,
+  })
+}
+
+fn required_flag_value(arguments: &[String], index: usize, flag: &str) -> AuvResult<String> {
+  arguments
+    .get(index + 1)
+    .cloned()
+    .ok_or_else(|| format!("{flag} requires a value"))
+}
+
 fn parse_skill(arguments: &[String]) -> AuvResult<CliCommand> {
   if arguments.len() < 2 {
     return Err("usage: auv-cli skill <list|show|run> ...".to_string());
@@ -770,6 +900,52 @@ mod tests {
       }
       other => panic!("unexpected command: {other:?}"),
     }
+  }
+
+  #[test]
+  fn parse_scan_window_region_command() {
+    let command = parse_cli(&[
+      "scan".to_string(),
+      "window-region".to_string(),
+      "--target".to_string(),
+      "com.example.App".to_string(),
+      "--region".to_string(),
+      "0.1,0.2,0.9,0.8".to_string(),
+      "--max-pages".to_string(),
+      "3".to_string(),
+    ])
+    .expect("scan window-region command should parse");
+
+    match command {
+      CliCommand::ScanWindowRegion {
+        target,
+        region,
+        max_pages,
+        ..
+      } => {
+        assert_eq!(target, "com.example.App");
+        assert_eq!(region, "0.1,0.2,0.9,0.8");
+        assert_eq!(max_pages, 3);
+      }
+      other => panic!("unexpected command: {other:?}"),
+    }
+  }
+
+  #[test]
+  fn parse_scan_window_region_rejects_zero_max_pages() {
+    let error = parse_cli(&[
+      "scan".to_string(),
+      "window-region".to_string(),
+      "--target".to_string(),
+      "com.example.App".to_string(),
+      "--region".to_string(),
+      "0.1,0.2,0.9,0.8".to_string(),
+      "--max-pages".to_string(),
+      "0".to_string(),
+    ])
+    .expect_err("zero max pages should fail");
+
+    assert!(error.contains("--max-pages must be greater than 0"));
   }
 
   #[test]

--- a/src/driver/fixture.rs
+++ b/src/driver/fixture.rs
@@ -1,4 +1,6 @@
 use super::Driver;
+use std::collections::BTreeMap;
+
 use crate::model::{AuvResult, DriverCall, DriverDescriptor, DriverResponse};
 
 pub(crate) struct FixtureObserveDriver;
@@ -32,13 +34,24 @@ impl Driver for FixtureObserveDriver {
       .cloned()
       .unwrap_or_else(|| "fixture-observation".to_string());
 
+    let mut signals = BTreeMap::new();
+    if let Some(action) = call.inputs.get("hook_action") {
+      signals.insert("last.scan.hook.action".to_string(), action.clone());
+    }
+    if let Some(reason) = call.inputs.get("hook_reason") {
+      signals.insert("last.scan.hook.reason".to_string(), reason.clone());
+    }
+    if let Some(context) = call.inputs.get("context") {
+      signals.insert("fixture.context".to_string(), context.clone());
+    }
+
     Ok(DriverResponse {
       summary: format!(
         "Observed deterministic fixture scene for target {} with label {}.",
         target, label
       ),
       backend: Some("fixture.static".to_string()),
-      signals: std::collections::BTreeMap::new(),
+      signals,
       notes: vec![
         "This command does not touch the real desktop.".to_string(),
         "Use it to verify that implicit run creation and inspect output stay stable.".to_string(),

--- a/src/driver/macos/control/mod.rs
+++ b/src/driver/macos/control/mod.rs
@@ -2,6 +2,7 @@ mod app;
 mod ax;
 pub(crate) mod common;
 mod pointer;
+mod region;
 mod screen;
 mod text;
 mod window;
@@ -13,6 +14,7 @@ pub(crate) use self::ax::{
   smart_press,
 };
 pub(crate) use self::pointer::{click_point, scroll_point};
+pub(crate) use self::region::{observe_window_region, scroll_window_region};
 pub(crate) use self::screen::{click_screen_row, click_screen_text};
 pub(crate) use self::text::{paste_text_preserve_clipboard, press_key, type_text};
 pub(crate) use self::window::click_window_point;

--- a/src/driver/macos/control/region.rs
+++ b/src/driver/macos/control/region.rs
@@ -1,0 +1,9 @@
+use super::super::*;
+
+pub(crate) fn observe_window_region(_call: &DriverCall) -> AuvResult<DriverResponse> {
+  Err("observe_window_region is not implemented yet".to_string())
+}
+
+pub(crate) fn scroll_window_region(_call: &DriverCall) -> AuvResult<DriverResponse> {
+  Err("scroll_window_region is not implemented yet".to_string())
+}

--- a/src/driver/macos/control/region.rs
+++ b/src/driver/macos/control/region.rs
@@ -1,9 +1,249 @@
 use super::super::*;
 
-pub(crate) fn observe_window_region(_call: &DriverCall) -> AuvResult<DriverResponse> {
-  Err("observe_window_region is not implemented yet".to_string())
+pub(crate) fn observe_window_region(call: &DriverCall) -> AuvResult<DriverResponse> {
+  let label = optional_string(call, "label").unwrap_or_else(|| "window-region-observe".to_string());
+  let min_confidence = optional_f64(call, "min_confidence")?.unwrap_or(0.0);
+  if !(0.0..=1.0).contains(&min_confidence) {
+    return Err(format!(
+      "invalid --min_confidence value {:.3}: expected a ratio within 0.0..=1.0",
+      min_confidence
+    ));
+  }
+  let max_observations = optional_i64(call, "max_observations")?
+    .unwrap_or(128)
+    .clamp(1, 512);
+  let region = region_ratios_from_call(call)?;
+  let capture = super::window_ocr::capture_resolved_window_observation(call, &label)?;
+  let ocr_region = region.to_observed_rect(capture.dimensions.width, capture.dimensions.height)?;
+  let detection = detect_screen_rows(
+    capture.screenshot_path.as_path(),
+    min_confidence,
+    max_observations,
+    Some(&ocr_region),
+  )?;
+  let rows = detection.rows;
+  let json = render_observe_window_region_json(
+    &rows,
+    &ocr_region,
+    &capture.dimensions,
+    &capture.screenshot_path,
+  )?;
+  let json_artifact = build_text_artifact(
+    "window-region-observation",
+    "json",
+    &format!("{}-rows", sanitize_file_component(&label)),
+    json,
+    "Machine-readable OCR row observation for a window region.",
+  )?;
+  // WORKAROUND: Window-region observation records the screenshot and OCR-region
+  // bounds, but does not yet emit a full capture contract artifact. Remove this
+  // once window capture contract staging is shared with scan artifacts.
+  let screenshot_artifact = ProducedArtifact {
+    kind: "screenshot".to_string(),
+    source_path: capture.screenshot_path,
+    preferred_name: format!("{}.png", sanitize_file_component(&label)),
+    note: Some("Window screenshot captured for region observation.".to_string()),
+  };
+
+  Ok(DriverResponse {
+    summary: format!(
+      "Observed {} OCR row(s) in resolved window region.",
+      rows.len()
+    ),
+    backend: Some("macos.vision.observe-window-region".to_string()),
+    signals: crate::driver::macos::observe::row_detection_signals(rows.len()),
+    notes: vec![
+      format!("scope={}", capture.scope),
+      format!("windowRef={}", capture.capture_source),
+      format!("region={}", render_rect_compact(&ocr_region)),
+      format!("rows.count={}", rows.len()),
+      format!("strategy={}", detection.strategy),
+      format!("minConfidence={min_confidence:.3}"),
+      format!("maxObservations={max_observations}"),
+      format!(
+        "screenshotPixels={}x{}",
+        capture.dimensions.width, capture.dimensions.height
+      ),
+    ],
+    artifacts: vec![screenshot_artifact, json_artifact],
+  })
 }
 
 pub(crate) fn scroll_window_region(_call: &DriverCall) -> AuvResult<DriverResponse> {
   Err("scroll_window_region is not implemented yet".to_string())
+}
+
+#[derive(Clone, Copy, Debug)]
+struct RegionRatios {
+  left: f64,
+  top: f64,
+  right: f64,
+  bottom: f64,
+}
+
+impl RegionRatios {
+  fn to_observed_rect(self, width: i64, height: i64) -> AuvResult<ObservedRect> {
+    if width <= 0 || height <= 0 {
+      return Err(format!(
+        "invalid screenshot dimensions {}x{}: expected positive width and height",
+        width, height
+      ));
+    }
+    let (left_px, right_px) = ratio_edges_to_pixels(self.left, self.right, width);
+    let (top_px, bottom_px) = ratio_edges_to_pixels(self.top, self.bottom, height);
+
+    Ok(ObservedRect {
+      x: left_px,
+      y: top_px,
+      width: right_px - left_px,
+      height: bottom_px - top_px,
+    })
+  }
+}
+
+fn ratio_edges_to_pixels(left: f64, right: f64, size: i64) -> (i64, i64) {
+  let size_f = size as f64;
+  let left_px = (left * size_f).floor() as i64;
+  let left_px = left_px.clamp(0, size - 1);
+  let right_px = (right * size_f).ceil() as i64;
+  let right_px = right_px.clamp(left_px + 1, size);
+
+  (left_px, right_px)
+}
+
+fn region_ratios_from_call(call: &DriverCall) -> AuvResult<RegionRatios> {
+  let left = optional_f64(call, "region_left_ratio")?.unwrap_or(0.0);
+  let top = optional_f64(call, "region_top_ratio")?.unwrap_or(0.0);
+  let right = optional_f64(call, "region_right_ratio")?.unwrap_or(1.0);
+  let bottom = optional_f64(call, "region_bottom_ratio")?.unwrap_or(1.0);
+  validate_region_ratios(left, top, right, bottom)?;
+  Ok(RegionRatios {
+    left,
+    top,
+    right,
+    bottom,
+  })
+}
+
+fn validate_region_ratios(left: f64, top: f64, right: f64, bottom: f64) -> AuvResult<()> {
+  if !(0.0 <= left && left < right && right <= 1.0) {
+    return Err("invalid region x ratios: expected 0.0 <= left < right <= 1.0".to_string());
+  }
+  if !(0.0 <= top && top < bottom && bottom <= 1.0) {
+    return Err("invalid region y ratios: expected 0.0 <= top < bottom <= 1.0".to_string());
+  }
+  Ok(())
+}
+
+fn render_observe_window_region_json(
+  rows: &[ObservedOcrRow],
+  region: &ObservedRect,
+  dimensions: &ScreenshotDimensions,
+  screenshot_path: &std::path::Path,
+) -> AuvResult<String> {
+  let rows = rows
+    .iter()
+    .map(|row| {
+      serde_json::json!({
+        "row_index": row.row_index,
+        "source": row.source,
+        "text": row.text_fragments.join(" | "),
+        "text_fragments": row.text_fragments,
+        "bounds": {
+          "x": row.bounds.x,
+          "y": row.bounds.y,
+          "width": row.bounds.width,
+          "height": row.bounds.height,
+        },
+      })
+    })
+    .collect::<Vec<_>>();
+  serde_json::to_string_pretty(&serde_json::json!({
+    "extractor": "ocr-row",
+    "coordinate_space": "window_screenshot_pixels",
+    "screenshot_path": screenshot_path.display().to_string(),
+    "screenshot_width": dimensions.width,
+    "screenshot_height": dimensions.height,
+    "region": {
+      "x": region.x,
+      "y": region.y,
+      "width": region.width,
+      "height": region.height,
+    },
+    "rows": rows,
+  }))
+  .map(|mut rendered| {
+    rendered.push('\n');
+    rendered
+  })
+  .map_err(|error| format!("failed to render window region observation json: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn validate_region_ratios_rejects_inverted_region() {
+    let error = validate_region_ratios(0.8, 0.2, 0.4, 0.9).expect_err("region should fail");
+    assert!(error.contains("expected 0.0 <= left < right <= 1.0"));
+  }
+
+  #[test]
+  fn validate_region_ratios_accepts_normal_region() {
+    validate_region_ratios(0.1, 0.2, 0.9, 0.8).expect("region should pass");
+  }
+
+  #[test]
+  fn region_ratios_to_observed_rect_clamps_near_right_edge() {
+    let region = RegionRatios {
+      left: 0.996,
+      top: 0.996,
+      right: 1.0,
+      bottom: 1.0,
+    }
+    .to_observed_rect(100, 100)
+    .expect("valid dimensions should convert");
+
+    assert_eq!(
+      region,
+      ObservedRect {
+        x: 99,
+        y: 99,
+        width: 1,
+        height: 1,
+      }
+    );
+    assert!(region.x < 100);
+    assert!(region.y < 100);
+    assert!(region.x + region.width <= 100);
+    assert!(region.y + region.height <= 100);
+  }
+
+  #[test]
+  fn render_observe_window_region_json_includes_coordinate_semantics() {
+    let json = render_observe_window_region_json(
+      &[],
+      &ObservedRect {
+        x: 99,
+        y: 10,
+        width: 1,
+        height: 80,
+      },
+      &ScreenshotDimensions {
+        width: 100,
+        height: 200,
+      },
+      std::path::Path::new("/tmp/window.png"),
+    )
+    .expect("json should render");
+    let value: serde_json::Value = serde_json::from_str(&json).expect("json should parse");
+
+    assert_eq!(
+      value["coordinate_space"],
+      serde_json::Value::String("window_screenshot_pixels".to_string())
+    );
+    assert_eq!(value["screenshot_width"], serde_json::Value::from(100));
+    assert_eq!(value["screenshot_height"], serde_json::Value::from(200));
+  }
 }

--- a/src/driver/macos/control/region.rs
+++ b/src/driver/macos/control/region.rs
@@ -37,15 +37,39 @@ pub(crate) fn observe_window_region(call: &DriverCall) -> AuvResult<DriverRespon
     json,
     "Machine-readable OCR row observation for a window region.",
   )?;
-  // WORKAROUND: Window-region observation records the screenshot and OCR-region
-  // bounds, but does not yet emit a full capture contract artifact. Remove this
-  // once window capture contract staging is shared with scan artifacts.
+  // TODO: Emit a full typed capture contract artifact for window-region
+  // observation. This command records the screenshot and OCR-region bounds so
+  // scroll scan can crop list item candidates, but it still lacks the same
+  // reusable capture contract produced by the dedicated capture commands.
+  // TODO: Extend window-region observation into a real region-segmentation
+  // pass. Scroll scan needs candidates for list bodies, section separators,
+  // sticky headers, empty states, and scrollbars/thumbs so the scan loop can
+  // distinguish top/bottom boundaries from ordinary repeated content.
   let screenshot_artifact = ProducedArtifact {
     kind: "screenshot".to_string(),
     source_path: capture.screenshot_path,
     preferred_name: format!("{}.png", sanitize_file_component(&label)),
     note: Some("Window screenshot captured for region observation.".to_string()),
   };
+  let mut artifacts = vec![screenshot_artifact.clone(), json_artifact];
+  let overlay_rows = rows
+    .iter()
+    .map(|row| OverlayEvidenceRow {
+      row_index: row.row_index,
+      source: row.source.clone(),
+      bounds: row.bounds.clone(),
+      text_fragments: row.text_fragments.clone(),
+    })
+    .collect::<Vec<_>>();
+  artifacts.extend(build_row_observation_overlay_artifacts(
+    RowObservationOverlayRequest {
+      label: label.clone(),
+      screenshot_path: screenshot_artifact.source_path.clone(),
+      screenshot_dimensions: capture.dimensions.clone(),
+      strategy: detection.strategy.clone(),
+      rows: overlay_rows,
+    },
+  )?);
 
   Ok(DriverResponse {
     summary: format!(
@@ -67,7 +91,7 @@ pub(crate) fn observe_window_region(call: &DriverCall) -> AuvResult<DriverRespon
         capture.dimensions.width, capture.dimensions.height
       ),
     ],
-    artifacts: vec![screenshot_artifact, json_artifact],
+    artifacts,
   })
 }
 
@@ -293,14 +317,48 @@ fn render_observe_window_region_json(
   dimensions: &ScreenshotDimensions,
   screenshot_path: &std::path::Path,
 ) -> AuvResult<String> {
-  let rows = rows
+  let filter = filter_list_row_candidates(rows);
+  let row_candidates = rows
     .iter()
     .map(|row| {
-      serde_json::json!({
+      let accepted = filter.accepted_indices.contains(&row.row_index);
+      let reject_reason = filter
+        .rejected
+        .iter()
+        .find(|rejected| rejected.row_index == row.row_index)
+        .map(|rejected| rejected.reason.as_str());
+      let mut value = serde_json::json!({
         "row_index": row.row_index,
         "source": row.source,
         "text": row.text_fragments.join(" | "),
         "text_fragments": row.text_fragments,
+        "accepted_by_row_filter": accepted,
+        "bounds": {
+          "x": row.bounds.x,
+          "y": row.bounds.y,
+          "width": row.bounds.width,
+          "height": row.bounds.height,
+        },
+      });
+      if let Some(reason) = reject_reason {
+        value["reject_reason"] = serde_json::Value::String(reason.to_string());
+      }
+      value
+    })
+    .collect::<Vec<_>>();
+  let item_candidates = rows
+    .iter()
+    .filter(|row| filter.accepted_indices.contains(&row.row_index))
+    .enumerate()
+    .map(|(item_index, row)| {
+      serde_json::json!({
+        "item_index": item_index,
+        "row_candidate_index": row.row_index,
+        "source": "row_filter",
+        "text": row.text_fragments.join(" | "),
+        "text_fragments": row.text_fragments,
+        "filter_reason": "accepted_repeating_row_geometry",
+        "segmented_region_role": "list_region",
         "bounds": {
           "x": row.bounds.x,
           "y": row.bounds.y,
@@ -310,6 +368,47 @@ fn render_observe_window_region_json(
       })
     })
     .collect::<Vec<_>>();
+  let rejected_row_candidates = filter
+    .rejected
+    .iter()
+    .filter_map(|rejected| {
+      rows
+        .iter()
+        .find(|row| row.row_index == rejected.row_index)
+        .map(|row| (rejected, row))
+    })
+    .map(|(rejected, row)| {
+      serde_json::json!({
+        "row_candidate_index": row.row_index,
+        "reject_reason": rejected.reason,
+        "source": row.source,
+        "bounds": {
+          "x": row.bounds.x,
+          "y": row.bounds.y,
+          "width": row.bounds.width,
+          "height": row.bounds.height,
+        },
+      })
+    })
+    .collect::<Vec<_>>();
+  let segmented_regions = filter
+    .list_region
+    .as_ref()
+    .map(|list_region| {
+      vec![serde_json::json!({
+        "region_index": 0,
+        "role": "list_region",
+        "confidence": filter.confidence,
+        "evidence": filter.evidence,
+        "bounds": {
+          "x": list_region.x,
+          "y": list_region.y,
+          "width": list_region.width,
+          "height": list_region.height,
+        },
+      })]
+    })
+    .unwrap_or_default();
   serde_json::to_string_pretty(&serde_json::json!({
     "extractor": "ocr-row",
     "coordinate_space": "window_screenshot_pixels",
@@ -322,13 +421,162 @@ fn render_observe_window_region_json(
       "width": region.width,
       "height": region.height,
     },
-    "rows": rows,
+    "segmented_regions": segmented_regions,
+    "rows": row_candidates,
+    "row_candidates": row_candidates,
+    "rejected_row_candidates": rejected_row_candidates,
+    "item_candidates": item_candidates,
   }))
   .map(|mut rendered| {
     rendered.push('\n');
     rendered
   })
   .map_err(|error| format!("failed to render window region observation json: {error}"))
+}
+
+#[derive(Clone, Debug)]
+struct ListRowFilterResult {
+  accepted_indices: Vec<usize>,
+  rejected: Vec<RejectedRowCandidate>,
+  list_region: Option<ObservedRect>,
+  confidence: &'static str,
+  evidence: &'static str,
+}
+
+#[derive(Clone, Debug)]
+struct RejectedRowCandidate {
+  row_index: usize,
+  reason: String,
+}
+
+fn filter_list_row_candidates(rows: &[ObservedOcrRow]) -> ListRowFilterResult {
+  if rows.is_empty() {
+    return ListRowFilterResult {
+      accepted_indices: Vec::new(),
+      rejected: Vec::new(),
+      list_region: None,
+      confidence: "none",
+      evidence: "no_row_candidates",
+    };
+  }
+
+  // TODO: Add OCR/AX anchor evidence and optional icon/template matching to the
+  // Row Filter before making semantic decisions. This is still geometry-only
+  // and intentionally rejects only clear height outliers so likely list rows
+  // remain available to later hooks. Icon evidence will matter for rows whose
+  // identity or state is mostly visual, such as selected/liked/downloaded
+  // markers or section-specific affordances.
+  let Some((height_band, evidence_count)) = repeating_row_height_band(rows) else {
+    let accepted_indices = rows.iter().map(|row| row.row_index).collect::<Vec<_>>();
+    return ListRowFilterResult {
+      list_region: union_row_bounds(rows),
+      accepted_indices,
+      rejected: Vec::new(),
+      confidence: "low",
+      evidence: "insufficient_repeating_row_evidence",
+    };
+  };
+
+  if rows.len() < 4 || evidence_count < 3 {
+    let accepted_indices = rows.iter().map(|row| row.row_index).collect::<Vec<_>>();
+    return ListRowFilterResult {
+      list_region: union_row_bounds(rows),
+      accepted_indices,
+      rejected: Vec::new(),
+      confidence: "low",
+      evidence: "insufficient_repeating_row_evidence",
+    };
+  }
+
+  let mut accepted = Vec::new();
+  let mut rejected = Vec::new();
+  for row in rows {
+    if height_band.contains(row.bounds.height) {
+      accepted.push(row.row_index);
+    } else {
+      rejected.push(RejectedRowCandidate {
+        row_index: row.row_index,
+        reason: "height_outside_repeating_row_band".to_string(),
+      });
+    }
+  }
+
+  let accepted_rows = rows
+    .iter()
+    .filter(|row| accepted.contains(&row.row_index))
+    .cloned()
+    .collect::<Vec<_>>();
+
+  ListRowFilterResult {
+    accepted_indices: accepted,
+    rejected,
+    list_region: union_row_bounds(&accepted_rows),
+    confidence: "heuristic",
+    evidence: "repeating_row_height_band",
+  }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct RowHeightBand {
+  min: i64,
+  max: i64,
+}
+
+impl RowHeightBand {
+  fn contains(self, height: i64) -> bool {
+    self.min <= height && height <= self.max
+  }
+}
+
+fn repeating_row_height_band(rows: &[ObservedOcrRow]) -> Option<(RowHeightBand, usize)> {
+  let mut heights = rows.iter().map(|row| row.bounds.height).collect::<Vec<_>>();
+  heights.sort_unstable();
+  if heights.is_empty() {
+    return None;
+  }
+
+  let sample = trimmed_height_sample(&heights);
+  let median = sample[sample.len() / 2];
+  let min = ((median as f64) * 0.80).floor() as i64;
+  let max = ((median as f64) * 1.45).ceil() as i64;
+  let band = RowHeightBand {
+    min: min.max(1),
+    max: max.max(min + 1),
+  };
+  let evidence_count = heights
+    .iter()
+    .filter(|height| band.contains(**height))
+    .count();
+  Some((band, evidence_count))
+}
+
+fn trimmed_height_sample(heights: &[i64]) -> &[i64] {
+  if heights.len() < 5 {
+    return heights;
+  }
+  let trim = (heights.len() / 5).max(1);
+  &heights[trim..heights.len() - trim]
+}
+
+fn union_row_bounds(rows: &[ObservedOcrRow]) -> Option<ObservedRect> {
+  let mut iter = rows.iter();
+  let first = iter.next()?;
+  Some(iter.fold(first.bounds.clone(), |bounds, row| {
+    union_observed_rects(&bounds, &row.bounds)
+  }))
+}
+
+fn union_observed_rects(left: &ObservedRect, right: &ObservedRect) -> ObservedRect {
+  let min_x = left.x.min(right.x);
+  let min_y = left.y.min(right.y);
+  let max_x = (left.x + left.width).max(right.x + right.width);
+  let max_y = (left.y + left.height).max(right.y + right.height);
+  ObservedRect {
+    x: min_x,
+    y: min_y,
+    width: max_x - min_x,
+    height: max_y - min_y,
+  }
 }
 
 #[cfg(test)]
@@ -424,5 +672,104 @@ mod tests {
     );
     assert_eq!(value["screenshot_width"], serde_json::Value::from(100));
     assert_eq!(value["screenshot_height"], serde_json::Value::from(200));
+  }
+
+  #[test]
+  fn render_observe_window_region_json_emits_list_item_candidates() {
+    let rows = vec![
+      observed_row(0, 100, 120, 500, 160),
+      observed_row(1, 100, 340, 700, 64),
+      observed_row(2, 120, 460, 700, 84),
+      observed_row(3, 120, 588, 700, 86),
+      observed_row(4, 120, 716, 700, 82),
+    ];
+
+    let json = render_observe_window_region_json(
+      &rows,
+      &ObservedRect {
+        x: 80,
+        y: 100,
+        width: 800,
+        height: 720,
+      },
+      &ScreenshotDimensions {
+        width: 1000,
+        height: 900,
+      },
+      std::path::Path::new("/tmp/window.png"),
+    )
+    .expect("json should render");
+    let value: serde_json::Value = serde_json::from_str(&json).expect("json should parse");
+
+    assert_eq!(value["row_candidates"].as_array().unwrap().len(), 5);
+    assert_eq!(value["item_candidates"].as_array().unwrap().len(), 3);
+    assert_eq!(
+      value["item_candidates"][0]["row_candidate_index"],
+      serde_json::Value::from(2)
+    );
+    assert_eq!(
+      value["rejected_row_candidates"][0]["reject_reason"],
+      serde_json::Value::from("height_outside_repeating_row_band")
+    );
+    assert_eq!(
+      value["segmented_regions"][0]["role"],
+      serde_json::Value::from("list_region")
+    );
+  }
+
+  #[test]
+  fn row_filter_keeps_varied_music_rows_and_rejects_clear_outliers() {
+    let heights = [213, 65, 113, 85, 100, 113, 92, 113, 97, 113, 63];
+    let rows = heights
+      .iter()
+      .enumerate()
+      .map(|(index, height)| observed_row(index, 120, 100 + index as i64 * 120, 700, *height))
+      .collect::<Vec<_>>();
+
+    let json = render_observe_window_region_json(
+      &rows,
+      &ObservedRect {
+        x: 80,
+        y: 100,
+        width: 800,
+        height: 1200,
+      },
+      &ScreenshotDimensions {
+        width: 1000,
+        height: 1400,
+      },
+      std::path::Path::new("/tmp/window.png"),
+    )
+    .expect("json should render");
+    let value: serde_json::Value = serde_json::from_str(&json).expect("json should parse");
+    let item_row_indices = value["item_candidates"]
+      .as_array()
+      .unwrap()
+      .iter()
+      .map(|item| item["row_candidate_index"].as_u64().unwrap())
+      .collect::<Vec<_>>();
+    let rejected_row_indices = value["rejected_row_candidates"]
+      .as_array()
+      .unwrap()
+      .iter()
+      .map(|item| item["row_candidate_index"].as_u64().unwrap())
+      .collect::<Vec<_>>();
+
+    assert_eq!(item_row_indices, vec![2, 3, 4, 5, 6, 7, 8, 9]);
+    assert_eq!(rejected_row_indices, vec![0, 1, 10]);
+  }
+
+  fn observed_row(index: usize, x: i64, y: i64, width: i64, height: i64) -> ObservedOcrRow {
+    ObservedOcrRow {
+      row_index: index,
+      source: "visual-bands".to_string(),
+      bounds: ObservedRect {
+        x,
+        y,
+        width,
+        height,
+      },
+      text_fragments: Vec::new(),
+    }
   }
 }

--- a/src/driver/macos/control/region.rs
+++ b/src/driver/macos/control/region.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use super::super::*;
 
 pub(crate) fn observe_window_region(call: &DriverCall) -> AuvResult<DriverResponse> {
@@ -69,8 +71,158 @@ pub(crate) fn observe_window_region(call: &DriverCall) -> AuvResult<DriverRespon
   })
 }
 
-pub(crate) fn scroll_window_region(_call: &DriverCall) -> AuvResult<DriverResponse> {
-  Err("scroll_window_region is not implemented yet".to_string())
+pub(crate) fn scroll_window_region(call: &DriverCall) -> AuvResult<DriverResponse> {
+  let app = app_identifier(call).ok_or_else(|| {
+    "scroll_window_region requires --target <application-id> or --app".to_string()
+  })?;
+  let raw_direction = optional_string(call, "direction").unwrap_or_else(|| "down".to_string());
+  let direction = normalize_scroll_direction(&raw_direction)?.to_string();
+  let amount = optional_f64(call, "amount")?.unwrap_or(6.0).max(1.0);
+  let settle_ms = optional_positive_u64(call, "settle_ms")?.unwrap_or(250);
+  let region = region_ratios_from_call(call)?;
+  activate_target_app(&app)?;
+  let snapshot = super::super::observe::observe_windows_snapshot(24, &app)?;
+  let xcap_displays = super::super::capture::xcap_backend::list_displays()?;
+  let display_snapshot = enumerate_displays()?;
+  let selector = parse_app_selector(&app)?;
+  let resolved_app = resolve_app_ref(&snapshot, &selector)?;
+  let candidate = resolve_window_candidate(
+    &snapshot,
+    &resolved_app,
+    &xcap_displays,
+    &parse_window_selection(call)?,
+  )?;
+  let window = &candidate.window_ref;
+  let x =
+    window.bounds.x as f64 + window.bounds.width as f64 * ((region.left + region.right) / 2.0);
+  let y =
+    window.bounds.y as f64 + window.bounds.height as f64 * ((region.top + region.bottom) / 2.0);
+  let resolution = resolve_display_point(&display_snapshot, x, y).ok_or_else(|| {
+    format!("resolved scroll point ({x:.3}, {y:.3}) is outside all connected displays")
+  })?;
+  let (delta_x, delta_y) = scan_scroll_delta(&direction, amount)?;
+  crate::driver::macos::native::pointer::scroll_point(x, y, delta_x, delta_y)?;
+  if settle_ms > 0 {
+    std::thread::sleep(std::time::Duration::from_millis(settle_ms));
+  }
+
+  let report = [
+    "coordinateSpace=global-logical".to_string(),
+    format!("applicationId={app}"),
+    format!("appSelector={}", resolved_app.selector.raw),
+    format!("matchStrategy={}", resolved_app.match_strategy),
+    format!(
+      "resolvedAppBundleId={}",
+      resolved_app
+        .resolved_bundle_id
+        .clone()
+        .unwrap_or_else(|| "n/a".to_string())
+    ),
+    format!("resolvedAppName={}", resolved_app.resolved_app_name),
+    format!("windowId={}", window.window_number),
+    format!("windowTitle={}", window.title),
+    format!("windowBounds={}", render_rect_compact(&window.bounds)),
+    format!(
+      "regionRatios={:.3},{:.3},{:.3},{:.3}",
+      region.left, region.top, region.right, region.bottom
+    ),
+    format!("scrollPoint={x:.3},{y:.3}"),
+    format!(
+      "backingPixelPoint={},{}",
+      resolution.backing_pixel_x, resolution.backing_pixel_y
+    ),
+    format!("displayId={}", resolution.display.display_id),
+    format!(
+      "displayBounds={}",
+      render_rect_compact(&resolution.display.bounds)
+    ),
+    format!("candidateIndex={}", candidate.candidate_index),
+    format!("selectionReason={}", candidate.selection_reason),
+    format!(
+      "isFullyContainedInDisplay={}",
+      candidate.is_fully_contained_in_display
+    ),
+    format!(
+      "displayRef={}",
+      candidate
+        .display_ref
+        .clone()
+        .unwrap_or_else(|| "n/a".to_string())
+    ),
+    format!(
+      "nativeDisplayId={}",
+      candidate
+        .native_display_id
+        .clone()
+        .unwrap_or_else(|| "n/a".to_string())
+    ),
+    format!("candidateArea={}", candidate.area),
+    format!("direction={direction}"),
+    format!("amount={amount:.3}"),
+    format!("deltaX={delta_x:.0}"),
+    format!("deltaY={delta_y:.0}"),
+    format!("settleMs={settle_ms}"),
+  ]
+  .join("\n");
+  let artifact = build_text_artifact(
+    "window-region-scroll",
+    "txt",
+    "window-region-scroll",
+    report,
+    "Scrolled at the center of a resolved window region.",
+  )?;
+
+  Ok(DriverResponse {
+    summary: format!("Scrolled window region {direction} by amount {amount:.3}."),
+    backend: Some("macos.swift.quartz-scroll-window-region".to_string()),
+    signals: BTreeMap::from([
+      ("scroll.direction".to_string(), direction),
+      ("scroll.amount".to_string(), format!("{amount:.3}")),
+    ]),
+    notes: vec![
+      "coordinateSpace=global-logical".to_string(),
+      format!("windowId={}", window.window_number),
+      format!("windowBounds={}", render_rect_compact(&window.bounds)),
+      format!(
+        "regionRatios={:.3},{:.3},{:.3},{:.3}",
+        region.left, region.top, region.right, region.bottom
+      ),
+      format!("scrollPoint={x:.3},{y:.3}"),
+      format!(
+        "backingPixelPoint={},{}",
+        resolution.backing_pixel_x, resolution.backing_pixel_y
+      ),
+      format!("displayId={}", resolution.display.display_id),
+      format!("candidateIndex={}", candidate.candidate_index),
+      format!("selectionReason={}", candidate.selection_reason),
+      format!("deltaX={delta_x:.0}"),
+      format!("deltaY={delta_y:.0}"),
+      format!("settleMs={settle_ms}"),
+    ],
+    artifacts: vec![artifact],
+  })
+}
+
+fn scan_scroll_delta(direction: &str, amount: f64) -> AuvResult<(f64, f64)> {
+  match normalize_scroll_direction(direction)? {
+    "down" => Ok((0.0, -amount)),
+    "up" => Ok((0.0, amount)),
+    "right" => Ok((-amount, 0.0)),
+    "left" => Ok((amount, 0.0)),
+    _ => unreachable!("normalize_scroll_direction only returns supported directions"),
+  }
+}
+
+fn normalize_scroll_direction(direction: &str) -> AuvResult<&'static str> {
+  match direction.trim().to_ascii_lowercase().as_str() {
+    "down" => Ok("down"),
+    "up" => Ok("up"),
+    "right" => Ok("right"),
+    "left" => Ok("left"),
+    other => Err(format!(
+      "invalid scroll direction {other:?}; expected down, up, left, or right"
+    )),
+  }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -192,6 +344,33 @@ mod tests {
   #[test]
   fn validate_region_ratios_accepts_normal_region() {
     validate_region_ratios(0.1, 0.2, 0.9, 0.8).expect("region should pass");
+  }
+
+  #[test]
+  fn scan_scroll_delta_defaults_to_vertical_down() {
+    let (delta_x, delta_y) = scan_scroll_delta("down", 6.0).expect("delta");
+    assert_eq!(delta_x, 0.0);
+    assert!(delta_y < 0.0);
+  }
+
+  #[test]
+  fn scan_scroll_delta_normalizes_direction_case() {
+    let (delta_x, delta_y) = scan_scroll_delta("DOWN", 6.0).expect("delta");
+    assert_eq!((delta_x, delta_y), (0.0, -6.0));
+  }
+
+  #[test]
+  fn scan_scroll_delta_maps_all_cardinal_directions() {
+    assert_eq!(scan_scroll_delta("up", 4.0).expect("up"), (0.0, 4.0));
+    assert_eq!(scan_scroll_delta("down", 4.0).expect("down"), (0.0, -4.0));
+    assert_eq!(scan_scroll_delta("left", 4.0).expect("left"), (4.0, 0.0));
+    assert_eq!(scan_scroll_delta("right", 4.0).expect("right"), (-4.0, 0.0));
+  }
+
+  #[test]
+  fn scan_scroll_delta_rejects_unknown_direction() {
+    let error = scan_scroll_delta("diagonal", 4.0).expect_err("direction should fail");
+    assert!(error.contains("expected down, up, left, or right"));
   }
 
   #[test]

--- a/src/driver/macos/dispatch.rs
+++ b/src/driver/macos/dispatch.rs
@@ -3,9 +3,9 @@ use super::capture::commands::{capture_display, capture_region, capture_window, 
 use super::control::{
   activate_app, ax_click_window_text, ax_focus_text_input, ax_press_button, click_point,
   click_screen_row, click_screen_text, click_window_point, click_window_row, click_window_text,
-  find_window_rows, find_window_text, focus_text_input, paste_text_preserve_clipboard,
-  press_button, press_key, scroll_point, smart_press, type_text, wait_for_window_rows,
-  wait_for_window_text,
+  find_window_rows, find_window_text, focus_text_input, observe_window_region,
+  paste_text_preserve_clipboard, press_button, press_key, scroll_point, scroll_window_region,
+  smart_press, type_text, wait_for_window_rows, wait_for_window_text,
 };
 use super::observe::{
   find_image_text, find_screen_rows, find_screen_text, identify_point, list_windows,
@@ -55,6 +55,8 @@ pub(crate) fn invoke_operation(call: &DriverCall) -> AuvResult<DriverResponse> {
     "wait_for_window_text" => wait_for_window_text(call),
     "find_window_rows" => find_window_rows(call),
     "wait_for_window_rows" => wait_for_window_rows(call),
+    "observe_window_region" => observe_window_region(call),
+    "scroll_window_region" => scroll_window_region(call),
     "find_image_text" => find_image_text(call),
     "probe_permissions" => probe_permissions(call),
     "verify_ax_text" => verify_ax_text(call),

--- a/src/driver/macos/native/swift/Sources/AuvMacosNative/Ocr.swift
+++ b/src/driver/macos/native/swift/Sources/AuvMacosNative/Ocr.swift
@@ -166,6 +166,9 @@ func find_ocr_text(request: NativeOcrTextRequest) -> NativeOcrTextResponse {
   let normalizedAnchorQuery = normalizeForAnchorMatch(rawQuery, caseSensitive: request.case_sensitive)
 
   func matches(_ text: String) -> Bool {
+    if rawQuery.isEmpty {
+      return true
+    }
     let normalizedText = request.case_sensitive ? text : text.lowercased()
     let normalizedAnchorText = normalizeForAnchorMatch(text, caseSensitive: request.case_sensitive)
     if request.exact {
@@ -179,7 +182,9 @@ func find_ocr_text(request: NativeOcrTextRequest) -> NativeOcrTextResponse {
   visionRequest.recognitionLevel = .accurate
   visionRequest.usesLanguageCorrection = true
   visionRequest.recognitionLanguages = ["zh-Hans", "zh-Hant", "en-US"]
-  visionRequest.customWords = [rawQuery]
+  if !rawQuery.isEmpty {
+    visionRequest.customWords = [rawQuery]
+  }
   if #available(macOS 26.0, *) {
     visionRequest.automaticallyDetectsLanguage = true
   }

--- a/src/driver/macos/support/ocr.rs
+++ b/src/driver/macos/support/ocr.rs
@@ -204,18 +204,75 @@ pub(crate) fn detect_screen_rows(
   let ocr_report = crate::driver::macos::native::ocr::render_ocr_text_report(&ocr_capture);
   let ocr_snapshot = ocr_capture.snapshot;
   let filtered_matches = filter_ocr_matches(&ocr_snapshot.matches, min_confidence, region);
-  let rows = group_ocr_matches_into_rows(&filtered_matches);
-  if !rows.is_empty() {
+  let ocr_rows = group_ocr_matches_into_rows(&filtered_matches);
+
+  let mut visual_detection = crate::driver::macos::native::ocr::find_rows(image_path, region)?.rows;
+  if visual_detection.rows.is_empty() && !ocr_rows.is_empty() {
     return Ok(DetectedScreenRows {
       strategy: "ocr-text".to_string(),
       raw_match_count: ocr_snapshot.matches.len(),
       filtered_match_count: filtered_matches.len(),
-      rows,
+      rows: ocr_rows,
       report: ocr_report,
     });
   }
+  attach_ocr_fragments_to_visual_rows(&mut visual_detection.rows, &filtered_matches);
+  let mut row_ocr_match_count = 0;
+  if visual_detection
+    .rows
+    .iter()
+    .any(|row| row.text_fragments.is_empty())
+  {
+    row_ocr_match_count = attach_row_crop_ocr_fragments(
+      image_path,
+      &mut visual_detection.rows,
+      min_confidence,
+      max_observations,
+      ocr_snapshot.image_width,
+      ocr_snapshot.image_height,
+    )?;
+  }
+  if visual_detection
+    .rows
+    .iter()
+    .any(|row| !row.text_fragments.is_empty())
+  {
+    visual_detection.strategy = "visual-bands+ocr-text".to_string();
+    visual_detection.raw_match_count = ocr_snapshot.matches.len() + row_ocr_match_count;
+    visual_detection.filtered_match_count = filtered_matches.len() + row_ocr_match_count;
+  }
 
-  crate::driver::macos::native::ocr::find_rows(image_path, region).map(|capture| capture.rows)
+  Ok(visual_detection)
+}
+
+pub(crate) fn ocr_text_fragments_in_image(
+  image_path: &Path,
+  min_confidence: f64,
+  max_observations: i64,
+) -> AuvResult<Vec<String>> {
+  let capture = crate::driver::macos::native::ocr::find_text(
+    image_path,
+    "",
+    false,
+    false,
+    max_observations.min(64),
+    None,
+  )?;
+  let mut matches = filter_ocr_matches(&capture.snapshot.matches, min_confidence, None);
+  matches.sort_by(|left, right| {
+    left
+      .bounds
+      .y
+      .cmp(&right.bounds.y)
+      .then_with(|| left.bounds.x.cmp(&right.bounds.x))
+  });
+  let mut fragments = Vec::new();
+  for matched in matches {
+    if !fragments.iter().any(|fragment| fragment == &matched.text) {
+      fragments.push(matched.text.clone());
+    }
+  }
+  Ok(fragments)
 }
 
 pub(crate) fn group_ocr_matches_into_rows(matches: &[&OcrTextMatch]) -> Vec<ObservedOcrRow> {
@@ -263,6 +320,108 @@ pub(crate) fn group_ocr_matches_into_rows(matches: &[&OcrTextMatch]) -> Vec<Obse
   rows
 }
 
+// REVIEW: Visual row bands and Vision text boxes do not share a stable list
+// model yet. This joins text by row containment/centerline as a conservative
+// bridge so scroll-scan artifacts expose readable row content before a richer
+// item extractor contract exists.
+pub(crate) fn attach_ocr_fragments_to_visual_rows(
+  rows: &mut [ObservedOcrRow],
+  matches: &[&OcrTextMatch],
+) -> usize {
+  let mut attached = 0;
+  for row in rows.iter_mut() {
+    for matched in matches {
+      let (_, center_y) = ocr_match_center(matched);
+      if !row_contains_y(&row.bounds, center_y) || !rects_overlap_x(&row.bounds, &matched.bounds) {
+        continue;
+      }
+      if !row
+        .text_fragments
+        .iter()
+        .any(|fragment| fragment == &matched.text)
+      {
+        row.text_fragments.push(matched.text.clone());
+        attached += 1;
+      }
+    }
+    if !row.text_fragments.is_empty() && row.source == "visual-bands" {
+      row.source = "visual-bands+ocr-text".to_string();
+    }
+  }
+  attached
+}
+
+fn attach_row_crop_ocr_fragments(
+  image_path: &Path,
+  rows: &mut [ObservedOcrRow],
+  min_confidence: f64,
+  max_observations: i64,
+  image_width: i64,
+  image_height: i64,
+) -> AuvResult<usize> {
+  let mut attached = 0;
+  for row in rows.iter_mut() {
+    if !row.text_fragments.is_empty() {
+      continue;
+    }
+    let row_region = expand_rect(&row.bounds, 12, 8, image_width, image_height);
+    let row_capture = crate::driver::macos::native::ocr::find_text(
+      image_path,
+      "",
+      false,
+      false,
+      max_observations.min(32),
+      Some(&row_region),
+    )?;
+    let row_matches = filter_ocr_matches(&row_capture.snapshot.matches, min_confidence, None);
+    for matched in row_matches {
+      if row
+        .text_fragments
+        .iter()
+        .any(|fragment| fragment == &matched.text)
+      {
+        continue;
+      }
+      row.text_fragments.push(matched.text.clone());
+      attached += 1;
+    }
+    if !row.text_fragments.is_empty() {
+      row.source = "visual-bands+row-ocr".to_string();
+    }
+  }
+  Ok(attached)
+}
+
+fn row_contains_y(row: &ObservedRect, y: f64) -> bool {
+  let padding = (row.height as f64 * 0.25).max(8.0);
+  y >= row.y as f64 - padding && y <= (row.y + row.height) as f64 + padding
+}
+
+fn rects_overlap_x(left: &ObservedRect, right: &ObservedRect) -> bool {
+  let left_max = left.x + left.width;
+  let right_max = right.x + right.width;
+  left.x < right_max && right.x < left_max
+}
+
+fn expand_rect(
+  rect: &ObservedRect,
+  pad_x: i64,
+  pad_y: i64,
+  image_width: i64,
+  image_height: i64,
+) -> ObservedRect {
+  let x = (rect.x - pad_x).clamp(0, image_width.saturating_sub(1));
+  let y = (rect.y - pad_y).clamp(0, image_height.saturating_sub(1));
+  let max_x = (rect.x + rect.width + pad_x).clamp(x + 1, image_width);
+  let max_y = (rect.y + rect.height + pad_y).clamp(y + 1, image_height);
+  ObservedRect {
+    x,
+    y,
+    width: max_x - x,
+    height: max_y - y,
+  }
+}
+
 pub(crate) fn render_ocr_row_note(row: &ObservedOcrRow) -> String {
   if row.text_fragments.is_empty() {
     return format!(
@@ -303,5 +462,79 @@ fn union_rects(left: &ObservedRect, right: &ObservedRect) -> ObservedRect {
     y: min_y,
     width: max_x - min_x,
     height: max_y - min_y,
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn attaches_ocr_fragments_to_overlapping_visual_rows() {
+    let mut rows = vec![
+      ObservedOcrRow {
+        row_index: 0,
+        source: "visual-bands".to_string(),
+        bounds: ObservedRect {
+          x: 100,
+          y: 200,
+          width: 400,
+          height: 80,
+        },
+        text_fragments: Vec::new(),
+      },
+      ObservedOcrRow {
+        row_index: 1,
+        source: "visual-bands".to_string(),
+        bounds: ObservedRect {
+          x: 100,
+          y: 320,
+          width: 400,
+          height: 80,
+        },
+        text_fragments: Vec::new(),
+      },
+    ];
+    let first = OcrTextMatch {
+      match_index: 0,
+      text: "Song A".to_string(),
+      confidence: 0.9,
+      bounds: ObservedRect {
+        x: 140,
+        y: 220,
+        width: 120,
+        height: 28,
+      },
+    };
+    let second = OcrTextMatch {
+      match_index: 1,
+      text: "Artist B".to_string(),
+      confidence: 0.9,
+      bounds: ObservedRect {
+        x: 150,
+        y: 340,
+        width: 120,
+        height: 28,
+      },
+    };
+    let outside = OcrTextMatch {
+      match_index: 2,
+      text: "Outside".to_string(),
+      confidence: 0.9,
+      bounds: ObservedRect {
+        x: 700,
+        y: 220,
+        width: 120,
+        height: 28,
+      },
+    };
+    let matches = vec![&first, &second, &outside];
+
+    let attached = attach_ocr_fragments_to_visual_rows(&mut rows, &matches);
+
+    assert_eq!(attached, 2);
+    assert_eq!(rows[0].source, "visual-bands+ocr-text");
+    assert_eq!(rows[0].text_fragments, vec!["Song A"]);
+    assert_eq!(rows[1].text_fragments, vec!["Artist B"]);
   }
 }

--- a/src/driver/macos/support/overlay_evidence.rs
+++ b/src/driver/macos/support/overlay_evidence.rs
@@ -101,6 +101,26 @@ pub(crate) struct OverlayEvidencePayload {
 }
 
 #[derive(Clone, Debug)]
+pub(crate) struct RowObservationOverlayRequest {
+  pub(crate) label: String,
+  pub(crate) screenshot_path: std::path::PathBuf,
+  pub(crate) screenshot_dimensions: ScreenshotDimensions,
+  pub(crate) strategy: String,
+  pub(crate) rows: Vec<OverlayEvidenceRow>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct RowObservationOverlayPayload {
+  pub(crate) version: String,
+  pub(crate) kind: String,
+  pub(crate) screenshot_path: String,
+  pub(crate) screenshot_width: i64,
+  pub(crate) screenshot_height: i64,
+  pub(crate) strategy: String,
+  pub(crate) rows: Vec<OverlayEvidenceRow>,
+}
+
+#[derive(Clone, Debug)]
 pub(crate) struct OverlayEvidenceRequest {
   pub(crate) kind: &'static str,
   pub(crate) label: String,
@@ -296,6 +316,86 @@ pub(crate) fn build_overlay_evidence_artifacts(
       note: Some(
         "Evidence screenshot with dual-cursor and interaction overlay annotations.".to_string(),
       ),
+    },
+    overlay_json_artifact,
+  ])
+}
+
+pub(crate) fn build_row_observation_overlay_artifacts(
+  request: RowObservationOverlayRequest,
+) -> AuvResult<Vec<ProducedArtifact>> {
+  let bytes = fs::read(&request.screenshot_path).map_err(|error| {
+    format!(
+      "failed to read screenshot source {} for row observation overlay: {error}",
+      request.screenshot_path.display()
+    )
+  })?;
+  let mut image = image::load_from_memory(&bytes)
+    .map_err(|error| {
+      format!("failed to decode screenshot PNG for row observation overlay: {error}")
+    })?
+    .to_rgba8();
+
+  for row in &request.rows {
+    draw_rect_outline(&mut image, &row.bounds, ROW_BOX, 2);
+    draw_label_chip(
+      &mut image,
+      row.bounds.x,
+      row.bounds.y.saturating_sub(18),
+      &format!("#{} {}", row.row_index + 1, row.source),
+      LABEL_BG,
+    );
+  }
+  draw_signal_panel(
+    &mut image,
+    vec![
+      "row observation".to_string(),
+      format!("strategy: {}", request.strategy),
+      format!("rows: {}", request.rows.len()),
+    ],
+  );
+
+  let overlay_png_path = temp_file_path(
+    &format!(
+      "{}-row-observation-overlay",
+      sanitize_file_component(&request.label)
+    ),
+    "png",
+  );
+  save_rgba_image(image, overlay_png_path.as_path())?;
+
+  let payload = RowObservationOverlayPayload {
+    version: "v1alpha1".to_string(),
+    kind: "row_observation_overlay".to_string(),
+    screenshot_path: request.screenshot_path.display().to_string(),
+    screenshot_width: request.screenshot_dimensions.width,
+    screenshot_height: request.screenshot_dimensions.height,
+    strategy: request.strategy,
+    rows: request.rows,
+  };
+  let overlay_json = serde_json::to_string_pretty(&payload)
+    .map_err(|error| format!("failed to encode row observation overlay JSON: {error}"))?
+    + "\n";
+  let overlay_json_artifact = build_text_artifact(
+    "row-observation.overlay.annotation",
+    "json",
+    &format!(
+      "{}-row-observation-overlay",
+      sanitize_file_component(&request.label)
+    ),
+    overlay_json,
+    "Structured annotation payload for the row observation overlay image.",
+  )?;
+
+  Ok(vec![
+    ProducedArtifact {
+      kind: "row-observation.overlay".to_string(),
+      source_path: overlay_png_path,
+      preferred_name: format!(
+        "{}-row-observation-overlay.png",
+        sanitize_file_component(&request.label)
+      ),
+      note: Some("Evidence screenshot with observed row bounds overlay.".to_string()),
     },
     overlay_json_artifact,
   ])

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -7,8 +7,9 @@ use self::macos::MacOsDesktopDriver;
 pub(crate) use self::macos::{
   ObservedAxNode, ObservedAxTreeSnapshot, ObservedDisplay, ObservedDisplaySnapshot, ObservedOcrRow,
   ObservedRect, ObservedWindow, OcrTextSnapshot, clear_stale_lock_file, compute_combined_bounds,
-  copy_file, describe_lock_owner, group_ocr_matches_into_rows, parse_observed_ax_tree,
-  parse_ocr_text_snapshot, parse_window_line, report_value, sanitized_artifact_name,
+  copy_file, describe_lock_owner, group_ocr_matches_into_rows, ocr_text_fragments_in_image,
+  parse_observed_ax_tree, parse_ocr_text_snapshot, parse_window_line, report_value,
+  sanitized_artifact_name,
 };
 
 mod fixture;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ pub mod model;
 pub mod recording;
 pub mod run_recording;
 pub mod runtime;
-pub mod scan;
+pub mod scroll_scan;
 pub mod skill;
 pub mod store;
 pub mod trace;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod model;
 pub mod recording;
 pub mod run_recording;
 pub mod runtime;
+pub mod scan;
 pub mod skill;
 pub mod store;
 pub mod trace;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use auv_cli::bundle::{
   verify_exported_bundle_package_standalone,
 };
 use auv_cli::model::RunStatus;
-use auv_cli::scan::{
+use auv_cli::scroll_scan::{
   ScanRegion, ScanTarget, ScanWindowRegionOptions, StopPolicy, scan_window_region,
 };
 use auv_cli::skill::{
@@ -195,6 +195,7 @@ async fn run() -> Result<(), String> {
       min_confidence,
       max_observations,
       per_page_after_observe_recipe,
+      per_list_item_candidate_recipe,
       on_stop_candidate_recipe,
     } => {
       let runtime = build_default_runtime(project_root.clone())?;
@@ -218,6 +219,7 @@ async fn run() -> Result<(), String> {
           min_confidence,
           max_observations,
           per_page_after_observe_recipe,
+          per_list_item_candidate_recipe,
           on_stop_candidate_recipe,
         },
       )?;
@@ -410,6 +412,7 @@ async fn run() -> Result<(), String> {
           dry_run,
           max_disturbance,
           overrides,
+          quiet: false,
         },
       )?;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,9 @@ use auv_cli::bundle::{
   verify_exported_bundle_package_standalone,
 };
 use auv_cli::model::RunStatus;
+use auv_cli::scan::{
+  ScanRegion, ScanTarget, ScanWindowRegionOptions, StopPolicy, scan_window_region,
+};
 use auv_cli::skill::{
   SkillCaseMatrixCatalog, SkillCatalog, render_skill_case_matrix_report, run_skill,
   run_skill_case_matrix,
@@ -180,6 +183,46 @@ async fn run() -> Result<(), String> {
     }
     CliCommand::InspectServe { .. } => {
       unreachable!("inspect serve is handled before runtime setup")
+    }
+    CliCommand::ScanWindowRegion {
+      target,
+      region,
+      max_pages,
+      max_scrolls,
+      direction,
+      scroll_amount,
+      settle_ms,
+      min_confidence,
+      max_observations,
+      per_page_after_observe_recipe,
+      on_stop_candidate_recipe,
+    } => {
+      let runtime = build_default_runtime(project_root.clone())?;
+      let region = parse_scan_region_arg(&region)?;
+      let run_id = scan_window_region(
+        &runtime,
+        ScanWindowRegionOptions {
+          target: ScanTarget {
+            application_id: Some(target),
+            window_title: None,
+            region,
+          },
+          stop_policy: StopPolicy::UntilEnd {
+            max_pages,
+            max_scrolls,
+            no_progress_limit: 2,
+          },
+          direction,
+          scroll_amount,
+          settle_ms,
+          min_confidence,
+          max_observations,
+          per_page_after_observe_recipe,
+          on_stop_candidate_recipe,
+        },
+      )?;
+      println!("runId: {run_id}");
+      println!("status: scanned");
     }
     CliCommand::SkillList => {
       for entry in skill_catalog.entries() {
@@ -373,6 +416,23 @@ async fn run() -> Result<(), String> {
   }
 
   Ok(())
+}
+
+fn parse_scan_region_arg(raw: &str) -> Result<ScanRegion, String> {
+  let values = raw
+    .split(',')
+    .map(|value| value.trim().parse::<f64>())
+    .collect::<Result<Vec<_>, _>>()
+    .map_err(|error| format!("invalid --region ratios: {error}"))?;
+  if values.len() != 4 {
+    return Err("--region must contain four comma-separated ratios".to_string());
+  }
+  Ok(ScanRegion {
+    left_ratio: values[0],
+    top_ratio: values[1],
+    right_ratio: values[2],
+    bottom_ratio: values[3],
+  })
 }
 
 fn resolve_store_root(project_root: &Path, explicit: Option<&String>) -> PathBuf {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -40,6 +40,10 @@ impl Runtime {
     self.commands.all()
   }
 
+  pub fn project_root(&self) -> &Path {
+    &self.project_root
+  }
+
   pub fn list_drivers(&self) -> Vec<DriverDescriptor> {
     self.drivers.descriptors()
   }

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -1,9 +1,13 @@
-use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
-use crate::model::AuvResult;
+use crate::model::{
+  AuvResult, DisturbanceClass, ExecutionTarget, InvokeRequest, InvokeResult, RunStatus,
+};
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ScanRegion {
@@ -174,6 +178,349 @@ pub struct ScrollScanArtifact {
   pub warnings: Vec<String>,
 }
 
+#[derive(Clone, Debug)]
+pub struct ScanWindowRegionOptions {
+  pub target: ScanTarget,
+  pub stop_policy: StopPolicy,
+  pub direction: String,
+  pub scroll_amount: f64,
+  pub settle_ms: u64,
+  pub min_confidence: f64,
+  pub max_observations: i64,
+  pub per_page_after_observe_recipe: Option<String>,
+  pub on_stop_candidate_recipe: Option<String>,
+}
+
+pub fn scan_window_region(
+  runtime: &crate::runtime::Runtime,
+  options: ScanWindowRegionOptions,
+) -> AuvResult<crate::trace::RunId> {
+  let mut run = runtime.start_run(crate::recording::RunSpec::new(
+    crate::trace::RunType::Execute,
+    "auv.scan.window_region",
+  ))?;
+  let root = run.root_span();
+
+  match scan_window_region_into_run(runtime, &mut run, &root, options) {
+    Ok(summary) => runtime.finish_run(
+      run,
+      crate::recording::RunFinish {
+        status_code: crate::trace::TraceStatusCode::Ok,
+        summary: Some(summary),
+        failure: None,
+      },
+    ),
+    Err(error) => {
+      let finish_result = runtime.finish_run(
+        run,
+        crate::recording::RunFinish {
+          status_code: crate::trace::TraceStatusCode::Error,
+          summary: Some(format!("Window region scan failed: {error}")),
+          failure: Some(error.clone()),
+        },
+      );
+      match finish_result {
+        Ok(_) => Err(error),
+        Err(finish_error) => Err(format!(
+          "{error}; additionally failed to persist failed scan run: {finish_error}"
+        )),
+      }
+    }
+  }
+}
+
+fn scan_window_region_into_run(
+  runtime: &crate::runtime::Runtime,
+  run: &mut crate::recording::RecordingRun,
+  root: &crate::recording::SpanRef,
+  options: ScanWindowRegionOptions,
+) -> AuvResult<String> {
+  let mut state = ScanWindowRegionState::default();
+  let mut scroll_count = 0;
+  let mut consecutive_no_progress = 0;
+  let mut final_decision = None;
+  let mut scan_error = None;
+
+  for page_index in 0..max_pages_for_policy(&options.stop_policy) {
+    let page_result = scan_window_region_page(runtime, run, root, page_index, &options, &mut state);
+    let page_outcome = match page_result {
+      Ok(page_outcome) => page_outcome,
+      Err(error) => {
+        scan_error = Some(error);
+        final_decision = Some(error_stop_decision(page_index));
+        break;
+      }
+    };
+    let new_observation_count = page_outcome.new_observation_count;
+
+    if new_observation_count == 0 {
+      consecutive_no_progress += 1;
+    } else {
+      consecutive_no_progress = 0;
+    }
+
+    // WORKAROUND: First scan progress uses OCR novelty only. Add lightweight
+    // screenshot-region diffing before treating no-progress as strong bottom
+    // evidence in broader workflows. Current novelty keys include page-local
+    // x/y/width/height bounds so repeated visible labels at different positions
+    // are not treated as inherently stale.
+    let progress = ScanProgress {
+      page_index,
+      scroll_count,
+      consecutive_no_progress,
+      new_observation_count,
+      hook_stop_requested: state
+        .hook_decisions
+        .last()
+        .is_some_and(|decision| decision.action == HookAction::Stop),
+      match_found: match_found_on_current_page(&options.stop_policy, &page_outcome.observations),
+      next_section_candidate: state
+        .hook_decisions
+        .last()
+        .is_some_and(|decision| decision.action == HookAction::Stop)
+        && matches!(options.stop_policy, StopPolicy::UntilNextSection { .. }),
+    };
+
+    if let Some(mut decision) = evaluate_stop_policy(&options.stop_policy, &progress) {
+      let stop_hook_result = run_optional_scan_hook(
+        runtime,
+        run,
+        root,
+        options.on_stop_candidate_recipe.as_deref(),
+        "on_stop_candidate",
+        page_index,
+        &options,
+        Some(&decision.stop_evidence),
+      );
+      let stop_hook_decision = match stop_hook_result {
+        Ok(decision) => decision,
+        Err(error) => {
+          scan_error = Some(error);
+          final_decision = Some(error_stop_decision(page_index));
+          break;
+        }
+      };
+
+      if let Some(hook_decision) = stop_hook_decision {
+        if let Err(error) = validate_scan_loop_hook_decision(&hook_decision) {
+          state.hook_decisions.push(hook_decision);
+          scan_error = Some(error);
+          final_decision = Some(error_stop_decision(page_index));
+          break;
+        }
+        if hook_decision.action == HookAction::Continue {
+          if let Some(hard_cap_decision) =
+            hard_cap_stop_decision_for_policy(&options.stop_policy, &progress)
+          {
+            state.warnings.push(format!(
+              "stop candidate {:?} coincided with hard cap {:?}; ignoring hook continue request",
+              decision.stop_evidence.reason, hard_cap_decision.stop_evidence.reason
+            ));
+            state.hook_decisions.push(hook_decision);
+            final_decision = Some(hard_cap_decision);
+            break;
+          } else {
+            state.warnings.push(format!(
+              "stop candidate {:?} was inspected by hook and scan continued",
+              decision.stop_evidence.reason
+            ));
+            state.hook_decisions.push(hook_decision);
+          }
+        } else {
+          if hook_decision.action == HookAction::Stop {
+            decision = stop_decision(
+              StopReason::HookRequestedStop,
+              hook_decision.reason.clone(),
+              page_index,
+              CompletenessClaim::Unknown,
+            );
+          }
+          state.hook_decisions.push(hook_decision);
+          final_decision = Some(decision);
+          break;
+        }
+      } else {
+        final_decision = Some(decision);
+        break;
+      }
+    }
+
+    match invoke_scan_command(
+      runtime,
+      run,
+      root,
+      scroll_request(&options),
+      "scroll window region",
+    ) {
+      Ok(_) => {
+        scroll_count += 1;
+      }
+      Err(error) => {
+        scan_error = Some(error);
+        final_decision = Some(error_stop_decision(page_index));
+        break;
+      }
+    }
+  }
+
+  let final_decision = final_decision.unwrap_or_else(|| {
+    stop_decision(
+      StopReason::MaxPages,
+      format!(
+        "reached max_pages={}",
+        max_pages_for_policy(&options.stop_policy)
+      ),
+      state.pages.last().map(|page| page.page_index).unwrap_or(0),
+      CompletenessClaim::PartialMaxPages,
+    )
+  });
+  if scan_error.is_some() {
+    state
+      .warnings
+      .push("scan ended with an error; artifact is partial".to_string());
+  }
+  let artifact = state.into_artifact(
+    run.id().to_string(),
+    options.target,
+    options.stop_policy,
+    final_decision,
+  );
+  if let Err(stage_error) = stage_scan_artifact(runtime, run, root, &artifact) {
+    if let Some(error) = scan_error {
+      return Err(format!(
+        "{error}; additionally failed to stage partial scroll-scan artifact: {stage_error}"
+      ));
+    }
+    return Err(stage_error);
+  }
+  if let Some(error) = scan_error {
+    return Err(error);
+  }
+
+  Ok(format!(
+    "Scanned {} page(s), captured {} observation(s), formed {} cluster(s).",
+    artifact.pages.len(),
+    artifact.observations.len(),
+    artifact.clusters.len()
+  ))
+}
+
+pub fn observations_from_observe_json(
+  page_index: usize,
+  raw: &str,
+  source_artifact: PathBuf,
+) -> AuvResult<Vec<CollectionObservation>> {
+  let value: Value =
+    serde_json::from_str(raw).map_err(|error| format!("malformed observe JSON: {error}"))?;
+  let rows = value
+    .get("rows")
+    .and_then(Value::as_array)
+    .ok_or_else(|| "malformed observe JSON: missing rows array".to_string())?;
+
+  rows
+    .iter()
+    .enumerate()
+    .map(|(row_index, row)| observation_from_row(page_index, row_index, row, &source_artifact))
+    .collect()
+}
+
+#[derive(Default)]
+struct ScanWindowRegionState {
+  pages: Vec<ScanPageRecord>,
+  observations: Vec<CollectionObservation>,
+  known_observation_signatures: BTreeSet<String>,
+  hook_decisions: Vec<HookDecisionRecord>,
+  warnings: Vec<String>,
+}
+
+struct PageScanOutcome {
+  new_observation_count: usize,
+  observations: Vec<CollectionObservation>,
+}
+
+impl ScanWindowRegionState {
+  fn into_artifact(
+    self,
+    scan_id: String,
+    target: ScanTarget,
+    stop_policy: StopPolicy,
+    final_decision: StopDecision,
+  ) -> ScrollScanArtifact {
+    let clusters = conservative_merge_observations(&self.observations);
+    ScrollScanArtifact {
+      scan_id,
+      target,
+      stop_policy,
+      pages: self.pages,
+      observations: self.observations,
+      clusters,
+      section_candidates: Vec::new(),
+      hook_decisions: self.hook_decisions,
+      stop_evidence: final_decision.stop_evidence,
+      completeness_claim: final_decision.completeness_claim,
+      warnings: self.warnings,
+    }
+  }
+}
+
+fn scan_window_region_page(
+  runtime: &crate::runtime::Runtime,
+  run: &mut crate::recording::RecordingRun,
+  root: &crate::recording::SpanRef,
+  page_index: usize,
+  options: &ScanWindowRegionOptions,
+  state: &mut ScanWindowRegionState,
+) -> AuvResult<PageScanOutcome> {
+  let observe_result = invoke_scan_command(
+    runtime,
+    run,
+    root,
+    observe_request(options, page_index),
+    "observe window region",
+  )?;
+  let screenshot_artifact = first_artifact_with_extension(&observe_result, "png");
+  let source_artifact = screenshot_artifact
+    .clone()
+    .unwrap_or_else(|| first_artifact_with_extension(&observe_result, "json").unwrap_or_default());
+  let page_observations =
+    observations_from_first_json_artifact(page_index, &observe_result, source_artifact)?;
+  let new_observation_count =
+    count_new_observations(&page_observations, &mut state.known_observation_signatures);
+  let observation_count = page_observations.len();
+  state.observations.extend(page_observations.clone());
+
+  state.pages.push(ScanPageRecord {
+    page_index,
+    observe_run_id: None,
+    screenshot_artifact,
+    observation_count,
+    new_observation_count,
+    summary: format!(
+      "observed {observation_count} row(s); {new_observation_count} new page-local signature(s); observe command recorded inside the scan run"
+    ),
+  });
+
+  if let Some(decision) = run_optional_scan_hook(
+    runtime,
+    run,
+    root,
+    options.per_page_after_observe_recipe.as_deref(),
+    "per_page_after_observe",
+    page_index,
+    options,
+    None,
+  )? {
+    let validation = validate_scan_loop_hook_decision(&decision);
+    state.hook_decisions.push(decision);
+    validation?;
+  }
+
+  Ok(PageScanOutcome {
+    new_observation_count,
+    observations: page_observations,
+  })
+}
+
 pub fn evaluate_stop_policy(policy: &StopPolicy, progress: &ScanProgress) -> Option<StopDecision> {
   if progress.hook_stop_requested {
     return Some(stop_decision(
@@ -266,6 +613,32 @@ fn bounded_stop(
   None
 }
 
+fn hard_cap_stop_decision_for_policy(
+  policy: &StopPolicy,
+  progress: &ScanProgress,
+) -> Option<StopDecision> {
+  match policy {
+    StopPolicy::UntilEnd {
+      max_pages,
+      max_scrolls,
+      ..
+    }
+    | StopPolicy::UntilNextSection {
+      max_pages,
+      max_scrolls,
+    }
+    | StopPolicy::UntilMatch {
+      max_pages,
+      max_scrolls,
+      ..
+    }
+    | StopPolicy::Bounded {
+      max_pages,
+      max_scrolls,
+    } => bounded_stop(*max_pages, *max_scrolls, progress),
+  }
+}
+
 fn stop_decision(
   reason: StopReason,
   message: impl Into<String>,
@@ -280,6 +653,15 @@ fn stop_decision(
     },
     completeness_claim,
   }
+}
+
+fn error_stop_decision(page_index: usize) -> StopDecision {
+  stop_decision(
+    StopReason::Error,
+    "scan stopped because an orchestration step failed",
+    page_index,
+    CompletenessClaim::Unknown,
+  )
 }
 
 pub fn hook_decision_from_variables(
@@ -301,6 +683,30 @@ pub fn hook_decision_from_variables(
     action,
     reason,
   }))
+}
+
+fn validate_scan_loop_hook_decision(decision: &HookDecisionRecord) -> AuvResult<()> {
+  match decision.action {
+    HookAction::Continue | HookAction::Stop => Ok(()),
+    HookAction::RetryObserve
+    | HookAction::AdjustRegion
+    | HookAction::AdjustScroll
+    | HookAction::Annotate => Err(format!(
+      "scan hook action {} is parsed but not implemented by scan_window_region yet",
+      hook_action_name(decision.action)
+    )),
+  }
+}
+
+fn hook_action_name(action: HookAction) -> &'static str {
+  match action {
+    HookAction::Continue => "continue",
+    HookAction::Stop => "stop",
+    HookAction::RetryObserve => "retry_observe",
+    HookAction::AdjustRegion => "adjust_region",
+    HookAction::AdjustScroll => "adjust_scroll",
+    HookAction::Annotate => "annotate",
+  }
 }
 
 fn parse_hook_action(raw: &str) -> AuvResult<HookAction> {
@@ -383,6 +789,290 @@ fn should_merge_adjacent_observations(
     return false;
   }
   (left.bounds.y - right.bounds.y).abs() <= 8
+}
+
+fn observation_from_row(
+  page_index: usize,
+  row_index: usize,
+  row: &Value,
+  source_artifact: &Path,
+) -> AuvResult<CollectionObservation> {
+  let raw_text = row
+    .get("text")
+    .and_then(Value::as_str)
+    .ok_or_else(|| format!("malformed observe JSON: row {row_index} missing text string"))?
+    .to_string();
+  let bounds = row
+    .get("bounds")
+    .ok_or_else(|| format!("malformed observe JSON: row {row_index} missing bounds object"))?;
+
+  Ok(CollectionObservation {
+    observation_id: format!("obs_{:04}_{:04}", page_index + 1, row_index + 1),
+    page_index,
+    raw_text: raw_text.clone(),
+    normalized_text_key: normalize_observation_text(&raw_text),
+    bounds: ScanRect {
+      x: json_i64(bounds, "x", row_index)?,
+      y: json_i64(bounds, "y", row_index)?,
+      width: json_i64(bounds, "width", row_index)?,
+      height: json_i64(bounds, "height", row_index)?,
+    },
+    section_context: None,
+    source_artifacts: vec![source_artifact.to_path_buf()],
+    attributes: BTreeMap::new(),
+  })
+}
+
+fn json_i64(bounds: &Value, key: &str, row_index: usize) -> AuvResult<i64> {
+  bounds.get(key).and_then(Value::as_i64).ok_or_else(|| {
+    format!("malformed observe JSON: row {row_index} bounds.{key} must be an integer")
+  })
+}
+
+fn max_pages_for_policy(policy: &StopPolicy) -> usize {
+  match policy {
+    StopPolicy::UntilEnd { max_pages, .. }
+    | StopPolicy::UntilNextSection { max_pages, .. }
+    | StopPolicy::UntilMatch { max_pages, .. }
+    | StopPolicy::Bounded { max_pages, .. } => *max_pages,
+  }
+}
+
+fn observe_request(options: &ScanWindowRegionOptions, page_index: usize) -> InvokeRequest {
+  let mut inputs = region_inputs(&options.target);
+  inputs.insert(
+    "label".to_string(),
+    format!("scan-page-{:04}", page_index + 1),
+  );
+  inputs.insert(
+    "min_confidence".to_string(),
+    format!("{:.3}", options.min_confidence),
+  );
+  inputs.insert(
+    "max_observations".to_string(),
+    options.max_observations.to_string(),
+  );
+  InvokeRequest {
+    command_id: "debug.observeWindowRegion".to_string(),
+    target: ExecutionTarget {
+      application_id: options.target.application_id.clone(),
+    },
+    inputs,
+  }
+}
+
+fn scroll_request(options: &ScanWindowRegionOptions) -> InvokeRequest {
+  let mut inputs = region_inputs(&options.target);
+  inputs.insert("direction".to_string(), options.direction.clone());
+  inputs.insert(
+    "amount".to_string(),
+    format!("{:.3}", options.scroll_amount),
+  );
+  inputs.insert("settle_ms".to_string(), options.settle_ms.to_string());
+  InvokeRequest {
+    command_id: "debug.scrollWindowRegion".to_string(),
+    target: ExecutionTarget {
+      application_id: options.target.application_id.clone(),
+    },
+    inputs,
+  }
+}
+
+fn region_inputs(target: &ScanTarget) -> BTreeMap<String, String> {
+  let mut inputs = BTreeMap::from([
+    (
+      "region_left_ratio".to_string(),
+      target.region.left_ratio.to_string(),
+    ),
+    (
+      "region_top_ratio".to_string(),
+      target.region.top_ratio.to_string(),
+    ),
+    (
+      "region_right_ratio".to_string(),
+      target.region.right_ratio.to_string(),
+    ),
+    (
+      "region_bottom_ratio".to_string(),
+      target.region.bottom_ratio.to_string(),
+    ),
+  ]);
+  if let Some(title) = &target.window_title {
+    inputs.insert("title".to_string(), title.clone());
+  }
+  inputs
+}
+
+fn invoke_scan_command(
+  runtime: &crate::runtime::Runtime,
+  run: &mut crate::recording::RecordingRun,
+  root: &crate::recording::SpanRef,
+  request: InvokeRequest,
+  label: &str,
+) -> AuvResult<InvokeResult> {
+  let result = runtime.invoke_in_span(run, root, request)?;
+  if result.status == RunStatus::Completed {
+    Ok(result)
+  } else {
+    Err(
+      result
+        .failure_message
+        .unwrap_or_else(|| format!("{label} command failed")),
+    )
+  }
+}
+
+fn observations_from_first_json_artifact(
+  page_index: usize,
+  result: &InvokeResult,
+  source_artifact: PathBuf,
+) -> AuvResult<Vec<CollectionObservation>> {
+  let json_path = first_artifact_with_extension(result, "json")
+    .ok_or_else(|| "observe window region did not produce a JSON artifact".to_string())?;
+  let raw = fs::read_to_string(&json_path).map_err(|error| {
+    format!(
+      "failed to read observe JSON {}: {error}",
+      json_path.display()
+    )
+  })?;
+  observations_from_observe_json(page_index, &raw, source_artifact)
+}
+
+fn first_artifact_with_extension(result: &InvokeResult, extension: &str) -> Option<PathBuf> {
+  result
+    .artifact_paths
+    .iter()
+    .find(|path| {
+      path
+        .extension()
+        .and_then(|value| value.to_str())
+        .is_some_and(|value| value.eq_ignore_ascii_case(extension))
+    })
+    .cloned()
+}
+
+fn count_new_observations(
+  observations: &[CollectionObservation],
+  known_observation_signatures: &mut BTreeSet<String>,
+) -> usize {
+  observations
+    .iter()
+    .filter(|observation| {
+      !observation.normalized_text_key.is_empty()
+        && known_observation_signatures.insert(observation_signature(observation))
+    })
+    .count()
+}
+
+fn observation_signature(observation: &CollectionObservation) -> String {
+  format!(
+    "{}|x={}|y={}|w={}|h={}",
+    observation.normalized_text_key,
+    observation.bounds.x,
+    observation.bounds.y,
+    observation.bounds.width,
+    observation.bounds.height
+  )
+}
+
+fn match_found_on_current_page(
+  policy: &StopPolicy,
+  current_page_observations: &[CollectionObservation],
+) -> bool {
+  let StopPolicy::UntilMatch { query, .. } = policy else {
+    return false;
+  };
+  let normalized_query = normalize_observation_text(query);
+  !normalized_query.is_empty()
+    && current_page_observations
+      .iter()
+      .any(|observation| observation.normalized_text_key.contains(&normalized_query))
+}
+
+fn run_optional_scan_hook(
+  runtime: &crate::runtime::Runtime,
+  run: &mut crate::recording::RecordingRun,
+  root: &crate::recording::SpanRef,
+  recipe: Option<&str>,
+  hook_name: &str,
+  page_index: usize,
+  options: &ScanWindowRegionOptions,
+  stop_evidence: Option<&StopEvidence>,
+) -> AuvResult<Option<HookDecisionRecord>> {
+  let Some(recipe) = recipe else {
+    return Ok(None);
+  };
+  let project_root = runtime.project_root();
+  let catalog = crate::skill::SkillCatalog::discover(project_root)?;
+  let entry = catalog.resolve(project_root, recipe)?;
+  let mut overrides = BTreeMap::from([
+    ("scan.hook.name".to_string(), hook_name.to_string()),
+    ("scan.page_index".to_string(), page_index.to_string()),
+    ("scan.direction".to_string(), options.direction.clone()),
+    (
+      "scan.target.application_id".to_string(),
+      options.target.application_id.clone().unwrap_or_default(),
+    ),
+  ]);
+  if let Some(stop_evidence) = stop_evidence {
+    overrides.insert(
+      "scan.stop.reason".to_string(),
+      format!("{:?}", stop_evidence.reason),
+    );
+    overrides.insert(
+      "scan.stop.message".to_string(),
+      stop_evidence.message.clone(),
+    );
+  }
+  let summary = crate::skill::run_skill_manifest_into_run(
+    runtime,
+    run,
+    root,
+    &entry.manifest,
+    crate::skill::SkillRunOptions {
+      dry_run: false,
+      max_disturbance: Some(DisturbanceClass::None),
+      overrides,
+    },
+  )?;
+  hook_decision_from_variables(hook_name, page_index, &summary.exported_variables)
+}
+
+fn stage_scan_artifact(
+  runtime: &crate::runtime::Runtime,
+  run: &mut crate::recording::RecordingRun,
+  root: &crate::recording::SpanRef,
+  artifact: &ScrollScanArtifact,
+) -> AuvResult<PathBuf> {
+  let temp_path = write_scan_artifact(artifact)?;
+  let stage_result = runtime.stage_artifact_file(
+    run,
+    root,
+    "scroll-scan",
+    &temp_path,
+    "scroll-scan.json",
+    Some("Runtime window-region scroll scan artifact.".to_string()),
+  );
+  let cleanup_result = fs::remove_file(&temp_path);
+  match (stage_result, cleanup_result) {
+    (Ok(staged_path), Ok(())) => Ok(staged_path),
+    (Ok(staged_path), Err(_)) => Ok(staged_path),
+    (Err(error), Ok(())) | (Err(error), Err(_)) => Err(error),
+  }
+}
+
+fn write_scan_artifact(artifact: &ScrollScanArtifact) -> AuvResult<PathBuf> {
+  let path = std::env::temp_dir().join(format!(
+    "auv-scroll-scan-{}-{}-{}.json",
+    artifact.scan_id,
+    std::process::id(),
+    crate::model::now_millis()
+  ));
+  let rendered = serde_json::to_string_pretty(artifact)
+    .map_err(|error| format!("failed to render scan artifact JSON: {error}"))?;
+  fs::write(&path, format!("{rendered}\n"))
+    .map_err(|error| format!("failed to write scan artifact {}: {error}", path.display()))?;
+  Ok(path)
 }
 
 #[cfg(test)]
@@ -554,6 +1244,118 @@ mod tests {
     assert_eq!(decision.action, HookAction::Stop);
     assert_eq!(decision.reason, "next section");
     assert_eq!(decision.page_index, 3);
+  }
+
+  #[test]
+  fn count_new_observations_uses_position_signature_for_repeated_text() {
+    let mut known_signatures = BTreeSet::new();
+    let first = vec![observation("obs_0001", 0, "Repeat", 10)];
+    let second = vec![observation("obs_0002", 1, "Repeat", 80)];
+
+    assert_eq!(count_new_observations(&first, &mut known_signatures), 1);
+    assert_eq!(count_new_observations(&second, &mut known_signatures), 1);
+  }
+
+  #[test]
+  fn until_match_uses_current_page_observations_only() {
+    let policy = StopPolicy::UntilMatch {
+      query: "needle".to_string(),
+      max_pages: 3,
+      max_scrolls: 3,
+    };
+    let old_accumulated_observations = vec![observation("obs_0001", 0, "needle", 10)];
+    let current_page_observations = vec![observation("obs_0002", 1, "other", 80)];
+
+    assert!(
+      old_accumulated_observations
+        .iter()
+        .any(|observation| observation.normalized_text_key.contains("needle"))
+    );
+    assert!(!match_found_on_current_page(
+      &policy,
+      &current_page_observations
+    ));
+  }
+
+  #[test]
+  fn scan_loop_rejects_unimplemented_hook_actions() {
+    let decision = HookDecisionRecord {
+      hook_name: "per_page_after_observe".to_string(),
+      page_index: 0,
+      action: HookAction::AdjustRegion,
+      reason: "need a wider region".to_string(),
+    };
+
+    let error = validate_scan_loop_hook_decision(&decision).expect_err("action should fail");
+
+    assert!(error.contains("parsed but not implemented by scan_window_region yet"));
+    assert!(error.contains("adjust_region"));
+  }
+
+  #[test]
+  fn stop_candidate_continue_hook_cannot_override_hard_caps() {
+    let policy = StopPolicy::UntilMatch {
+      query: "needle".to_string(),
+      max_pages: 1,
+      max_scrolls: 0,
+    };
+    let progress = ScanProgress {
+      page_index: 0,
+      scroll_count: 0,
+      consecutive_no_progress: 0,
+      new_observation_count: 1,
+      hook_stop_requested: false,
+      match_found: true,
+      next_section_candidate: false,
+    };
+
+    let hard_cap =
+      hard_cap_stop_decision_for_policy(&policy, &progress).expect("hard cap should win");
+
+    assert_eq!(hard_cap.stop_evidence.reason, StopReason::MaxPages);
+  }
+
+  #[test]
+  fn stop_candidate_continue_hook_allowed_before_hard_caps() {
+    let policy = StopPolicy::UntilMatch {
+      query: "needle".to_string(),
+      max_pages: 3,
+      max_scrolls: 2,
+    };
+    let progress = ScanProgress {
+      page_index: 0,
+      scroll_count: 0,
+      consecutive_no_progress: 0,
+      new_observation_count: 1,
+      hook_stop_requested: false,
+      match_found: true,
+      next_section_candidate: false,
+    };
+
+    assert!(hard_cap_stop_decision_for_policy(&policy, &progress).is_none());
+  }
+
+  #[test]
+  fn parse_observe_rows_json_returns_collection_observations() {
+    let raw = r#"{
+    "extractor": "ocr-row",
+    "screenshot_path": "/tmp/page.png",
+    "rows": [
+      {
+        "row_index": 0,
+        "text": "Alpha",
+        "bounds": { "x": 1, "y": 2, "width": 30, "height": 10 },
+        "peak_density": 0.42
+      }
+    ]
+  }"#;
+
+    let observations = observations_from_observe_json(0, raw, PathBuf::from("artifacts/page.png"))
+      .expect("parse observations");
+
+    assert_eq!(observations.len(), 1);
+    assert_eq!(observations[0].raw_text, "Alpha");
+    assert_eq!(observations[0].normalized_text_key, "alpha");
   }
 
   fn observation(id: &str, page_index: usize, text: &str, y: i64) -> CollectionObservation {

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -3,6 +3,8 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
+use crate::model::AuvResult;
+
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ScanRegion {
   pub left_ratio: f64,
@@ -280,6 +282,41 @@ fn stop_decision(
   }
 }
 
+pub fn hook_decision_from_variables(
+  hook_name: &str,
+  page_index: usize,
+  variables: &BTreeMap<String, String>,
+) -> AuvResult<Option<HookDecisionRecord>> {
+  let Some(action) = variables.get("last.scan.hook.action") else {
+    return Ok(None);
+  };
+  let action = parse_hook_action(action)?;
+  let reason = variables
+    .get("last.scan.hook.reason")
+    .cloned()
+    .unwrap_or_else(|| "hook did not provide a reason".to_string());
+  Ok(Some(HookDecisionRecord {
+    hook_name: hook_name.to_string(),
+    page_index,
+    action,
+    reason,
+  }))
+}
+
+fn parse_hook_action(raw: &str) -> AuvResult<HookAction> {
+  match raw.trim() {
+    "continue" => Ok(HookAction::Continue),
+    "stop" => Ok(HookAction::Stop),
+    "retry_observe" => Ok(HookAction::RetryObserve),
+    "adjust_region" => Ok(HookAction::AdjustRegion),
+    "adjust_scroll" => Ok(HookAction::AdjustScroll),
+    "annotate" => Ok(HookAction::Annotate),
+    other => Err(format!(
+      "invalid scan hook action {other:?}; expected continue, stop, retry_observe, adjust_region, adjust_scroll, or annotate"
+    )),
+  }
+}
+
 pub fn normalize_observation_text(raw: &str) -> String {
   raw
     .split_whitespace()
@@ -498,6 +535,25 @@ mod tests {
       decision.completeness_claim,
       CompletenessClaim::CompleteByNoVisualProgress
     );
+  }
+
+  #[test]
+  fn hook_decision_parses_exported_recipe_variables() {
+    let variables = BTreeMap::from([
+      ("last.scan.hook.action".to_string(), "stop".to_string()),
+      (
+        "last.scan.hook.reason".to_string(),
+        "next section".to_string(),
+      ),
+    ]);
+
+    let decision = hook_decision_from_variables("per_page_after_observe", 3, &variables)
+      .expect("decision should parse")
+      .expect("decision should exist");
+
+    assert_eq!(decision.action, HookAction::Stop);
+    assert_eq!(decision.reason, "next section");
+    assert_eq!(decision.page_index, 3);
   }
 
   fn observation(id: &str, page_index: usize, text: &str, y: i64) -> CollectionObservation {

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -155,6 +155,74 @@ pub struct ScrollScanArtifact {
   pub warnings: Vec<String>,
 }
 
+pub fn normalize_observation_text(raw: &str) -> String {
+  raw
+    .split_whitespace()
+    .collect::<Vec<_>>()
+    .join(" ")
+    .trim()
+    .to_lowercase()
+}
+
+pub fn conservative_merge_observations(
+  observations: &[CollectionObservation],
+) -> Vec<ObservationCluster> {
+  let mut clusters: Vec<ObservationCluster> = Vec::new();
+  let mut assigned = vec![false; observations.len()];
+
+  for (index, observation) in observations.iter().enumerate() {
+    if assigned[index] {
+      continue;
+    }
+
+    let mut ids = vec![observation.observation_id.clone()];
+    assigned[index] = true;
+    let mut merge_reason = "single_observation".to_string();
+    let mut confidence = 1.0;
+
+    for (candidate_index, candidate) in observations.iter().enumerate().skip(index + 1) {
+      if assigned[candidate_index] {
+        continue;
+      }
+      if should_merge_adjacent_observations(observation, candidate) {
+        ids.push(candidate.observation_id.clone());
+        assigned[candidate_index] = true;
+        merge_reason = "same_text_adjacent_page_near_y".to_string();
+        confidence = 0.72;
+      }
+    }
+
+    clusters.push(ObservationCluster {
+      cluster_id: format!("cluster_{:04}", clusters.len() + 1),
+      observation_ids: ids,
+      representative_text: observation.raw_text.clone(),
+      merge_reason,
+      confidence,
+    });
+  }
+
+  clusters
+}
+
+// REVIEW: This first merge rule is intentionally conservative and only merges
+// adjacent-page overlap with nearly identical y positions. Revisit after
+// real scan artifacts show whether OCR y jitter needs a wider threshold.
+fn should_merge_adjacent_observations(
+  left: &CollectionObservation,
+  right: &CollectionObservation,
+) -> bool {
+  if left.normalized_text_key.is_empty() || left.normalized_text_key != right.normalized_text_key {
+    return false;
+  }
+  if left.section_context != right.section_context {
+    return false;
+  }
+  if left.page_index.abs_diff(right.page_index) != 1 {
+    return false;
+  }
+  (left.bounds.y - right.bounds.y).abs() <= 8
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;
@@ -223,5 +291,54 @@ mod tests {
     assert!(rendered.contains("\"completeness_claim\": \"partial_max_pages\""));
     assert!(rendered.contains("\"normalized_text_key\": \"alpha\""));
     assert!(rendered.contains("\"merge_reason\": \"single_observation\""));
+  }
+
+  #[test]
+  fn conservative_merge_keeps_same_text_on_same_page_separate() {
+    let observations = vec![
+      observation("obs_0001", 0, "Repeat", 10),
+      observation("obs_0002", 0, "Repeat", 80),
+    ];
+
+    let clusters = conservative_merge_observations(&observations);
+
+    assert_eq!(clusters.len(), 2);
+    assert_eq!(clusters[0].merge_reason, "single_observation");
+    assert_eq!(clusters[1].merge_reason, "single_observation");
+  }
+
+  #[test]
+  fn conservative_merge_groups_same_text_on_adjacent_overlap_pages() {
+    let observations = vec![
+      observation("obs_0001", 0, "Repeat", 120),
+      observation("obs_0002", 1, "Repeat", 118),
+    ];
+
+    let clusters = conservative_merge_observations(&observations);
+
+    assert_eq!(clusters.len(), 1);
+    assert_eq!(
+      clusters[0].observation_ids,
+      vec!["obs_0001".to_string(), "obs_0002".to_string()]
+    );
+    assert_eq!(clusters[0].merge_reason, "same_text_adjacent_page_near_y");
+  }
+
+  fn observation(id: &str, page_index: usize, text: &str, y: i64) -> CollectionObservation {
+    CollectionObservation {
+      observation_id: id.to_string(),
+      page_index,
+      raw_text: text.to_string(),
+      normalized_text_key: normalize_observation_text(text),
+      bounds: ScanRect {
+        x: 10,
+        y,
+        width: 100,
+        height: 24,
+      },
+      section_context: None,
+      source_artifacts: Vec::new(),
+      attributes: BTreeMap::new(),
+    }
   }
 }

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -1,0 +1,227 @@
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ScanRegion {
+  pub left_ratio: f64,
+  pub top_ratio: f64,
+  pub right_ratio: f64,
+  pub bottom_ratio: f64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ScanTarget {
+  pub application_id: Option<String>,
+  pub window_title: Option<String>,
+  pub region: ScanRegion,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum StopPolicy {
+  UntilEnd {
+    max_pages: usize,
+    max_scrolls: usize,
+    no_progress_limit: usize,
+  },
+  UntilNextSection {
+    max_pages: usize,
+    max_scrolls: usize,
+  },
+  UntilMatch {
+    query: String,
+    max_pages: usize,
+    max_scrolls: usize,
+  },
+  Bounded {
+    max_pages: usize,
+    max_scrolls: usize,
+  },
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CompletenessClaim {
+  CompleteByNoVisualProgress,
+  CompleteByReachedBoundary,
+  PartialMaxPages,
+  PartialMaxDuration,
+  PartialUnstableContent,
+  PartialNextSectionCandidate,
+  Unknown,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum StopReason {
+  NoProgressLimit,
+  ReachedBoundary,
+  MaxPages,
+  MaxScrolls,
+  HookRequestedStop,
+  MatchFound,
+  NextSectionCandidate,
+  Error,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ScanRect {
+  pub x: i64,
+  pub y: i64,
+  pub width: i64,
+  pub height: i64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CollectionObservation {
+  pub observation_id: String,
+  pub page_index: usize,
+  pub raw_text: String,
+  pub normalized_text_key: String,
+  pub bounds: ScanRect,
+  pub section_context: Option<String>,
+  pub source_artifacts: Vec<PathBuf>,
+  pub attributes: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ObservationCluster {
+  pub cluster_id: String,
+  pub observation_ids: Vec<String>,
+  pub representative_text: String,
+  pub merge_reason: String,
+  pub confidence: f64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SectionCandidate {
+  pub section_id: String,
+  pub page_index: usize,
+  pub text: String,
+  pub bounds: ScanRect,
+  pub confidence: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HookDecisionRecord {
+  pub hook_name: String,
+  pub page_index: usize,
+  pub action: HookAction,
+  pub reason: String,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum HookAction {
+  Continue,
+  Stop,
+  RetryObserve,
+  AdjustRegion,
+  AdjustScroll,
+  Annotate,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ScanPageRecord {
+  pub page_index: usize,
+  pub observe_run_id: Option<String>,
+  pub screenshot_artifact: Option<PathBuf>,
+  pub observation_count: usize,
+  pub new_observation_count: usize,
+  pub summary: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StopEvidence {
+  pub reason: StopReason,
+  pub message: String,
+  pub page_index: usize,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ScrollScanArtifact {
+  pub scan_id: String,
+  pub target: ScanTarget,
+  pub stop_policy: StopPolicy,
+  pub pages: Vec<ScanPageRecord>,
+  pub observations: Vec<CollectionObservation>,
+  pub clusters: Vec<ObservationCluster>,
+  pub section_candidates: Vec<SectionCandidate>,
+  pub hook_decisions: Vec<HookDecisionRecord>,
+  pub stop_evidence: StopEvidence,
+  pub completeness_claim: CompletenessClaim,
+  pub warnings: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn scan_artifact_serializes_completeness_and_observations() {
+    let artifact = ScrollScanArtifact {
+      scan_id: "scan_test".to_string(),
+      target: ScanTarget {
+        application_id: Some("com.example.App".to_string()),
+        window_title: Some("Library".to_string()),
+        region: ScanRegion {
+          left_ratio: 0.1,
+          top_ratio: 0.2,
+          right_ratio: 0.9,
+          bottom_ratio: 0.8,
+        },
+      },
+      stop_policy: StopPolicy::Bounded {
+        max_pages: 2,
+        max_scrolls: 1,
+      },
+      pages: vec![ScanPageRecord {
+        page_index: 0,
+        observe_run_id: Some("run_observe".to_string()),
+        screenshot_artifact: Some(PathBuf::from("artifacts/page.png")),
+        observation_count: 1,
+        new_observation_count: 1,
+        summary: "observed 1 row".to_string(),
+      }],
+      observations: vec![CollectionObservation {
+        observation_id: "obs_0001".to_string(),
+        page_index: 0,
+        raw_text: "Alpha".to_string(),
+        normalized_text_key: "alpha".to_string(),
+        bounds: ScanRect {
+          x: 10,
+          y: 20,
+          width: 100,
+          height: 30,
+        },
+        section_context: None,
+        source_artifacts: vec![PathBuf::from("artifacts/page.png")],
+        attributes: BTreeMap::new(),
+      }],
+      clusters: vec![ObservationCluster {
+        cluster_id: "cluster_0001".to_string(),
+        observation_ids: vec!["obs_0001".to_string()],
+        representative_text: "Alpha".to_string(),
+        merge_reason: "single_observation".to_string(),
+        confidence: 1.0,
+      }],
+      section_candidates: Vec::new(),
+      hook_decisions: Vec::new(),
+      stop_evidence: StopEvidence {
+        reason: StopReason::MaxPages,
+        message: "reached max_pages=2".to_string(),
+        page_index: 1,
+      },
+      completeness_claim: CompletenessClaim::PartialMaxPages,
+      warnings: vec!["bounded scan".to_string()],
+    };
+
+    let rendered = serde_json::to_string_pretty(&artifact).expect("serialize");
+
+    assert!(rendered.contains("\"completeness_claim\": \"partial_max_pages\""));
+    assert!(rendered.contains("\"normalized_text_key\": \"alpha\""));
+    assert!(rendered.contains("\"merge_reason\": \"single_observation\""));
+  }
+}

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -140,6 +140,23 @@ pub struct StopEvidence {
   pub page_index: usize,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ScanProgress {
+  pub page_index: usize,
+  pub scroll_count: usize,
+  pub consecutive_no_progress: usize,
+  pub new_observation_count: usize,
+  pub hook_stop_requested: bool,
+  pub match_found: bool,
+  pub next_section_candidate: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StopDecision {
+  pub stop_evidence: StopEvidence,
+  pub completeness_claim: CompletenessClaim,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ScrollScanArtifact {
   pub scan_id: String,
@@ -153,6 +170,114 @@ pub struct ScrollScanArtifact {
   pub stop_evidence: StopEvidence,
   pub completeness_claim: CompletenessClaim,
   pub warnings: Vec<String>,
+}
+
+pub fn evaluate_stop_policy(policy: &StopPolicy, progress: &ScanProgress) -> Option<StopDecision> {
+  if progress.hook_stop_requested {
+    return Some(stop_decision(
+      StopReason::HookRequestedStop,
+      "scan hook requested stop",
+      progress.page_index,
+      CompletenessClaim::Unknown,
+    ));
+  }
+  if progress.match_found {
+    return Some(stop_decision(
+      StopReason::MatchFound,
+      "target match found",
+      progress.page_index,
+      CompletenessClaim::Unknown,
+    ));
+  }
+  if progress.next_section_candidate && matches!(policy, StopPolicy::UntilNextSection { .. }) {
+    return Some(stop_decision(
+      StopReason::NextSectionCandidate,
+      "next section candidate observed",
+      progress.page_index,
+      CompletenessClaim::PartialNextSectionCandidate,
+    ));
+  }
+
+  match policy {
+    StopPolicy::UntilEnd {
+      max_pages,
+      max_scrolls,
+      no_progress_limit,
+    } => bounded_or_no_progress_stop(*max_pages, *max_scrolls, *no_progress_limit, progress),
+    StopPolicy::UntilNextSection {
+      max_pages,
+      max_scrolls,
+    }
+    | StopPolicy::UntilMatch {
+      max_pages,
+      max_scrolls,
+      ..
+    }
+    | StopPolicy::Bounded {
+      max_pages,
+      max_scrolls,
+    } => bounded_stop(*max_pages, *max_scrolls, progress),
+  }
+}
+
+fn bounded_or_no_progress_stop(
+  max_pages: usize,
+  max_scrolls: usize,
+  no_progress_limit: usize,
+  progress: &ScanProgress,
+) -> Option<StopDecision> {
+  if progress.consecutive_no_progress >= no_progress_limit {
+    return Some(stop_decision(
+      StopReason::NoProgressLimit,
+      format!("reached no_progress_limit={no_progress_limit}"),
+      progress.page_index,
+      // REVIEW: "Complete by no visual progress" is an evidence claim, not a proof
+      // that the application has no hidden content. Keep this wording visible in
+      // reports and docs.
+      CompletenessClaim::CompleteByNoVisualProgress,
+    ));
+  }
+  bounded_stop(max_pages, max_scrolls, progress)
+}
+
+fn bounded_stop(
+  max_pages: usize,
+  max_scrolls: usize,
+  progress: &ScanProgress,
+) -> Option<StopDecision> {
+  if progress.page_index + 1 >= max_pages {
+    return Some(stop_decision(
+      StopReason::MaxPages,
+      format!("reached max_pages={max_pages}"),
+      progress.page_index,
+      CompletenessClaim::PartialMaxPages,
+    ));
+  }
+  if progress.scroll_count >= max_scrolls {
+    return Some(stop_decision(
+      StopReason::MaxScrolls,
+      format!("reached max_scrolls={max_scrolls}"),
+      progress.page_index,
+      CompletenessClaim::Unknown,
+    ));
+  }
+  None
+}
+
+fn stop_decision(
+  reason: StopReason,
+  message: impl Into<String>,
+  page_index: usize,
+  completeness_claim: CompletenessClaim,
+) -> StopDecision {
+  StopDecision {
+    stop_evidence: StopEvidence {
+      reason,
+      message: message.into(),
+      page_index,
+    },
+    completeness_claim,
+  }
 }
 
 pub fn normalize_observation_text(raw: &str) -> String {
@@ -322,6 +447,57 @@ mod tests {
       vec!["obs_0001".to_string(), "obs_0002".to_string()]
     );
     assert_eq!(clusters[0].merge_reason, "same_text_adjacent_page_near_y");
+  }
+
+  #[test]
+  fn bounded_policy_stops_at_max_pages() {
+    let decision = evaluate_stop_policy(
+      &StopPolicy::Bounded {
+        max_pages: 2,
+        max_scrolls: 10,
+      },
+      &ScanProgress {
+        page_index: 1,
+        scroll_count: 1,
+        consecutive_no_progress: 0,
+        new_observation_count: 3,
+        hook_stop_requested: false,
+        match_found: false,
+        next_section_candidate: false,
+      },
+    );
+
+    assert_eq!(
+      decision.expect("stop expected").completeness_claim,
+      CompletenessClaim::PartialMaxPages
+    );
+  }
+
+  #[test]
+  fn until_end_policy_stops_after_no_progress_limit() {
+    let decision = evaluate_stop_policy(
+      &StopPolicy::UntilEnd {
+        max_pages: 20,
+        max_scrolls: 20,
+        no_progress_limit: 2,
+      },
+      &ScanProgress {
+        page_index: 3,
+        scroll_count: 3,
+        consecutive_no_progress: 2,
+        new_observation_count: 0,
+        hook_stop_requested: false,
+        match_found: false,
+        next_section_candidate: false,
+      },
+    );
+
+    let decision = decision.expect("stop expected");
+    assert_eq!(decision.stop_evidence.reason, StopReason::NoProgressLimit);
+    assert_eq!(
+      decision.completeness_claim,
+      CompletenessClaim::CompleteByNoVisualProgress
+    );
   }
 
   fn observation(id: &str, page_index: usize, text: &str, y: i64) -> CollectionObservation {

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -669,6 +669,9 @@ pub fn hook_decision_from_variables(
   page_index: usize,
   variables: &BTreeMap<String, String>,
 ) -> AuvResult<Option<HookDecisionRecord>> {
+  // REVIEW: Hook recipes currently communicate decisions through exported
+  // variables such as last.scan.hook.action. Revisit if hooks need a smaller
+  // manifest or a first-class typed return artifact.
   let Some(action) = variables.get("last.scan.hook.action") else {
     return Ok(None);
   };
@@ -1244,6 +1247,16 @@ mod tests {
     assert_eq!(decision.action, HookAction::Stop);
     assert_eq!(decision.reason, "next section");
     assert_eq!(decision.page_index, 3);
+  }
+
+  #[test]
+  fn hook_decision_rejects_unknown_action() {
+    let variables = BTreeMap::from([("last.scan.hook.action".to_string(), "teleport".to_string())]);
+
+    let error = hook_decision_from_variables("per_page_after_observe", 0, &variables)
+      .expect_err("invalid action should fail");
+
+    assert!(error.contains("invalid scan hook action"));
   }
 
   #[test]

--- a/src/scroll_scan.rs
+++ b/src/scroll_scan.rs
@@ -114,6 +114,10 @@ pub struct SectionCandidate {
 pub struct HookDecisionRecord {
   pub hook_name: String,
   pub page_index: usize,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub item_index: Option<usize>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub row_candidate_index: Option<usize>,
   pub action: HookAction,
   pub reason: String,
 }
@@ -188,6 +192,7 @@ pub struct ScanWindowRegionOptions {
   pub min_confidence: f64,
   pub max_observations: i64,
   pub per_page_after_observe_recipe: Option<String>,
+  pub per_list_item_candidate_recipe: Option<String>,
   pub on_stop_candidate_recipe: Option<String>,
 }
 
@@ -259,11 +264,24 @@ fn scan_window_region_into_run(
       consecutive_no_progress = 0;
     }
 
-    // WORKAROUND: First scan progress uses OCR novelty only. Add lightweight
-    // screenshot-region diffing before treating no-progress as strong bottom
-    // evidence in broader workflows. Current novelty keys include page-local
-    // x/y/width/height bounds so repeated visible labels at different positions
-    // are not treated as inherently stale.
+    // TODO: Replace this weak no-progress proxy with explicit directional
+    // scroll-boundary evidence. Downward scans need reliable bottom detection;
+    // upward scans need reliable top detection; both directions also need
+    // "scroll until match" semantics so UntilMatch can search above or below
+    // the current viewport instead of only checking already visible rows.
+    // Today we infer progress only from newly observed item signatures, so
+    // repeated virtualized rows, OCR churn, or duplicated labels can make
+    // "top/bottom reached" ambiguous. We need at least one of:
+    // screenshot-region diffing before/after scroll, scrollbar/thumb geometry,
+    // AX scroll value when available, or driver-level scroll-effect evidence.
+    // Sectioned lists also need middleware that can detect separators,
+    // sticky headers, or section boundary regions during the scroll loop so a
+    // scan can stop at, enter, or report section transitions deliberately.
+    // MaaFW reference: Context::wait_freezes and ActionHelper compare image
+    // stability around an action, while Pipeline roi/target references keep
+    // image evidence tied to a node result; see:
+    // /Users/neko/Git/github.com/MaaXYZ/MaaFramework/source/MaaFramework/Task/Context.cpp
+    // /Users/neko/Git/github.com/MaaXYZ/MaaFramework/source/MaaFramework/Task/Component/ActionHelper.cpp
     let progress = ScanProgress {
       page_index,
       scroll_count,
@@ -413,8 +431,10 @@ pub fn observations_from_observe_json(
   let value: Value =
     serde_json::from_str(raw).map_err(|error| format!("malformed observe JSON: {error}"))?;
   let rows = value
-    .get("rows")
+    .get("item_candidates")
     .and_then(Value::as_array)
+    .filter(|candidates| !candidates.is_empty())
+    .or_else(|| value.get("rows").and_then(Value::as_array))
     .ok_or_else(|| "malformed observe JSON: missing rows array".to_string())?;
 
   rows
@@ -482,8 +502,26 @@ fn scan_window_region_page(
   let source_artifact = screenshot_artifact
     .clone()
     .unwrap_or_else(|| first_artifact_with_extension(&observe_result, "json").unwrap_or_default());
-  let page_observations =
+  let mut page_observations =
     observations_from_first_json_artifact(page_index, &observe_result, source_artifact)?;
+  enrich_list_item_observations_with_crops(
+    runtime,
+    run,
+    root,
+    page_index,
+    screenshot_artifact.as_deref(),
+    &options,
+    &mut page_observations,
+  )?;
+  run_list_item_candidate_hooks(
+    runtime,
+    run,
+    root,
+    options.per_list_item_candidate_recipe.as_deref(),
+    options,
+    &page_observations,
+    state,
+  )?;
   let new_observation_count =
     count_new_observations(&page_observations, &mut state.known_observation_signatures);
   let observation_count = page_observations.len();
@@ -580,9 +618,11 @@ fn bounded_or_no_progress_stop(
       StopReason::NoProgressLimit,
       format!("reached no_progress_limit={no_progress_limit}"),
       progress.page_index,
-      // REVIEW: "Complete by no visual progress" is an evidence claim, not a proof
-      // that the application has no hidden content. Keep this wording visible in
-      // reports and docs.
+      // TODO: Back this completeness claim with explicit boundary evidence.
+      // "Complete by no visual progress" is only an evidence claim today, not
+      // proof that the application has no hidden content. Split the future
+      // evidence into direction-aware top/bottom claims so upward and downward
+      // scans do not both collapse into generic no-progress.
       CompletenessClaim::CompleteByNoVisualProgress,
     ));
   }
@@ -669,9 +709,13 @@ pub fn hook_decision_from_variables(
   page_index: usize,
   variables: &BTreeMap<String, String>,
 ) -> AuvResult<Option<HookDecisionRecord>> {
-  // REVIEW: Hook recipes currently communicate decisions through exported
-  // variables such as last.scan.hook.action. Revisit if hooks need a smaller
-  // manifest or a first-class typed return artifact.
+  // TODO: Replace exported scalar variables with a typed recipe return value.
+  // Hook recipes currently communicate decisions through strings such as
+  // last.scan.hook.action because SkillRunSummary has no structured return
+  // channel. MaaFW keeps recognition/action details as JSON in runtime cache
+  // and exposes them by id; the closest references are:
+  // /Users/neko/Git/github.com/MaaXYZ/MaaFramework/source/MaaFramework/Task/Component/Recognizer.cpp
+  // /Users/neko/Git/github.com/MaaXYZ/MaaFramework/source/MaaFramework/Tasker/RuntimeCache.cpp
   let Some(action) = variables.get("last.scan.hook.action") else {
     return Ok(None);
   };
@@ -683,6 +727,8 @@ pub fn hook_decision_from_variables(
   Ok(Some(HookDecisionRecord {
     hook_name: hook_name.to_string(),
     page_index,
+    item_index: None,
+    row_candidate_index: None,
     action,
     reason,
   }))
@@ -775,9 +821,9 @@ pub fn conservative_merge_observations(
   clusters
 }
 
-// REVIEW: This first merge rule is intentionally conservative and only merges
-// adjacent-page overlap with nearly identical y positions. Revisit after
-// real scan artifacts show whether OCR y jitter needs a wider threshold.
+// TODO: Revisit merge identity after scroll-boundary evidence and row-local
+// image hashes exist. This first rule is intentionally conservative and only
+// merges adjacent-page overlap with nearly identical y positions.
 fn should_merge_adjacent_observations(
   left: &CollectionObservation,
   right: &CollectionObservation,
@@ -822,8 +868,44 @@ fn observation_from_row(
     },
     section_context: None,
     source_artifacts: vec![source_artifact.to_path_buf()],
-    attributes: BTreeMap::new(),
+    attributes: observation_attributes_from_row(row),
   })
+}
+
+fn observation_attributes_from_row(row: &Value) -> BTreeMap<String, String> {
+  let mut attributes = BTreeMap::new();
+  if let Some(source) = row.get("source").and_then(Value::as_str) {
+    attributes.insert("source".to_string(), source.to_string());
+  }
+  if let Some(row_index) = row.get("row_index").and_then(Value::as_u64) {
+    attributes.insert("row_index".to_string(), row_index.to_string());
+  }
+  if let Some(item_index) = row.get("item_index").and_then(Value::as_u64) {
+    attributes.insert("item_index".to_string(), item_index.to_string());
+  }
+  if let Some(row_candidate_index) = row.get("row_candidate_index").and_then(Value::as_u64) {
+    attributes.insert(
+      "row_candidate_index".to_string(),
+      row_candidate_index.to_string(),
+    );
+  }
+  if let Some(role) = row.get("segmented_region_role").and_then(Value::as_str) {
+    attributes.insert("segmented_region_role".to_string(), role.to_string());
+  }
+  if let Some(reason) = row.get("filter_reason").and_then(Value::as_str) {
+    attributes.insert("filter_reason".to_string(), reason.to_string());
+  }
+  if let Some(fragments) = row.get("text_fragments").and_then(Value::as_array) {
+    let text = fragments
+      .iter()
+      .filter_map(Value::as_str)
+      .collect::<Vec<_>>()
+      .join(" | ");
+    if !text.is_empty() {
+      attributes.insert("text_fragments".to_string(), text);
+    }
+  }
+  attributes
 }
 
 fn json_i64(bounds: &Value, key: &str, row_index: usize) -> AuvResult<i64> {
@@ -866,6 +948,11 @@ fn observe_request(options: &ScanWindowRegionOptions, page_index: usize) -> Invo
 
 fn scroll_request(options: &ScanWindowRegionOptions) -> InvokeRequest {
   let mut inputs = region_inputs(&options.target);
+  // TODO: Preserve scroll-effect evidence in the scroll command result. The
+  // scan loop needs to know whether an up/down scroll actually moved the
+  // viewport, hit the top, hit the bottom, or crossed a section boundary; the
+  // current request only sends direction/amount and treats command success as
+  // movement.
   inputs.insert("direction".to_string(), options.direction.clone());
   inputs.insert(
     "amount".to_string(),
@@ -960,17 +1047,34 @@ fn count_new_observations(
 ) -> usize {
   observations
     .iter()
-    .filter(|observation| {
-      !observation.normalized_text_key.is_empty()
-        && known_observation_signatures.insert(observation_signature(observation))
-    })
+    .filter(|observation| known_observation_signatures.insert(observation_signature(observation)))
     .count()
 }
 
 fn observation_signature(observation: &CollectionObservation) -> String {
+  let identity = if observation.normalized_text_key.is_empty() {
+    // TODO: Replace visual-only geometry identity with row OCR, AX ids, or
+    // local image hashes. Source + viewport geometry is only a bounded progress
+    // signal and can misidentify virtualized or repeated rows.
+    format!(
+      "visual:{}:{}",
+      observation
+        .attributes
+        .get("source")
+        .map(String::as_str)
+        .unwrap_or("unknown"),
+      observation
+        .attributes
+        .get("row_index")
+        .map(String::as_str)
+        .unwrap_or("?")
+    )
+  } else {
+    observation.normalized_text_key.clone()
+  };
   format!(
     "{}|x={}|y={}|w={}|h={}",
-    observation.normalized_text_key,
+    identity,
     observation.bounds.x,
     observation.bounds.y,
     observation.bounds.width,
@@ -990,6 +1094,479 @@ fn match_found_on_current_page(
     && current_page_observations
       .iter()
       .any(|observation| observation.normalized_text_key.contains(&normalized_query))
+}
+
+fn list_item_candidate_hook_overrides(
+  options: &ScanWindowRegionOptions,
+  item: &CollectionObservation,
+) -> BTreeMap<String, String> {
+  // TODO: Replace these scalar scan.item.* overrides with one typed hook
+  // context object. We keep the scalar surface small for now because recipe
+  // step args are still rendered as strings, but list-item parsing needs the
+  // crop artifact, OCR fragments, bounds, and provenance as one coherent value.
+  // MaaFW reference: custom_recognition_param/custom_action_param are JSON
+  // values, and custom recognition returns a box plus JSON detail:
+  // /Users/neko/Git/github.com/MaaXYZ/MaaFramework/source/MaaFramework/Resource/PipelineTypes.h
+  // /Users/neko/Git/github.com/MaaXYZ/MaaFramework/source/MaaFramework/Task/Component/CustomRecognition.cpp
+  // TODO: Include section-boundary and segmentation context here once region
+  // segmentation can identify list bodies, sticky headers, separators, and
+  // section-local item ranges. That middleware is the core difference between
+  // "scroll until match" and "scroll within this section until match".
+  let mut overrides = BTreeMap::from([
+    (
+      "scan.hook.name".to_string(),
+      "per_list_item_candidate".to_string(),
+    ),
+    (
+      "scan.hook.stage".to_string(),
+      "per_list_item_candidate".to_string(),
+    ),
+    ("scan.page_index".to_string(), item.page_index.to_string()),
+    ("scan.direction".to_string(), options.direction.clone()),
+    (
+      "scan.target.application_id".to_string(),
+      options.target.application_id.clone().unwrap_or_default(),
+    ),
+    (
+      "scan.item.index".to_string(),
+      item
+        .attributes
+        .get("item_index")
+        .cloned()
+        .unwrap_or_else(|| "0".to_string()),
+    ),
+    (
+      "scan.item.row_candidate_index".to_string(),
+      item
+        .attributes
+        .get("row_candidate_index")
+        .cloned()
+        .unwrap_or_default(),
+    ),
+    ("scan.item.text".to_string(), item.raw_text.clone()),
+    ("scan.item.bounds.x".to_string(), item.bounds.x.to_string()),
+    ("scan.item.bounds.y".to_string(), item.bounds.y.to_string()),
+    (
+      "scan.item.bounds.width".to_string(),
+      item.bounds.width.to_string(),
+    ),
+    (
+      "scan.item.bounds.height".to_string(),
+      item.bounds.height.to_string(),
+    ),
+  ]);
+  for key in [
+    "source",
+    "filter_reason",
+    "segmented_region_role",
+    "text_fragments",
+  ] {
+    if let Some(value) = item.attributes.get(key) {
+      overrides.insert(format!("scan.item.{key}"), value.clone());
+    }
+  }
+  if let Some(source_artifact) = item.source_artifacts.first() {
+    overrides.insert(
+      "scan.item.source_artifact".to_string(),
+      source_artifact.display().to_string(),
+    );
+  }
+  if let Some(crop_artifact) = item.attributes.get("crop_artifact") {
+    overrides.insert("scan.item.crop_artifact".to_string(), crop_artifact.clone());
+  }
+  if let Some(context_artifact) = item.attributes.get("context_artifact") {
+    overrides.insert(
+      "scan.item.context_artifact".to_string(),
+      context_artifact.clone(),
+    );
+  }
+  overrides
+}
+
+#[derive(Clone, Debug)]
+struct ListItemCropOcrResult {
+  crop_artifact: PathBuf,
+  context_artifact: PathBuf,
+  text_fragments: Vec<String>,
+  strategy: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+struct ListItemCandidateContextArtifact {
+  schema: String,
+  observation_id: String,
+  page_index: usize,
+  raw_text: String,
+  text_fragments: Vec<String>,
+  bounds: ScanRect,
+  attributes: BTreeMap<String, String>,
+  source_artifacts: Vec<PathBuf>,
+  crop_artifact: PathBuf,
+  ocr_strategy: String,
+}
+
+impl ListItemCandidateContextArtifact {
+  const SCHEMA: &'static str = "auv.scan.list_item_candidate_context.v1";
+  const OCR_STRATEGY: &'static str = "crop_ocr";
+}
+
+fn enrich_list_item_observations_with_crops(
+  runtime: &crate::runtime::Runtime,
+  run: &mut crate::recording::RecordingRun,
+  root: &crate::recording::SpanRef,
+  page_index: usize,
+  screenshot_artifact: Option<&Path>,
+  options: &ScanWindowRegionOptions,
+  observations: &mut [CollectionObservation],
+) -> AuvResult<()> {
+  let Some(screenshot_artifact) = screenshot_artifact else {
+    return Ok(());
+  };
+
+  let mut crop_jobs = Vec::new();
+  for (observation_index, observation) in observations.iter().enumerate() {
+    let item_index = observation_item_index(observation);
+    let crop_temp_path = crop_list_item_image(
+      screenshot_artifact,
+      &observation.bounds,
+      &format!(
+        "scan-page-{:04}-list-item-{:04}",
+        page_index + 1,
+        item_index + 1
+      ),
+    )?;
+    crop_jobs.push((observation_index, item_index, crop_temp_path));
+  }
+
+  let text_results =
+    ocr_list_item_crops_parallel(&crop_jobs, options.min_confidence, options.max_observations)?;
+
+  for (observation_index, item_index, crop_temp_path) in crop_jobs {
+    let observation = &mut observations[observation_index];
+    let text_fragments = text_results
+      .get(observation_index)
+      .cloned()
+      .unwrap_or_default();
+    let crop_artifact = runtime.stage_artifact_file(
+      run,
+      root,
+      "list-item-crop",
+      &crop_temp_path,
+      format!(
+        "scan-page-{:04}-list-item-{:04}.png",
+        page_index + 1,
+        item_index + 1
+      ),
+      Some("Cropped screenshot for one list item candidate.".to_string()),
+    )?;
+    let context_temp_path =
+      write_list_item_context_artifact(observation, &crop_artifact, &text_fragments)?;
+    let context_artifact = runtime.stage_artifact_file(
+      run,
+      root,
+      "list-item-context",
+      &context_temp_path,
+      format!(
+        "scan-page-{:04}-list-item-{:04}-context.json",
+        page_index + 1,
+        item_index + 1
+      ),
+      Some("Typed context for one list item candidate.".to_string()),
+    )?;
+    let _ = fs::remove_file(&crop_temp_path);
+    let _ = fs::remove_file(&context_temp_path);
+    apply_list_item_crop_ocr_result(
+      observation,
+      ListItemCropOcrResult {
+        crop_artifact,
+        context_artifact,
+        text_fragments,
+        strategy: "crop_ocr".to_string(),
+      },
+    );
+  }
+
+  Ok(())
+}
+
+fn ocr_list_item_crops_parallel(
+  crop_jobs: &[(usize, usize, PathBuf)],
+  min_confidence: f64,
+  max_observations: i64,
+) -> AuvResult<Vec<Vec<String>>> {
+  let mut handles = Vec::new();
+  for (observation_index, _, crop_path) in crop_jobs {
+    let crop_path = crop_path.clone();
+    let observation_index = *observation_index;
+    handles.push(std::thread::spawn(move || {
+      crate::driver::ocr_text_fragments_in_image(&crop_path, min_confidence, max_observations)
+        .map(|fragments| (observation_index, fragments))
+    }));
+  }
+
+  let mut results = vec![Vec::new(); crop_jobs.len()];
+  for handle in handles {
+    let (observation_index, fragments) = handle
+      .join()
+      .map_err(|_| "list item crop OCR worker panicked".to_string())??;
+    if let Some(slot) = results.get_mut(observation_index) {
+      *slot = fragments;
+    }
+  }
+  Ok(results)
+}
+
+fn observation_item_index(observation: &CollectionObservation) -> usize {
+  observation
+    .attributes
+    .get("item_index")
+    .and_then(|value| value.parse::<usize>().ok())
+    .unwrap_or(0)
+}
+
+fn crop_list_item_image(source: &Path, bounds: &ScanRect, label: &str) -> AuvResult<PathBuf> {
+  let image = image::open(source).map_err(|error| {
+    format!(
+      "failed to open list item source image {}: {error}",
+      source.display()
+    )
+  })?;
+  let image_width = image.width() as i64;
+  let image_height = image.height() as i64;
+  let crop = clamped_crop_rect(bounds, image_width, image_height)?;
+  let cropped = image.crop_imm(
+    crop.x as u32,
+    crop.y as u32,
+    crop.width as u32,
+    crop.height as u32,
+  );
+  let path = std::env::temp_dir().join(format!(
+    "auv-{}-{}-{}.png",
+    sanitize_scan_artifact_component(label),
+    std::process::id(),
+    crate::model::now_millis()
+  ));
+  cropped
+    .save(&path)
+    .map_err(|error| format!("failed to write list item crop {}: {error}", path.display()))?;
+  Ok(path)
+}
+
+fn clamped_crop_rect(
+  bounds: &ScanRect,
+  image_width: i64,
+  image_height: i64,
+) -> AuvResult<ScanRect> {
+  if image_width <= 0 || image_height <= 0 {
+    return Err(format!(
+      "invalid source image dimensions {}x{} for list item crop",
+      image_width, image_height
+    ));
+  }
+  let x = bounds.x.clamp(0, image_width.saturating_sub(1));
+  let y = bounds.y.clamp(0, image_height.saturating_sub(1));
+  let max_x = (bounds.x + bounds.width).clamp(x + 1, image_width);
+  let max_y = (bounds.y + bounds.height).clamp(y + 1, image_height);
+  Ok(ScanRect {
+    x,
+    y,
+    width: max_x - x,
+    height: max_y - y,
+  })
+}
+
+fn write_list_item_context_artifact(
+  observation: &CollectionObservation,
+  crop_artifact: &Path,
+  text_fragments: &[String],
+) -> AuvResult<PathBuf> {
+  let path = std::env::temp_dir().join(format!(
+    "auv-list-item-context-{}-{}-{}.json",
+    sanitize_scan_artifact_component(&observation.observation_id),
+    std::process::id(),
+    crate::model::now_millis()
+  ));
+  let payload = build_list_item_context_payload(observation, crop_artifact, text_fragments);
+  let rendered = serde_json::to_string_pretty(&payload)
+    .map_err(|error| format!("failed to render list item context JSON: {error}"))?;
+  fs::write(&path, format!("{rendered}\n")).map_err(|error| {
+    format!(
+      "failed to write list item context {}: {error}",
+      path.display()
+    )
+  })?;
+  Ok(path)
+}
+
+fn build_list_item_context_payload(
+  observation: &CollectionObservation,
+  crop_artifact: &Path,
+  text_fragments: &[String],
+) -> ListItemCandidateContextArtifact {
+  let raw_text = joined_text_fragments(text_fragments);
+  let mut attributes = observation.attributes.clone();
+  if !raw_text.is_empty() {
+    attributes.insert("text_fragments".to_string(), raw_text.clone());
+  }
+  attributes.insert(
+    "ocr_strategy".to_string(),
+    ListItemCandidateContextArtifact::OCR_STRATEGY.to_string(),
+  );
+
+  ListItemCandidateContextArtifact {
+    schema: ListItemCandidateContextArtifact::SCHEMA.to_string(),
+    observation_id: observation.observation_id.clone(),
+    page_index: observation.page_index,
+    raw_text,
+    text_fragments: text_fragments.to_vec(),
+    bounds: observation.bounds.clone(),
+    attributes,
+    source_artifacts: observation.source_artifacts.clone(),
+    crop_artifact: crop_artifact.to_path_buf(),
+    ocr_strategy: ListItemCandidateContextArtifact::OCR_STRATEGY.to_string(),
+  }
+}
+
+fn apply_list_item_crop_ocr_result(
+  observation: &mut CollectionObservation,
+  result: ListItemCropOcrResult,
+) {
+  observation.attributes.insert(
+    "crop_artifact".to_string(),
+    result.crop_artifact.display().to_string(),
+  );
+  observation.attributes.insert(
+    "context_artifact".to_string(),
+    result.context_artifact.display().to_string(),
+  );
+  observation
+    .attributes
+    .insert("ocr_strategy".to_string(), result.strategy);
+  if !result.text_fragments.is_empty() {
+    let raw_text = joined_text_fragments(&result.text_fragments);
+    observation.raw_text = raw_text.clone();
+    observation.normalized_text_key = normalize_observation_text(&raw_text);
+    observation
+      .attributes
+      .insert("text_fragments".to_string(), raw_text);
+  }
+}
+
+fn joined_text_fragments(text_fragments: &[String]) -> String {
+  text_fragments.join(" | ")
+}
+
+fn sanitize_scan_artifact_component(raw: &str) -> String {
+  let sanitized = raw
+    .chars()
+    .map(|character| {
+      if character.is_ascii_alphanumeric() || matches!(character, '-' | '_') {
+        character
+      } else {
+        '-'
+      }
+    })
+    .collect::<String>()
+    .trim_matches('-')
+    .to_string();
+  if sanitized.is_empty() {
+    "item".to_string()
+  } else {
+    sanitized
+  }
+}
+
+fn run_list_item_candidate_hooks(
+  runtime: &crate::runtime::Runtime,
+  run: &mut crate::recording::RecordingRun,
+  root: &crate::recording::SpanRef,
+  recipe: Option<&str>,
+  options: &ScanWindowRegionOptions,
+  items: &[CollectionObservation],
+  state: &mut ScanWindowRegionState,
+) -> AuvResult<()> {
+  let Some(recipe) = recipe else {
+    return Ok(());
+  };
+  let project_root = runtime.project_root();
+  // TODO: Allow recipe manifests to declare inline hook/sub-recipe blocks.
+  // This standalone recipe lookup exists because SkillCatalog currently resolves
+  // only top-level recipe_id values from recipes/**/*.json, while scroll scan
+  // needs a per-list-item hook that belongs conceptually to the parent workflow.
+  // MaaFW reference: Context::run_task/run_recognition/run_action accept a JSON
+  // pipeline_override, so a caller can synthesize or override nested pipeline
+  // nodes without creating a separate resource file for every hook:
+  // /Users/neko/Git/github.com/MaaXYZ/MaaFramework/source/MaaFramework/Task/Context.cpp
+  // /Users/neko/Git/github.com/MaaXYZ/MaaFramework/docs/zh_cn/3.1-任务流水线协议.md
+  let catalog = crate::skill::SkillCatalog::discover(project_root)?;
+  let entry = catalog.resolve(project_root, recipe)?;
+  validate_scan_sub_recipe(&entry.manifest, "per_list_item_candidate")?;
+
+  for item in items {
+    let summary = crate::skill::run_skill_manifest_into_run(
+      runtime,
+      run,
+      root,
+      &entry.manifest,
+      crate::skill::SkillRunOptions {
+        dry_run: false,
+        max_disturbance: Some(DisturbanceClass::None),
+        overrides: list_item_candidate_hook_overrides(options, item),
+        quiet: true,
+      },
+    )?;
+    let Some(mut decision) = hook_decision_from_variables(
+      "per_list_item_candidate",
+      item.page_index,
+      &summary.exported_variables,
+    )?
+    else {
+      continue;
+    };
+    decision.item_index = item
+      .attributes
+      .get("item_index")
+      .and_then(|value| value.parse::<usize>().ok());
+    decision.row_candidate_index = item
+      .attributes
+      .get("row_candidate_index")
+      .and_then(|value| value.parse::<usize>().ok());
+    validate_list_item_candidate_hook_decision(&decision)?;
+    let should_stop = decision.action == HookAction::Stop;
+    state.hook_decisions.push(decision);
+    if should_stop {
+      break;
+    }
+  }
+
+  Ok(())
+}
+
+fn validate_scan_sub_recipe(
+  manifest: &crate::skill::SkillManifest,
+  expected_stage: &str,
+) -> AuvResult<()> {
+  let invocation = &manifest.invocation;
+  if invocation.kind != "sub_recipe"
+    || invocation.host != "scroll_scan"
+    || invocation.stage != expected_stage
+  {
+    return Err(format!(
+      "recipe {} is not a scroll_scan sub_recipe for stage {expected_stage}",
+      manifest.recipe_id
+    ));
+  }
+  Ok(())
+}
+
+fn validate_list_item_candidate_hook_decision(decision: &HookDecisionRecord) -> AuvResult<()> {
+  match decision.action {
+    HookAction::Continue | HookAction::Stop | HookAction::Annotate => Ok(()),
+    HookAction::RetryObserve | HookAction::AdjustRegion | HookAction::AdjustScroll => Err(format!(
+      "list item hook action {} is parsed but not implemented by scan_window_region yet",
+      hook_action_name(decision.action)
+    )),
+  }
 }
 
 fn run_optional_scan_hook(
@@ -1036,6 +1613,7 @@ fn run_optional_scan_hook(
       dry_run: false,
       max_disturbance: Some(DisturbanceClass::None),
       overrides,
+      quiet: false,
     },
   )?;
   hook_decision_from_variables(hook_name, page_index, &summary.exported_variables)
@@ -1295,6 +1873,8 @@ mod tests {
     let decision = HookDecisionRecord {
       hook_name: "per_page_after_observe".to_string(),
       page_index: 0,
+      item_index: None,
+      row_candidate_index: None,
       action: HookAction::AdjustRegion,
       reason: "need a wider region".to_string(),
     };
@@ -1356,7 +1936,9 @@ mod tests {
     "rows": [
       {
         "row_index": 0,
+        "source": "visual-bands+ocr-text",
         "text": "Alpha",
+        "text_fragments": ["Alpha"],
         "bounds": { "x": 1, "y": 2, "width": 30, "height": 10 },
         "peak_density": 0.42
       }
@@ -1369,6 +1951,225 @@ mod tests {
     assert_eq!(observations.len(), 1);
     assert_eq!(observations[0].raw_text, "Alpha");
     assert_eq!(observations[0].normalized_text_key, "alpha");
+    assert_eq!(
+      observations[0].attributes.get("source").map(String::as_str),
+      Some("visual-bands+ocr-text")
+    );
+    assert_eq!(
+      observations[0]
+        .attributes
+        .get("text_fragments")
+        .map(String::as_str),
+      Some("Alpha")
+    );
+  }
+
+  #[test]
+  fn parse_observe_json_prefers_list_item_candidates_over_raw_rows() {
+    let raw = r#"{
+    "extractor": "ocr-row",
+    "screenshot_path": "/tmp/page.png",
+    "rows": [
+      {
+        "row_index": 0,
+        "source": "visual-bands",
+        "text": "",
+        "text_fragments": [],
+        "bounds": { "x": 10, "y": 20, "width": 400, "height": 160 }
+      }
+    ],
+    "item_candidates": [
+      {
+        "item_index": 0,
+        "row_candidate_index": 2,
+        "source": "row_filter",
+        "text": "Whisper of time",
+        "text_fragments": ["Whisper of time"],
+        "bounds": { "x": 100, "y": 220, "width": 600, "height": 84 }
+      },
+      {
+        "item_index": 1,
+        "row_candidate_index": 3,
+        "source": "row_filter",
+        "text": "万书隙",
+        "text_fragments": ["万书隙"],
+        "bounds": { "x": 100, "y": 348, "width": 600, "height": 86 }
+      }
+    ]
+  }"#;
+
+    let observations = observations_from_observe_json(0, raw, PathBuf::from("artifacts/page.png"))
+      .expect("parse observations");
+
+    assert_eq!(observations.len(), 2);
+    assert_eq!(observations[0].raw_text, "Whisper of time");
+    assert_eq!(
+      observations[0]
+        .attributes
+        .get("row_candidate_index")
+        .map(String::as_str),
+      Some("2")
+    );
+    assert_eq!(
+      observations[0].attributes.get("source").map(String::as_str),
+      Some("row_filter")
+    );
+  }
+
+  #[test]
+  fn count_new_observations_tracks_visual_only_rows_once() {
+    let mut known = BTreeSet::new();
+    let mut visual = observation("obs_0001_0001", 0, "", 120);
+    visual
+      .attributes
+      .insert("source".to_string(), "visual-bands".to_string());
+    visual
+      .attributes
+      .insert("row_index".to_string(), "0".to_string());
+
+    assert_eq!(count_new_observations(&[visual.clone()], &mut known), 1);
+    assert_eq!(count_new_observations(&[visual], &mut known), 0);
+  }
+
+  #[test]
+  fn list_item_candidate_hook_overrides_include_outer_scan_context() {
+    let mut item = observation("obs_0001_0001", 2, "Song A", 120);
+    item
+      .attributes
+      .insert("item_index".to_string(), "4".to_string());
+    item
+      .attributes
+      .insert("row_candidate_index".to_string(), "7".to_string());
+    item
+      .attributes
+      .insert("source".to_string(), "row_filter".to_string());
+    item.attributes.insert(
+      "filter_reason".to_string(),
+      "accepted_repeating_row_geometry".to_string(),
+    );
+    item
+      .source_artifacts
+      .push(PathBuf::from("artifacts/page.png"));
+    let options = ScanWindowRegionOptions {
+      target: ScanTarget {
+        application_id: Some("com.example.App".to_string()),
+        window_title: None,
+        region: ScanRegion {
+          left_ratio: 0.2,
+          top_ratio: 0.3,
+          right_ratio: 0.9,
+          bottom_ratio: 0.8,
+        },
+      },
+      stop_policy: StopPolicy::Bounded {
+        max_pages: 1,
+        max_scrolls: 0,
+      },
+      direction: "down".to_string(),
+      scroll_amount: 40.0,
+      settle_ms: 250,
+      min_confidence: 0.0,
+      max_observations: 128,
+      per_page_after_observe_recipe: None,
+      per_list_item_candidate_recipe: Some(
+        "scan.fixture.list_item_candidate_continue.v0".to_string(),
+      ),
+      on_stop_candidate_recipe: None,
+    };
+
+    let overrides = list_item_candidate_hook_overrides(&options, &item);
+
+    assert_eq!(
+      overrides.get("scan.hook.stage").map(String::as_str),
+      Some("per_list_item_candidate")
+    );
+    assert_eq!(
+      overrides.get("scan.page_index").map(String::as_str),
+      Some("2")
+    );
+    assert_eq!(
+      overrides.get("scan.item.index").map(String::as_str),
+      Some("4")
+    );
+    assert_eq!(
+      overrides
+        .get("scan.item.row_candidate_index")
+        .map(String::as_str),
+      Some("7")
+    );
+    assert_eq!(
+      overrides.get("scan.item.bounds.y").map(String::as_str),
+      Some("120")
+    );
+    assert_eq!(
+      overrides
+        .get("scan.item.source_artifact")
+        .map(String::as_str),
+      Some("artifacts/page.png")
+    );
+  }
+
+  #[test]
+  fn crop_ocr_enrichment_writes_text_and_artifact_context() {
+    let mut observation = observation("obs_0001_0001", 0, "", 120);
+    observation
+      .attributes
+      .insert("item_index".to_string(), "2".to_string());
+
+    let enrichment = ListItemCropOcrResult {
+      crop_artifact: PathBuf::from("artifacts/list-item-0003.png"),
+      context_artifact: PathBuf::from("artifacts/list-item-0003-context.json"),
+      text_fragments: vec!["Song A".to_string(), "Artist B".to_string()],
+      strategy: "crop_ocr".to_string(),
+    };
+
+    apply_list_item_crop_ocr_result(&mut observation, enrichment);
+
+    assert_eq!(observation.raw_text, "Song A | Artist B");
+    assert_eq!(observation.normalized_text_key, "song a | artist b");
+    assert_eq!(
+      observation
+        .attributes
+        .get("crop_artifact")
+        .map(String::as_str),
+      Some("artifacts/list-item-0003.png")
+    );
+    assert_eq!(
+      observation
+        .attributes
+        .get("context_artifact")
+        .map(String::as_str),
+      Some("artifacts/list-item-0003-context.json")
+    );
+    assert_eq!(
+      observation
+        .attributes
+        .get("text_fragments")
+        .map(String::as_str),
+      Some("Song A | Artist B")
+    );
+  }
+
+  #[test]
+  fn list_item_context_payload_uses_crop_ocr_fragments_as_single_text_source() {
+    let mut observation = observation("obs_0001_0001", 0, "old observe text", 120);
+    observation
+      .attributes
+      .insert("text_fragments".to_string(), "old observe text".to_string());
+    let fragments = vec!["Song A".to_string(), "Artist B".to_string()];
+
+    let payload = build_list_item_context_payload(
+      &observation,
+      Path::new("artifacts/list-item-0001.png"),
+      &fragments,
+    );
+
+    assert_eq!(payload.raw_text, "Song A | Artist B");
+    assert_eq!(payload.text_fragments, fragments);
+    assert_eq!(
+      payload.attributes.get("text_fragments").map(String::as_str),
+      Some("Song A | Artist B")
+    );
   }
 
   fn observation(id: &str, page_index: usize, text: &str, y: i64) -> CollectionObservation {

--- a/src/skill.rs
+++ b/src/skill.rs
@@ -27,6 +27,8 @@ pub struct SkillManifest {
   pub target_app: SkillTargetApp,
   #[serde(default)]
   pub strategy: SkillStrategy,
+  #[serde(default)]
+  pub invocation: SkillInvocation,
   pub objective: String,
   #[serde(default)]
   pub inputs: BTreeMap<String, SkillInputSpec>,
@@ -62,6 +64,20 @@ pub struct SkillStrategy {
   pub activation: String,
   #[serde(default, rename = "verificationContract")]
   pub verification_contract: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Default, PartialEq, Eq)]
+pub struct SkillInvocation {
+  #[serde(default)]
+  pub kind: String,
+  #[serde(default)]
+  pub host: String,
+  #[serde(default)]
+  pub stage: String,
+  #[serde(default)]
+  pub context_schema: String,
+  #[serde(default)]
+  pub return_schema: String,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -456,6 +472,7 @@ pub struct SkillRunOptions {
   pub dry_run: bool,
   pub max_disturbance: Option<DisturbanceClass>,
   pub overrides: BTreeMap<String, String>,
+  pub quiet: bool,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -687,14 +704,16 @@ pub(crate) fn run_skill_manifest_into_run(
   let active_max = validate_disturbance_policy(manifest, options.max_disturbance)?;
   let _lock = maybe_acquire_live_app_lock(manifest, &variables, options.dry_run)?;
 
-  println!("skill: {}", manifest.recipe_id);
-  println!("version: {}", manifest.version);
-  println!("objective: {}", manifest.objective);
-  println!(
-    "target: {}",
-    render_template(&manifest.target_app.bundle_id, &variables)
-  );
-  println!("max disturbance: {}", active_max.as_str());
+  if !options.quiet {
+    println!("skill: {}", manifest.recipe_id);
+    println!("version: {}", manifest.version);
+    println!("objective: {}", manifest.objective);
+    println!(
+      "target: {}",
+      render_template(&manifest.target_app.bundle_id, &variables)
+    );
+    println!("max disturbance: {}", active_max.as_str());
+  }
 
   for (index, step) in manifest.steps.iter().enumerate() {
     let step_id = step_id(step, index);
@@ -722,6 +741,7 @@ pub(crate) fn run_skill_manifest_into_run(
         step_span: &step_span,
         manifest,
         dry_run: options.dry_run,
+        quiet: options.quiet,
         variables: &mut variables,
         top_level_signal_exports: &mut top_level_signal_exports,
       };
@@ -766,6 +786,7 @@ struct SkillStepRuntime<'a> {
   step_span: &'a crate::recording::SpanRef,
   manifest: &'a SkillManifest,
   dry_run: bool,
+  quiet: bool,
   variables: &'a mut BTreeMap<String, String>,
   top_level_signal_exports: &'a mut BTreeSet<String>,
 }
@@ -783,14 +804,16 @@ fn run_skill_step_into_span(
   } else {
     step.disturbance.classes.join(", ")
   };
-  print_step_preview(
-    index + 1,
-    context.manifest.steps.len(),
-    step_id,
-    &request,
-    step_max,
-    &step_classes,
-  );
+  if !context.quiet {
+    print_step_preview(
+      index + 1,
+      context.manifest.steps.len(),
+      step_id,
+      &request,
+      step_max,
+      &step_classes,
+    );
+  }
 
   if context.dry_run {
     return Ok(());
@@ -799,7 +822,9 @@ fn run_skill_step_into_span(
   let result = context
     .runtime
     .invoke_in_span(context.run, context.step_span, request)?;
-  print_invoke_result(&result);
+  if !context.quiet {
+    print_invoke_result(&result);
+  }
   enforce_step_expectations(step_id, step, &result, context.variables)?;
   export_step_variables(
     step_id,
@@ -1385,6 +1410,7 @@ pub(crate) fn run_skill_case_matrix_into_run(
         dry_run: options.dry_run,
         max_disturbance: options.max_disturbance,
         overrides: case.inputs.clone(),
+        quiet: false,
       },
     );
 
@@ -2424,6 +2450,35 @@ mod tests {
   }
 
   #[test]
+  fn skill_manifest_parses_sub_recipe_invocation_contract() {
+    let manifest: SkillManifest = serde_json::from_value(json!({
+      "recipe_id": "scan.fixture.list_item_candidate_continue.v0",
+      "version": "0.1.0",
+      "target_app": { "bundle_id": "fixture://scan-hook", "display_mode": "fixture" },
+      "strategy": {
+        "family": "native-text",
+        "grounding": "ax-text",
+        "activation": "pointer-focus-clipboard-paste",
+        "verificationContract": "verifyAxText"
+      },
+      "invocation": {
+        "kind": "sub_recipe",
+        "host": "scroll_scan",
+        "stage": "per_list_item_candidate",
+        "context_schema": "auv.scan.list_item_candidate.scalar_context.v0",
+        "return_schema": "auv.scan.hook_decision.v0"
+      },
+      "objective": "test",
+      "steps": []
+    }))
+    .expect("manifest should deserialize");
+
+    assert_eq!(manifest.invocation.kind, "sub_recipe");
+    assert_eq!(manifest.invocation.host, "scroll_scan");
+    assert_eq!(manifest.invocation.stage, "per_list_item_candidate");
+  }
+
+  #[test]
   fn render_value_substitutes_step_artifact_placeholders() {
     let rendered = render_value(
       &json!("${step_capture_evidence_artifact_image_0}"),
@@ -2503,6 +2558,7 @@ mod tests {
         dry_run: false,
         max_disturbance: None,
         overrides: BTreeMap::new(),
+        quiet: false,
       },
     )
     .expect("skill should run");
@@ -2712,6 +2768,7 @@ mod tests {
         dry_run: false,
         max_disturbance: None,
         overrides: BTreeMap::new(),
+        quiet: false,
       },
     )
     .expect("recorded skill should run");

--- a/src/skill.rs
+++ b/src/skill.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -459,6 +459,12 @@ pub struct SkillRunOptions {
 }
 
 #[derive(Clone, Debug, Default)]
+pub(crate) struct SkillRunSummary {
+  #[allow(dead_code)]
+  pub exported_variables: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Debug, Default)]
 pub struct SkillCaseRunOptions {
   pub dry_run: bool,
   pub max_disturbance: Option<DisturbanceClass>,
@@ -647,7 +653,7 @@ pub(crate) fn run_skill_manifest_recorded(
   let root = run.root_span();
 
   match run_skill_manifest_into_run(runtime, &mut run, &root, manifest, options) {
-    Ok(()) => runtime.finish_run(
+    Ok(_summary) => runtime.finish_run(
       run,
       crate::recording::RunFinish {
         status_code: TraceStatusCode::Ok,
@@ -670,12 +676,13 @@ pub(crate) fn run_skill_manifest_into_run(
   parent: &crate::recording::SpanRef,
   manifest: &SkillManifest,
   options: SkillRunOptions,
-) -> AuvResult<()> {
+) -> AuvResult<SkillRunSummary> {
   validate_skill_manifest_with_commands(manifest, runtime.list_commands())?;
   let mut variables = default_inputs(manifest)?;
   for (key, value) in options.overrides {
     variables.insert(key, value);
   }
+  let mut top_level_signal_exports = BTreeSet::new();
 
   let active_max = validate_disturbance_policy(manifest, options.max_disturbance)?;
   let _lock = maybe_acquire_live_app_lock(manifest, &variables, options.dry_run)?;
@@ -716,6 +723,7 @@ pub(crate) fn run_skill_manifest_into_run(
         manifest,
         dry_run: options.dry_run,
         variables: &mut variables,
+        top_level_signal_exports: &mut top_level_signal_exports,
       };
       run_skill_step_into_span(&mut step_context, step, index, &step_id)
     };
@@ -747,7 +755,9 @@ pub(crate) fn run_skill_manifest_into_run(
     }
   }
 
-  Ok(())
+  Ok(SkillRunSummary {
+    exported_variables: variables,
+  })
 }
 
 struct SkillStepRuntime<'a> {
@@ -757,6 +767,7 @@ struct SkillStepRuntime<'a> {
   manifest: &'a SkillManifest,
   dry_run: bool,
   variables: &'a mut BTreeMap<String, String>,
+  top_level_signal_exports: &'a mut BTreeSet<String>,
 }
 
 fn run_skill_step_into_span(
@@ -790,7 +801,12 @@ fn run_skill_step_into_span(
     .invoke_in_span(context.run, context.step_span, request)?;
   print_invoke_result(&result);
   enforce_step_expectations(step_id, step, &result, context.variables)?;
-  export_step_variables(step_id, &result, context.variables);
+  export_step_variables(
+    step_id,
+    &result,
+    context.variables,
+    context.top_level_signal_exports,
+  );
   enforce_invoke_success(&result)?;
   Ok(())
 }
@@ -1373,7 +1389,7 @@ pub(crate) fn run_skill_case_matrix_into_run(
     );
 
     match case_result {
-      Ok(()) => {
+      Ok(_summary) => {
         run.finish_span(
           &execute_span,
           crate::recording::SpanFinish {
@@ -2121,6 +2137,7 @@ fn export_step_variables(
   step_id: &str,
   result: &InvokeResult,
   variables: &mut BTreeMap<String, String>,
+  top_level_signal_exports: &mut BTreeSet<String>,
 ) {
   let prefix = format!("step_{}", sanitize_step_component(step_id));
   variables.insert(format!("{prefix}_run_id"), result.run_id.clone());
@@ -2156,6 +2173,21 @@ fn export_step_variables(
   if let Some(last_image) = image_paths.last() {
     variables.insert(format!("{prefix}_artifact_image_last"), last_image.clone());
   }
+
+  for (key, value) in &result.signals {
+    let signal_key = format!("{prefix}_signal_{}", sanitize_step_component(key));
+    variables.entry(signal_key).or_insert_with(|| value.clone());
+    if is_top_level_hook_signal(key)
+      && (!variables.contains_key(key) || top_level_signal_exports.contains(key))
+    {
+      variables.insert(key.clone(), value.clone());
+      top_level_signal_exports.insert(key.clone());
+    }
+  }
+}
+
+fn is_top_level_hook_signal(key: &str) -> bool {
+  matches!(key, "last.scan.hook.action" | "last.scan.hook.reason")
 }
 
 fn enforce_invoke_success(result: &InvokeResult) -> AuvResult<()> {
@@ -2304,7 +2336,7 @@ fn step_id(step: &SkillStep, fallback_index: usize) -> String {
 
 #[cfg(test)]
 mod tests {
-  use std::collections::BTreeMap;
+  use std::collections::{BTreeMap, BTreeSet};
   use std::env;
   use std::fs;
   use std::path::PathBuf;
@@ -2313,10 +2345,11 @@ mod tests {
 
   use super::{
     SkillCaseMatrix, SkillCaseMatrixCatalog, SkillCatalog, SkillManifest, SkillRunOptions,
-    SkillStep, default_inputs, enforce_step_expectations, export_step_variables, is_image_artifact,
-    render_template, render_value, run_skill_case_matrix_recorded, run_skill_manifest_recorded,
-    sanitize_lock_component, validate_case_matrix_against_skill, validate_case_matrix_manifest,
-    validate_skill_manifest, validate_skill_manifest_with_commands,
+    SkillRunSummary, SkillStep, default_inputs, enforce_step_expectations, export_step_variables,
+    is_image_artifact, render_template, render_value, run_skill_case_matrix_recorded,
+    run_skill_manifest_into_run, run_skill_manifest_recorded, sanitize_lock_component,
+    validate_case_matrix_against_skill, validate_case_matrix_manifest, validate_skill_manifest,
+    validate_skill_manifest_with_commands,
   };
   use crate::catalog::{CommandCatalog, default_command_catalog};
   use crate::driver::{Driver, DriverRegistry};
@@ -2342,7 +2375,19 @@ mod tests {
       Ok(DriverResponse {
         summary: format!("ok {}", call.operation),
         backend: Some("test.backend".to_string()),
-        signals: BTreeMap::from([("outcome".to_string(), "ok".to_string())]),
+        signals: BTreeMap::from([
+          ("outcome".to_string(), "ok".to_string()),
+          ("query".to_string(), "driver query".to_string()),
+          (
+            "step_first_run_id".to_string(),
+            "driver overwritten run id".to_string(),
+          ),
+          ("last.scan.hook.action".to_string(), "continue".to_string()),
+          (
+            "last.scan.hook.reason".to_string(),
+            "test driver signal".to_string(),
+          ),
+        ]),
         notes: vec!["outcome=ok".to_string()],
         artifacts: vec![],
       })
@@ -2394,6 +2439,7 @@ mod tests {
   #[test]
   fn export_step_variables_captures_image_artifacts() {
     let mut variables = BTreeMap::new();
+    let mut top_level_signal_exports = BTreeSet::new();
     export_step_variables(
       "capture-evidence",
       &InvokeResult {
@@ -2408,6 +2454,7 @@ mod tests {
         failure_message: None,
       },
       &mut variables,
+      &mut top_level_signal_exports,
     );
 
     assert_eq!(
@@ -2416,6 +2463,87 @@ mod tests {
         .expect("image artifact should export"),
       "/tmp/evidence.png"
     );
+  }
+
+  #[test]
+  fn skill_run_summary_exposes_exported_variables() {
+    let summary = SkillRunSummary {
+      exported_variables: BTreeMap::from([(
+        "last.scan.hook.action".to_string(),
+        "continue".to_string(),
+      )]),
+    };
+
+    assert_eq!(
+      summary.exported_variables.get("last.scan.hook.action"),
+      Some(&"continue".to_string())
+    );
+  }
+
+  #[test]
+  fn run_skill_manifest_summary_includes_signal_exported_variables() {
+    let project_root = temp_dir("summary-signal-project");
+    let store_root = temp_dir("summary-signal-store");
+    let runtime = skill_test_runtime(project_root.clone(), store_root.clone());
+    let manifest = two_step_manifest();
+    let mut run = runtime
+      .start_run(crate::recording::RunSpec::new(
+        crate::trace::RunType::Execute,
+        "auv.execute",
+      ))
+      .expect("run should start");
+    let root = run.root_span();
+
+    let summary = run_skill_manifest_into_run(
+      &runtime,
+      &mut run,
+      &root,
+      &manifest,
+      SkillRunOptions {
+        dry_run: false,
+        max_disturbance: None,
+        overrides: BTreeMap::new(),
+      },
+    )
+    .expect("skill should run");
+
+    assert_eq!(
+      summary.exported_variables.get("last.scan.hook.action"),
+      Some(&"continue".to_string())
+    );
+    assert_eq!(
+      summary.exported_variables.get("last.scan.hook.reason"),
+      Some(&"test driver signal".to_string())
+    );
+    assert_eq!(
+      summary.exported_variables.get("query"),
+      Some(&"default query".to_string())
+    );
+    assert_ne!(
+      summary.exported_variables.get("step_first_run_id"),
+      Some(&"driver overwritten run id".to_string())
+    );
+    assert_eq!(
+      summary.exported_variables.get("step_first_signal_query"),
+      Some(&"driver query".to_string())
+    );
+    assert_eq!(
+      summary
+        .exported_variables
+        .get("step_first_signal_step_first_run_id"),
+      Some(&"driver overwritten run id".to_string())
+    );
+
+    let _ = runtime.finish_run(
+      run,
+      crate::recording::RunFinish {
+        status_code: crate::trace::TraceStatusCode::Ok,
+        summary: Some("test finished".to_string()),
+        failure: None,
+      },
+    );
+    let _ = fs::remove_dir_all(project_root);
+    let _ = fs::remove_dir_all(store_root);
   }
 
   #[test]
@@ -3648,6 +3776,9 @@ mod tests {
         "verificationContract": "verifyAxText"
       },
       "objective": "test recorded skill execution",
+      "inputs": {
+        "query": { "type": "string", "default": "default query" }
+      },
       "disturbance_policy": {
         "max_disturbance": "none",
         "declared_classes": ["none"]


### PR DESCRIPTION
## Summary

- Add the scroll_scan runtime module for window-region collection with visual row/list item candidates, per-item crop artifacts, crop OCR enrichment, and prototype per-list-item sub-recipe hooks.
- Add the scan.fixture.list_item_candidate_continue.v0 fixture recipe and invocation metadata for scroll_scan sub-recipes.
- Update shared terminology and AGENTS documentation placement rules.

## Manual reproduction

Run against NetEase Cloud Music with the target app open:

```bash
cargo run --quiet -- scan window-region --target com.netease.163music --region 0.20,0.18,0.98,0.90 --max-pages 1 --max-scrolls 0 --scroll-amount 40 --settle-ms 350 --max-observations 256 --per-list-item-candidate-recipe scan.fixture.list_item_candidate_continue.v0
```

Expected live result: a `scroll-scan.json` artifact with list item observations, per-item crop PNG artifacts, per-item context JSON artifacts, and hook decisions. During development, run `run_1779467814105_71828_0` captured 8 complete NetEase list rows, and the crop images matched the visible UI rows.

## Known limits

- Semantic item parsing is not implemented; `raw_text` is a debug/display join of crop OCR fragments.
- OCR fragment boxes are not persisted yet.
- Recipe hook inputs and returns are still scalar variables plus context artifacts, not typed JSON context/return values.
- The standalone scan fixture recipe exists because manifests cannot yet declare inline hook/sub-recipe blocks.
- Scroll boundary detection is weak: downward bottom detection and upward top detection do not have explicit scrollbar, AX scroll value, or screenshot-diff evidence yet.
- Section boundary middleware, region segmentation, and icon/template matching are TODOs only.

## Verification

- `cargo fmt --check`
- `cargo check`
- `cargo test`
- `git diff --check`
- `git diff --cached --check`
- `cargo run --quiet -- list-commands`
- `cargo run --quiet -- skill cases list`
- `cargo run --quiet -- skill bundle list`
