### PR TITLE
feat: add macOS no-steal window input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,7 @@ version = "0.0.1"
 dependencies = [
  "image",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/auv-driver-macos/native/swift/Sources/AuvMacosNative/Keyboard.swift
+++ b/crates/auv-driver-macos/native/swift/Sources/AuvMacosNative/Keyboard.swift
@@ -1,0 +1,188 @@
+import AppKit
+import CoreGraphics
+import Foundation
+
+private func keyboardEventSource() -> CGEventSource? {
+  CGEventSource(stateID: .hidSystemState)
+}
+
+private func stampKeyboardTarget(_ event: CGEvent, pid: Int64, windowNumber: Int64) {
+  event.setIntegerValueField(.eventTargetUnixProcessID, value: pid)
+  event.setIntegerValueField(.mouseEventWindowUnderMousePointer, value: windowNumber)
+  event.setIntegerValueField(.mouseEventWindowUnderMousePointerThatCanHandleThisEvent, value: windowNumber)
+  if let eventWindowNumber = CGEventField(rawValue: 51) {
+    event.setIntegerValueField(eventWindowNumber, value: windowNumber)
+  }
+  if let eventWindowId = CGEventField(rawValue: 40) {
+    event.setIntegerValueField(eventWindowId, value: windowNumber)
+  }
+}
+
+private func postKeyboardEvent(_ event: CGEvent, pid: Int64, windowNumber: Int64) {
+  stampKeyboardTarget(event, pid: pid, windowNumber: windowNumber)
+  event.postToPid(pid_t(pid))
+}
+
+private func modifierFlags(
+  command: Bool,
+  shift: Bool,
+  option: Bool,
+  control: Bool
+) -> CGEventFlags {
+  var flags = CGEventFlags()
+  if command {
+    flags.insert(.maskCommand)
+  }
+  if shift {
+    flags.insert(.maskShift)
+  }
+  if option {
+    flags.insert(.maskAlternate)
+  }
+  if control {
+    flags.insert(.maskControl)
+  }
+  return flags
+}
+
+private func modifierKeyCodes(
+  command: Bool,
+  shift: Bool,
+  option: Bool,
+  control: Bool
+) -> [CGKeyCode] {
+  var keyCodes: [CGKeyCode] = []
+  if command {
+    keyCodes.append(55)
+  }
+  if shift {
+    keyCodes.append(56)
+  }
+  if option {
+    keyCodes.append(58)
+  }
+  if control {
+    keyCodes.append(59)
+  }
+  return keyCodes
+}
+
+private func makeKeyboardEvent(
+  source: CGEventSource?,
+  keyCode: CGKeyCode,
+  keyDown: Bool,
+  flags: CGEventFlags = []
+) -> CGEvent? {
+  let event = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: keyDown)
+  event?.flags = flags
+  return event
+}
+
+func type_text_in_window(
+  pid: Int64,
+  window_number: Int64,
+  text: RustString,
+  inter_char_delay_ms: UInt64
+) -> NativeActionResponse {
+  let source = keyboardEventSource()
+  let delaySeconds = Double(inter_char_delay_ms) / 1000.0
+  let characters = Array(text.toString())
+
+  for (index, character) in characters.enumerated() {
+    guard
+      let down = makeKeyboardEvent(source: source, keyCode: 0, keyDown: true),
+      let up = makeKeyboardEvent(source: source, keyCode: 0, keyDown: false)
+    else {
+      return nativeActionError(
+        "failed to create window-targeted keyboard event",
+        "grant Accessibility permission and retry"
+      )
+    }
+
+    let utf16 = Array(String(character).utf16)
+    utf16.withUnsafeBufferPointer { buffer in
+      down.keyboardSetUnicodeString(stringLength: buffer.count, unicodeString: buffer.baseAddress)
+      up.keyboardSetUnicodeString(stringLength: buffer.count, unicodeString: buffer.baseAddress)
+    }
+
+    // Provenance: CUA keyboard and KWWK keyboard background dispatch patterns.
+    // https://github.com/trycua/cua/blob/a3448588286b6373013a5fa9072ac8bafb6681d6/libs/cua-driver-rs/crates/platform-macos/src/input/keyboard.rs#L35-L90
+    // https://github.com/EYHN/kwwk-computer-use-core/blob/eddd9e5475095de58bcb81cafbad79d1f5c5495d/Sources/KWWKComputerUseCore/BackgroundInputDispatcher.swift#L264-L333
+    postKeyboardEvent(down, pid: pid, windowNumber: window_number)
+    postKeyboardEvent(up, pid: pid, windowNumber: window_number)
+
+    if index < characters.count - 1 && delaySeconds > 0 {
+      Thread.sleep(forTimeInterval: delaySeconds)
+    }
+  }
+
+  return nativeActionOk()
+}
+
+func press_key_in_window(pid: Int64, window_number: Int64, key_code: Int32) -> NativeActionResponse {
+  let source = keyboardEventSource()
+  let virtualKey = CGKeyCode(UInt16(truncatingIfNeeded: key_code))
+  guard
+    let down = makeKeyboardEvent(source: source, keyCode: virtualKey, keyDown: true),
+    let up = makeKeyboardEvent(source: source, keyCode: virtualKey, keyDown: false)
+  else {
+    return nativeActionError(
+      "failed to create window-targeted key press event",
+      "grant Accessibility permission and retry"
+    )
+  }
+
+  postKeyboardEvent(down, pid: pid, windowNumber: window_number)
+  postKeyboardEvent(up, pid: pid, windowNumber: window_number)
+  return nativeActionOk()
+}
+
+func hotkey_in_window(
+  pid: Int64,
+  window_number: Int64,
+  key_code: Int32,
+  command: Bool,
+  shift: Bool,
+  option: Bool,
+  control: Bool
+) -> NativeActionResponse {
+  let source = keyboardEventSource()
+  let flags = modifierFlags(command: command, shift: shift, option: option, control: control)
+  let modifierCodes = modifierKeyCodes(command: command, shift: shift, option: option, control: control)
+  let virtualKey = CGKeyCode(UInt16(truncatingIfNeeded: key_code))
+
+  for modifierCode in modifierCodes {
+    guard let event = makeKeyboardEvent(source: source, keyCode: modifierCode, keyDown: true, flags: flags) else {
+      return nativeActionError(
+        "failed to create window-targeted modifier key event",
+        "grant Accessibility permission and retry"
+      )
+    }
+    postKeyboardEvent(event, pid: pid, windowNumber: window_number)
+  }
+
+  guard
+    let down = makeKeyboardEvent(source: source, keyCode: virtualKey, keyDown: true, flags: flags),
+    let up = makeKeyboardEvent(source: source, keyCode: virtualKey, keyDown: false, flags: flags)
+  else {
+    return nativeActionError(
+      "failed to create window-targeted hotkey event",
+      "grant Accessibility permission and retry"
+    )
+  }
+
+  postKeyboardEvent(down, pid: pid, windowNumber: window_number)
+  postKeyboardEvent(up, pid: pid, windowNumber: window_number)
+
+  for modifierCode in modifierCodes.reversed() {
+    guard let event = makeKeyboardEvent(source: source, keyCode: modifierCode, keyDown: false) else {
+      return nativeActionError(
+        "failed to create window-targeted modifier key event",
+        "grant Accessibility permission and retry"
+      )
+    }
+    postKeyboardEvent(event, pid: pid, windowNumber: window_number)
+  }
+
+  return nativeActionOk()
+}

--- a/crates/auv-driver-macos/native/swift/Sources/AuvMacosNative/Keyboard.swift
+++ b/crates/auv-driver-macos/native/swift/Sources/AuvMacosNative/Keyboard.swift
@@ -45,26 +45,38 @@ private func modifierFlags(
   return flags
 }
 
-private func modifierKeyCodes(
+private struct ModifierKey {
+  let keyCode: CGKeyCode
+  let flag: CGEventFlags
+}
+
+private func modifierKeys(
   command: Bool,
   shift: Bool,
   option: Bool,
   control: Bool
-) -> [CGKeyCode] {
-  var keyCodes: [CGKeyCode] = []
+) -> [ModifierKey] {
+  var keys: [ModifierKey] = []
   if command {
-    keyCodes.append(55)
+    keys.append(ModifierKey(keyCode: 55, flag: .maskCommand))
   }
   if shift {
-    keyCodes.append(56)
+    keys.append(ModifierKey(keyCode: 56, flag: .maskShift))
   }
   if option {
-    keyCodes.append(58)
+    keys.append(ModifierKey(keyCode: 58, flag: .maskAlternate))
   }
   if control {
-    keyCodes.append(59)
+    keys.append(ModifierKey(keyCode: 59, flag: .maskControl))
   }
-  return keyCodes
+  return keys
+}
+
+private func validatedKeyCode(_ keyCode: Int32) -> CGKeyCode? {
+  guard keyCode >= 0 && keyCode <= Int32(UInt16.max) else {
+    return nil
+  }
+  return CGKeyCode(UInt16(keyCode))
 }
 
 private func makeKeyboardEvent(
@@ -121,7 +133,12 @@ func type_text_in_window(
 
 func press_key_in_window(pid: Int64, window_number: Int64, key_code: Int32) -> NativeActionResponse {
   let source = keyboardEventSource()
-  let virtualKey = CGKeyCode(UInt16(truncatingIfNeeded: key_code))
+  guard let virtualKey = validatedKeyCode(key_code) else {
+    return nativeActionError(
+      "invalid key_code \(key_code)",
+      "pass a key_code between 0 and \(UInt16.max)"
+    )
+  }
   guard
     let down = makeKeyboardEvent(source: source, keyCode: virtualKey, keyDown: true),
     let up = makeKeyboardEvent(source: source, keyCode: virtualKey, keyDown: false)
@@ -147,40 +164,66 @@ func hotkey_in_window(
   control: Bool
 ) -> NativeActionResponse {
   let source = keyboardEventSource()
-  let flags = modifierFlags(command: command, shift: shift, option: option, control: control)
-  let modifierCodes = modifierKeyCodes(command: command, shift: shift, option: option, control: control)
-  let virtualKey = CGKeyCode(UInt16(truncatingIfNeeded: key_code))
+  guard let virtualKey = validatedKeyCode(key_code) else {
+    return nativeActionError(
+      "invalid key_code \(key_code)",
+      "pass a key_code between 0 and \(UInt16.max)"
+    )
+  }
+  let fullFlags = modifierFlags(command: command, shift: shift, option: option, control: control)
+  let modifiers = modifierKeys(command: command, shift: shift, option: option, control: control)
+  var events: [CGEvent] = []
+  var currentFlags = CGEventFlags()
 
-  for modifierCode in modifierCodes {
-    guard let event = makeKeyboardEvent(source: source, keyCode: modifierCode, keyDown: true, flags: flags) else {
+  for modifier in modifiers {
+    currentFlags.insert(modifier.flag)
+    guard
+      let event = makeKeyboardEvent(
+        source: source,
+        keyCode: modifier.keyCode,
+        keyDown: true,
+        flags: currentFlags
+      )
+    else {
       return nativeActionError(
         "failed to create window-targeted modifier key event",
         "grant Accessibility permission and retry"
       )
     }
-    postKeyboardEvent(event, pid: pid, windowNumber: window_number)
+    events.append(event)
   }
 
   guard
-    let down = makeKeyboardEvent(source: source, keyCode: virtualKey, keyDown: true, flags: flags),
-    let up = makeKeyboardEvent(source: source, keyCode: virtualKey, keyDown: false, flags: flags)
+    let down = makeKeyboardEvent(source: source, keyCode: virtualKey, keyDown: true, flags: fullFlags),
+    let up = makeKeyboardEvent(source: source, keyCode: virtualKey, keyDown: false, flags: fullFlags)
   else {
     return nativeActionError(
       "failed to create window-targeted hotkey event",
       "grant Accessibility permission and retry"
     )
   }
+  events.append(down)
+  events.append(up)
 
-  postKeyboardEvent(down, pid: pid, windowNumber: window_number)
-  postKeyboardEvent(up, pid: pid, windowNumber: window_number)
-
-  for modifierCode in modifierCodes.reversed() {
-    guard let event = makeKeyboardEvent(source: source, keyCode: modifierCode, keyDown: false) else {
+  for modifier in modifiers.reversed() {
+    currentFlags.remove(modifier.flag)
+    guard
+      let event = makeKeyboardEvent(
+        source: source,
+        keyCode: modifier.keyCode,
+        keyDown: false,
+        flags: currentFlags
+      )
+    else {
       return nativeActionError(
         "failed to create window-targeted modifier key event",
         "grant Accessibility permission and retry"
       )
     }
+    events.append(event)
+  }
+
+  for event in events {
     postKeyboardEvent(event, pid: pid, windowNumber: window_number)
   }
 

--- a/crates/auv-driver-macos/native/swift/Sources/AuvMacosNative/Pointer.swift
+++ b/crates/auv-driver-macos/native/swift/Sources/AuvMacosNative/Pointer.swift
@@ -8,6 +8,11 @@ private typealias CGEventSetWindowLocationFn = @convention(c) (
   CGPoint
 ) -> Void
 
+private typealias SLEventPostToPidFn = @convention(c) (
+  pid_t,
+  CGEvent
+) -> Void
+
 private let cgEventSetWindowLocation: CGEventSetWindowLocationFn? = {
   let symbolName = "CGEventSetWindowLocation"
   let globalHandle = UnsafeMutableRawPointer(bitPattern: -2)
@@ -24,6 +29,22 @@ private let cgEventSetWindowLocation: CGEventSetWindowLocationFn? = {
   }
   return unsafeBitCast(symbol, to: CGEventSetWindowLocationFn.self)
 }()
+
+private let slEventPostToPid: SLEventPostToPidFn? = {
+  let symbolName = "SLEventPostToPid"
+  let skyLightPath = "/System/Library/PrivateFrameworks/SkyLight.framework/SkyLight"
+  _ = dlopen(skyLightPath, RTLD_LAZY | RTLD_GLOBAL)
+  let globalHandle = UnsafeMutableRawPointer(bitPattern: -2)
+  guard let symbol = dlsym(globalHandle, symbolName) else {
+    return nil
+  }
+  return unsafeBitCast(symbol, to: SLEventPostToPidFn.self)
+}()
+
+private enum WindowClickStrategyCode: Int32 {
+  case chromiumCompatible = 0
+  case pidTargeted = 1
+}
 
 private func mouseButton(_ value: Int32) -> CGMouseButton {
   switch value {
@@ -49,23 +70,272 @@ private func mouseUpType(_ button: CGMouseButton) -> CGEventType {
   }
 }
 
-private func stampWindowTarget(
+private func setRawIntegerField(_ event: CGEvent, _ raw: UInt32, _ value: Int64) {
+  if let field = CGEventField(rawValue: raw) {
+    event.setIntegerValueField(field, value: value)
+  }
+}
+
+private func stampCompatibilityMouseEvent(
   _ event: CGEvent,
   pid: Int64,
   windowNumber: Int64,
   windowLocation: CGPoint,
+  clickGroupId: Int64,
+  clickState: Int64,
+  phase: Int64,
+  buttonNumber: Int64,
+  setWindowLocation: CGEventSetWindowLocationFn
+) {
+  setRawIntegerField(event, 0, phase)
+  setRawIntegerField(event, 1, clickState)
+  setRawIntegerField(event, 3, buttonNumber)
+  setRawIntegerField(event, 7, 3)
+  setRawIntegerField(event, 40, pid)
+  setRawIntegerField(event, 51, windowNumber)
+  setRawIntegerField(event, 58, clickGroupId)
+  setRawIntegerField(event, 91, windowNumber)
+  setRawIntegerField(event, 92, windowNumber)
+  setWindowLocation(event, windowLocation)
+}
+
+private func postCompatibilityMouseEvent(_ event: CGEvent, pid: Int64) {
+  slEventPostToPid?(pid_t(pid), event)
+  event.postToPid(pid_t(pid))
+}
+
+private func stampPidTargetedMouseEvent(
+  _ event: CGEvent,
+  pid: Int64,
+  windowNumber: Int64,
+  windowLocation: CGPoint,
+  clickState: Int64,
+  buttonNumber: Int64,
   setWindowLocation: CGEventSetWindowLocationFn
 ) {
   event.setIntegerValueField(.eventTargetUnixProcessID, value: pid)
+  event.setIntegerValueField(.mouseEventClickState, value: clickState)
   event.setIntegerValueField(.mouseEventWindowUnderMousePointer, value: windowNumber)
   event.setIntegerValueField(.mouseEventWindowUnderMousePointerThatCanHandleThisEvent, value: windowNumber)
-  if let eventWindowNumber = CGEventField(rawValue: 51) {
-    event.setIntegerValueField(eventWindowNumber, value: windowNumber)
-  }
-  if let eventWindowId = CGEventField(rawValue: 40) {
-    event.setIntegerValueField(eventWindowId, value: windowNumber)
-  }
+  setRawIntegerField(event, 3, buttonNumber)
+  setRawIntegerField(event, 40, pid)
+  setRawIntegerField(event, 51, windowNumber)
+  setRawIntegerField(event, 91, windowNumber)
+  setRawIntegerField(event, 92, windowNumber)
   setWindowLocation(event, windowLocation)
+}
+
+private func runPidTargetedWindowClick(
+  source: CGEventSource?,
+  pid: Int64,
+  windowNumber: Int64,
+  button: CGMouseButton,
+  screenLocation: CGPoint,
+  windowLocation: CGPoint,
+  clickCount: Int64,
+  clickIntervalMicros: useconds_t,
+  setWindowLocation: CGEventSetWindowLocationFn
+) -> NativeActionResponse {
+  let buttonNumber: Int64 = switch button {
+  case .right: 1
+  case .center: 2
+  default: 0
+  }
+
+  for clickNumber in 1...clickCount {
+    guard
+      let down = CGEvent(
+        mouseEventSource: source,
+        mouseType: mouseDownType(button),
+        mouseCursorPosition: screenLocation,
+        mouseButton: button
+      ),
+      let up = CGEvent(
+        mouseEventSource: source,
+        mouseType: mouseUpType(button),
+        mouseCursorPosition: screenLocation,
+        mouseButton: button
+      )
+    else {
+      return nativeActionError(
+        "failed to create window-targeted mouse click event",
+        "grant Accessibility permission and retry"
+      )
+    }
+    stampPidTargetedMouseEvent(
+      down,
+      pid: pid,
+      windowNumber: windowNumber,
+      windowLocation: windowLocation,
+      clickState: clickNumber,
+      buttonNumber: buttonNumber,
+      setWindowLocation: setWindowLocation
+    )
+    stampPidTargetedMouseEvent(
+      up,
+      pid: pid,
+      windowNumber: windowNumber,
+      windowLocation: windowLocation,
+      clickState: clickNumber,
+      buttonNumber: buttonNumber,
+      setWindowLocation: setWindowLocation
+    )
+    down.postToPid(pid_t(pid))
+    up.postToPid(pid_t(pid))
+    if clickNumber < clickCount {
+      usleep(clickIntervalMicros)
+    }
+  }
+
+  return nativeActionOk()
+}
+
+private func runCompatibilityWindowClick(
+  source: CGEventSource?,
+  pid: Int64,
+  windowNumber: Int64,
+  button: CGMouseButton,
+  screenLocation: CGPoint,
+  windowLocation: CGPoint,
+  clickCount: Int,
+  clickIntervalMicros: useconds_t,
+  setWindowLocation: CGEventSetWindowLocationFn
+) -> NativeActionResponse {
+  let clickGroupId = Int64(Date().timeIntervalSince1970 * 1_000_000) & 0x7fff_ffff
+  let offscreen = CGPoint(x: -1, y: -1)
+  let offscreenLocal = CGPoint(x: -1, y: -1)
+  let clickPairs = min(max(clickCount, 1), 2)
+  let buttonNumber: Int64 = switch button {
+  case .right: 1
+  case .center: 2
+  default: 0
+  }
+
+  guard
+    let move = CGEvent(
+      mouseEventSource: source,
+      mouseType: .mouseMoved,
+      mouseCursorPosition: screenLocation,
+      mouseButton: button
+    )
+  else {
+    return nativeActionError(
+      "failed to create compatibility mouse move event",
+      "grant Accessibility permission and retry"
+    )
+  }
+  stampCompatibilityMouseEvent(
+    move,
+    pid: pid,
+    windowNumber: windowNumber,
+    windowLocation: windowLocation,
+    clickGroupId: clickGroupId,
+    clickState: 0,
+    phase: 2,
+    buttonNumber: buttonNumber,
+    setWindowLocation: setWindowLocation
+  )
+  postCompatibilityMouseEvent(move, pid: pid)
+  usleep(15_000)
+
+  guard
+    let primerDown = CGEvent(
+      mouseEventSource: source,
+      mouseType: mouseDownType(button),
+      mouseCursorPosition: offscreen,
+      mouseButton: button
+    ),
+    let primerUp = CGEvent(
+      mouseEventSource: source,
+      mouseType: mouseUpType(button),
+      mouseCursorPosition: offscreen,
+      mouseButton: button
+    )
+  else {
+    return nativeActionError(
+      "failed to create compatibility primer click events",
+      "grant Accessibility permission and retry"
+    )
+  }
+  stampCompatibilityMouseEvent(
+    primerDown,
+    pid: pid,
+    windowNumber: windowNumber,
+    windowLocation: offscreenLocal,
+    clickGroupId: clickGroupId,
+    clickState: 1,
+    phase: 1,
+    buttonNumber: buttonNumber,
+    setWindowLocation: setWindowLocation
+  )
+  stampCompatibilityMouseEvent(
+    primerUp,
+    pid: pid,
+    windowNumber: windowNumber,
+    windowLocation: offscreenLocal,
+    clickGroupId: clickGroupId,
+    clickState: 1,
+    phase: 2,
+    buttonNumber: buttonNumber,
+    setWindowLocation: setWindowLocation
+  )
+  postCompatibilityMouseEvent(primerDown, pid: pid)
+  usleep(1_000)
+  postCompatibilityMouseEvent(primerUp, pid: pid)
+  usleep(100_000)
+
+  for pairIndex in 1...clickPairs {
+    guard
+      let down = CGEvent(
+        mouseEventSource: source,
+        mouseType: mouseDownType(button),
+        mouseCursorPosition: screenLocation,
+        mouseButton: button
+      ),
+      let up = CGEvent(
+        mouseEventSource: source,
+        mouseType: mouseUpType(button),
+        mouseCursorPosition: screenLocation,
+        mouseButton: button
+      )
+    else {
+      return nativeActionError(
+        "failed to create compatibility target click events",
+        "grant Accessibility permission and retry"
+      )
+    }
+    let clickState = Int64(pairIndex)
+    stampCompatibilityMouseEvent(
+      down,
+      pid: pid,
+      windowNumber: windowNumber,
+      windowLocation: windowLocation,
+      clickGroupId: clickGroupId,
+      clickState: clickState,
+      phase: 3,
+      buttonNumber: buttonNumber,
+      setWindowLocation: setWindowLocation
+    )
+    stampCompatibilityMouseEvent(
+      up,
+      pid: pid,
+      windowNumber: windowNumber,
+      windowLocation: windowLocation,
+      clickGroupId: clickGroupId,
+      clickState: clickState,
+      phase: 3,
+      buttonNumber: buttonNumber,
+      setWindowLocation: setWindowLocation
+    )
+    postCompatibilityMouseEvent(down, pid: pid)
+    usleep(1_000)
+    postCompatibilityMouseEvent(up, pid: pid)
+    if pairIndex < clickPairs {
+      usleep(clickIntervalMicros)
+    }
+  }
+
+  return nativeActionOk()
 }
 
 func click_point(
@@ -127,12 +397,29 @@ func click_window_point(
   window_y: Double,
   button_code: Int32,
   click_count: Int64,
-  click_interval_ms: UInt64
+  click_interval_ms: UInt64,
+  window_strategy_code: Int32
 ) -> NativeActionResponse {
   let button = mouseButton(button_code)
   let clickCount = max(click_count, 1)
-  let clickIntervalSeconds = Double(click_interval_ms) / 1000.0
+  guard let strategy = WindowClickStrategyCode(rawValue: window_strategy_code) else {
+    return nativeActionError(
+      "unsupported window click strategy",
+      "use a WindowClickStrategy value supported by this macOS driver build"
+    )
+  }
+  let clickIntervalMicros = useconds_t(min(click_interval_ms, UInt64(useconds_t.max) / 1000) * 1000)
   let screenLocation = CGPoint(x: screen_x, y: screen_y)
+  // NOTICE: `CGEventSetWindowLocation` is used here as a routing hint for
+  // background window delivery. AUV's `WindowPoint` and CUA's macOS pixel path
+  // both use screenshot/window-local coordinates with a top-left origin, so keep
+  // that y value intact when stamping the event. Flipping to `windowHeight - y`
+  // makes canvas-style apps such as NetEase Cloud Music consume the click near
+  // the bottom of the window even when the event's screen point is visually on
+  // the search box.
+  //
+  // References:
+  // https://github.com/trycua/cua/blob/a3448588286b6373013a5fa9072ac8bafb6681d6/libs/cua-driver-rs/crates/platform-macos/src/input/mouse.rs#L388-L413
   let windowLocation = CGPoint(x: window_x, y: window_y)
   guard let setWindowLocation = cgEventSetWindowLocation else {
     return nativeActionError(
@@ -141,56 +428,52 @@ func click_window_point(
     )
   }
 
-  for clickNumber in 1...clickCount {
-    guard
-      let down = CGEvent(
-        mouseEventSource: nil,
-        mouseType: mouseDownType(button),
-        mouseCursorPosition: screenLocation,
-        mouseButton: button
-      ),
-      let up = CGEvent(
-        mouseEventSource: nil,
-        mouseType: mouseUpType(button),
-        mouseCursorPosition: screenLocation,
-        mouseButton: button
-      )
-    else {
-      return nativeActionError(
-        "failed to create window-targeted mouse click event",
-        "grant Accessibility permission and retry"
-      )
-    }
-
-    down.setIntegerValueField(.mouseEventClickState, value: clickNumber)
-    up.setIntegerValueField(.mouseEventClickState, value: clickNumber)
-
-    // Provenance: CUA mouse and KWWK mouse background dispatch patterns.
+  if strategy == .chromiumCompatible {
+    // NOTICE: Chromium/WebView/Catalyst targets can ignore plain
+    // `CGEvent.postToPid` mouse pairs even when AppKit receives them. Keep this
+    // strategy explicit at the Rust API layer because it is more invasive than a
+    // direct pid-targeted click: it posts a move, an off-screen primer click,
+    // then the target click pair(s).
+    //
+    // WORKAROUND: NetEase Cloud Music accepts this CUA-style Chromium sequence
+    // but did not react to plain `postToPid`, `cghidEventTap`, or pid+HID
+    // variants during `2026-05-27` live testing. The primer and raw event fields
+    // keep Chromium's user-activation and synthetic-event filters satisfied
+    // without foregrounding the target app.
+    //
+    // References:
+    // https://github.com/trycua/cua/blob/a3448588286b6373013a5fa9072ac8bafb6681d6/libs/cua-driver-rs/crates/platform-macos/src/input/mouse.rs#L103-L224
     // https://github.com/trycua/cua/blob/a3448588286b6373013a5fa9072ac8bafb6681d6/libs/cua-driver-rs/crates/platform-macos/src/input/mouse.rs#L383-L438
-    // https://github.com/EYHN/kwwk-computer-use-core/blob/eddd9e5475095de58bcb81cafbad79d1f5c5495d/Sources/KWWKComputerUseCore/BackgroundInputDispatcher.swift#L130-L162
-    stampWindowTarget(
-      down,
+    return runCompatibilityWindowClick(
+      source: nil,
       pid: pid,
       windowNumber: window_number,
+      button: button,
+      screenLocation: screenLocation,
       windowLocation: windowLocation,
+      clickCount: Int(clickCount),
+      clickIntervalMicros: clickIntervalMicros,
       setWindowLocation: setWindowLocation
     )
-    stampWindowTarget(
-      up,
-      pid: pid,
-      windowNumber: window_number,
-      windowLocation: windowLocation,
-      setWindowLocation: setWindowLocation
-    )
-
-    down.postToPid(pid_t(pid))
-    up.postToPid(pid_t(pid))
-    if clickNumber < clickCount && clickIntervalSeconds > 0 {
-      Thread.sleep(forTimeInterval: clickIntervalSeconds)
-    }
   }
 
-  return nativeActionOk()
+  // NOTICE: This is the narrower public pid-targeted route. It is useful for
+  // AppKit targets and for comparing delivery behavior, but Chromium/WebView
+  // apps may ignore it while still reporting native post success.
+  //
+  // References:
+  // https://github.com/EYHN/kwwk-computer-use-core/blob/eddd9e5475095de58bcb81cafbad79d1f5c5495d/Sources/KWWKComputerUseCore/BackgroundInputDispatcher.swift#L130-L162
+  return runPidTargetedWindowClick(
+    source: nil,
+    pid: pid,
+    windowNumber: window_number,
+    button: button,
+    screenLocation: screenLocation,
+    windowLocation: windowLocation,
+    clickCount: clickCount,
+    clickIntervalMicros: clickIntervalMicros,
+    setWindowLocation: setWindowLocation
+  )
 }
 
 func current_mouse_location() -> NativeMouseLocationResponse {

--- a/crates/auv-driver-macos/native/swift/Sources/AuvMacosNative/Pointer.swift
+++ b/crates/auv-driver-macos/native/swift/Sources/AuvMacosNative/Pointer.swift
@@ -53,7 +53,8 @@ private func stampWindowTarget(
   _ event: CGEvent,
   pid: Int64,
   windowNumber: Int64,
-  windowLocation: CGPoint
+  windowLocation: CGPoint,
+  setWindowLocation: CGEventSetWindowLocationFn
 ) {
   event.setIntegerValueField(.eventTargetUnixProcessID, value: pid)
   event.setIntegerValueField(.mouseEventWindowUnderMousePointer, value: windowNumber)
@@ -64,7 +65,7 @@ private func stampWindowTarget(
   if let eventWindowId = CGEventField(rawValue: 40) {
     event.setIntegerValueField(eventWindowId, value: windowNumber)
   }
-  cgEventSetWindowLocation?(event, windowLocation)
+  setWindowLocation(event, windowLocation)
 }
 
 func click_point(
@@ -133,6 +134,12 @@ func click_window_point(
   let clickIntervalSeconds = Double(click_interval_ms) / 1000.0
   let screenLocation = CGPoint(x: screen_x, y: screen_y)
   let windowLocation = CGPoint(x: window_x, y: window_y)
+  guard let setWindowLocation = cgEventSetWindowLocation else {
+    return nativeActionError(
+      "unsupported window-local event location",
+      "CGEventSetWindowLocation is unavailable; retry on a macOS version that exposes the SkyLight symbol"
+    )
+  }
 
   for clickNumber in 1...clickCount {
     guard
@@ -161,8 +168,20 @@ func click_window_point(
     // Provenance: CUA mouse and KWWK mouse background dispatch patterns.
     // https://github.com/trycua/cua/blob/a3448588286b6373013a5fa9072ac8bafb6681d6/libs/cua-driver-rs/crates/platform-macos/src/input/mouse.rs#L383-L438
     // https://github.com/EYHN/kwwk-computer-use-core/blob/eddd9e5475095de58bcb81cafbad79d1f5c5495d/Sources/KWWKComputerUseCore/BackgroundInputDispatcher.swift#L130-L162
-    stampWindowTarget(down, pid: pid, windowNumber: window_number, windowLocation: windowLocation)
-    stampWindowTarget(up, pid: pid, windowNumber: window_number, windowLocation: windowLocation)
+    stampWindowTarget(
+      down,
+      pid: pid,
+      windowNumber: window_number,
+      windowLocation: windowLocation,
+      setWindowLocation: setWindowLocation
+    )
+    stampWindowTarget(
+      up,
+      pid: pid,
+      windowNumber: window_number,
+      windowLocation: windowLocation,
+      setWindowLocation: setWindowLocation
+    )
 
     down.postToPid(pid_t(pid))
     up.postToPid(pid_t(pid))

--- a/crates/auv-driver-macos/native/swift/Sources/AuvMacosNative/Pointer.swift
+++ b/crates/auv-driver-macos/native/swift/Sources/AuvMacosNative/Pointer.swift
@@ -1,6 +1,30 @@
 import AppKit
 import CoreGraphics
+import Darwin
 import Foundation
+
+private typealias CGEventSetWindowLocationFn = @convention(c) (
+  CGEvent,
+  UInt32,
+  CGPoint
+) -> Void
+
+private let cgEventSetWindowLocation: CGEventSetWindowLocationFn? = {
+  let symbolName = "CGEventSetWindowLocation"
+  let globalHandle = UnsafeMutableRawPointer(bitPattern: -2)
+  if let symbol = dlsym(globalHandle, symbolName) {
+    return unsafeBitCast(symbol, to: CGEventSetWindowLocationFn.self)
+  }
+
+  let skyLightPath = "/System/Library/PrivateFrameworks/SkyLight.framework/SkyLight"
+  guard let handle = dlopen(skyLightPath, RTLD_LAZY) else {
+    return nil
+  }
+  guard let symbol = dlsym(handle, symbolName) else {
+    return nil
+  }
+  return unsafeBitCast(symbol, to: CGEventSetWindowLocationFn.self)
+}()
 
 private func mouseButton(_ value: Int32) -> CGMouseButton {
   switch value {
@@ -24,6 +48,24 @@ private func mouseUpType(_ button: CGMouseButton) -> CGEventType {
   case .center: return .otherMouseUp
   default: return .leftMouseUp
   }
+}
+
+private func stampMouseTarget(
+  _ event: CGEvent,
+  pid: Int64,
+  windowNumber: Int64,
+  windowLocation: CGPoint
+) {
+  event.setIntegerValueField(.eventTargetUnixProcessID, value: pid)
+  event.setIntegerValueField(.mouseEventWindowUnderMousePointer, value: windowNumber)
+  event.setIntegerValueField(.mouseEventWindowUnderMousePointerThatCanHandleThisEvent, value: windowNumber)
+  if let eventWindowNumber = CGEventField(rawValue: 51) {
+    event.setIntegerValueField(eventWindowNumber, value: windowNumber)
+  }
+  if let eventWindowId = CGEventField(rawValue: 40) {
+    event.setIntegerValueField(eventWindowId, value: windowNumber)
+  }
+  cgEventSetWindowLocation?(event, UInt32(truncatingIfNeeded: windowNumber), windowLocation)
 }
 
 func click_point(
@@ -68,6 +110,63 @@ func click_point(
     up.setIntegerValueField(.mouseEventClickState, value: clickNumber)
     down.post(tap: .cghidEventTap)
     up.post(tap: .cghidEventTap)
+    if clickNumber < clickCount && clickIntervalSeconds > 0 {
+      Thread.sleep(forTimeInterval: clickIntervalSeconds)
+    }
+  }
+
+  return nativeActionOk()
+}
+
+func click_window_point(
+  pid: Int64,
+  window_number: Int64,
+  screen_x: Double,
+  screen_y: Double,
+  window_x: Double,
+  window_y: Double,
+  button_code: Int32,
+  click_count: Int64,
+  click_interval_ms: UInt64
+) -> NativeActionResponse {
+  let button = mouseButton(button_code)
+  let clickCount = max(click_count, 1)
+  let clickIntervalSeconds = Double(click_interval_ms) / 1000.0
+  let screenLocation = CGPoint(x: screen_x, y: screen_y)
+  let windowLocation = CGPoint(x: window_x, y: window_y)
+
+  for clickNumber in 1...clickCount {
+    guard
+      let down = CGEvent(
+        mouseEventSource: nil,
+        mouseType: mouseDownType(button),
+        mouseCursorPosition: screenLocation,
+        mouseButton: button
+      ),
+      let up = CGEvent(
+        mouseEventSource: nil,
+        mouseType: mouseUpType(button),
+        mouseCursorPosition: screenLocation,
+        mouseButton: button
+      )
+    else {
+      return nativeActionError(
+        "failed to create window-targeted mouse click event",
+        "grant Accessibility permission and retry"
+      )
+    }
+
+    down.setIntegerValueField(.mouseEventClickState, value: clickNumber)
+    up.setIntegerValueField(.mouseEventClickState, value: clickNumber)
+
+    // Provenance: CUA mouse and KWWK mouse background dispatch patterns.
+    // https://github.com/trycua/cua/blob/a3448588286b6373013a5fa9072ac8bafb6681d6/libs/cua-driver-rs/crates/platform-macos/src/input/mouse.rs#L383-L438
+    // https://github.com/EYHN/kwwk-computer-use-core/blob/eddd9e5475095de58bcb81cafbad79d1f5c5495d/Sources/KWWKComputerUseCore/BackgroundInputDispatcher.swift#L130-L162
+    stampMouseTarget(down, pid: pid, windowNumber: window_number, windowLocation: windowLocation)
+    stampMouseTarget(up, pid: pid, windowNumber: window_number, windowLocation: windowLocation)
+
+    down.postToPid(pid_t(pid))
+    up.postToPid(pid_t(pid))
     if clickNumber < clickCount && clickIntervalSeconds > 0 {
       Thread.sleep(forTimeInterval: clickIntervalSeconds)
     }

--- a/crates/auv-driver-macos/native/swift/Sources/AuvMacosNative/Pointer.swift
+++ b/crates/auv-driver-macos/native/swift/Sources/AuvMacosNative/Pointer.swift
@@ -5,7 +5,6 @@ import Foundation
 
 private typealias CGEventSetWindowLocationFn = @convention(c) (
   CGEvent,
-  UInt32,
   CGPoint
 ) -> Void
 
@@ -50,7 +49,7 @@ private func mouseUpType(_ button: CGMouseButton) -> CGEventType {
   }
 }
 
-private func stampMouseTarget(
+private func stampWindowTarget(
   _ event: CGEvent,
   pid: Int64,
   windowNumber: Int64,
@@ -65,7 +64,7 @@ private func stampMouseTarget(
   if let eventWindowId = CGEventField(rawValue: 40) {
     event.setIntegerValueField(eventWindowId, value: windowNumber)
   }
-  cgEventSetWindowLocation?(event, UInt32(truncatingIfNeeded: windowNumber), windowLocation)
+  cgEventSetWindowLocation?(event, windowLocation)
 }
 
 func click_point(
@@ -162,8 +161,8 @@ func click_window_point(
     // Provenance: CUA mouse and KWWK mouse background dispatch patterns.
     // https://github.com/trycua/cua/blob/a3448588286b6373013a5fa9072ac8bafb6681d6/libs/cua-driver-rs/crates/platform-macos/src/input/mouse.rs#L383-L438
     // https://github.com/EYHN/kwwk-computer-use-core/blob/eddd9e5475095de58bcb81cafbad79d1f5c5495d/Sources/KWWKComputerUseCore/BackgroundInputDispatcher.swift#L130-L162
-    stampMouseTarget(down, pid: pid, windowNumber: window_number, windowLocation: windowLocation)
-    stampMouseTarget(up, pid: pid, windowNumber: window_number, windowLocation: windowLocation)
+    stampWindowTarget(down, pid: pid, windowNumber: window_number, windowLocation: windowLocation)
+    stampWindowTarget(up, pid: pid, windowNumber: window_number, windowLocation: windowLocation)
 
     down.postToPid(pid_t(pid))
     up.postToPid(pid_t(pid))

--- a/crates/auv-driver-macos/src/native.rs
+++ b/crates/auv-driver-macos/src/native.rs
@@ -4,6 +4,7 @@ mod binding;
 pub mod capture;
 pub mod clipboard;
 pub mod error;
+pub mod input;
 pub mod ocr;
 pub mod permission;
 pub mod pointer;

--- a/crates/auv-driver-macos/src/native/binding.rs
+++ b/crates/auv-driver-macos/src/native/binding.rs
@@ -303,8 +303,35 @@ pub(crate) mod ffi {
       click_count: i64,
       click_interval_ms: u64,
     ) -> NativeActionResponse;
+    fn click_window_point(
+      pid: i64,
+      window_number: i64,
+      screen_x: f64,
+      screen_y: f64,
+      window_x: f64,
+      window_y: f64,
+      button_code: i32,
+      click_count: i64,
+      click_interval_ms: u64,
+    ) -> NativeActionResponse;
     fn current_mouse_location() -> NativeMouseLocationResponse;
     fn scroll_point(x: f64, y: f64, delta_x: f64, delta_y: f64) -> NativeActionResponse;
+    fn type_text_in_window(
+      pid: i64,
+      window_number: i64,
+      text: String,
+      inter_char_delay_ms: u64,
+    ) -> NativeActionResponse;
+    fn press_key_in_window(pid: i64, window_number: i64, key_code: i32) -> NativeActionResponse;
+    fn hotkey_in_window(
+      pid: i64,
+      window_number: i64,
+      key_code: i32,
+      command: bool,
+      shift: bool,
+      option: bool,
+      control: bool,
+    ) -> NativeActionResponse;
     fn capture_clipboard() -> NativeClipboardSnapshotResponse;
     fn restore_clipboard(snapshot_payload: String) -> NativeActionResponse;
     fn set_clipboard_text(text: String) -> NativeActionResponse;

--- a/crates/auv-driver-macos/src/native/binding.rs
+++ b/crates/auv-driver-macos/src/native/binding.rs
@@ -313,6 +313,7 @@ pub(crate) mod ffi {
       button_code: i32,
       click_count: i64,
       click_interval_ms: u64,
+      window_strategy_code: i32,
     ) -> NativeActionResponse;
     fn current_mouse_location() -> NativeMouseLocationResponse;
     fn scroll_point(x: f64, y: f64, delta_x: f64, delta_y: f64) -> NativeActionResponse;

--- a/crates/auv-driver-macos/src/native/input.rs
+++ b/crates/auv-driver-macos/src/native/input.rs
@@ -1,0 +1,155 @@
+#[cfg(target_os = "macos")]
+use super::binding::ffi::{
+  NativeActionResponse, click_window_point as native_click_window_point,
+  hotkey_in_window as native_hotkey_in_window, press_key_in_window as native_press_key_in_window,
+  type_text_in_window as native_type_text_in_window,
+};
+use super::types::AuvResult;
+
+#[cfg(target_os = "macos")]
+pub fn click_window_point(
+  pid: i64,
+  window_number: i64,
+  screen_x: f64,
+  screen_y: f64,
+  window_x: f64,
+  window_y: f64,
+  button_code: i32,
+  click_count: i64,
+  click_interval_ms: u64,
+) -> AuvResult<()> {
+  action_result(
+    "click_window_point",
+    native_click_window_point(
+      pid,
+      window_number,
+      screen_x,
+      screen_y,
+      window_x,
+      window_y,
+      button_code,
+      click_count,
+      click_interval_ms,
+    ),
+  )
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn click_window_point(
+  _pid: i64,
+  _window_number: i64,
+  _screen_x: f64,
+  _screen_y: f64,
+  _window_x: f64,
+  _window_y: f64,
+  _button_code: i32,
+  _click_count: i64,
+  _click_interval_ms: u64,
+) -> AuvResult<()> {
+  Err("macOS native window-targeted click is unsupported on this target".to_string())
+}
+
+#[cfg(target_os = "macos")]
+pub fn type_text_in_window(
+  pid: i64,
+  window_number: i64,
+  text: String,
+  inter_char_delay_ms: u64,
+) -> AuvResult<()> {
+  action_result(
+    "type_text_in_window",
+    native_type_text_in_window(pid, window_number, text, inter_char_delay_ms),
+  )
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn type_text_in_window(
+  _pid: i64,
+  _window_number: i64,
+  _text: String,
+  _inter_char_delay_ms: u64,
+) -> AuvResult<()> {
+  Err("macOS native window-targeted text input is unsupported on this target".to_string())
+}
+
+#[cfg(target_os = "macos")]
+pub fn press_key_in_window(pid: i64, window_number: i64, key_code: i32) -> AuvResult<()> {
+  action_result(
+    "press_key_in_window",
+    native_press_key_in_window(pid, window_number, key_code),
+  )
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn press_key_in_window(_pid: i64, _window_number: i64, _key_code: i32) -> AuvResult<()> {
+  Err("macOS native window-targeted key press is unsupported on this target".to_string())
+}
+
+#[cfg(target_os = "macos")]
+pub fn hotkey_in_window(
+  pid: i64,
+  window_number: i64,
+  key_code: i32,
+  command: bool,
+  shift: bool,
+  option: bool,
+  control: bool,
+) -> AuvResult<()> {
+  action_result(
+    "hotkey_in_window",
+    native_hotkey_in_window(
+      pid,
+      window_number,
+      key_code,
+      command,
+      shift,
+      option,
+      control,
+    ),
+  )
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn hotkey_in_window(
+  _pid: i64,
+  _window_number: i64,
+  _key_code: i32,
+  _command: bool,
+  _shift: bool,
+  _option: bool,
+  _control: bool,
+) -> AuvResult<()> {
+  Err("macOS native window-targeted hotkey is unsupported on this target".to_string())
+}
+
+#[cfg(target_os = "macos")]
+fn action_result(operation: &str, response: NativeActionResponse) -> AuvResult<()> {
+  super::error::native_result(
+    operation,
+    response.ok.then_some(()),
+    response.error_message,
+    response.recovery_hint,
+  )
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[cfg(target_os = "macos")]
+  #[test]
+  fn action_result_includes_operation_name() {
+    let error = action_result(
+      "type_text_in_window",
+      NativeActionResponse {
+        ok: false,
+        error_message: Some("failed to create keyboard event".to_string()),
+        recovery_hint: Some("grant Accessibility permission".to_string()),
+      },
+    )
+    .unwrap_err();
+
+    assert!(error.contains("type_text_in_window"));
+    assert!(error.contains("failed to create keyboard event"));
+  }
+}

--- a/crates/auv-driver-macos/src/native/input.rs
+++ b/crates/auv-driver-macos/src/native/input.rs
@@ -17,6 +17,7 @@ pub fn click_window_point(
   button_code: i32,
   click_count: i64,
   click_interval_ms: u64,
+  window_strategy_code: i32,
 ) -> AuvResult<()> {
   action_result(
     "click_window_point",
@@ -30,6 +31,7 @@ pub fn click_window_point(
       button_code,
       click_count,
       click_interval_ms,
+      window_strategy_code,
     ),
   )
 }
@@ -45,6 +47,7 @@ pub fn click_window_point(
   _button_code: i32,
   _click_count: i64,
   _click_interval_ms: u64,
+  _window_strategy_code: i32,
 ) -> AuvResult<()> {
   Err("macOS native window-targeted click is unsupported on this target".to_string())
 }

--- a/crates/auv-driver-macos/src/session.rs
+++ b/crates/auv-driver-macos/src/session.rs
@@ -221,9 +221,15 @@ impl WindowApi<'_> {
       }
       ActivationPolicy::FocusWithoutRaise => Err(DriverError::unsupported("focus_without_raise")),
       ActivationPolicy::Foreground { settle } => {
+        if options.preserve_frontmost || options.install_focus_guard {
+          return Err(DriverError::unsupported("foreground_restore"));
+        }
         activate_app_for_window(window)?;
         if !settle.is_zero() {
           thread::sleep(settle);
+        }
+        if !options.settle.is_zero() {
+          thread::sleep(options.settle);
         }
         Ok(InputPreparationLease::noop())
       }
@@ -919,6 +925,27 @@ mod no_steal_tests {
     let point = window_point_for_screen_point(&window, ScreenPoint::new(125.0, 230.0));
 
     assert_eq!(point, WindowPoint::new(25.0, 30.0));
+  }
+
+  #[test]
+  fn foreground_input_with_default_restore_options_is_unsupported() {
+    let session = MacosDriverSession { _private: () };
+    let window = sample_window();
+    let options = PrepareForInputOptions {
+      activation: ActivationPolicy::Foreground {
+        settle: Duration::ZERO,
+      },
+      ..PrepareForInputOptions::default()
+    };
+
+    let result = session.window().prepare_for_input(&window, options);
+
+    assert!(matches!(
+      result,
+      Err(DriverError::Unsupported {
+        operation: "foreground_restore"
+      })
+    ));
   }
 }
 

--- a/crates/auv-driver-macos/src/session.rs
+++ b/crates/auv-driver-macos/src/session.rs
@@ -281,7 +281,9 @@ impl WindowApi<'_> {
       Ok(()) => Ok(InputActionResult::single_success(
         InputDeliveryPath::WindowTargetedKeyboard,
       )),
+      Err(background_error @ DriverError::InvalidInput { .. }) => Err(background_error),
       Err(background_error) => match options.policy {
+        // Task 4 intentionally keeps BackgroundPreferred background-only during no-steal rollout.
         InputPolicy::BackgroundOnly | InputPolicy::BackgroundPreferred => Err(background_error),
         InputPolicy::ForegroundPreferred if options.allow_clipboard_fallback => {
           let fallback_reason = background_error.to_string();
@@ -702,19 +704,14 @@ fn type_text_in_window(
   text: &str,
   options: TypeTextOptions,
 ) -> DriverResult<()> {
-  let submit_key_code = text_submit_key_code(options.submit)?;
+  let (submit_key_code, inter_char_delay_ms) = type_text_parts(options)?;
   if options.replace_existing {
     crate::native::input::hotkey_in_window(pid, number, 0, true, false, false, false)
       .map_err(backend)?;
     crate::native::input::press_key_in_window(pid, number, 51).map_err(backend)?;
   }
-  crate::native::input::type_text_in_window(
-    pid,
-    number,
-    text.to_string(),
-    duration_millis(options.inter_char_delay)?,
-  )
-  .map_err(backend)?;
+  crate::native::input::type_text_in_window(pid, number, text.to_string(), inter_char_delay_ms)
+    .map_err(backend)?;
   if let Some(key_code) = submit_key_code {
     crate::native::input::press_key_in_window(pid, number, key_code).map_err(backend)?;
   }
@@ -722,6 +719,12 @@ fn type_text_in_window(
     thread::sleep(options.settle);
   }
   Ok(())
+}
+
+fn type_text_parts(options: TypeTextOptions) -> DriverResult<(Option<i32>, u64)> {
+  let submit_key_code = text_submit_key_code(options.submit)?;
+  let inter_char_delay_ms = duration_millis(options.inter_char_delay)?;
+  Ok((submit_key_code, inter_char_delay_ms))
 }
 
 fn foreground_prepare_options(settle: Duration) -> PrepareForInputOptions {
@@ -1146,6 +1149,33 @@ mod no_steal_tests {
       .expect("double click"),
       (2, 75)
     );
+  }
+
+  #[test]
+  fn type_text_parts_validate_submit_and_delay_without_delivery() {
+    let parts = type_text_parts(TypeTextOptions {
+      submit: TextSubmit::Return,
+      inter_char_delay: Duration::from_millis(12),
+      ..TypeTextOptions::default()
+    })
+    .expect("type text parts");
+
+    assert_eq!(parts, (Some(36), 12));
+
+    assert!(matches!(
+      type_text_parts(TypeTextOptions {
+        submit: TextSubmit::Search,
+        ..TypeTextOptions::default()
+      }),
+      Err(DriverError::InvalidInput { .. })
+    ));
+    assert!(matches!(
+      type_text_parts(TypeTextOptions {
+        inter_char_delay: Duration::MAX,
+        ..TypeTextOptions::default()
+      }),
+      Err(DriverError::InvalidInput { .. })
+    ));
   }
 
   #[test]

--- a/crates/auv-driver-macos/src/session.rs
+++ b/crates/auv-driver-macos/src/session.rs
@@ -10,7 +10,7 @@ use auv_driver::geometry::{CoordinateSpace, Point, RatioRect, Rect, ScreenPoint,
 use auv_driver::input::{
   ActivationPolicy, Click, ClickOptions, DisturbanceLevel, InputActionResult, InputAttempt,
   InputDeliveryPath, InputPolicy, InputPreparationLease, PasteTextOptions, PrepareForInputOptions,
-  TextSubmit, TypeTextOptions, WaitOptions,
+  TextSubmit, TypeTextOptions, WaitOptions, WindowClickStrategy,
 };
 use auv_driver::selector::{AppSelector, TextMatcher, WindowSelector};
 use auv_driver::vision::{RecognizedText, TextRecognition};
@@ -219,6 +219,10 @@ impl WindowApi<'_> {
     let screen = screen_point.point();
     let window_point = point.point();
     let (click_count, click_interval_ms) = click_parts(&options.click)?;
+    let window_strategy_code = match options.window_strategy {
+      WindowClickStrategy::ChromiumCompatible => 0,
+      WindowClickStrategy::PidTargeted => 1,
+    };
     let background_result = crate::native::input::click_window_point(
       pid,
       number,
@@ -229,6 +233,7 @@ impl WindowApi<'_> {
       0,
       click_count,
       click_interval_ms,
+      window_strategy_code,
     )
     .map_err(backend);
 

--- a/crates/auv-driver-macos/src/session.rs
+++ b/crates/auv-driver-macos/src/session.rs
@@ -8,8 +8,9 @@ use auv_driver::capture::{Activation, Capture, CaptureOptions};
 use auv_driver::error::{DriverError, DriverResult};
 use auv_driver::geometry::{CoordinateSpace, Point, RatioRect, Rect, ScreenPoint, WindowPoint};
 use auv_driver::input::{
-  ActivationPolicy, Click, InputPreparationLease, PasteTextOptions, PrepareForInputOptions,
-  TextSubmit, WaitOptions,
+  ActivationPolicy, Click, ClickOptions, DisturbanceLevel, InputActionResult, InputAttempt,
+  InputDeliveryPath, InputPolicy, InputPreparationLease, PasteTextOptions, PrepareForInputOptions,
+  TextSubmit, TypeTextOptions, WaitOptions,
 };
 use auv_driver::selector::{AppSelector, TextMatcher, WindowSelector};
 use auv_driver::vision::{RecognizedText, TextRecognition};
@@ -204,6 +205,114 @@ impl WindowApi<'_> {
   pub fn to_window_point(&self, window: &Window, point: ScreenPoint) -> DriverResult<WindowPoint> {
     let _ = self.session;
     Ok(window_point_for_screen_point(window, point))
+  }
+
+  pub fn click(
+    &self,
+    window: &Window,
+    point: WindowPoint,
+    options: ClickOptions,
+  ) -> DriverResult<InputActionResult> {
+    let pid = window_pid(window)?;
+    let number = window_number(window)?;
+    let screen_point = self.to_screen_point(window, point)?;
+    let screen = screen_point.point();
+    let window_point = point.point();
+    let (click_count, click_interval_ms) = click_parts(&options.click)?;
+    let background_result = crate::native::input::click_window_point(
+      pid,
+      number,
+      screen.x,
+      screen.y,
+      window_point.x,
+      window_point.y,
+      0,
+      click_count,
+      click_interval_ms,
+    )
+    .map_err(backend);
+
+    match background_result {
+      Ok(()) => Ok(InputActionResult::single_success(
+        InputDeliveryPath::WindowTargetedMouse,
+      )),
+      Err(background_error) => match options.policy {
+        InputPolicy::BackgroundOnly | InputPolicy::BackgroundPreferred => Err(background_error),
+        InputPolicy::ForegroundPreferred => {
+          let fallback_reason = background_error.to_string();
+          let lease = self.prepare_for_input(window, foreground_prepare_options(Duration::ZERO))?;
+          let action_result = self
+            .session
+            .input()
+            .click_at(screen_point.point(), options.click.clone());
+          let restore_result = self.restore_input(lease);
+          action_result?;
+          restore_result?;
+          Ok(InputActionResult {
+            selected_path: InputDeliveryPath::ForegroundSystemEvents,
+            attempts: vec![
+              InputAttempt::failure(
+                InputDeliveryPath::WindowTargetedMouse,
+                fallback_reason.clone(),
+              ),
+              InputAttempt::success(InputDeliveryPath::ForegroundSystemEvents),
+            ],
+            fallback_reason: Some(fallback_reason),
+            mouse_disturbance: DisturbanceLevel::Temporary,
+            focus_disturbance: DisturbanceLevel::Foreground,
+            clipboard_disturbance: DisturbanceLevel::None,
+          })
+        }
+      },
+    }
+  }
+
+  pub fn type_text(
+    &self,
+    window: &Window,
+    text: &str,
+    options: TypeTextOptions,
+  ) -> DriverResult<InputActionResult> {
+    let pid = window_pid(window)?;
+    let number = window_number(window)?;
+    let background_result = type_text_in_window(pid, number, text, options);
+
+    match background_result {
+      Ok(()) => Ok(InputActionResult::single_success(
+        InputDeliveryPath::WindowTargetedKeyboard,
+      )),
+      Err(background_error) => match options.policy {
+        InputPolicy::BackgroundOnly | InputPolicy::BackgroundPreferred => Err(background_error),
+        InputPolicy::ForegroundPreferred if options.allow_clipboard_fallback => {
+          let fallback_reason = background_error.to_string();
+          let lease = self.prepare_for_input(window, foreground_prepare_options(Duration::ZERO))?;
+          let action_result = self.session.input().paste_text(PasteTextOptions {
+            text: text.to_string(),
+            replace_existing: options.replace_existing,
+            submit: options.submit,
+            settle: options.settle,
+          });
+          let restore_result = self.restore_input(lease);
+          action_result?;
+          restore_result?;
+          Ok(InputActionResult {
+            selected_path: InputDeliveryPath::ClipboardPaste,
+            attempts: vec![
+              InputAttempt::failure(
+                InputDeliveryPath::WindowTargetedKeyboard,
+                fallback_reason.clone(),
+              ),
+              InputAttempt::success(InputDeliveryPath::ClipboardPaste),
+            ],
+            fallback_reason: Some(fallback_reason),
+            mouse_disturbance: DisturbanceLevel::None,
+            focus_disturbance: DisturbanceLevel::Foreground,
+            clipboard_disturbance: DisturbanceLevel::Temporary,
+          })
+        }
+        InputPolicy::ForegroundPreferred => Err(background_error),
+      },
+    }
   }
 
   pub fn prepare_for_input(
@@ -561,6 +670,69 @@ fn window_point_for_screen_point(window: &Window, point: ScreenPoint) -> WindowP
   )
 }
 
+fn window_number(window: &Window) -> DriverResult<i64> {
+  if window.reference.id.trim().is_empty() {
+    return Err(invalid_input("window is missing a native macOS window id"));
+  }
+  window.reference.id.parse::<i64>().map_err(|error| {
+    invalid_input(format!(
+      "window ref {} was not a native macOS window id: {error}",
+      window.reference.id
+    ))
+  })
+}
+
+fn window_pid(window: &Window) -> DriverResult<i64> {
+  window
+    .process_id
+    .map(i64::from)
+    .ok_or_else(|| invalid_input("window is missing an owner process id"))
+}
+
+fn click_parts(click: &Click) -> DriverResult<(i64, u64)> {
+  match click {
+    Click::Single => Ok((1, 0)),
+    Click::Double { interval } => Ok((2, duration_millis(*interval)?)),
+  }
+}
+
+fn type_text_in_window(
+  pid: i64,
+  number: i64,
+  text: &str,
+  options: TypeTextOptions,
+) -> DriverResult<()> {
+  let submit_key_code = text_submit_key_code(options.submit)?;
+  if options.replace_existing {
+    crate::native::input::hotkey_in_window(pid, number, 0, true, false, false, false)
+      .map_err(backend)?;
+    crate::native::input::press_key_in_window(pid, number, 51).map_err(backend)?;
+  }
+  crate::native::input::type_text_in_window(
+    pid,
+    number,
+    text.to_string(),
+    duration_millis(options.inter_char_delay)?,
+  )
+  .map_err(backend)?;
+  if let Some(key_code) = submit_key_code {
+    crate::native::input::press_key_in_window(pid, number, key_code).map_err(backend)?;
+  }
+  if !options.settle.is_zero() {
+    thread::sleep(options.settle);
+  }
+  Ok(())
+}
+
+fn foreground_prepare_options(settle: Duration) -> PrepareForInputOptions {
+  PrepareForInputOptions {
+    activation: ActivationPolicy::Foreground { settle },
+    preserve_frontmost: false,
+    install_focus_guard: false,
+    settle: Duration::ZERO,
+  }
+}
+
 fn activate_app_for_window(window: &Window) -> DriverResult<()> {
   if let Some(bundle_id) = &window.app_bundle_id {
     run_osascript(&[&format!(
@@ -780,7 +952,7 @@ fn run_osascript_lines(lines: &[String]) -> DriverResult<()> {
   }
 }
 
-fn text_submit_key_code(submit: TextSubmit) -> DriverResult<Option<u32>> {
+fn text_submit_key_code(submit: TextSubmit) -> DriverResult<Option<i32>> {
   match submit {
     TextSubmit::No => Ok(None),
     TextSubmit::Return => Ok(Some(36)),
@@ -925,6 +1097,55 @@ mod no_steal_tests {
     let point = window_point_for_screen_point(&window, ScreenPoint::new(125.0, 230.0));
 
     assert_eq!(point, WindowPoint::new(25.0, 30.0));
+  }
+
+  #[test]
+  fn window_number_parses_native_window_id() {
+    let window = sample_window();
+
+    let number = window_number(&window).expect("window number");
+
+    assert_eq!(number, 42);
+  }
+
+  #[test]
+  fn window_number_rejects_missing_or_invalid_native_window_id() {
+    let mut missing = sample_window();
+    missing.reference.id.clear();
+    let mut invalid = sample_window();
+    invalid.reference.id = "not-a-window-number".to_string();
+
+    assert!(matches!(
+      window_number(&missing),
+      Err(DriverError::InvalidInput { .. })
+    ));
+    assert!(matches!(
+      window_number(&invalid),
+      Err(DriverError::InvalidInput { .. })
+    ));
+  }
+
+  #[test]
+  fn window_pid_requires_owner_process_id() {
+    let mut window = sample_window();
+    window.process_id = None;
+
+    assert!(matches!(
+      window_pid(&window),
+      Err(DriverError::InvalidInput { .. })
+    ));
+  }
+
+  #[test]
+  fn click_parts_converts_click_count_and_interval() {
+    assert_eq!(click_parts(&Click::Single).expect("single click"), (1, 0));
+    assert_eq!(
+      click_parts(&Click::Double {
+        interval: Duration::from_millis(75),
+      })
+      .expect("double click"),
+      (2, 75)
+    );
   }
 
   #[test]

--- a/crates/auv-driver-macos/src/session.rs
+++ b/crates/auv-driver-macos/src/session.rs
@@ -6,8 +6,11 @@ use std::time::Duration;
 
 use auv_driver::capture::{Activation, Capture, CaptureOptions};
 use auv_driver::error::{DriverError, DriverResult};
-use auv_driver::geometry::{CoordinateSpace, Point, RatioRect, Rect};
-use auv_driver::input::{Click, PasteTextOptions, TextSubmit, WaitOptions};
+use auv_driver::geometry::{CoordinateSpace, Point, RatioRect, Rect, ScreenPoint, WindowPoint};
+use auv_driver::input::{
+  ActivationPolicy, Click, InputPreparationLease, PasteTextOptions, PrepareForInputOptions,
+  TextSubmit, WaitOptions,
+};
 use auv_driver::selector::{AppSelector, TextMatcher, WindowSelector};
 use auv_driver::vision::{RecognizedText, TextRecognition};
 use auv_driver::window::{Window, WindowRef};
@@ -191,6 +194,46 @@ impl WindowApi<'_> {
     } else {
       Ok(matches)
     }
+  }
+
+  pub fn to_screen_point(&self, window: &Window, point: WindowPoint) -> DriverResult<ScreenPoint> {
+    let _ = self.session;
+    Ok(screen_point_for_window_point(window, point))
+  }
+
+  pub fn to_window_point(&self, window: &Window, point: ScreenPoint) -> DriverResult<WindowPoint> {
+    let _ = self.session;
+    Ok(window_point_for_screen_point(window, point))
+  }
+
+  pub fn prepare_for_input(
+    &self,
+    window: &Window,
+    options: PrepareForInputOptions,
+  ) -> DriverResult<InputPreparationLease> {
+    let _ = self.session;
+    match options.activation {
+      ActivationPolicy::NoChange | ActivationPolicy::Background => {
+        if !options.settle.is_zero() {
+          thread::sleep(options.settle);
+        }
+        Ok(InputPreparationLease::noop())
+      }
+      ActivationPolicy::FocusWithoutRaise => Err(DriverError::unsupported("focus_without_raise")),
+      ActivationPolicy::Foreground { settle } => {
+        activate_app_for_window(window)?;
+        if !settle.is_zero() {
+          thread::sleep(settle);
+        }
+        Ok(InputPreparationLease::noop())
+      }
+    }
+  }
+
+  pub fn restore_input(&self, mut lease: InputPreparationLease) -> DriverResult<()> {
+    let _ = self.session;
+    lease.mark_restored();
+    Ok(())
   }
 }
 
@@ -493,6 +536,22 @@ fn rect_from_observed(rect: &ObservedRect) -> Rect {
     rect.y as f64,
     rect.width as f64,
     rect.height as f64,
+  )
+}
+
+fn screen_point_for_window_point(window: &Window, point: WindowPoint) -> ScreenPoint {
+  let point = point.point();
+  ScreenPoint::new(
+    window.frame.origin.x + point.x,
+    window.frame.origin.y + point.y,
+  )
+}
+
+fn window_point_for_screen_point(window: &Window, point: ScreenPoint) -> WindowPoint {
+  let point = point.point();
+  WindowPoint::new(
+    point.x - window.frame.origin.x,
+    point.y - window.frame.origin.y,
   )
 }
 
@@ -819,6 +878,47 @@ fn invalid_input(message: impl std::fmt::Display) -> DriverError {
 fn not_found(target: impl std::fmt::Display) -> DriverError {
   DriverError::NotFound {
     target: target.to_string(),
+  }
+}
+
+#[cfg(test)]
+mod no_steal_tests {
+  use auv_driver::geometry::{ScreenPoint, WindowPoint};
+
+  use super::*;
+
+  fn sample_window() -> Window {
+    Window {
+      reference: WindowRef {
+        id: "42".to_string(),
+      },
+      title: None,
+      app_name: None,
+      app_bundle_id: None,
+      process_id: Some(123),
+      frame: Rect::new(100.0, 200.0, 800.0, 600.0),
+      coordinate_space: CoordinateSpace::Screen,
+      is_main: true,
+      is_visible: true,
+    }
+  }
+
+  #[test]
+  fn window_point_converts_to_screen_point() {
+    let window = sample_window();
+
+    let point = screen_point_for_window_point(&window, WindowPoint::new(25.0, 30.0));
+
+    assert_eq!(point, ScreenPoint::new(125.0, 230.0));
+  }
+
+  #[test]
+  fn screen_point_converts_to_window_point() {
+    let window = sample_window();
+
+    let point = window_point_for_screen_point(&window, ScreenPoint::new(125.0, 230.0));
+
+    assert_eq!(point, WindowPoint::new(25.0, 30.0));
   }
 }
 

--- a/crates/auv-driver-macos/src/session.rs
+++ b/crates/auv-driver-macos/src/session.rs
@@ -323,6 +323,9 @@ impl WindowApi<'_> {
     options: PrepareForInputOptions,
   ) -> DriverResult<InputPreparationLease> {
     let _ = self.session;
+    if options.install_focus_guard {
+      return Err(DriverError::unsupported("focus_guard"));
+    }
     match options.activation {
       ActivationPolicy::NoChange | ActivationPolicy::Background => {
         if !options.settle.is_zero() {
@@ -332,7 +335,7 @@ impl WindowApi<'_> {
       }
       ActivationPolicy::FocusWithoutRaise => Err(DriverError::unsupported("focus_without_raise")),
       ActivationPolicy::Foreground { settle } => {
-        if options.preserve_frontmost || options.install_focus_guard {
+        if options.preserve_frontmost {
           return Err(DriverError::unsupported("foreground_restore"));
         }
         activate_app_for_window(window)?;
@@ -1175,6 +1178,27 @@ mod no_steal_tests {
         ..TypeTextOptions::default()
       }),
       Err(DriverError::InvalidInput { .. })
+    ));
+  }
+
+  #[test]
+  fn prepare_for_input_rejects_unimplemented_focus_guard_without_activation() {
+    let session = MacosDriverSession { _private: () };
+    let window = sample_window();
+    let options = PrepareForInputOptions {
+      activation: ActivationPolicy::NoChange,
+      preserve_frontmost: false,
+      install_focus_guard: true,
+      settle: Duration::ZERO,
+    };
+
+    let result = session.window().prepare_for_input(&window, options);
+
+    assert!(matches!(
+      result,
+      Err(DriverError::Unsupported {
+        operation: "focus_guard"
+      })
     ));
   }
 

--- a/crates/auv-driver-macos/src/session.rs
+++ b/crates/auv-driver-macos/src/session.rs
@@ -712,6 +712,7 @@ fn type_text_in_window(
     crate::native::input::hotkey_in_window(pid, number, 0, true, false, false, false)
       .map_err(backend)?;
     crate::native::input::press_key_in_window(pid, number, 51).map_err(backend)?;
+    thread::sleep(Duration::from_millis(100));
   }
   crate::native::input::type_text_in_window(pid, number, text.to_string(), inter_char_delay_ms)
     .map_err(backend)?;

--- a/crates/auv-driver/Cargo.toml
+++ b/crates/auv-driver/Cargo.toml
@@ -15,3 +15,6 @@ repository.workspace = true
 [dependencies]
 image.workspace = true
 serde.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/crates/auv-driver/src/geometry.rs
+++ b/crates/auv-driver/src/geometry.rs
@@ -27,6 +27,56 @@ impl Point {
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct ScreenPoint(pub Point);
+
+impl ScreenPoint {
+  pub const fn new(x: f64, y: f64) -> Self {
+    Self(Point::new(x, y))
+  }
+
+  pub const fn point(self) -> Point {
+    self.0
+  }
+}
+
+impl From<Point> for ScreenPoint {
+  fn from(point: Point) -> Self {
+    Self(point)
+  }
+}
+
+impl From<ScreenPoint> for Point {
+  fn from(point: ScreenPoint) -> Self {
+    point.0
+  }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct WindowPoint(pub Point);
+
+impl WindowPoint {
+  pub const fn new(x: f64, y: f64) -> Self {
+    Self(Point::new(x, y))
+  }
+
+  pub const fn point(self) -> Point {
+    self.0
+  }
+}
+
+impl From<Point> for WindowPoint {
+  fn from(point: Point) -> Self {
+    Self(point)
+  }
+}
+
+impl From<WindowPoint> for Point {
+  fn from(point: WindowPoint) -> Self {
+    point.0
+  }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct Size {
   pub width: f64,
   pub height: f64,

--- a/crates/auv-driver/src/input.rs
+++ b/crates/auv-driver/src/input.rs
@@ -101,7 +101,7 @@ impl Default for PrepareForInputOptions {
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct InputPreparationLease {
-  pub restored: bool,
+  restored: bool,
 }
 
 impl InputPreparationLease {

--- a/crates/auv-driver/src/input.rs
+++ b/crates/auv-driver/src/input.rs
@@ -120,6 +120,7 @@ impl InputPreparationLease {
 pub struct ClickOptions {
   pub policy: InputPolicy,
   pub click: Click,
+  pub window_strategy: WindowClickStrategy,
 }
 
 impl Default for ClickOptions {
@@ -127,8 +128,23 @@ impl Default for ClickOptions {
     Self {
       policy: InputPolicy::BackgroundPreferred,
       click: Click::Single,
+      window_strategy: WindowClickStrategy::default(),
     }
   }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WindowClickStrategy {
+  /// Use the Chromium-compatible background window click route.
+  ///
+  /// This stamps extra window-routing fields and sends a CUA-derived synthetic
+  /// event sequence for Chromium/WebView/Catalyst-style targets that ignore
+  /// the narrower pid-targeted route.
+  #[default]
+  ChromiumCompatible,
+  /// Use a direct pid-targeted mouse pair with window-local routing fields.
+  PidTargeted,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -251,6 +267,7 @@ mod tests {
       click: Click::Double {
         interval: Duration::from_millis(100),
       },
+      window_strategy: WindowClickStrategy::PidTargeted,
     };
 
     let encoded = serde_json::to_string(&options).expect("serialize click options");

--- a/crates/auv-driver/src/input.rs
+++ b/crates/auv-driver/src/input.rs
@@ -55,3 +55,176 @@ impl Default for WaitOptions {
     }
   }
 }
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InputPolicy {
+  BackgroundOnly,
+  #[default]
+  BackgroundPreferred,
+  ForegroundPreferred,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ActivationPolicy {
+  NoChange,
+  Background,
+  FocusWithoutRaise,
+  Foreground { settle: Duration },
+}
+
+impl Default for ActivationPolicy {
+  fn default() -> Self {
+    Self::NoChange
+  }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PrepareForInputOptions {
+  pub activation: ActivationPolicy,
+  pub preserve_frontmost: bool,
+  pub install_focus_guard: bool,
+  pub settle: Duration,
+}
+
+impl Default for PrepareForInputOptions {
+  fn default() -> Self {
+    Self {
+      activation: ActivationPolicy::NoChange,
+      preserve_frontmost: true,
+      install_focus_guard: false,
+      settle: Duration::ZERO,
+    }
+  }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InputPreparationLease {
+  pub restored: bool,
+}
+
+impl InputPreparationLease {
+  pub const fn noop() -> Self {
+    Self { restored: false }
+  }
+
+  pub fn mark_restored(&mut self) {
+    self.restored = true;
+  }
+
+  pub const fn is_restored(self) -> bool {
+    self.restored
+  }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ClickOptions {
+  pub policy: InputPolicy,
+  pub click: Click,
+}
+
+impl Default for ClickOptions {
+  fn default() -> Self {
+    Self {
+      policy: InputPolicy::BackgroundPreferred,
+      click: Click::Single,
+    }
+  }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TypeTextOptions {
+  pub policy: InputPolicy,
+  pub replace_existing: bool,
+  pub submit: TextSubmit,
+  pub inter_char_delay: Duration,
+  pub allow_clipboard_fallback: bool,
+  pub settle: Duration,
+}
+
+impl Default for TypeTextOptions {
+  fn default() -> Self {
+    Self {
+      policy: InputPolicy::BackgroundPreferred,
+      replace_existing: false,
+      submit: TextSubmit::No,
+      inter_char_delay: Duration::from_millis(8),
+      allow_clipboard_fallback: false,
+      settle: Duration::ZERO,
+    }
+  }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InputDeliveryPath {
+  Noop,
+  AxPress,
+  AxFocus,
+  AxSetValue,
+  AxSelectedText,
+  WindowTargetedMouse,
+  WindowTargetedKeyboard,
+  ClipboardPaste,
+  ForegroundSystemEvents,
+  Unsupported,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DisturbanceLevel {
+  #[default]
+  None,
+  Temporary,
+  Foreground,
+  Unknown,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InputAttempt {
+  pub path: InputDeliveryPath,
+  pub succeeded: bool,
+  pub message: Option<String>,
+}
+
+impl InputAttempt {
+  pub fn success(path: InputDeliveryPath) -> Self {
+    Self {
+      path,
+      succeeded: true,
+      message: None,
+    }
+  }
+
+  pub fn failure(path: InputDeliveryPath, message: impl Into<String>) -> Self {
+    Self {
+      path,
+      succeeded: false,
+      message: Some(message.into()),
+    }
+  }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InputActionResult {
+  pub selected_path: InputDeliveryPath,
+  pub attempts: Vec<InputAttempt>,
+  pub fallback_reason: Option<String>,
+  pub mouse_disturbance: DisturbanceLevel,
+  pub focus_disturbance: DisturbanceLevel,
+  pub clipboard_disturbance: DisturbanceLevel,
+}
+
+impl InputActionResult {
+  pub fn single_success(path: InputDeliveryPath) -> Self {
+    Self {
+      selected_path: path,
+      attempts: vec![InputAttempt::success(path)],
+      fallback_reason: None,
+      mouse_disturbance: DisturbanceLevel::None,
+      focus_disturbance: DisturbanceLevel::None,
+      clipboard_disturbance: DisturbanceLevel::None,
+    }
+  }
+}

--- a/crates/auv-driver/src/input.rs
+++ b/crates/auv-driver/src/input.rs
@@ -16,7 +16,8 @@ impl Default for MouseButton {
   }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Click {
   Single,
   Double { interval: Duration },
@@ -65,19 +66,16 @@ pub enum InputPolicy {
   ForegroundPreferred,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ActivationPolicy {
+  #[default]
   NoChange,
   Background,
   FocusWithoutRaise,
-  Foreground { settle: Duration },
-}
-
-impl Default for ActivationPolicy {
-  fn default() -> Self {
-    Self::NoChange
-  }
+  Foreground {
+    settle: Duration,
+  },
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -99,7 +97,7 @@ impl Default for PrepareForInputOptions {
   }
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, PartialEq, Eq)]
 pub struct InputPreparationLease {
   restored: bool,
 }
@@ -113,12 +111,12 @@ impl InputPreparationLease {
     self.restored = true;
   }
 
-  pub const fn is_restored(self) -> bool {
+  pub const fn is_restored(&self) -> bool {
     self.restored
   }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ClickOptions {
   pub policy: InputPolicy,
   pub click: Click,
@@ -226,5 +224,47 @@ impl InputActionResult {
       focus_disturbance: DisturbanceLevel::None,
       clipboard_disturbance: DisturbanceLevel::None,
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn click_and_click_options_serde_roundtrip() {
+    let clicks = [
+      Click::Single,
+      Click::Double {
+        interval: Duration::from_millis(42),
+      },
+    ];
+
+    for click in clicks {
+      let encoded = serde_json::to_string(&click).expect("serialize click");
+      let decoded: Click = serde_json::from_str(&encoded).expect("deserialize click");
+      assert_eq!(decoded, click);
+    }
+
+    let options = ClickOptions {
+      policy: InputPolicy::ForegroundPreferred,
+      click: Click::Double {
+        interval: Duration::from_millis(100),
+      },
+    };
+
+    let encoded = serde_json::to_string(&options).expect("serialize click options");
+    let decoded: ClickOptions = serde_json::from_str(&encoded).expect("deserialize click options");
+    assert_eq!(decoded, options);
+  }
+
+  #[test]
+  fn input_preparation_lease_tracks_restoration() {
+    let mut lease = InputPreparationLease::noop();
+    assert!(!lease.is_restored());
+
+    lease.mark_restored();
+
+    assert!(lease.is_restored());
   }
 }

--- a/crates/auv-driver/src/lib.rs
+++ b/crates/auv-driver/src/lib.rs
@@ -27,15 +27,14 @@ mod tests {
   use std::time::Duration;
 
   use crate::{
+    ActivationPolicy, Click, ClickOptions, DisturbanceLevel, InputActionResult, InputAttempt,
+    InputDeliveryPath, InputPolicy, InputPreparationLease, PrepareForInputOptions, ScreenPoint,
+    TextSubmit, TypeTextOptions, WindowPoint,
     capture::{Activation, Capture, CaptureOptions, ImageView},
     display::{Display, ObservedDisplays},
     error::{DriverError, DriverResult},
-    geometry::{CoordinateSpace, Point, RatioRect, Rect, ScreenPoint, Size, WindowPoint},
-    input::{
-      ActivationPolicy, Click, ClickOptions, DisturbanceLevel, InputActionResult, InputAttempt,
-      InputDeliveryPath, InputPolicy, InputPreparationLease, PasteTextOptions,
-      PrepareForInputOptions, TextSubmit, TypeTextOptions, WaitOptions,
-    },
+    geometry::{CoordinateSpace, Point, RatioRect, Rect, Size},
+    input::{PasteTextOptions, WaitOptions},
     selector::{App, AppSelector, TextMatcher, Window as SelectWindow, WindowSelector},
     traits::{Driver, DriverDescriptor, DriverSession, PlatformKind},
     vision::{ImageMatch, ImageMatchResult, RecognizedText, TextRecognition},

--- a/crates/auv-driver/src/lib.rs
+++ b/crates/auv-driver/src/lib.rs
@@ -15,7 +15,7 @@ pub use geometry::{CoordinateSpace, Point, RatioRect, Rect, ScreenPoint, Size, W
 pub use input::{
   ActivationPolicy, Click, ClickOptions, DisturbanceLevel, InputActionResult, InputAttempt,
   InputDeliveryPath, InputPolicy, InputPreparationLease, PasteTextOptions, PrepareForInputOptions,
-  TextSubmit, TypeTextOptions, WaitOptions,
+  TextSubmit, TypeTextOptions, WaitOptions, WindowClickStrategy,
 };
 pub use selector::{App, AppSelector, TextMatcher, WindowSelector};
 pub use traits::{Driver, DriverDescriptor, DriverSession, PlatformKind};
@@ -29,7 +29,7 @@ mod tests {
   use crate::{
     ActivationPolicy, Click, ClickOptions, DisturbanceLevel, InputActionResult, InputAttempt,
     InputDeliveryPath, InputPolicy, InputPreparationLease, PrepareForInputOptions, ScreenPoint,
-    TextSubmit, TypeTextOptions, WindowPoint,
+    TextSubmit, TypeTextOptions, WindowClickStrategy, WindowPoint,
     capture::{Activation, Capture, CaptureOptions, ImageView},
     display::{Display, ObservedDisplays},
     error::{DriverError, DriverResult},
@@ -63,6 +63,7 @@ mod tests {
     let _click_options = ClickOptions {
       policy: InputPolicy::BackgroundOnly,
       click: Click::Single,
+      window_strategy: WindowClickStrategy::ChromiumCompatible,
     };
     let _type_options = TypeTextOptions {
       policy: InputPolicy::BackgroundPreferred,

--- a/crates/auv-driver/src/lib.rs
+++ b/crates/auv-driver/src/lib.rs
@@ -11,8 +11,12 @@ pub mod window;
 pub use capture::{Activation, Capture, CaptureOptions, ImageView};
 pub use display::{Display, ObservedDisplays};
 pub use error::{DriverError, DriverResult};
-pub use geometry::{CoordinateSpace, Point, RatioRect, Rect, Size};
-pub use input::{Click, PasteTextOptions, TextSubmit, WaitOptions};
+pub use geometry::{CoordinateSpace, Point, RatioRect, Rect, ScreenPoint, Size, WindowPoint};
+pub use input::{
+  ActivationPolicy, Click, ClickOptions, DisturbanceLevel, InputActionResult, InputAttempt,
+  InputDeliveryPath, InputPolicy, InputPreparationLease, PasteTextOptions, PrepareForInputOptions,
+  TextSubmit, TypeTextOptions, WaitOptions,
+};
 pub use selector::{App, AppSelector, TextMatcher, WindowSelector};
 pub use traits::{Driver, DriverDescriptor, DriverSession, PlatformKind};
 pub use vision::{ImageMatch, ImageMatchResult, RecognizedText, TextRecognition};
@@ -26,8 +30,12 @@ mod tests {
     capture::{Activation, Capture, CaptureOptions, ImageView},
     display::{Display, ObservedDisplays},
     error::{DriverError, DriverResult},
-    geometry::{CoordinateSpace, Point, RatioRect, Rect, Size},
-    input::{Click, PasteTextOptions, TextSubmit, WaitOptions},
+    geometry::{CoordinateSpace, Point, RatioRect, Rect, ScreenPoint, Size, WindowPoint},
+    input::{
+      ActivationPolicy, Click, ClickOptions, DisturbanceLevel, InputActionResult, InputAttempt,
+      InputDeliveryPath, InputPolicy, InputPreparationLease, PasteTextOptions,
+      PrepareForInputOptions, TextSubmit, TypeTextOptions, WaitOptions,
+    },
     selector::{App, AppSelector, TextMatcher, Window as SelectWindow, WindowSelector},
     traits::{Driver, DriverDescriptor, DriverSession, PlatformKind},
     vision::{ImageMatch, ImageMatchResult, RecognizedText, TextRecognition},
@@ -51,6 +59,36 @@ mod tests {
     let _click = Click::Double {
       interval: Duration::from_millis(100),
     };
+    let _screen_point = ScreenPoint::new(10.0, 20.0);
+    let _window_point = WindowPoint::new(3.0, 4.0);
+    let _click_options = ClickOptions {
+      policy: InputPolicy::BackgroundOnly,
+      click: Click::Single,
+    };
+    let _type_options = TypeTextOptions {
+      policy: InputPolicy::BackgroundPreferred,
+      replace_existing: true,
+      submit: TextSubmit::Return,
+      inter_char_delay: Duration::from_millis(8),
+      allow_clipboard_fallback: false,
+      settle: Duration::from_millis(50),
+    };
+    let _prepare_options = PrepareForInputOptions {
+      activation: ActivationPolicy::NoChange,
+      preserve_frontmost: true,
+      install_focus_guard: false,
+      settle: Duration::from_millis(0),
+    };
+    let _lease = InputPreparationLease::noop();
+    let _attempt = InputAttempt::success(InputDeliveryPath::WindowTargetedKeyboard);
+    let _result = InputActionResult::single_success(InputDeliveryPath::WindowTargetedKeyboard);
+    let _ = DisturbanceLevel::None;
+    let _ = ActivationPolicy::Background;
+    let _ = ActivationPolicy::FocusWithoutRaise;
+    let _ = ActivationPolicy::Foreground {
+      settle: Duration::from_millis(100),
+    };
+    let _ = InputPolicy::ForegroundPreferred;
 
     let _ = std::any::type_name::<Capture>();
     let _ = std::any::type_name::<CaptureOptions>();

--- a/crates/auv-overlay-macos/native/swift/Sources/AuvMacosOverlayNative/Overlay.swift
+++ b/crates/auv-overlay-macos/native/swift/Sources/AuvMacosOverlayNative/Overlay.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CoreGraphics
 import Foundation
 
 /// Pixel-art cursor sprite ported from the AUV design system.
@@ -409,7 +410,8 @@ final class NativeOverlayController {
     window.backgroundColor = .clear
     window.ignoresMouseEvents = true
     window.hasShadow = false
-    window.level = .floating
+    window.level = .screenSaver
+    window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
     window.isReleasedWhenClosed = false
 
     return (window, view)
@@ -444,12 +446,11 @@ final class NativeOverlayController {
     // target point — matches the hover offset in the design preview.
     let offsetX = 4.0
     let offsetY = 4.0
-    let topLeftX = x + offsetX
-    let topLeftY = y + offsetY
-    let appKitY = referenceHeight() - topLeftY - Double(viewSize.height)
+    let auvTopLeft = CGPoint(x: x + offsetX, y: y + offsetY)
+    let appKitTopLeft = appKitPoint(fromAuvScreenPoint: auvTopLeft)
     let frame = NSRect(
-      x: topLeftX,
-      y: appKitY,
+      x: appKitTopLeft.x,
+      y: appKitTopLeft.y - Double(viewSize.height),
       width: Double(viewSize.width),
       height: Double(viewSize.height)
     )
@@ -613,18 +614,109 @@ final class NativeOverlayController {
   }
 
   private func currentMouseLogicalPoint() -> (x: Double, y: Double) {
-    // NSEvent.mouseLocation is in AppKit global coordinates, with a
-    // bottom-left origin on the main display. Convert it to the same
-    // top-left global-logical space accepted by show_overlay_cursor.
+    // NSEvent.mouseLocation is in AppKit screen coordinates. Convert it to
+    // the same AUV ScreenPoint space accepted by the public overlay API so
+    // the "you" cursor can share the same renderer path as the AUV cursor.
     let location = NSEvent.mouseLocation
-    return (
-      x: Double(location.x),
-      y: referenceHeight() - Double(location.y)
+    let auvPoint = auvScreenPoint(fromAppKitPoint: location)
+    return (x: auvPoint.x, y: auvPoint.y)
+  }
+
+  private struct DisplayCoordinateSpace {
+    let appKitFrame: CGRect
+    let cgFrame: CGRect
+  }
+
+  // NOTICE: AUV ScreenPoint values come from CGWindow/CGDisplay coordinates,
+  // while NSWindow.setFrame expects AppKit screen coordinates. These coordinate
+  // spaces match on the main display, but can diverge on secondary displays
+  // with negative AppKit origins. Do not convert by subtracting from one global
+  // desktop height; first choose the display containing the point, then map the
+  // point locally between CGDisplayBounds and NSScreen.frame.
+  //
+  // Reference:
+  // https://github.com/EYHN/kwwk-computer-use-core/blob/eddd9e5475095de58bcb81cafbad79d1f5c5495d/Sources/KWWKComputerUseCore/CoordinateSpaces.swift#L27-L43
+  private func appKitPoint(fromAuvScreenPoint point: CGPoint) -> CGPoint {
+    guard let space = displaySpace(containingCgPoint: point) else {
+      return point
+    }
+
+    let localX = point.x - space.cgFrame.minX
+    let localY = point.y - space.cgFrame.minY
+    return CGPoint(
+      x: space.appKitFrame.minX + localX,
+      y: space.appKitFrame.maxY - localY
     )
   }
 
-  private func referenceHeight() -> Double {
-    Double(NSScreen.main?.frame.height ?? NSScreen.screens.first?.frame.height ?? 0)
+  private func auvScreenPoint(fromAppKitPoint point: CGPoint) -> CGPoint {
+    guard let space = displaySpace(containingAppKitPoint: point) else {
+      return point
+    }
+
+    let localX = point.x - space.appKitFrame.minX
+    let localY = space.appKitFrame.maxY - point.y
+    return CGPoint(
+      x: space.cgFrame.minX + localX,
+      y: space.cgFrame.minY + localY
+    )
+  }
+
+  private func displaySpace(containingCgPoint point: CGPoint) -> DisplayCoordinateSpace? {
+    let spaces = displayCoordinateSpaces()
+    return spaces.first(where: { $0.cgFrame.contains(point) })
+      ?? spaces.min {
+        distanceSquared(from: point, to: $0.cgFrame) < distanceSquared(from: point, to: $1.cgFrame)
+      }
+  }
+
+  private func displaySpace(containingAppKitPoint point: CGPoint) -> DisplayCoordinateSpace? {
+    let spaces = displayCoordinateSpaces()
+    return spaces.first(where: { $0.appKitFrame.contains(point) })
+      ?? spaces.min {
+        distanceSquared(from: point, to: $0.appKitFrame)
+          < distanceSquared(from: point, to: $1.appKitFrame)
+      }
+  }
+
+  private func displayCoordinateSpaces() -> [DisplayCoordinateSpace] {
+    NSScreen.screens.compactMap { screen in
+      guard
+        let number = screen.deviceDescription[
+          NSDeviceDescriptionKey("NSScreenNumber")
+        ] as? NSNumber
+      else {
+        return nil
+      }
+
+      let displayId = CGDirectDisplayID(number.uint32Value)
+      return DisplayCoordinateSpace(
+        appKitFrame: screen.frame,
+        cgFrame: CGDisplayBounds(displayId)
+      )
+    }
+  }
+
+  private func distanceSquared(from point: CGPoint, to rect: CGRect) -> CGFloat {
+    let dx: CGFloat
+    if point.x < rect.minX {
+      dx = rect.minX - point.x
+    } else if point.x > rect.maxX {
+      dx = point.x - rect.maxX
+    } else {
+      dx = 0
+    }
+
+    let dy: CGFloat
+    if point.y < rect.minY {
+      dy = rect.minY - point.y
+    } else if point.y > rect.maxY {
+      dy = point.y - rect.maxY
+    } else {
+      dy = 0
+    }
+
+    return (dx * dx) + (dy * dy)
   }
 
   private func drainEvents(until deadline: Date) {

--- a/docs/ai/references/2026-05-26-macos-no-steal-input-design.md
+++ b/docs/ai/references/2026-05-26-macos-no-steal-input-design.md
@@ -2,7 +2,7 @@
 
 Date: 2026-05-26
 
-Status: draft for review
+Status: stage 1 implemented, later stages provisional
 
 ## Purpose
 
@@ -128,11 +128,14 @@ pub enum InputPolicy {
 
 - `BackgroundOnly`: only no-steal or background delivery is allowed. If no such
   path works, the action fails.
-- `BackgroundPreferred`: try no-steal/background paths first. Foreground
-  fallback is allowed, but the result must record the fallback reason and
-  disturbance.
-- `ForegroundPreferred`: choose the most stable foreground path first. This is
-  useful for debug and supervised runs.
+- `BackgroundPreferred`: try no-steal/background paths first. In the stage 1
+  macOS implementation this does not foreground-fallback yet; later interaction
+  policy can choose whether to allow that and must record the fallback reason
+  and disturbance when it does.
+- `ForegroundPreferred`: in the stage 1 macOS implementation, try
+  no-steal/window-targeted delivery first and use foreground fallback only if
+  that fails. The name is provisional and may be refined once action policy is
+  separated from delivery preference.
 
 ```rust
 pub enum ActivationPolicy {
@@ -205,8 +208,9 @@ AUV should follow that shape:
 4. If AX text paths fail, try pid/window-targeted keyboard delivery.
 5. Use clipboard paste only when `allow_clipboard_fallback` is true.
 6. Use foreground System Events only when the action policy is
-   `ForegroundPreferred`, or when the policy is `BackgroundPreferred` and all
-   no-steal/background paths failed.
+   `ForegroundPreferred` in stage 1. `BackgroundPreferred` foreground fallback
+   is intentionally deferred until the interaction policy layer can make that
+   disturbance explicit.
 
 Clipboard fallback must snapshot and restore the clipboard, and the action
 result must record clipboard disturbance even when restoration succeeds.
@@ -278,18 +282,33 @@ from CUA or KWWK, using GitHub permalinks with commit hashes and line anchors.
 
 ### Stage 1: Close the NetEase Loop
 
-- Add public macOS window APIs:
+- Added shared `WindowPoint`, `ScreenPoint`, input policy, preparation,
+  option, attempt, and result types in `auv-driver`.
+- Added public macOS window APIs:
   - `prepare_for_input`
   - `restore_input`
   - `click`
   - `type_text`
   - coordinate conversion helpers
-- Add result/attempt records for selected path and fallback reason.
-- Implement AX text path and background keyboard path where feasible.
-- Implement window-local background mouse click where feasible.
-- Migrate `examples/netease_play_visible_anchor.rs` away from
+- Added native Swift/Rust bridge wrappers for pid/window-targeted mouse and
+  keyboard delivery.
+- Added result/attempt records for selected path and fallback reason.
+- Implemented window-local background mouse click and pid/window-targeted
+  keyboard delivery where the macOS backend supports the required event
+  routing fields.
+- Migrated `examples/netease_play_visible_anchor.rs` away from
   `session.input().click_at` and `session.input().paste_text`.
 
+Deferred from stage 1:
+
+- AX text path (`AXSelectedText`, `AXValue`) is still a next step.
+- `FocusWithoutRaise`, foreground restoration, and focus guard installation
+  currently return unsupported where restoration semantics would otherwise be
+  misleading.
+- Window-level scroll, drag, hotkey, and press-key public helpers are not yet
+  exposed, although native keyboard wrappers exist for `type_text` internals.
+- Driver results are not yet written into run trace data beyond existing
+  example spans and screenshot artifacts.
 ### Stage 2: Improve Coverage
 
 - Add `press_key`, `hotkey`, `scroll`, and `drag` under `session.window()`.

--- a/examples/netease_play_visible_anchor.rs
+++ b/examples/netease_play_visible_anchor.rs
@@ -6,10 +6,10 @@ use auv_cli::recorded_operation::RecordedOperationContext;
 use auv_cli::run_builder::{Attributes, RunSpec};
 use auv_cli::trace::{RunType, string_attr};
 use auv_driver::capture::{Activation, Capture, CaptureOptions};
-use auv_driver::input::{Click, PasteTextOptions, TextSubmit};
+use auv_driver::input::{Click, ClickOptions, InputPolicy, TextSubmit, TypeTextOptions};
 use auv_driver::selector::{App, Window};
 use auv_driver::vision::TextRecognition;
-use auv_driver::{Driver, Point, RatioRect};
+use auv_driver::{Driver, RatioRect, ScreenPoint, WindowPoint};
 use auv_driver_macos::MacosDriver;
 
 static TEMP_CAPTURE_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -180,9 +180,17 @@ fn run_steps(
         .vision()
         .find_text_in_capture(&before, "取消", full_window_region)?;
     if let Some(cancel) = cancel_matches.best_match() {
-      session
-        .input()
-        .click_at(cancel.action_point(), Click::Single)?;
+      let cancel_point = session
+        .window()
+        .to_window_point(&window, ScreenPoint::from(cancel.action_point()))?;
+      session.window().click(
+        &window,
+        cancel_point,
+        ClickOptions {
+          policy: InputPolicy::ForegroundPreferred,
+          click: Click::Single,
+        },
+      )?;
       std::thread::sleep(Duration::from_millis(500));
       before = session.window().capture(&window)?;
     }
@@ -195,12 +203,19 @@ fn run_steps(
       full_window_region,
     )?;
     if marker_matches.best_match().is_none() {
-      let collapse_point = window_relative_point(
+      let collapse_point = window_relative_window_point(
         &window,
         inputs.collapse_relative_x,
         inputs.collapse_relative_y,
       );
-      session.input().click_at(collapse_point, Click::Single)?;
+      session.window().click(
+        &window,
+        collapse_point,
+        ClickOptions {
+          policy: InputPolicy::ForegroundPreferred,
+          click: Click::Single,
+        },
+      )?;
       std::thread::sleep(Duration::from_millis(500));
       focus_capture = session.window().capture(&window)?;
       record_capture(context, "after-collapse-to-main", &focus_capture)?;
@@ -211,19 +226,32 @@ fn run_steps(
 
   let selected_point = context.in_span("auv.example.netease.search", |context| {
     let search_point =
-      window_relative_point(&window, inputs.search_relative_x, inputs.search_relative_y);
+      window_relative_window_point(&window, inputs.search_relative_x, inputs.search_relative_y);
 
-    session.input().click_at(search_point, Click::Single)?;
+    session.window().click(
+      &window,
+      search_point,
+      ClickOptions {
+        policy: InputPolicy::ForegroundPreferred,
+        click: Click::Single,
+      },
+    )?;
     std::thread::sleep(Duration::from_millis(500));
     let after_search_click = session.window().capture(&window)?;
     record_capture(context, "after-search-click", &after_search_click)?;
 
-    session.input().paste_text(PasteTextOptions {
-      text: inputs.query.clone(),
-      replace_existing: true,
-      submit: TextSubmit::Return,
-      settle: Duration::from_millis(inputs.submit_settle_ms),
-    })?;
+    session.window().type_text(
+      &window,
+      &inputs.query,
+      TypeTextOptions {
+        policy: InputPolicy::ForegroundPreferred,
+        replace_existing: true,
+        submit: TextSubmit::Return,
+        inter_char_delay: Duration::from_millis(8),
+        allow_clipboard_fallback: true,
+        settle: Duration::from_millis(inputs.submit_settle_ms),
+      },
+    )?;
 
     let after_search = session.window().capture(&window)?;
     record_capture(context, "after-search", &after_search)?;
@@ -248,14 +276,21 @@ fn run_steps(
         inputs.result_index
       )
     })?;
-    Ok::<_, Box<dyn std::error::Error>>(selected.action_point())
+    let selected_point = session
+      .window()
+      .to_window_point(&window, ScreenPoint::from(selected.action_point()))?;
+    Ok::<_, Box<dyn std::error::Error>>(selected_point)
   })?;
 
   context.in_span("auv.example.netease.playback", |context| {
-    session.input().click_at(
+    session.window().click(
+      &window,
       selected_point,
-      Click::Double {
-        interval: Duration::from_millis(inputs.click_interval_ms),
+      ClickOptions {
+        policy: InputPolicy::ForegroundPreferred,
+        click: Click::Double {
+          interval: Duration::from_millis(inputs.click_interval_ms),
+        },
       },
     )?;
     std::thread::sleep(Duration::from_millis(inputs.activation_settle_ms));
@@ -299,10 +334,14 @@ fn record_capture(
   Ok(staged)
 }
 
-fn window_relative_point(window: &auv_driver::Window, relative_x: f64, relative_y: f64) -> Point {
-  Point::new(
-    window.frame.origin.x + window.frame.size.width * relative_x,
-    window.frame.origin.y + window.frame.size.height * relative_y,
+fn window_relative_window_point(
+  window: &auv_driver::Window,
+  relative_x: f64,
+  relative_y: f64,
+) -> WindowPoint {
+  WindowPoint::new(
+    window.frame.size.width * relative_x,
+    window.frame.size.height * relative_y,
   )
 }
 

--- a/examples/netease_play_visible_anchor.rs
+++ b/examples/netease_play_visible_anchor.rs
@@ -5,10 +5,10 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use auv_cli::recorded_operation::RecordedOperationContext;
 use auv_cli::run_builder::{Attributes, RunSpec};
 use auv_cli::trace::{RunType, string_attr};
-use auv_driver::capture::{Activation, Capture, CaptureOptions};
-use auv_driver::input::{Click, ClickOptions, InputPolicy, TextSubmit, TypeTextOptions};
+use auv_driver::capture::Capture;
+use auv_driver::input::{Click, ClickOptions, TextSubmit, TypeTextOptions, WindowClickStrategy};
 use auv_driver::selector::{App, Window};
-use auv_driver::vision::TextRecognition;
+use auv_driver::vision::{RecognizedText, TextRecognition};
 use auv_driver::{Driver, RatioRect, ScreenPoint, WindowPoint};
 use auv_driver_macos::MacosDriver;
 
@@ -28,6 +28,8 @@ struct Inputs {
   click_interval_ms: u64,
   activation_settle_ms: u64,
   submit_settle_ms: u64,
+  show_overlay: bool,
+  overlay_pause_ms: u64,
   result_region: RatioRect,
   player_region: RatioRect,
 }
@@ -51,6 +53,8 @@ fn parse_inputs(args: Vec<String>) -> Result<Inputs, String> {
   let mut click_interval_ms = 80_u64;
   let mut submit_settle_ms = 1200_u64;
   let mut activation_settle_ms = 500_u64;
+  let mut show_overlay = true;
+  let mut overlay_pause_ms = 450_u64;
 
   let mut iter = args.into_iter();
   while let Some(flag) = iter.next() {
@@ -103,6 +107,12 @@ fn parse_inputs(args: Vec<String>) -> Result<Inputs, String> {
           .parse()
           .map_err(|error| format!("invalid --activation-settle-ms: {error}"))?;
       }
+      "--show-overlay" => show_overlay = parse_bool(&value)?,
+      "--overlay-pause-ms" => {
+        overlay_pause_ms = value
+          .parse()
+          .map_err(|error| format!("invalid --overlay-pause-ms: {error}"))?;
+      }
       other => return Err(format!("unknown argument {other}")),
     }
   }
@@ -121,9 +131,19 @@ fn parse_inputs(args: Vec<String>) -> Result<Inputs, String> {
     click_interval_ms,
     activation_settle_ms,
     submit_settle_ms,
+    show_overlay,
+    overlay_pause_ms,
     result_region: RatioRect::new(0.12, 0.14, 0.74, 0.64),
     player_region: RatioRect::new(0.03, 0.86, 0.32, 0.14),
   })
+}
+
+fn parse_bool(value: &str) -> Result<bool, String> {
+  match value {
+    "true" | "1" | "yes" | "on" => Ok(true),
+    "false" | "0" | "no" | "off" => Ok(false),
+    other => Err(format!("invalid boolean value {other:?}")),
+  }
 }
 
 fn run_recorded(inputs: Inputs) -> Result<(), Box<dyn std::error::Error>> {
@@ -164,17 +184,10 @@ fn run_steps(
     .window()
     .resolve(Window::main_visible().owned_by(app))?;
   let full_window_region = RatioRect::new(0.0, 0.0, 1.0, 1.0);
+  let overlay = AnchorOverlay::new(inputs.show_overlay, inputs.overlay_pause_ms);
 
   context.in_span("auv.example.netease.prepare", |context| {
-    let mut before = session.window().capture_with(
-      &window,
-      CaptureOptions {
-        activation: Activation::ActivateFirst {
-          settle: Duration::from_millis(200),
-        },
-        ..CaptureOptions::default()
-      },
-    )?;
+    let mut before = session.window().capture(&window)?;
     let cancel_matches =
       session
         .vision()
@@ -183,14 +196,17 @@ fn run_steps(
       let cancel_point = session
         .window()
         .to_window_point(&window, ScreenPoint::from(cancel.action_point()))?;
+      overlay.before_click(&session, &window, cancel_point, "cancel")?;
       session.window().click(
         &window,
         cancel_point,
         ClickOptions {
-          policy: InputPolicy::ForegroundPreferred,
           click: Click::Single,
+          window_strategy: WindowClickStrategy::ChromiumCompatible,
+          ..ClickOptions::default()
         },
       )?;
+      overlay.after_click(&session, &window, cancel_point, "cancel")?;
       std::thread::sleep(Duration::from_millis(500));
       before = session.window().capture(&window)?;
     }
@@ -208,14 +224,17 @@ fn run_steps(
         inputs.collapse_relative_x,
         inputs.collapse_relative_y,
       );
+      overlay.before_click(&session, &window, collapse_point, "collapse")?;
       session.window().click(
         &window,
         collapse_point,
         ClickOptions {
-          policy: InputPolicy::ForegroundPreferred,
           click: Click::Single,
+          window_strategy: WindowClickStrategy::ChromiumCompatible,
+          ..ClickOptions::default()
         },
       )?;
+      overlay.after_click(&session, &window, collapse_point, "collapse")?;
       std::thread::sleep(Duration::from_millis(500));
       focus_capture = session.window().capture(&window)?;
       record_capture(context, "after-collapse-to-main", &focus_capture)?;
@@ -228,28 +247,47 @@ fn run_steps(
     let search_point =
       window_relative_window_point(&window, inputs.search_relative_x, inputs.search_relative_y);
 
+    // WORKAROUND:
+    //
+    // NetEase Cloud Music's CEF search entry can report a successful
+    // pid-targeted mouse delivery without actually entering text-input state
+    // after a single background click. A double click at the visible search
+    // anchor did focus the field during live testing, and the subsequent
+    // window-targeted keyboard path accepted text without foregrounding the app.
+    //
+    // Verification used the temporary `/private/tmp/auv-post-pid-probe` harness:
+    // `AUV_CLICK_REL_X=0.31 AUV_CLICK_REL_Y=0.06 AUV_TYPE_TEXT=auv_probe_double_type cargo run --quiet -- com.netease.163music`
+    // followed by this example with `--search-relative-y 0.045`. Remove this
+    // workaround only after NetEase accepts a single Chromium-compatible click
+    // plus background typing on the same visible anchor.
+    overlay.before_click(&session, &window, search_point, "search")?;
     session.window().click(
       &window,
       search_point,
       ClickOptions {
-        policy: InputPolicy::ForegroundPreferred,
-        click: Click::Single,
+        click: Click::Double {
+          interval: Duration::from_millis(inputs.click_interval_ms),
+        },
+        window_strategy: WindowClickStrategy::ChromiumCompatible,
+        ..ClickOptions::default()
       },
     )?;
+    overlay.after_click(&session, &window, search_point, "search")?;
     std::thread::sleep(Duration::from_millis(500));
     let after_search_click = session.window().capture(&window)?;
     record_capture(context, "after-search-click", &after_search_click)?;
 
+    overlay.mark_point(&session, &window, search_point, "type target")?;
     session.window().type_text(
       &window,
       &inputs.query,
       TypeTextOptions {
-        policy: InputPolicy::ForegroundPreferred,
         replace_existing: true,
         submit: TextSubmit::Return,
         inter_char_delay: Duration::from_millis(8),
-        allow_clipboard_fallback: true,
+        allow_clipboard_fallback: false,
         settle: Duration::from_millis(inputs.submit_settle_ms),
+        ..TypeTextOptions::default()
       },
     )?;
 
@@ -269,13 +307,7 @@ fn run_steps(
       "result title on comprehensive results",
     )?;
 
-    let title_matches = search_text.find_contains(&inputs.result_title);
-    let selected = title_matches.get(inputs.result_index).ok_or_else(|| {
-      format!(
-        "result title was not visible for playback activation at index {}",
-        inputs.result_index
-      )
-    })?;
+    let selected = select_song_result(&search_text, &inputs.result_title, inputs.result_index)?;
     let selected_point = session
       .window()
       .to_window_point(&window, ScreenPoint::from(selected.action_point()))?;
@@ -283,27 +315,22 @@ fn run_steps(
   })?;
 
   context.in_span("auv.example.netease.playback", |context| {
+    overlay.before_click(&session, &window, selected_point, "play result")?;
     session.window().click(
       &window,
       selected_point,
       ClickOptions {
-        policy: InputPolicy::ForegroundPreferred,
         click: Click::Double {
           interval: Duration::from_millis(inputs.click_interval_ms),
         },
+        window_strategy: WindowClickStrategy::ChromiumCompatible,
+        ..ClickOptions::default()
       },
     )?;
+    overlay.after_click(&session, &window, selected_point, "play result")?;
     std::thread::sleep(Duration::from_millis(inputs.activation_settle_ms));
 
-    let after_play = session.window().capture_with(
-      &window,
-      CaptureOptions {
-        activation: Activation::ActivateFirst {
-          settle: Duration::from_millis(200),
-        },
-        ..CaptureOptions::default()
-      },
-    )?;
+    let after_play = session.window().capture(&window)?;
     record_capture(context, "after-play", &after_play)?;
     let player_text = session
       .vision()
@@ -315,6 +342,74 @@ fn run_steps(
   })?;
 
   Ok(())
+}
+
+struct AnchorOverlay {
+  enabled: bool,
+  pause_ms: u64,
+}
+
+impl AnchorOverlay {
+  const fn new(enabled: bool, pause_ms: u64) -> Self {
+    Self { enabled, pause_ms }
+  }
+
+  fn mark_point(
+    &self,
+    session: &auv_driver_macos::MacosDriverSession,
+    window: &auv_driver::Window,
+    point: WindowPoint,
+    label: &str,
+  ) -> Result<(), Box<dyn std::error::Error>> {
+    if !self.enabled {
+      return Ok(());
+    }
+    let screen = session.window().to_screen_point(window, point)?.point();
+    auv_overlay_macos::set_cursor("netease-visible-anchor", screen.x, screen.y, label, "auv")?;
+    auv_overlay_macos::pump_events(self.pause_ms)?;
+    Ok(())
+  }
+
+  fn before_click(
+    &self,
+    session: &auv_driver_macos::MacosDriverSession,
+    window: &auv_driver::Window,
+    point: WindowPoint,
+    label: &str,
+  ) -> Result<(), Box<dyn std::error::Error>> {
+    self.mark_point(session, window, point, &format!("{label} before"))
+  }
+
+  fn after_click(
+    &self,
+    session: &auv_driver_macos::MacosDriverSession,
+    window: &auv_driver::Window,
+    point: WindowPoint,
+    label: &str,
+  ) -> Result<(), Box<dyn std::error::Error>> {
+    if !self.enabled {
+      return Ok(());
+    }
+    let screen = session.window().to_screen_point(window, point)?.point();
+    auv_overlay_macos::flash_cursor_id(
+      "netease-visible-anchor",
+      screen.x,
+      screen.y,
+      &format!("{label} fired"),
+      350,
+    )?;
+    auv_overlay_macos::pump_events(450)?;
+    Ok(())
+  }
+}
+
+impl Drop for AnchorOverlay {
+  fn drop(&mut self) {
+    if self.enabled {
+      let _ = auv_overlay_macos::hide_cursor_id("netease-visible-anchor");
+      let _ = auv_overlay_macos::pump_events(100);
+    }
+  }
 }
 
 fn record_capture(
@@ -367,4 +462,23 @@ fn expect_text_visible(
   } else {
     Ok(())
   }
+}
+
+fn select_song_result<'a>(
+  recognition: &'a TextRecognition,
+  title: &str,
+  index: usize,
+) -> Result<&'a RecognizedText, Box<dyn std::error::Error>> {
+  let song_section_y = recognition
+    .best_contains("单曲")
+    .map(|section| section.bounds.origin.y)
+    .unwrap_or(f64::NEG_INFINITY);
+  let title_matches = recognition
+    .find_contains(title)
+    .into_iter()
+    .filter(|candidate| candidate.bounds.origin.y > song_section_y)
+    .collect::<Vec<_>>();
+  title_matches.get(index).copied().ok_or_else(|| {
+    format!("song result title was not visible for playback activation at index {index}").into()
+  })
 }


### PR DESCRIPTION
## Summary
- add typed no-steal input APIs for macOS window actions, including window-local click and text entry
- implement Chromium-compatible background mouse delivery with CUA/KWWK reference notes and selectable click strategy
- migrate the NetEase visible-anchor example to window-targeted input with visible anchors and documented search-focus workaround

## Verification
- cargo check --example netease_play_visible_anchor
- cargo test -p auv-driver -p auv-driver-macos
- hack/generate-swift-bridge
- swift build in crates/auv-driver-macos/native/swift
- swift build in crates/auv-overlay-macos/native/swift
- git diff --check