### PR TITLE
feat(app): close surface analyze v0 boundary

### DIFF
--- a/docs/ai/references/2026-05-28-pr8-surface-analyze-handoff.md
+++ b/docs/ai/references/2026-05-28-pr8-surface-analyze-handoff.md
@@ -1,0 +1,240 @@
+# PR #8 Surface Analyze Handoff
+
+Date: 2026-05-28
+
+Branch: `codex/surface-analyze-evidence-refs`
+
+PR: <https://github.com/moeru-ai/auv/pull/8>
+
+Base at time of handoff: `origin/main` at `baa8997`
+
+Current branch head at time of handoff: `899ac79`
+
+Status: implementation mostly complete; one small documentation/test closure
+slice remains if the next agent wants to make the PR review-ready.
+
+## Purpose
+
+This PR closes the `surface analyze v0` evidence/promotion boundary.
+
+The important product decision is:
+
+`app analyze` may emit reviewable surface candidates, selector queries, evidence
+refs, and promotion blockers. It must not quietly promote OCR text, row bands,
+or window regions into action-grade `contract::Candidate` values.
+
+That separation is intentional. Promotion into runtime/action objects is a later
+slice.
+
+## Commits In This PR
+
+### `6e0c7fd feat(app): attach artifact refs to surface candidates`
+
+Implemented durable evidence references for analyze candidates.
+
+Main changes:
+
+- Added `evidence_refs: Vec<contract::ArtifactRef>` to `AppSurfaceCandidate`.
+- Added probe-artifact lookup from `AppProbeStep.run_id` and
+  `AppProbeStep.artifact_paths`.
+- Mapped matching `ArtifactRecordV1Alpha1` entries from
+  `.auv/runs/<run_id>/artifacts.jsonl` into `ArtifactRef`.
+- Attached refs to candidates derived from:
+  - `list-windows`
+  - `capture-ax-tree`
+  - `ocr-sample`
+- Rendered `evidenceRefs` in the app analyze Markdown report.
+- Added regression coverage for OCR/row candidates carrying evidence refs.
+
+Design note:
+
+The implementation does not synthesize fake `span_id`, `event_id`, or
+`artifact_id` values. If artifact records are unavailable, refs remain empty.
+That is deliberate; missing evidence should be visible, not fabricated.
+
+### `899ac79 feat(app): report surface promotion gates`
+
+Implemented machine-readable promotion blockers for analyze candidates.
+
+Main changes:
+
+- Added `AppCandidatePromotionGate`.
+- Added `AppCandidatePromotionStatus`:
+  - `blocked`
+  - `distill_strategy_only`
+  - `action_grade_candidate`
+- Added `promotion_gate: Option<AppCandidatePromotionGate>` to
+  `AppSurfaceCandidate`.
+- Generated promotion gates for candidates built by `build_annotation_candidates`.
+- Rendered `promotionGate` in the app analyze Markdown report.
+- Updated `docs/ai/references/2026-05-28-surface-analyze-v0.md` so missing
+  gates are recorded in `AppSurfaceCandidate.promotion_gate.missing_gates`
+  instead of Markdown-only prose.
+- Added tests that:
+  - OCR visible-text candidates are `blocked`.
+  - OCR candidates require `action_contract` and
+    `semantic_verification_contract`.
+  - row candidates are `blocked`.
+  - row candidates require `row_action_contract`.
+  - window-region candidates are only `distill_strategy_only`, not action-grade.
+
+Design note:
+
+This commit intentionally does not convert `AppSurfaceCandidate` into
+`contract::Candidate`. The current `contract::Candidate` shape needs stronger
+action-time liveness/control fields than analyze can honestly produce for these
+surfaces.
+
+## Current Behavior
+
+`app analyze` now emits candidates with these layers:
+
+- observable surface fields: `area`, `kind`, `source`, text, bounds, click point
+- optional `CandidateQuery` for re-location
+- optional `ArtifactRef` chain for evidence
+- `input_bindings` for distillation templates
+- compatibility taxonomy IDs
+- `promotion_gate` explaining whether the candidate is:
+  - blocked
+  - usable only as distillation strategy input
+  - action-grade candidate
+
+Current generated gates are conservative:
+
+- OCR visible text: `blocked`
+- row/list grouping: `blocked`
+- known direct taxonomy candidates: `distill_strategy_only`
+- candidates with no known action path: `blocked`
+
+No current analyzer-produced candidate should be treated as a validated semantic
+target.
+
+## Validation Already Run
+
+The following commands passed after `899ac79`:
+
+```bash
+cargo fmt --check
+cargo check
+cargo test
+git diff --check
+cargo run --quiet -- list-commands
+cargo run --quiet -- skill cases list
+cargo run --quiet -- skill bundle list
+```
+
+Observed test count:
+
+```text
+395 lib tests passed
+25 main/CLI tests passed
+```
+
+The working tree was clean after pushing `899ac79`.
+
+## What Remains
+
+If the next agent wants to finish PR #8 cleanly, the remaining work is small.
+
+### 1. Convert the spec tail from "next slice" to implementation status
+
+File:
+
+```text
+docs/ai/references/2026-05-28-surface-analyze-v0.md
+```
+
+Problem:
+
+The bottom section still reads like future work:
+
+- add evidence refs
+- add promotion gate
+- then later convert to `contract::Candidate`
+
+But the first two are already done in PR #8.
+
+Recommended fix:
+
+- Replace `## Immediate Next Slice` with `## Implementation Status`.
+- Mark evidence refs as implemented in `6e0c7fd`.
+- Mark promotion gates as implemented in `899ac79`.
+- Keep `AppSurfaceCandidate -> contract::Candidate` promotion explicitly as
+  future work.
+
+### 2. Add one JSON serialization regression for `promotion_gate`
+
+Current tests cover Rust values and Markdown rendering. Add one narrow test that
+serializes an analysis/candidate and asserts the JSON contains:
+
+```json
+"promotion_gate": {
+  "status": "blocked",
+  "missing_gates": [...]
+}
+```
+
+This closes the "write JSON that another operation can use without scraping
+Markdown" requirement from the surface analyze v0 spec.
+
+Suggested location:
+
+```text
+src/app/mod.rs
+```
+
+Near:
+
+```text
+build_annotation_candidates_keeps_raw_ocr_as_visible_text_and_adds_selectors
+```
+
+### 3. Re-run the same validation commands
+
+Run:
+
+```bash
+cargo fmt --check
+cargo check
+cargo test
+git diff --check
+cargo run --quiet -- list-commands
+cargo run --quiet -- skill cases list
+cargo run --quiet -- skill bundle list
+```
+
+Then push to the same branch:
+
+```bash
+git push origin codex/surface-analyze-evidence-refs
+```
+
+Do not open a new PR. Push updates directly to PR #8.
+
+## Do Not Expand This PR
+
+Do not add these to PR #8:
+
+- actual `AppSurfaceCandidate -> contract::Candidate` promotion
+- ActionResolver consuming analyze candidates
+- new surface kinds
+- DOM/CDP selector backend
+- icon/template matching changes
+- YOLO/ONNX/CV backend
+- scroll-scan parser or orchestration work
+- recipe language redesign
+
+Those are separate slices. This PR should stay focused on the analyze evidence
+and promotion-boundary report contract.
+
+## Current Repo State Notes
+
+At the time this handoff was written:
+
+- branch was `codex/surface-analyze-evidence-refs`
+- remote branch was `origin/codex/surface-analyze-evidence-refs`
+- branch was clean before this handoff document was added
+- PR #8 already had the two implementation commits pushed
+
+This document itself may be uncommitted depending on where the next agent starts.
+Check `git status --short --branch` before continuing.

--- a/docs/ai/references/2026-05-28-surface-analyze-closure.md
+++ b/docs/ai/references/2026-05-28-surface-analyze-closure.md
@@ -1,0 +1,258 @@
+# Surface Analyze Closure — 2026-05-28
+
+Status: v0 boundary mostly closed
+
+PR branch tip before this closure note was added:
+
+- `codex/surface-analyze-evidence-refs` at `915dbff`
+
+Current `origin/main` during this closure note:
+
+- `5c67054`
+
+## Purpose
+
+This note records the **actual closure state** of the `surface analyze v0`
+work after PR #8 was extended beyond the original evidence-ref / promotion-gate
+ slice.
+
+It exists to answer three questions plainly:
+
+1. what has actually been closed
+2. what is still open
+3. whether the next step should stay in `surface analyze` or move to the newer
+   `View*` parsing line
+
+This is not a new design spec. It is a repo-state closure note for handoff and
+review.
+
+## What Is Closed
+
+The important `surface analyze v0` seam is now largely closed:
+
+```text
+surface candidate
+  != direct executable candidate
+```
+
+More specifically, the following behaviors are now locked by code and tests.
+
+### 1. Analyze output is honest about row and OCR candidate status
+
+`AppSurfaceCandidate` now carries:
+
+- `candidate_query`
+- `evidence_refs`
+- `promotion_gate`
+- compatibility metadata
+
+Current gate behavior is intentionally conservative:
+
+- OCR visible text stays blocked as semantic result selection
+- row/list grouping stays blocked as semantic result selection
+- window region stays `distill_strategy_only`
+
+This means `app analyze` can emit reviewable surfaces without pretending they
+are already `contract::Candidate`.
+
+### 2. Distillation shape does not smuggle row candidates into direct inputs
+
+For row/context-only cases:
+
+- `direct_candidate_ids` stays empty
+- `context_candidate_ids` carries the row ids
+- `provided_inputs` stays empty
+- shape notes explicitly record that no direct candidate shape exists
+
+This closes the easiest accidental bug: using "was suggested in distill" as if
+it meant "is safe to execute".
+
+### 3. Grounding does not treat row-only candidates as OCR anchors
+
+The result-selection grounding path still requires a real anchor source.
+
+If only row/context evidence exists:
+
+- row-only candidates are not consumed as anchor grounding
+- unresolved inputs remain unresolved
+- validate fails instead of inventing a target
+
+This is the core behavior that keeps structural evidence from being mistaken
+for semantic identity.
+
+### 4. Read-side reports preserve review-only semantics
+
+All three report layers now keep the same distinction:
+
+- `render_app_analysis_report`
+- `render_app_distillation_report`
+- `render_app_validation_report`
+
+For row/context-only cases, the reports now show review-only suggestions,
+blocked promotion, unresolved grounding, and failure context without inventing
+used annotations or direct candidate claims.
+
+### 5. JSON persistence preserves review-only semantics
+
+The persisted JSON artifacts now have coverage for the same seam:
+
+- `analysis.json`
+- `distillation.json`
+- `validation.json`
+
+Round-trip and persistence assertions now cover:
+
+- review-only `suggested_annotation_ids`
+- empty `direct_candidate_ids`
+- context-only candidate ids
+- empty `provided_inputs`
+- rejected validation output with unresolved grounding
+- empty `used_annotation_ids` for row/context-only failures
+
+This matters because the v0 contract promised machine-readable output, not only
+Markdown prose.
+
+## What Is Not Closed
+
+The closure above is **boundary closure**, not product completion.
+
+The following remain open.
+
+### 1. `AppSurfaceCandidate -> contract::Candidate`
+
+This is still the main unclosed seam.
+
+The project now has a stronger definition of:
+
+- what surface candidates are
+- why they are blocked
+- how review-only candidates survive distill/validate/report/json
+
+But there is still no implemented promotion path from
+`AppSurfaceCandidate` into an action-grade `contract::Candidate`.
+
+That is the next real architecture slice if the team wants surface analyze to
+feed runtime consumers directly.
+
+### 2. Row action + semantic verification do not exist
+
+Row/list grouping remains structural evidence because two concrete contracts are
+still missing:
+
+- row action contract
+- semantic verification contract
+
+Until those exist, rows should stay exactly where they are now: visible,
+reviewable, machine-readable, but not executable.
+
+### 3. OCR anchor is still evidence-first, not semantic success
+
+`anchor-text` is closer to consumption than row grouping, but it is still not a
+semantic result-selection guarantee.
+
+Current result-selection candidate scaffolding still uses
+`captureEvidence`, not a semantic verifier. That is an intentional limitation.
+
+### 4. Surface type coverage is still narrow
+
+Implemented v0 surface kinds are effectively:
+
+- AX focus/query candidates
+- OCR visible-text candidates
+- grouped row candidates
+- window region candidates
+
+The v0 doc mentions icon/template matches, menu/shortcut affordances, future
+DOM/CDP, and future CV/YOLO as reserved or future directions. Those are still
+not closed here.
+
+### 5. `surface analyze` is still a candidate pipeline, not a view model
+
+The current app workflow is:
+
+```text
+probe -> analyze -> distill -> validate
+```
+
+That pipeline is now much more honest and much better defended, but it is still
+about candidate surfacing and recipe scaffolding. It is not yet a generic
+reconstruction/view substrate.
+
+## Relationship To The New View Parser Document
+
+Since this closure pass started, `origin/main` advanced with a new document
+stack ending at:
+
+- `5c67054 docs: clarify view reconstruction model`
+
+Resulting file:
+
+- `docs/ai/references/2026-05-28-view-parser-ir-netease-playlist-example-design.md`
+
+That document is **not** a tail task for PR #8.
+
+It opens a new direction:
+
+- `ViewObservation`
+- `ViewEvidenceNode`
+- `ViewReconstruction`
+- `ViewProjection`
+- `ViewMemory`
+
+In plain terms:
+
+- `surface analyze v0` closes an evidence/promotion boundary
+- `View*` parsing opens a new reconstruction substrate
+
+They are related, but they are not the same slice.
+
+So the right reading is:
+
+- do not keep grinding row/context-only report details forever
+- do not pretend `surface analyze` is now a complete view parser
+- treat `View*` parsing as the next line, not as "one more small follow-up" to
+  PR #8
+
+This closure note assumes the PR branch stays focused on `surface analyze v0`
+boundary work and does **not** absorb the newer `View*` planning documents.
+
+## Recommended Next Step
+
+The next step should **not** be more `surface analyze` read-side polish by
+default.
+
+The two serious next options are:
+
+1. implement a narrow promotion seam for one candidate family that can honestly
+   satisfy `contract::Candidate`
+2. start the new `View*` parsing vertical slice described in the NetEase
+   playlist example design
+
+If the goal is to finish PR #8 cleanly, the first option should stay very
+small.
+
+If the goal is to move the product forward, the second option is likely more
+valuable now that the `surface analyze v0` boundary is mostly defended.
+
+## Bottom Line
+
+`surface analyze v0` is **mostly closed as a boundary**.
+
+It is **not closed as a full product capability**.
+
+What is closed:
+
+- evidence refs
+- selector attachment
+- promotion blockers
+- row/context-only honesty across analyze, distill, validate, report, and JSON
+
+What is not closed:
+
+- action-grade promotion
+- row action + semantic verification
+- OCR anchor semantic success
+- broader surface kinds
+- generic view reconstruction
+
+That is the real state of the repo after this closure pass.

--- a/docs/ai/references/2026-05-28-surface-analyze-v0.md
+++ b/docs/ai/references/2026-05-28-surface-analyze-v0.md
@@ -134,7 +134,9 @@ Promotion is allowed only when all required gates are satisfied:
 | Failure layer | Failure can be classified as grounding, candidate expiration, control, verification, or semantic mismatch. |
 
 If any gate is missing, keep the item as a surface candidate and record the
-missing gate in `known_limits`.
+blocker in `AppSurfaceCandidate.promotion_gate.missing_gates`. Use candidate
+notes or known boundaries for prose context, but do not rely on Markdown-only
+text as the machine-readable gate.
 
 This gate is the seam between `app analyze` and `ActionResolver`. Do not bypass
 it by letting a driver action consume `AppSurfaceCandidate` directly.
@@ -228,6 +230,7 @@ The next code slice should be evidence closure, not new surface kinds:
 2. Keep coordinate and capture context as candidate fields or candidate detail.
 3. Add regression tests showing OCR and row candidates have evidence refs but do
    not auto-promote to semantic result selection.
-4. Only after this should a promotion implementation convert selected analyze
+4. Add `promotion_gate` to the JSON and Markdown report so blocked OCR/row
+   candidates and strategy-only candidates are explicit.
+5. Only after this should a promotion implementation convert selected analyze
    candidates into `contract::Candidate`.
-

--- a/docs/ai/references/2026-05-28-surface-analyze-v0.md
+++ b/docs/ai/references/2026-05-28-surface-analyze-v0.md
@@ -221,16 +221,29 @@ distillation decisions; operation results are for machine consumption and replay
 Anything beyond this, including full DOM selectors, YOLO, broad visual
 segmentation, or a new orchestration language, is outside v0.
 
-## Immediate Next Slice
+## Implementation Status
 
-The next code slice should be evidence closure, not new surface kinds:
+The `surface analyze v0` evidence/promotion boundary is now partially
+implemented on top of the `b702be0` selector baseline:
 
-1. Add evidence references to `AppSurfaceCandidate` using `ArtifactRef` where
-   current probe/run data makes that possible.
-2. Keep coordinate and capture context as candidate fields or candidate detail.
-3. Add regression tests showing OCR and row candidates have evidence refs but do
-   not auto-promote to semantic result selection.
-4. Add `promotion_gate` to the JSON and Markdown report so blocked OCR/row
-   candidates and strategy-only candidates are explicit.
-5. Only after this should a promotion implementation convert selected analyze
-   candidates into `contract::Candidate`.
+1. Evidence references on `AppSurfaceCandidate` landed in `6e0c7fd`.
+   Candidates derived from current probe artifacts may now carry durable
+   `ArtifactRef` values instead of Markdown-only evidence prose.
+2. Promotion blockers on `AppSurfaceCandidate.promotion_gate` landed in
+   `899ac79`. Blocked OCR/row candidates and strategy-only candidates are now
+   explicit in the analyze report contract instead of being inferred from
+   reviewer notes.
+3. OCR visible text and row/list grouping remain surface candidates, not
+   action-grade runtime candidates. The v0 boundary still treats them as
+   observable evidence unless a later slice provides the missing action,
+   liveness, and verification contracts.
+4. Coordinate and capture context remain candidate-side detail rather than being
+   pushed into a separate evidence-ref schema.
+
+The remaining future step is still the same seam:
+
+```text
+AppSurfaceCandidate -> contract::Candidate
+```
+
+That promotion work is intentionally outside the current v0 analyze closure.

--- a/src/app/analysis.rs
+++ b/src/app/analysis.rs
@@ -15,7 +15,9 @@ use std::path::{Path, PathBuf};
 
 use serde_json::Value;
 
-use crate::contract::{CandidateQuery, SelectorScope, SurfaceSelector, SurfaceSelectorClause};
+use crate::contract::{
+  ArtifactRef, CandidateQuery, SelectorScope, SurfaceSelector, SurfaceSelectorClause,
+};
 use crate::driver::{
   ObservedAxTreeSnapshot, ObservedDisplay, ObservedDisplaySnapshot, ObservedOcrRow, ObservedRect,
   ObservedWindow, OcrTextSnapshot, compute_combined_bounds, group_ocr_matches_into_rows,
@@ -23,6 +25,7 @@ use crate::driver::{
 };
 use crate::model::{AuvResult, RunStatus, now_millis};
 use crate::skill::{SkillCaseMatrix, SkillStrategy};
+use crate::trace::{ArtifactRecordV1Alpha1, RunId};
 
 use super::infra::first_non_empty_string;
 use super::recipe::recipe_app_slug;
@@ -184,6 +187,7 @@ pub(crate) fn build_app_analysis(probe_path: &Path, probe: &AppProbe) -> AuvResu
     overlay_debug_artifacts_recommended: ocr_snapshot.matches.is_empty()
       || ax_quality != AssessmentStatus::Available,
   };
+  let evidence_refs_by_step = build_probe_evidence_refs(probe);
   let annotation_candidates = build_annotation_candidates(
     &probe.app,
     primary_window,
@@ -191,6 +195,7 @@ pub(crate) fn build_app_analysis(probe_path: &Path, probe: &AppProbe) -> AuvResu
     &ax_snapshot,
     &ocr_snapshot,
     has_collection_like_surface(&ax_snapshot),
+    &evidence_refs_by_step,
   );
 
   let mut control_notes = Vec::new();
@@ -537,6 +542,7 @@ pub(crate) fn build_annotation_candidates(
   ax_snapshot: &ObservedAxTreeSnapshot,
   ocr_snapshot: &OcrTextSnapshot,
   has_collection_surface: bool,
+  evidence_refs_by_step: &BTreeMap<String, Vec<ArtifactRef>>,
 ) -> Vec<AppSurfaceCandidate> {
   let mut candidates = Vec::new();
 
@@ -576,6 +582,7 @@ pub(crate) fn build_annotation_candidates(
       confidence: None,
       evidence_step_id: evidence_step_id.to_string(),
       candidate_query: None,
+      evidence_refs: evidence_refs_for_step(evidence_refs_by_step, evidence_step_id),
       input_bindings,
       compatibility: candidate_compatibility(
         &["window-action.window-point.pointer-click.capture-evidence"],
@@ -600,6 +607,7 @@ pub(crate) fn build_annotation_candidates(
         &[],
       ),
       "AX-exposed search-entry or search-like input candidate.",
+      evidence_refs_for_step(evidence_refs_by_step, "capture-ax-tree"),
     ));
   }
 
@@ -618,6 +626,7 @@ pub(crate) fn build_annotation_candidates(
         &[],
       ),
       "AX-exposed editable text-surface candidate.",
+      evidence_refs_for_step(evidence_refs_by_step, "capture-ax-tree"),
     ));
   }
 
@@ -658,6 +667,7 @@ pub(crate) fn build_annotation_candidates(
         &matched.text,
         Some(matched.confidence),
       )),
+      evidence_refs: evidence_refs_for_step(evidence_refs_by_step, "ocr-sample"),
       input_bindings: BTreeMap::from([("anchor_text".to_string(), matched.text.clone())]),
       compatibility: AppCandidateCompatibility::default(),
       notes,
@@ -667,7 +677,10 @@ pub(crate) fn build_annotation_candidates(
   if has_collection_surface && ocr_snapshot.matches.len() >= 2 {
     let rows = group_ocr_rows_from_ocr_snapshot(ocr_snapshot);
     for row in rows.into_iter().take(8) {
-      candidates.push(row_candidate(row));
+      candidates.push(row_candidate(
+        row,
+        evidence_refs_for_step(evidence_refs_by_step, "ocr-sample"),
+      ));
     }
   }
 
@@ -696,6 +709,7 @@ fn ax_focus_candidate(
   evidence_step_id: &str,
   compatibility: AppCandidateCompatibility,
   note: &str,
+  evidence_refs: Vec<ArtifactRef>,
 ) -> AppSurfaceCandidate {
   let bounds = AppRect::from_observed(&node.bounds);
   let focus_query = query_value.clone();
@@ -714,6 +728,7 @@ fn ax_focus_candidate(
     confidence: None,
     evidence_step_id: evidence_step_id.to_string(),
     candidate_query: Some(ax_candidate_query(candidate_id, node, &query_value, kind)),
+    evidence_refs,
     input_bindings: BTreeMap::from([("focus_query".to_string(), focus_query)]),
     compatibility,
     notes: vec![note.to_string()],
@@ -725,7 +740,7 @@ fn group_ocr_rows_from_ocr_snapshot(snapshot: &OcrTextSnapshot) -> Vec<ObservedO
   group_ocr_matches_into_rows(&matches)
 }
 
-fn row_candidate(row: ObservedOcrRow) -> AppSurfaceCandidate {
+fn row_candidate(row: ObservedOcrRow, evidence_refs: Vec<ArtifactRef>) -> AppSurfaceCandidate {
   let bounds = AppRect::from_observed(&row.bounds);
   AppSurfaceCandidate {
     candidate_id: format!("visible-row-{}", row.row_index + 1),
@@ -746,6 +761,7 @@ fn row_candidate(row: ObservedOcrRow) -> AppSurfaceCandidate {
       row.row_index + 1,
       &row.text_fragments.join(" "),
     )),
+    evidence_refs,
     input_bindings: BTreeMap::from([("row_index".to_string(), format!("{}", row.row_index + 1))]),
     compatibility: candidate_compatibility(
       &[],
@@ -772,6 +788,85 @@ pub(crate) fn candidate_compatibility(
       .map(|value| value.to_string())
       .collect(),
   }
+}
+
+fn evidence_refs_for_step(
+  evidence_refs_by_step: &BTreeMap<String, Vec<ArtifactRef>>,
+  step_id: &str,
+) -> Vec<ArtifactRef> {
+  evidence_refs_by_step
+    .get(step_id)
+    .cloned()
+    .unwrap_or_default()
+}
+
+pub(crate) fn build_probe_evidence_refs(probe: &AppProbe) -> BTreeMap<String, Vec<ArtifactRef>> {
+  let mut refs_by_step = BTreeMap::new();
+  for step in &probe.steps {
+    let refs = artifact_refs_for_probe_step(probe, step);
+    if !refs.is_empty() {
+      refs_by_step.insert(step.id.clone(), refs);
+    }
+  }
+  refs_by_step
+}
+
+fn artifact_refs_for_probe_step(probe: &AppProbe, step: &AppProbeStep) -> Vec<ArtifactRef> {
+  if step.run_id.trim().is_empty() || step.artifact_paths.is_empty() {
+    return Vec::new();
+  }
+  let run_dir = probe
+    .project_root
+    .join(".auv")
+    .join("runs")
+    .join(step.run_id.trim());
+  let Some(records) = read_artifact_records_jsonl(&run_dir.join("artifacts.jsonl")) else {
+    return Vec::new();
+  };
+
+  let mut refs = Vec::new();
+  for artifact_path in &step.artifact_paths {
+    if let Some(record) = records
+      .iter()
+      .find(|record| artifact_path_matches(&run_dir, &record.path, artifact_path))
+      && !refs
+        .iter()
+        .any(|existing: &ArtifactRef| existing.artifact_id == record.artifact_id)
+    {
+      refs.push(ArtifactRef {
+        run_id: RunId::new(step.run_id.clone()),
+        artifact_id: record.artifact_id.clone(),
+        span_id: record.span_id.clone(),
+        captured_event_id: record.event_id.clone(),
+      });
+    }
+  }
+  refs
+}
+
+fn read_artifact_records_jsonl(path: &Path) -> Option<Vec<ArtifactRecordV1Alpha1>> {
+  let raw = fs::read_to_string(path).ok()?;
+  let records = raw
+    .lines()
+    .map(str::trim)
+    .filter(|line| !line.is_empty())
+    .filter_map(|line| serde_json::from_str::<ArtifactRecordV1Alpha1>(line).ok())
+    .collect::<Vec<_>>();
+  Some(records)
+}
+
+fn artifact_path_matches(run_dir: &Path, record_path: &str, artifact_path: &Path) -> bool {
+  let record_path = Path::new(record_path);
+  if let Ok(relative_path) = artifact_path.strip_prefix(run_dir)
+    && paths_equal(relative_path, record_path)
+  {
+    return true;
+  }
+  artifact_path.ends_with(record_path) || artifact_path.file_name() == record_path.file_name()
+}
+
+fn paths_equal(left: &Path, right: &Path) -> bool {
+  left.to_string_lossy() == right.to_string_lossy()
 }
 
 fn grouped_result_row_count(candidates: &[AppSurfaceCandidate]) -> usize {

--- a/src/app/analysis.rs
+++ b/src/app/analysis.rs
@@ -561,7 +561,7 @@ pub(crate) fn build_annotation_candidates(
     } else {
       "Primary window bounds inferred from the AX root window because the window snapshot did not expose a visible window."
     };
-    candidates.push(AppSurfaceCandidate {
+    let mut candidate = AppSurfaceCandidate {
       candidate_id: "window-primary-region".to_string(),
       area: "window.primary".to_string(),
       kind: "region".to_string(),
@@ -591,7 +591,9 @@ pub(crate) fn build_annotation_candidates(
         &[],
       ),
       notes: vec![note.to_string()],
-    });
+    };
+    candidate.promotion_gate = Some(promotion_gate_for_candidate(&candidate));
+    candidates.push(candidate);
   }
 
   if let Some(node) = find_search_entry_node(ax_snapshot)
@@ -646,7 +648,7 @@ pub(crate) fn build_annotation_candidates(
           .to_string(),
       );
     }
-    candidates.push(AppSurfaceCandidate {
+    let mut candidate = AppSurfaceCandidate {
       candidate_id: format!("ocr-anchor-{}", matched.match_index),
       area: area.to_string(),
       kind: "anchor-text".to_string(),
@@ -674,7 +676,9 @@ pub(crate) fn build_annotation_candidates(
       input_bindings: BTreeMap::from([("anchor_text".to_string(), matched.text.clone())]),
       compatibility: AppCandidateCompatibility::default(),
       notes,
-    });
+    };
+    candidate.promotion_gate = Some(promotion_gate_for_candidate(&candidate));
+    candidates.push(candidate);
   }
 
   if has_collection_surface && ocr_snapshot.matches.len() >= 2 {
@@ -685,10 +689,6 @@ pub(crate) fn build_annotation_candidates(
         evidence_refs_for_step(evidence_refs_by_step, "ocr-sample"),
       ));
     }
-  }
-
-  for candidate in &mut candidates {
-    candidate.promotion_gate = Some(promotion_gate_for_candidate(candidate));
   }
 
   candidates
@@ -720,7 +720,7 @@ fn ax_focus_candidate(
 ) -> AppSurfaceCandidate {
   let bounds = AppRect::from_observed(&node.bounds);
   let focus_query = query_value.clone();
-  AppSurfaceCandidate {
+  let mut candidate = AppSurfaceCandidate {
     candidate_id: candidate_id.to_string(),
     area: area.to_string(),
     kind: kind.to_string(),
@@ -740,7 +740,9 @@ fn ax_focus_candidate(
     input_bindings: BTreeMap::from([("focus_query".to_string(), focus_query)]),
     compatibility,
     notes: vec![note.to_string()],
-  }
+  };
+  candidate.promotion_gate = Some(promotion_gate_for_candidate(&candidate));
+  candidate
 }
 
 fn group_ocr_rows_from_ocr_snapshot(snapshot: &OcrTextSnapshot) -> Vec<ObservedOcrRow> {
@@ -750,7 +752,7 @@ fn group_ocr_rows_from_ocr_snapshot(snapshot: &OcrTextSnapshot) -> Vec<ObservedO
 
 fn row_candidate(row: ObservedOcrRow, evidence_refs: Vec<ArtifactRef>) -> AppSurfaceCandidate {
   let bounds = AppRect::from_observed(&row.bounds);
-  AppSurfaceCandidate {
+  let mut candidate = AppSurfaceCandidate {
     candidate_id: format!("visible-row-{}", row.row_index + 1),
     area: "result-selection".to_string(),
     kind: "row".to_string(),
@@ -780,7 +782,9 @@ fn row_candidate(row: ObservedOcrRow, evidence_refs: Vec<ArtifactRef>) -> AppSur
       "Visible row candidate grouped from OCR observations; useful for list-like UI targets."
         .to_string(),
     ],
-  }
+  };
+  candidate.promotion_gate = Some(promotion_gate_for_candidate(&candidate));
+  candidate
 }
 
 fn promotion_gate_for_candidate(candidate: &AppSurfaceCandidate) -> AppCandidatePromotionGate {

--- a/src/app/analysis.rs
+++ b/src/app/analysis.rs
@@ -31,10 +31,11 @@ use super::infra::first_non_empty_string;
 use super::recipe::recipe_app_slug;
 use super::{
   APP_ANALYSIS_VERSION, AppAnalysis, AppAvailableSurfaces, AppCandidateCompatibility,
-  AppCandidateGroundingTaxonomy, AppControlAssessment, AppDistilledCandidateShape,
-  AppDisturbanceProfile, AppGroundingAssessment, AppIdentity, AppPermissionState, AppPoint,
-  AppProbe, AppProbeStep, AppRecommendedStrategy, AppRect, AppSurfaceCandidate,
-  AppVerificationAssessment, AppVerificationMode, AppWindowContext, AssessmentStatus,
+  AppCandidateGroundingTaxonomy, AppCandidatePromotionGate, AppCandidatePromotionStatus,
+  AppControlAssessment, AppDistilledCandidateShape, AppDisturbanceProfile, AppGroundingAssessment,
+  AppIdentity, AppPermissionState, AppPoint, AppProbe, AppProbeStep, AppRecommendedStrategy,
+  AppRect, AppSurfaceCandidate, AppVerificationAssessment, AppVerificationMode, AppWindowContext,
+  AssessmentStatus,
 };
 
 #[derive(Clone, Debug)]
@@ -583,6 +584,7 @@ pub(crate) fn build_annotation_candidates(
       evidence_step_id: evidence_step_id.to_string(),
       candidate_query: None,
       evidence_refs: evidence_refs_for_step(evidence_refs_by_step, evidence_step_id),
+      promotion_gate: None,
       input_bindings,
       compatibility: candidate_compatibility(
         &["window-action.window-point.pointer-click.capture-evidence"],
@@ -668,6 +670,7 @@ pub(crate) fn build_annotation_candidates(
         Some(matched.confidence),
       )),
       evidence_refs: evidence_refs_for_step(evidence_refs_by_step, "ocr-sample"),
+      promotion_gate: None,
       input_bindings: BTreeMap::from([("anchor_text".to_string(), matched.text.clone())]),
       compatibility: AppCandidateCompatibility::default(),
       notes,
@@ -682,6 +685,10 @@ pub(crate) fn build_annotation_candidates(
         evidence_refs_for_step(evidence_refs_by_step, "ocr-sample"),
       ));
     }
+  }
+
+  for candidate in &mut candidates {
+    candidate.promotion_gate = Some(promotion_gate_for_candidate(candidate));
   }
 
   candidates
@@ -729,6 +736,7 @@ fn ax_focus_candidate(
     evidence_step_id: evidence_step_id.to_string(),
     candidate_query: Some(ax_candidate_query(candidate_id, node, &query_value, kind)),
     evidence_refs,
+    promotion_gate: None,
     input_bindings: BTreeMap::from([("focus_query".to_string(), focus_query)]),
     compatibility,
     notes: vec![note.to_string()],
@@ -762,6 +770,7 @@ fn row_candidate(row: ObservedOcrRow, evidence_refs: Vec<ArtifactRef>) -> AppSur
       &row.text_fragments.join(" "),
     )),
     evidence_refs,
+    promotion_gate: None,
     input_bindings: BTreeMap::from([("row_index".to_string(), format!("{}", row.row_index + 1))]),
     compatibility: candidate_compatibility(
       &[],
@@ -771,6 +780,74 @@ fn row_candidate(row: ObservedOcrRow, evidence_refs: Vec<ArtifactRef>) -> AppSur
       "Visible row candidate grouped from OCR observations; useful for list-like UI targets."
         .to_string(),
     ],
+  }
+}
+
+fn promotion_gate_for_candidate(candidate: &AppSurfaceCandidate) -> AppCandidatePromotionGate {
+  let mut missing_gates = Vec::new();
+  let mut notes = Vec::new();
+
+  if candidate.evidence_refs.is_empty() {
+    missing_gates.push("artifact_ref".to_string());
+    notes.push(
+      "Candidate has no ArtifactRef; action consumers cannot reconstruct the source evidence chain."
+        .to_string(),
+    );
+  }
+
+  if candidate.candidate_query.is_none() && candidate.input_bindings.is_empty() {
+    missing_gates.push("relocation_query_or_inputs".to_string());
+    notes.push(
+      "Candidate has neither a surface selector query nor recipe input bindings for re-grounding."
+        .to_string(),
+    );
+  }
+
+  let status = match (candidate.area.as_str(), candidate.kind.as_str()) {
+    ("ocr-visible-text", _) => {
+      push_unique(&mut missing_gates, "semantic_verification_contract");
+      push_unique(&mut missing_gates, "action_contract");
+      notes.push(
+        "OCR visible text remains evidence only; it is not a validated semantic target."
+          .to_string(),
+      );
+      AppCandidatePromotionStatus::Blocked
+    }
+    ("result-selection", "row") => {
+      push_unique(&mut missing_gates, "row_action_contract");
+      push_unique(&mut missing_gates, "semantic_verification_contract");
+      notes.push(
+        "Row/list grouping is a surface candidate; it needs a row action and semantic verifier before action-grade promotion."
+          .to_string(),
+      );
+      AppCandidatePromotionStatus::Blocked
+    }
+    _ if !candidate.compatibility.direct_taxonomy_ids.is_empty() => {
+      notes.push(
+        "Candidate can seed a known distillation strategy, but analyze does not mint action-grade contract::Candidate values."
+          .to_string(),
+      );
+      AppCandidatePromotionStatus::DistillStrategyOnly
+    }
+    _ => {
+      push_unique(&mut missing_gates, "promotion_path");
+      notes.push(
+        "No direct taxonomy or action contract currently consumes this candidate.".to_string(),
+      );
+      AppCandidatePromotionStatus::Blocked
+    }
+  };
+
+  AppCandidatePromotionGate {
+    status,
+    missing_gates,
+    notes,
+  }
+}
+
+fn push_unique(values: &mut Vec<String>, value: &str) {
+  if !values.iter().any(|existing| existing == value) {
+    values.push(value.to_string());
   }
 }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1751,6 +1751,25 @@ mod tests {
   }
 
   #[test]
+  fn distill_candidate_shape_records_note_when_strategy_has_no_direct_surface_candidate() {
+    let analysis =
+      sample_analysis_with_strategy("search-entry.ax-text-input.clipboard-submit.capture-evidence");
+
+    let candidate_shape = build_distilled_candidate_shape(
+      &analysis,
+      "search-entry.ax-text-input.clipboard-submit.capture-evidence",
+    );
+
+    assert!(candidate_shape.direct_candidate_ids.is_empty());
+    assert!(
+      candidate_shape
+        .notes
+        .iter()
+        .any(|note| note.contains("No direct candidate shape was available"))
+    );
+  }
+
+  #[test]
   fn build_distilled_candidate_shape_projects_direct_inputs() {
     let mut analysis =
       sample_analysis_with_strategy("window-action.window-point.pointer-click.capture-evidence");

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1771,6 +1771,162 @@ mod tests {
   }
 
   #[test]
+  fn row_surface_candidates_stay_context_only_in_distilled_shape() {
+    let analysis = AppAnalysis {
+      analysis_version: APP_ANALYSIS_VERSION.to_string(),
+      created_at_millis: 0,
+      probe_path: PathBuf::from("/tmp/probe.json"),
+      app_identity: AppIdentity {
+        bundle_id: "com.example.App".to_string(),
+        app_name: "Example".to_string(),
+        app_path: Some(PathBuf::from("/Applications/Example.app")),
+        main_executable_path: None,
+        version: "1.0".to_string(),
+        build_version: "100".to_string(),
+        url_schemes: vec![],
+        apple_script_addressable: false,
+        launch_services_resolved: true,
+        resolution_notes: vec![],
+      },
+      window_context: AppWindowContext {
+        observed_window_count: 1,
+        observed_at: "2026-05-18T00:00:00Z".to_string(),
+        frontmost_app_name: "Example".to_string(),
+        frontmost_window_title: "Example".to_string(),
+        primary_window_title: "Example".to_string(),
+        primary_window_bounds: Some(AppRect {
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 100,
+        }),
+        primary_window_display_scale: Some(2.0),
+      },
+      permissions: AppPermissionState {
+        screen_recording: "granted".to_string(),
+        accessibility: "granted".to_string(),
+        automation_to_system_events: "granted".to_string(),
+        launch_host_process: "Atlas".to_string(),
+      },
+      available_surfaces: AppAvailableSurfaces {
+        accessibility_tree: AssessmentStatus::Candidate,
+        menu_surface: AssessmentStatus::Unknown,
+        shortcut_surface: AssessmentStatus::Candidate,
+        apple_script_surface: AssessmentStatus::Unavailable,
+        url_scheme_surface: AssessmentStatus::Unavailable,
+        keyboard_first_surface: AssessmentStatus::Candidate,
+        pointer_fallback_surface: AssessmentStatus::Likely,
+      },
+      grounding_assessment: AppGroundingAssessment {
+        ocr_sample_query: "Example".to_string(),
+        ocr_sample_status: AssessmentStatus::Candidate,
+        ocr_sample_match_count: 1,
+        stable_anchor_candidates: vec![],
+        stable_region_candidates: vec![],
+        overlay_debug_artifacts_recommended: false,
+      },
+      control_assessment: AppControlAssessment {
+        preferred_path: "non-pointer first".to_string(),
+        non_pointer_path: AssessmentStatus::Candidate,
+        keyboard_path: AssessmentStatus::Candidate,
+        pointer_fallback: AssessmentStatus::Likely,
+        notes: vec![],
+      },
+      verification_assessment: AppVerificationAssessment {
+        ax_verify: AssessmentStatus::Candidate,
+        image_verify: AssessmentStatus::Candidate,
+        ui_state_verify: AssessmentStatus::Candidate,
+        semantic_success: AssessmentStatus::Unknown,
+        notes: vec![],
+      },
+      disturbance_profile: AppDisturbanceProfile {
+        observation: vec!["none".to_string()],
+        non_pointer_control: vec!["keyboard".to_string()],
+        pointer_fallback: vec!["pointer".to_string()],
+      },
+      annotation_candidates: vec![AppSurfaceCandidate {
+        candidate_id: "visible-row-1".to_string(),
+        area: "result-selection".to_string(),
+        kind: "row".to_string(),
+        source: "ocr-text".to_string(),
+        status: AssessmentStatus::Candidate,
+        primary_text: "AURORA | Playlist".to_string(),
+        secondary_text: "rowIndex=1".to_string(),
+        query_value: "1".to_string(),
+        coordinate_space: "global-logical".to_string(),
+        bounds: Some(AppRect {
+          x: 10,
+          y: 20,
+          width: 120,
+          height: 24,
+        }),
+        click_point: Some(AppPoint { x: 70, y: 32 }),
+        confidence: None,
+        evidence_step_id: "ocr-sample".to_string(),
+        candidate_query: Some(CandidateQuery {
+          query_id: "visible-row-1".to_string(),
+          selector: SurfaceSelector {
+            any_of: vec![SurfaceSelectorClause::Row {
+              row_index: Some(1),
+              contains_text: Some("AURORA".to_string()),
+              region_hint: None,
+            }],
+            within: SelectorScope::TargetWindow,
+            require_visible: true,
+          },
+          output_kind: Some("row".to_string()),
+          known_limits: vec!["row only".to_string()],
+        }),
+        evidence_refs: Vec::new(),
+        promotion_gate: Some(AppCandidatePromotionGate {
+          status: AppCandidatePromotionStatus::Blocked,
+          missing_gates: vec![
+            "row_action_contract".to_string(),
+            "semantic_verification_contract".to_string(),
+          ],
+          notes: vec!["row candidate stays structural".to_string()],
+        }),
+        input_bindings: BTreeMap::from([("row_index".to_string(), "1".to_string())]),
+        compatibility: candidate_compatibility(
+          &[],
+          &["result-selection.ocr-anchor.pointer-click.capture-evidence"],
+        ),
+        notes: vec!["sample row candidate".to_string()],
+      }],
+      known_boundaries: vec![],
+      recommended_strategies: vec![AppRecommendedStrategy {
+        taxonomy_id: "result-selection.ocr-anchor.pointer-click.capture-evidence".to_string(),
+        status: AssessmentStatus::Candidate,
+        rationale: "row candidates stay review-only until a row action exists".to_string(),
+      }],
+    };
+
+    let candidate_shape = build_distilled_candidate_shape(
+      &analysis,
+      "result-selection.ocr-anchor.pointer-click.capture-evidence",
+    );
+
+    assert!(candidate_shape.direct_candidate_ids.is_empty());
+    assert_eq!(
+      candidate_shape.context_candidate_ids,
+      vec!["visible-row-1".to_string()]
+    );
+    assert!(candidate_shape.provided_inputs.is_empty());
+    assert!(
+      candidate_shape
+        .notes
+        .iter()
+        .any(|note| note.contains("No direct candidate shape was available"))
+    );
+    assert!(
+      candidate_shape
+        .notes
+        .iter()
+        .any(|note| note.contains("Context-only candidates were recorded"))
+    );
+  }
+
+  #[test]
   fn result_selection_grounding_ignores_row_only_candidates() {
     let analysis = AppAnalysis {
       analysis_version: APP_ANALYSIS_VERSION.to_string(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1940,6 +1940,7 @@ mod tests {
         .iter()
         .any(|candidate_id| candidate_id == "window-primary-region")
     );
+    assert_eq!(used_annotations.len(), 1);
     assert_eq!(
       matrix.cases[0].inputs.get("relative_x"),
       Some(&"0.500000".to_string())

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3075,6 +3075,124 @@ mod tests {
   }
 
   #[test]
+  fn distillation_report_keeps_row_suggestions_review_only() {
+    let analysis = AppAnalysis {
+      analysis_version: APP_ANALYSIS_VERSION.to_string(),
+      created_at_millis: 0,
+      probe_path: PathBuf::from("/tmp/probe.json"),
+      app_identity: AppIdentity {
+        bundle_id: "com.example.App".to_string(),
+        app_name: "Example".to_string(),
+        app_path: Some(PathBuf::from("/Applications/Example.app")),
+        main_executable_path: None,
+        version: "1.0".to_string(),
+        build_version: "100".to_string(),
+        url_schemes: vec![],
+        apple_script_addressable: false,
+        launch_services_resolved: true,
+        resolution_notes: vec![],
+      },
+      window_context: AppWindowContext {
+        observed_window_count: 1,
+        observed_at: "2026-05-18T00:00:00Z".to_string(),
+        frontmost_app_name: "Example".to_string(),
+        frontmost_window_title: "Example".to_string(),
+        primary_window_title: "Example".to_string(),
+        primary_window_bounds: Some(AppRect {
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 100,
+        }),
+        primary_window_display_scale: Some(2.0),
+      },
+      permissions: AppPermissionState {
+        screen_recording: "granted".to_string(),
+        accessibility: "granted".to_string(),
+        automation_to_system_events: "granted".to_string(),
+        launch_host_process: "Atlas".to_string(),
+      },
+      available_surfaces: AppAvailableSurfaces {
+        accessibility_tree: AssessmentStatus::Candidate,
+        menu_surface: AssessmentStatus::Unknown,
+        shortcut_surface: AssessmentStatus::Candidate,
+        apple_script_surface: AssessmentStatus::Unavailable,
+        url_scheme_surface: AssessmentStatus::Unavailable,
+        keyboard_first_surface: AssessmentStatus::Candidate,
+        pointer_fallback_surface: AssessmentStatus::Likely,
+      },
+      grounding_assessment: AppGroundingAssessment {
+        ocr_sample_query: "Example".to_string(),
+        ocr_sample_status: AssessmentStatus::Candidate,
+        ocr_sample_match_count: 1,
+        stable_anchor_candidates: vec![],
+        stable_region_candidates: vec![],
+        overlay_debug_artifacts_recommended: false,
+      },
+      control_assessment: AppControlAssessment {
+        preferred_path: "non-pointer first".to_string(),
+        non_pointer_path: AssessmentStatus::Candidate,
+        keyboard_path: AssessmentStatus::Candidate,
+        pointer_fallback: AssessmentStatus::Likely,
+        notes: vec![],
+      },
+      verification_assessment: AppVerificationAssessment {
+        ax_verify: AssessmentStatus::Candidate,
+        image_verify: AssessmentStatus::Candidate,
+        ui_state_verify: AssessmentStatus::Candidate,
+        semantic_success: AssessmentStatus::Unknown,
+        notes: vec![],
+      },
+      disturbance_profile: AppDisturbanceProfile {
+        observation: vec!["none".to_string()],
+        non_pointer_control: vec!["keyboard".to_string()],
+        pointer_fallback: vec!["pointer".to_string()],
+      },
+      annotation_candidates: vec![],
+      known_boundaries: vec![
+        "Grouped visible rows remain surface candidates until a row action exists.".to_string(),
+      ],
+      recommended_strategies: vec![],
+    };
+    let distillation = AppDistillation {
+      distill_version: APP_DISTILL_VERSION.to_string(),
+      created_at_millis: 0,
+      source_analysis_path: PathBuf::from("/tmp/analysis.json"),
+      app_identity: analysis.app_identity.clone(),
+      candidates: vec![AppDistilledCandidate {
+        recipe_id: "test.result.selection".to_string(),
+        taxonomy_id: "result-selection.ocr-anchor.pointer-click.capture-evidence".to_string(),
+        status: AssessmentStatus::Candidate,
+        rationale: "row suggestions stay review-only".to_string(),
+        suggested_annotation_ids: vec!["visible-row-1".to_string()],
+        candidate_shape: AppDistilledCandidateShape {
+          direct_candidate_ids: Vec::new(),
+          context_candidate_ids: vec!["visible-row-1".to_string()],
+          provided_inputs: BTreeMap::new(),
+          notes: vec![
+            "No direct candidate shape was available for taxonomy result-selection.ocr-anchor.pointer-click.capture-evidence during distill.".to_string(),
+            "Context-only candidates were recorded for later review, but they did not project directly into recipe inputs.".to_string(),
+          ],
+        },
+        recipe_path: PathBuf::from("/tmp/result-selection.recipe.json"),
+        case_matrix_path: PathBuf::from("/tmp/result-selection.cases.json"),
+      }],
+      known_boundaries: analysis.known_boundaries.clone(),
+    };
+
+    let report = render_app_distillation_report(&analysis, &distillation);
+
+    assert!(report.contains("suggested annotations:"));
+    assert!(report.contains("`visible-row-1`"));
+    assert!(report.contains("context candidate ids:"));
+    assert!(!report.contains("direct candidate ids:"));
+    assert!(!report.contains("candidate shape inputs:"));
+    assert!(report.contains("shape note: No direct candidate shape was available"));
+    assert!(report.contains("shape note: Context-only candidates were recorded"));
+    assert!(report.contains("Grouped visible rows remain surface candidates"));
+  }
+
+  #[test]
   fn build_annotation_candidates_keeps_raw_ocr_as_visible_text_and_adds_selectors() {
     let app = AppIdentity {
       bundle_id: "com.example.music".to_string(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2477,6 +2477,161 @@ mod tests {
   }
 
   #[test]
+  fn app_analysis_json_round_trip_preserves_surface_contract_fields() {
+    let root = temp_dir("app-analysis-round-trip");
+    let analysis_path = root.join("analysis.json");
+    let analysis = AppAnalysis {
+      analysis_version: APP_ANALYSIS_VERSION.to_string(),
+      created_at_millis: 0,
+      probe_path: PathBuf::from("/tmp/probe.json"),
+      app_identity: AppIdentity {
+        bundle_id: "com.example.App".to_string(),
+        app_name: "Example".to_string(),
+        app_path: Some(PathBuf::from("/Applications/Example.app")),
+        main_executable_path: None,
+        version: "1.0".to_string(),
+        build_version: "100".to_string(),
+        url_schemes: vec![],
+        apple_script_addressable: false,
+        launch_services_resolved: true,
+        resolution_notes: vec![],
+      },
+      window_context: AppWindowContext {
+        observed_window_count: 1,
+        observed_at: "2026-05-18T00:00:00Z".to_string(),
+        frontmost_app_name: "Example".to_string(),
+        frontmost_window_title: "Example".to_string(),
+        primary_window_title: "Example".to_string(),
+        primary_window_bounds: Some(AppRect {
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 100,
+        }),
+        primary_window_display_scale: Some(2.0),
+      },
+      permissions: AppPermissionState {
+        screen_recording: "granted".to_string(),
+        accessibility: "granted".to_string(),
+        automation_to_system_events: "granted".to_string(),
+        launch_host_process: "Atlas".to_string(),
+      },
+      available_surfaces: AppAvailableSurfaces {
+        accessibility_tree: AssessmentStatus::Available,
+        menu_surface: AssessmentStatus::Unknown,
+        shortcut_surface: AssessmentStatus::Candidate,
+        apple_script_surface: AssessmentStatus::Available,
+        url_scheme_surface: AssessmentStatus::Available,
+        keyboard_first_surface: AssessmentStatus::Candidate,
+        pointer_fallback_surface: AssessmentStatus::Likely,
+      },
+      grounding_assessment: AppGroundingAssessment {
+        ocr_sample_query: "Example".to_string(),
+        ocr_sample_status: AssessmentStatus::Candidate,
+        ocr_sample_match_count: 1,
+        stable_anchor_candidates: vec!["appName: Example".to_string()],
+        stable_region_candidates: vec!["primaryWindow=0,0,100,100".to_string()],
+        overlay_debug_artifacts_recommended: false,
+      },
+      control_assessment: AppControlAssessment {
+        preferred_path: "non-pointer first".to_string(),
+        non_pointer_path: AssessmentStatus::Candidate,
+        keyboard_path: AssessmentStatus::Candidate,
+        pointer_fallback: AssessmentStatus::Likely,
+        notes: vec![],
+      },
+      verification_assessment: AppVerificationAssessment {
+        ax_verify: AssessmentStatus::Candidate,
+        image_verify: AssessmentStatus::Candidate,
+        ui_state_verify: AssessmentStatus::Candidate,
+        semantic_success: AssessmentStatus::Unknown,
+        notes: vec![],
+      },
+      disturbance_profile: AppDisturbanceProfile {
+        observation: vec!["none".to_string()],
+        non_pointer_control: vec!["keyboard".to_string()],
+        pointer_fallback: vec!["pointer".to_string()],
+      },
+      annotation_candidates: vec![AppSurfaceCandidate {
+        candidate_id: "search-entry-focus-ax".to_string(),
+        area: "search-entry".to_string(),
+        kind: "focus-query".to_string(),
+        source: "ax".to_string(),
+        status: AssessmentStatus::Candidate,
+        primary_text: "Search".to_string(),
+        secondary_text: "role=AXTextField path=0.1".to_string(),
+        query_value: "Search".to_string(),
+        coordinate_space: "global-logical".to_string(),
+        bounds: Some(AppRect {
+          x: 10,
+          y: 10,
+          width: 80,
+          height: 20,
+        }),
+        click_point: Some(AppPoint { x: 50, y: 20 }),
+        confidence: None,
+        evidence_step_id: "capture-ax-tree".to_string(),
+        candidate_query: Some(CandidateQuery {
+          query_id: "search-entry-focus-ax".to_string(),
+          selector: SurfaceSelector {
+            any_of: vec![SurfaceSelectorClause::Ax {
+              role: Some("AXTextField".to_string()),
+              label: Some("Search".to_string()),
+              path: Some("0.1".to_string()),
+              enabled: None,
+              visible: Some(true),
+            }],
+            within: SelectorScope::TargetWindow,
+            require_visible: true,
+          },
+          output_kind: Some("focus-query".to_string()),
+          known_limits: vec!["test query".to_string()],
+        }),
+        evidence_refs: vec![ArtifactRef {
+          run_id: crate::trace::RunId::new("run_probe"),
+          span_id: crate::trace::SpanId::new("span_probe"),
+          artifact_id: crate::trace::ArtifactId::new("artifact_0001"),
+          captured_event_id: Some(crate::trace::EventId::new("event_probe")),
+        }],
+        promotion_gate: Some(AppCandidatePromotionGate {
+          status: AppCandidatePromotionStatus::DistillStrategyOnly,
+          missing_gates: Vec::new(),
+          notes: vec!["Sample candidate can seed a known distillation strategy.".to_string()],
+        }),
+        input_bindings: BTreeMap::from([("focus_query".to_string(), "Search".to_string())]),
+        compatibility: candidate_compatibility(
+          &["search-entry.ax-text-input.clipboard-submit.capture-evidence"],
+          &[],
+        ),
+        notes: vec!["sample note".to_string()],
+      }],
+      known_boundaries: vec![],
+      recommended_strategies: vec![],
+    };
+
+    write_pretty_json(&analysis_path, &analysis).expect("analysis should write");
+    let loaded: AppAnalysis = read_json(&analysis_path).expect("analysis should read");
+
+    let candidate = loaded
+      .annotation_candidates
+      .first()
+      .expect("sample analysis should carry one candidate");
+    assert!(candidate.candidate_query.is_some());
+    assert_eq!(candidate.evidence_refs.len(), 1);
+    let promotion_gate = candidate
+      .promotion_gate
+      .as_ref()
+      .expect("promotion gate should survive round trip");
+    assert_eq!(
+      promotion_gate.status,
+      AppCandidatePromotionStatus::DistillStrategyOnly
+    );
+    assert!(promotion_gate.missing_gates.is_empty());
+
+    let _ = fs::remove_dir_all(root);
+  }
+
+  #[test]
   fn build_probe_evidence_refs_resolves_artifact_records_from_probe_steps() {
     let root = temp_dir("probe-evidence-refs");
     let run_dir = root.join(".auv").join("runs").join("run_fixture");

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2382,6 +2382,62 @@ mod tests {
   }
 
   #[test]
+  fn app_surface_candidate_serializes_promotion_gate_for_machine_consumers() {
+    let candidate = AppSurfaceCandidate {
+      candidate_id: "candidate_ocr_0".to_string(),
+      area: "ocr-visible-text".to_string(),
+      kind: "anchor-text".to_string(),
+      source: "ocr".to_string(),
+      status: AssessmentStatus::Available,
+      primary_text: "AURORA".to_string(),
+      secondary_text: String::new(),
+      query_value: "AURORA".to_string(),
+      coordinate_space: "target-window".to_string(),
+      bounds: Some(AppRect {
+        x: 120,
+        y: 80,
+        width: 90,
+        height: 24,
+      }),
+      click_point: None,
+      confidence: Some(0.95),
+      evidence_step_id: "ocr-sample".to_string(),
+      candidate_query: None,
+      evidence_refs: Vec::new(),
+      compatibility: AppCandidateCompatibility {
+        direct_taxonomy_ids: Vec::new(),
+        context_taxonomy_ids: Vec::new(),
+      },
+      input_bindings: BTreeMap::new(),
+      notes: vec!["visible OCR text only".to_string()],
+      promotion_gate: Some(AppCandidatePromotionGate {
+        status: AppCandidatePromotionStatus::Blocked,
+        missing_gates: vec![
+          "action_contract".to_string(),
+          "semantic_verification_contract".to_string(),
+        ],
+        notes: Vec::new(),
+      }),
+    };
+
+    let value = serde_json::to_value(&candidate).expect("candidate should serialize");
+    let promotion_gate = value
+      .get("promotion_gate")
+      .expect("promotion gate should exist in JSON");
+    assert_eq!(
+      promotion_gate.get("status"),
+      Some(&serde_json::json!("blocked"))
+    );
+    assert_eq!(
+      promotion_gate.get("missing_gates"),
+      Some(&serde_json::json!([
+        "action_contract",
+        "semantic_verification_contract"
+      ]))
+    );
+  }
+
+  #[test]
   fn build_probe_evidence_refs_resolves_artifact_records_from_probe_steps() {
     let root = temp_dir("probe-evidence-refs");
     let run_dir = root.join(".auv").join("runs").join("run_fixture");

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1173,6 +1173,7 @@ mod tests {
   use crate::model::{CommandSpec, DisturbanceClass, DriverCall, DriverDescriptor, DriverResponse};
   use crate::recording::{MemoryRunRecorder, RunUpdate};
   use crate::run_builder::RunSpec;
+  use crate::skill::SkillCase;
   use crate::store::LocalStore;
   use crate::trace::RunType;
   use auv_driver_macos::types::OcrTextMatch;
@@ -1767,6 +1768,160 @@ mod tests {
         .iter()
         .any(|note| note.contains("No direct candidate shape was available"))
     );
+  }
+
+  #[test]
+  fn result_selection_grounding_ignores_row_only_candidates() {
+    let analysis = AppAnalysis {
+      analysis_version: APP_ANALYSIS_VERSION.to_string(),
+      created_at_millis: 0,
+      probe_path: PathBuf::from("/tmp/probe.json"),
+      app_identity: AppIdentity {
+        bundle_id: "com.example.App".to_string(),
+        app_name: "Example".to_string(),
+        app_path: Some(PathBuf::from("/Applications/Example.app")),
+        main_executable_path: None,
+        version: "1.0".to_string(),
+        build_version: "100".to_string(),
+        url_schemes: vec![],
+        apple_script_addressable: false,
+        launch_services_resolved: true,
+        resolution_notes: vec![],
+      },
+      window_context: AppWindowContext {
+        observed_window_count: 1,
+        observed_at: "2026-05-18T00:00:00Z".to_string(),
+        frontmost_app_name: "Example".to_string(),
+        frontmost_window_title: "Example".to_string(),
+        primary_window_title: "Example".to_string(),
+        primary_window_bounds: Some(AppRect {
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 100,
+        }),
+        primary_window_display_scale: Some(2.0),
+      },
+      permissions: AppPermissionState {
+        screen_recording: "granted".to_string(),
+        accessibility: "granted".to_string(),
+        automation_to_system_events: "granted".to_string(),
+        launch_host_process: "Atlas".to_string(),
+      },
+      available_surfaces: AppAvailableSurfaces {
+        accessibility_tree: AssessmentStatus::Candidate,
+        menu_surface: AssessmentStatus::Unknown,
+        shortcut_surface: AssessmentStatus::Candidate,
+        apple_script_surface: AssessmentStatus::Unavailable,
+        url_scheme_surface: AssessmentStatus::Unavailable,
+        keyboard_first_surface: AssessmentStatus::Candidate,
+        pointer_fallback_surface: AssessmentStatus::Likely,
+      },
+      grounding_assessment: AppGroundingAssessment {
+        ocr_sample_query: "Example".to_string(),
+        ocr_sample_status: AssessmentStatus::Candidate,
+        ocr_sample_match_count: 1,
+        stable_anchor_candidates: vec![],
+        stable_region_candidates: vec![],
+        overlay_debug_artifacts_recommended: false,
+      },
+      control_assessment: AppControlAssessment {
+        preferred_path: "non-pointer first".to_string(),
+        non_pointer_path: AssessmentStatus::Candidate,
+        keyboard_path: AssessmentStatus::Candidate,
+        pointer_fallback: AssessmentStatus::Likely,
+        notes: vec![],
+      },
+      verification_assessment: AppVerificationAssessment {
+        ax_verify: AssessmentStatus::Candidate,
+        image_verify: AssessmentStatus::Candidate,
+        ui_state_verify: AssessmentStatus::Candidate,
+        semantic_success: AssessmentStatus::Unknown,
+        notes: vec![],
+      },
+      disturbance_profile: AppDisturbanceProfile {
+        observation: vec!["none".to_string()],
+        non_pointer_control: vec!["keyboard".to_string()],
+        pointer_fallback: vec!["pointer".to_string()],
+      },
+      annotation_candidates: vec![AppSurfaceCandidate {
+        candidate_id: "visible-row-1".to_string(),
+        area: "result-selection".to_string(),
+        kind: "row".to_string(),
+        source: "ocr-text".to_string(),
+        status: AssessmentStatus::Candidate,
+        primary_text: "AURORA | Playlist".to_string(),
+        secondary_text: "rowIndex=1".to_string(),
+        query_value: "1".to_string(),
+        coordinate_space: "global-logical".to_string(),
+        bounds: Some(AppRect {
+          x: 10,
+          y: 20,
+          width: 120,
+          height: 24,
+        }),
+        click_point: Some(AppPoint { x: 70, y: 32 }),
+        confidence: None,
+        evidence_step_id: "ocr-sample".to_string(),
+        candidate_query: Some(CandidateQuery {
+          query_id: "visible-row-1".to_string(),
+          selector: SurfaceSelector {
+            any_of: vec![SurfaceSelectorClause::Row {
+              row_index: Some(1),
+              contains_text: Some("AURORA".to_string()),
+              region_hint: None,
+            }],
+            within: SelectorScope::TargetWindow,
+            require_visible: true,
+          },
+          output_kind: Some("row".to_string()),
+          known_limits: vec!["row only".to_string()],
+        }),
+        evidence_refs: Vec::new(),
+        promotion_gate: Some(AppCandidatePromotionGate {
+          status: AppCandidatePromotionStatus::Blocked,
+          missing_gates: vec![
+            "row_action_contract".to_string(),
+            "semantic_verification_contract".to_string(),
+          ],
+          notes: vec!["row candidate stays structural".to_string()],
+        }),
+        input_bindings: BTreeMap::from([("row_index".to_string(), "1".to_string())]),
+        compatibility: candidate_compatibility(
+          &[],
+          &["result-selection.ocr-anchor.pointer-click.capture-evidence"],
+        ),
+        notes: vec!["sample row candidate".to_string()],
+      }],
+      known_boundaries: vec![],
+      recommended_strategies: vec![],
+    };
+    let mut matrix = SkillCaseMatrix {
+      version: "0.1.0".to_string(),
+      skill_id: "test.result.selection".to_string(),
+      status: "validated".to_string(),
+      cases: vec![SkillCase {
+        case_id: "row-only".to_string(),
+        status: "validated".to_string(),
+        inputs: BTreeMap::from([("anchor_text".to_string(), "TODO_ANCHOR_TEXT".to_string())]),
+        disturbance: String::new(),
+        notes: Vec::new(),
+      }],
+    };
+    let mut resolved = BTreeMap::new();
+
+    let (unresolved, used_annotations) = apply_candidate_grounding(
+      &analysis,
+      None,
+      "result-selection.ocr-anchor.pointer-click.capture-evidence",
+      &mut matrix,
+      &mut resolved,
+    )
+    .expect("known taxonomy should ground");
+
+    assert!(used_annotations.is_empty());
+    assert!(unresolved.iter().any(|key| key == "anchor_text"));
+    assert!(!resolved.contains_key("anchor_text"));
   }
 
   #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1152,7 +1152,7 @@ mod tests {
   use super::analysis::{
     apply_candidate_grounding, build_annotation_candidates, build_app_analysis,
     build_distilled_candidate_shape, build_probe_evidence_refs, candidate_compatibility,
-    recommended_strategy,
+    recommended_strategy, suggested_annotation_ids_for_candidate_shape,
   };
   use super::infra::{
     invoke_probe_step, read_json, resolve_distillation_path, resolve_probe_path, write_pretty_json,
@@ -1726,6 +1726,28 @@ mod tests {
     );
     assert!(candidate_shape.context_candidate_ids.is_empty());
     assert!(candidate_shape.notes.is_empty());
+  }
+
+  #[test]
+  fn suggested_annotation_ids_preserve_direct_then_context_candidates() {
+    let candidate_shape = AppDistilledCandidateShape {
+      direct_candidate_ids: vec![
+        "window-primary-region".to_string(),
+        "search-entry-focus-ax".to_string(),
+      ],
+      context_candidate_ids: vec!["visible-row-1".to_string()],
+      provided_inputs: BTreeMap::new(),
+      notes: vec![],
+    };
+
+    assert_eq!(
+      suggested_annotation_ids_for_candidate_shape(&candidate_shape),
+      vec![
+        "window-primary-region".to_string(),
+        "search-entry-focus-ax".to_string(),
+        "visible-row-1".to_string(),
+      ]
+    );
   }
 
   #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3071,6 +3071,24 @@ mod tests {
     assert!(error.contains("test.recorded.skill"));
     assert!(error.contains("focus_query"));
 
+    let validation: AppValidation =
+      read_json(&root.join("validation.json")).expect("validation output should still write");
+    assert_eq!(
+      validation.candidates[0].status,
+      AppValidationStatus::Rejected
+    );
+    assert!(validation.candidates[0].used_annotation_ids.is_empty());
+    assert_eq!(
+      validation.candidates[0].unresolved_inputs,
+      vec!["focus_query".to_string()]
+    );
+    assert!(
+      validation.candidates[0]
+        .failure_message
+        .as_deref()
+        .is_some_and(|message| message.contains("grounding left unresolved inputs"))
+    );
+
     let _ = fs::remove_dir_all(root);
   }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1616,7 +1616,14 @@ mod tests {
       evidence_step_id: "observe-window-tree".to_string(),
       candidate_query: None,
       evidence_refs: Vec::new(),
-      promotion_gate: None,
+      promotion_gate: Some(AppCandidatePromotionGate {
+        status: AppCandidatePromotionStatus::DistillStrategyOnly,
+        missing_gates: vec!["artifact_ref".to_string()],
+        notes: vec![
+          "Candidate can seed a known distillation strategy, but analyze does not mint action-grade contract::Candidate values.".to_string(),
+          "Candidate has no ArtifactRef; action consumers cannot reconstruct the source evidence chain.".to_string(),
+        ],
+      }),
       input_bindings: BTreeMap::from([
         ("window_bounds".to_string(), "100,200,800,600".to_string()),
         ("relative_x".to_string(), "0.500000".to_string()),
@@ -1646,6 +1653,24 @@ mod tests {
       Some(&"0.500000".to_string())
     );
     assert!(candidate_shape.notes.is_empty());
+    let promotion_gate = analysis
+      .annotation_candidates
+      .iter()
+      .find(|candidate| candidate.candidate_id == "window-primary-region")
+      .expect("window candidate should exist")
+      .promotion_gate
+      .as_ref()
+      .expect("window candidate should expose promotion gate");
+    assert_eq!(
+      promotion_gate.status,
+      AppCandidatePromotionStatus::DistillStrategyOnly
+    );
+    assert!(
+      promotion_gate
+        .missing_gates
+        .iter()
+        .any(|item| item == "artifact_ref")
+    );
   }
 
   #[test]
@@ -1696,7 +1721,14 @@ mod tests {
       evidence_step_id: "capture-ax-tree".to_string(),
       candidate_query: None,
       evidence_refs: Vec::new(),
-      promotion_gate: None,
+      promotion_gate: Some(AppCandidatePromotionGate {
+        status: AppCandidatePromotionStatus::DistillStrategyOnly,
+        missing_gates: vec!["artifact_ref".to_string()],
+        notes: vec![
+          "Candidate can seed a known distillation strategy, but analyze does not mint action-grade contract::Candidate values.".to_string(),
+          "Candidate has no ArtifactRef; action consumers cannot reconstruct the source evidence chain.".to_string(),
+        ],
+      }),
       input_bindings: BTreeMap::from([
         ("window_bounds".to_string(), "100,200,800,600".to_string()),
         ("relative_x".to_string(), "0.500000".to_string()),
@@ -1943,7 +1975,14 @@ mod tests {
       evidence_step_id: "capture-ax-tree".to_string(),
       candidate_query: None,
       evidence_refs: Vec::new(),
-      promotion_gate: None,
+      promotion_gate: Some(AppCandidatePromotionGate {
+        status: AppCandidatePromotionStatus::DistillStrategyOnly,
+        missing_gates: vec!["artifact_ref".to_string()],
+        notes: vec![
+          "Candidate can seed a known distillation strategy, but analyze does not mint action-grade contract::Candidate values.".to_string(),
+          "Candidate has no ArtifactRef; action consumers cannot reconstruct the source evidence chain.".to_string(),
+        ],
+      }),
       input_bindings: BTreeMap::from([
         ("window_bounds".to_string(), "100,200,800,600".to_string()),
         ("relative_x".to_string(), "0.500000".to_string()),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1592,6 +1592,143 @@ mod tests {
   }
 
   #[test]
+  fn recommended_surface_strategy_projects_to_direct_candidate_shape() {
+    let analysis = AppAnalysis {
+      analysis_version: APP_ANALYSIS_VERSION.to_string(),
+      created_at_millis: 0,
+      probe_path: PathBuf::from("/tmp/probe.json"),
+      app_identity: AppIdentity {
+        bundle_id: "com.example.App".to_string(),
+        app_name: "Example".to_string(),
+        app_path: Some(PathBuf::from("/Applications/Example.app")),
+        main_executable_path: None,
+        version: "1.0".to_string(),
+        build_version: "100".to_string(),
+        url_schemes: vec![],
+        apple_script_addressable: false,
+        launch_services_resolved: true,
+        resolution_notes: vec![],
+      },
+      window_context: AppWindowContext {
+        observed_window_count: 1,
+        observed_at: "2026-05-18T00:00:00Z".to_string(),
+        frontmost_app_name: "Example".to_string(),
+        frontmost_window_title: "Example".to_string(),
+        primary_window_title: "Example".to_string(),
+        primary_window_bounds: Some(AppRect {
+          x: 100,
+          y: 200,
+          width: 800,
+          height: 600,
+        }),
+        primary_window_display_scale: Some(2.0),
+      },
+      permissions: AppPermissionState {
+        screen_recording: "granted".to_string(),
+        accessibility: "granted".to_string(),
+        automation_to_system_events: "granted".to_string(),
+        launch_host_process: "Atlas".to_string(),
+      },
+      available_surfaces: AppAvailableSurfaces {
+        accessibility_tree: AssessmentStatus::Candidate,
+        menu_surface: AssessmentStatus::Unknown,
+        shortcut_surface: AssessmentStatus::Candidate,
+        apple_script_surface: AssessmentStatus::Unavailable,
+        url_scheme_surface: AssessmentStatus::Unavailable,
+        keyboard_first_surface: AssessmentStatus::Candidate,
+        pointer_fallback_surface: AssessmentStatus::Likely,
+      },
+      grounding_assessment: AppGroundingAssessment {
+        ocr_sample_query: "Example".to_string(),
+        ocr_sample_status: AssessmentStatus::Candidate,
+        ocr_sample_match_count: 1,
+        stable_anchor_candidates: vec![],
+        stable_region_candidates: vec!["primaryWindow=100,200,800,600".to_string()],
+        overlay_debug_artifacts_recommended: false,
+      },
+      control_assessment: AppControlAssessment {
+        preferred_path: "non-pointer first".to_string(),
+        non_pointer_path: AssessmentStatus::Candidate,
+        keyboard_path: AssessmentStatus::Candidate,
+        pointer_fallback: AssessmentStatus::Likely,
+        notes: vec![],
+      },
+      verification_assessment: AppVerificationAssessment {
+        ax_verify: AssessmentStatus::Candidate,
+        image_verify: AssessmentStatus::Candidate,
+        ui_state_verify: AssessmentStatus::Candidate,
+        semantic_success: AssessmentStatus::Unknown,
+        notes: vec![],
+      },
+      disturbance_profile: AppDisturbanceProfile {
+        observation: vec!["none".to_string()],
+        non_pointer_control: vec!["keyboard".to_string()],
+        pointer_fallback: vec!["pointer".to_string()],
+      },
+      annotation_candidates: vec![AppSurfaceCandidate {
+        candidate_id: "window-primary-region".to_string(),
+        area: "window.primary".to_string(),
+        kind: "region".to_string(),
+        source: "window".to_string(),
+        status: AssessmentStatus::Candidate,
+        primary_text: "Example".to_string(),
+        secondary_text: "com.example.App".to_string(),
+        query_value: "100,200,800,600".to_string(),
+        coordinate_space: "global-logical".to_string(),
+        bounds: Some(AppRect {
+          x: 100,
+          y: 200,
+          width: 800,
+          height: 600,
+        }),
+        click_point: Some(AppPoint { x: 500, y: 500 }),
+        confidence: None,
+        evidence_step_id: "list-windows".to_string(),
+        candidate_query: None,
+        evidence_refs: vec![ArtifactRef {
+          run_id: crate::trace::RunId::new("run_probe"),
+          span_id: crate::trace::SpanId::new("span_probe"),
+          artifact_id: crate::trace::ArtifactId::new("artifact_0002"),
+          captured_event_id: Some(crate::trace::EventId::new("event_probe")),
+        }],
+        promotion_gate: Some(AppCandidatePromotionGate {
+          status: AppCandidatePromotionStatus::DistillStrategyOnly,
+          missing_gates: Vec::new(),
+          notes: vec!["Window region can seed a known distillation strategy.".to_string()],
+        }),
+        input_bindings: BTreeMap::from([
+          ("window_bounds".to_string(), "100,200,800,600".to_string()),
+          ("relative_x".to_string(), "0.500000".to_string()),
+          ("relative_y".to_string(), "0.500000".to_string()),
+        ]),
+        compatibility: candidate_compatibility(
+          &["window-action.window-point.pointer-click.capture-evidence"],
+          &[],
+        ),
+        notes: vec!["sample window region".to_string()],
+      }],
+      known_boundaries: vec![],
+      recommended_strategies: vec![AppRecommendedStrategy {
+        taxonomy_id: "window-action.window-point.pointer-click.capture-evidence".to_string(),
+        status: AssessmentStatus::Candidate,
+        rationale: "test".to_string(),
+      }],
+    };
+
+    let candidate_shape = build_distilled_candidate_shape(
+      &analysis,
+      "window-action.window-point.pointer-click.capture-evidence",
+    );
+
+    assert_eq!(
+      candidate_shape.direct_candidate_ids,
+      vec!["window-primary-region".to_string()]
+    );
+    assert!(candidate_shape.context_candidate_ids.is_empty());
+    assert!(candidate_shape.notes.is_empty());
+  }
+
+  #[test]
   fn build_distilled_candidate_shape_projects_direct_inputs() {
     let mut analysis =
       sample_analysis_with_strategy("window-action.window-point.pointer-click.capture-evidence");

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -377,12 +377,41 @@ pub struct AppSurfaceCandidate {
   pub candidate_query: Option<crate::contract::CandidateQuery>,
   #[serde(default, skip_serializing_if = "Vec::is_empty")]
   pub evidence_refs: Vec<crate::contract::ArtifactRef>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub promotion_gate: Option<AppCandidatePromotionGate>,
   #[serde(default)]
   pub input_bindings: BTreeMap<String, String>,
   #[serde(default)]
   pub compatibility: AppCandidateCompatibility,
   #[serde(default)]
   pub notes: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AppCandidatePromotionGate {
+  pub status: AppCandidatePromotionStatus,
+  #[serde(default)]
+  pub missing_gates: Vec<String>,
+  #[serde(default)]
+  pub notes: Vec<String>,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AppCandidatePromotionStatus {
+  Blocked,
+  DistillStrategyOnly,
+  ActionGradeCandidate,
+}
+
+impl AppCandidatePromotionStatus {
+  pub(crate) fn as_str(&self) -> &'static str {
+    match self {
+      Self::Blocked => "blocked",
+      Self::DistillStrategyOnly => "distill_strategy_only",
+      Self::ActionGradeCandidate => "action_grade_candidate",
+    }
+  }
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -1458,6 +1487,11 @@ mod tests {
           artifact_id: crate::trace::ArtifactId::new("artifact_0001"),
           captured_event_id: Some(crate::trace::EventId::new("event_probe")),
         }],
+        promotion_gate: Some(AppCandidatePromotionGate {
+          status: AppCandidatePromotionStatus::DistillStrategyOnly,
+          missing_gates: Vec::new(),
+          notes: vec!["Sample candidate can seed a known distillation strategy.".to_string()],
+        }),
         input_bindings: BTreeMap::from([("focus_query".to_string(), "Search".to_string())]),
         compatibility: candidate_compatibility(
           &["search-entry.ax-text-input.clipboard-submit.capture-evidence"],
@@ -1488,6 +1522,7 @@ mod tests {
     assert!(report.contains("candidateQuery"));
     assert!(report.contains("sources=`ax`"));
     assert!(report.contains("evidenceRefs"));
+    assert!(report.contains("promotionGate: `distill_strategy_only`"));
     assert!(report.contains("inputBindings"));
     assert!(report.contains("## 5. Control Strategy"));
     assert!(report.contains("## 6. Verification Assessment"));
@@ -1581,6 +1616,7 @@ mod tests {
       evidence_step_id: "observe-window-tree".to_string(),
       candidate_query: None,
       evidence_refs: Vec::new(),
+      promotion_gate: None,
       input_bindings: BTreeMap::from([
         ("window_bounds".to_string(), "100,200,800,600".to_string()),
         ("relative_x".to_string(), "0.500000".to_string()),
@@ -1660,6 +1696,7 @@ mod tests {
       evidence_step_id: "capture-ax-tree".to_string(),
       candidate_query: None,
       evidence_refs: Vec::new(),
+      promotion_gate: None,
       input_bindings: BTreeMap::from([
         ("window_bounds".to_string(), "100,200,800,600".to_string()),
         ("relative_x".to_string(), "0.500000".to_string()),
@@ -1906,6 +1943,7 @@ mod tests {
       evidence_step_id: "capture-ax-tree".to_string(),
       candidate_query: None,
       evidence_refs: Vec::new(),
+      promotion_gate: None,
       input_bindings: BTreeMap::from([
         ("window_bounds".to_string(), "100,200,800,600".to_string()),
         ("relative_x".to_string(), "0.500000".to_string()),
@@ -2279,6 +2317,23 @@ mod tests {
       assert_eq!(candidate.area, "ocr-visible-text");
       assert!(candidate.compatibility.direct_taxonomy_ids.is_empty());
       assert_eq!(candidate.evidence_refs, evidence_refs["ocr-sample"]);
+      let gate = candidate
+        .promotion_gate
+        .as_ref()
+        .expect("OCR candidate should expose promotion gate");
+      assert_eq!(gate.status, AppCandidatePromotionStatus::Blocked);
+      assert!(
+        gate
+          .missing_gates
+          .iter()
+          .any(|item| item == "action_contract")
+      );
+      assert!(
+        gate
+          .missing_gates
+          .iter()
+          .any(|item| item == "semantic_verification_contract")
+      );
       assert!(
         candidate
           .notes
@@ -2306,6 +2361,17 @@ mod tests {
       .as_ref()
       .expect("row candidate should expose selector query");
     assert_eq!(row_candidates[0].evidence_refs, evidence_refs["ocr-sample"]);
+    let row_gate = row_candidates[0]
+      .promotion_gate
+      .as_ref()
+      .expect("row candidate should expose promotion gate");
+    assert_eq!(row_gate.status, AppCandidatePromotionStatus::Blocked);
+    assert!(
+      row_gate
+        .missing_gates
+        .iter()
+        .any(|item| item == "row_action_contract")
+    );
     assert!(matches!(
       row_query.selector.any_of.as_slice(),
       [SurfaceSelectorClause::Row {
@@ -2594,6 +2660,20 @@ mod tests {
     assert_eq!(
       window_candidate.input_bindings.get("relative_y"),
       Some(&"0.500000".to_string())
+    );
+    let promotion_gate = window_candidate
+      .promotion_gate
+      .as_ref()
+      .expect("window candidate should expose promotion gate");
+    assert_eq!(
+      promotion_gate.status,
+      AppCandidatePromotionStatus::DistillStrategyOnly
+    );
+    assert!(
+      promotion_gate
+        .missing_gates
+        .iter()
+        .any(|item| item == "artifact_ref")
     );
     assert!(analysis.recommended_strategies.iter().any(|strategy| {
       strategy.taxonomy_id == "window-action.window-point.pointer-click.capture-evidence"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3193,6 +3193,61 @@ mod tests {
   }
 
   #[test]
+  fn validation_report_keeps_row_context_failures_review_only() {
+    let validation = AppValidation {
+      validate_version: APP_VALIDATE_VERSION.to_string(),
+      created_at_millis: 0,
+      source_distillation_path: PathBuf::from("/tmp/distillation.json"),
+      source_analysis_path: PathBuf::from("/tmp/analysis.json"),
+      app_identity: AppIdentity {
+        bundle_id: "com.example.App".to_string(),
+        app_name: "Example".to_string(),
+        app_path: Some(PathBuf::from("/Applications/Example.app")),
+        main_executable_path: None,
+        version: "1.0".to_string(),
+        build_version: "100".to_string(),
+        url_schemes: vec![],
+        apple_script_addressable: false,
+        launch_services_resolved: true,
+        resolution_notes: vec![],
+      },
+      candidates: vec![AppValidatedCandidate {
+        recipe_id: "test.recorded.skill".to_string(),
+        taxonomy_id: "native-text.ax-text.pointer-focus-clipboard-paste.verify-ax-text"
+          .to_string(),
+        status: AppValidationStatus::Rejected,
+        verification_mode: AppVerificationMode::MachineAsserted,
+        rationale: "row context-only suggestions must not become executable".to_string(),
+        selected_case_count: 1,
+        recipe_path: PathBuf::from("/tmp/native-text.recipe.json"),
+        case_matrix_path: PathBuf::from("/tmp/native-text.cases.json"),
+        used_annotation_ids: Vec::new(),
+        resolved_inputs: BTreeMap::new(),
+        unresolved_inputs: vec!["focus_query".to_string()],
+        failure_message: Some(
+          "Validation could not execute test.recorded.skill because grounding left unresolved inputs: focus_query."
+            .to_string(),
+        ),
+      }],
+      known_boundaries: vec![
+        "Grouped visible rows remain surface candidates until a row action exists."
+          .to_string(),
+      ],
+    };
+
+    let report = render_app_validation_report(&validation);
+
+    assert!(report.contains("manual review required: `no`"));
+    assert!(report.contains("- unresolved inputs:"));
+    assert!(report.contains("`focus_query`"));
+    assert!(report.contains("- failure:"));
+    assert!(report.contains("grounding left unresolved inputs"));
+    assert!(report.contains("Grouped visible rows remain surface candidates"));
+    assert!(!report.contains("- used annotations:"));
+    assert!(!report.contains("`visible-row-1`"));
+  }
+
+  #[test]
   fn build_annotation_candidates_keeps_raw_ocr_as_visible_text_and_adds_selectors() {
     let app = AppIdentity {
       bundle_id: "com.example.music".to_string(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1927,6 +1927,153 @@ mod tests {
   }
 
   #[test]
+  fn analysis_report_surfaces_row_context_and_blocked_promotion() {
+    let analysis = AppAnalysis {
+      analysis_version: APP_ANALYSIS_VERSION.to_string(),
+      created_at_millis: 0,
+      probe_path: PathBuf::from("/tmp/probe.json"),
+      app_identity: AppIdentity {
+        bundle_id: "com.example.App".to_string(),
+        app_name: "Example".to_string(),
+        app_path: Some(PathBuf::from("/Applications/Example.app")),
+        main_executable_path: None,
+        version: "1.0".to_string(),
+        build_version: "100".to_string(),
+        url_schemes: vec![],
+        apple_script_addressable: false,
+        launch_services_resolved: true,
+        resolution_notes: vec![],
+      },
+      window_context: AppWindowContext {
+        observed_window_count: 1,
+        observed_at: "2026-05-18T00:00:00Z".to_string(),
+        frontmost_app_name: "Example".to_string(),
+        frontmost_window_title: "Example".to_string(),
+        primary_window_title: "Example".to_string(),
+        primary_window_bounds: Some(AppRect {
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 100,
+        }),
+        primary_window_display_scale: Some(2.0),
+      },
+      permissions: AppPermissionState {
+        screen_recording: "granted".to_string(),
+        accessibility: "granted".to_string(),
+        automation_to_system_events: "granted".to_string(),
+        launch_host_process: "Atlas".to_string(),
+      },
+      available_surfaces: AppAvailableSurfaces {
+        accessibility_tree: AssessmentStatus::Candidate,
+        menu_surface: AssessmentStatus::Unknown,
+        shortcut_surface: AssessmentStatus::Candidate,
+        apple_script_surface: AssessmentStatus::Unavailable,
+        url_scheme_surface: AssessmentStatus::Unavailable,
+        keyboard_first_surface: AssessmentStatus::Candidate,
+        pointer_fallback_surface: AssessmentStatus::Likely,
+      },
+      grounding_assessment: AppGroundingAssessment {
+        ocr_sample_query: "Example".to_string(),
+        ocr_sample_status: AssessmentStatus::Candidate,
+        ocr_sample_match_count: 1,
+        stable_anchor_candidates: vec![],
+        stable_region_candidates: vec![],
+        overlay_debug_artifacts_recommended: false,
+      },
+      control_assessment: AppControlAssessment {
+        preferred_path: "non-pointer first".to_string(),
+        non_pointer_path: AssessmentStatus::Candidate,
+        keyboard_path: AssessmentStatus::Candidate,
+        pointer_fallback: AssessmentStatus::Likely,
+        notes: vec![],
+      },
+      verification_assessment: AppVerificationAssessment {
+        ax_verify: AssessmentStatus::Candidate,
+        image_verify: AssessmentStatus::Candidate,
+        ui_state_verify: AssessmentStatus::Candidate,
+        semantic_success: AssessmentStatus::Unknown,
+        notes: vec![],
+      },
+      disturbance_profile: AppDisturbanceProfile {
+        observation: vec!["none".to_string()],
+        non_pointer_control: vec!["keyboard".to_string()],
+        pointer_fallback: vec!["pointer".to_string()],
+      },
+      annotation_candidates: vec![AppSurfaceCandidate {
+        candidate_id: "visible-row-1".to_string(),
+        area: "result-selection".to_string(),
+        kind: "row".to_string(),
+        source: "ocr-text".to_string(),
+        status: AssessmentStatus::Candidate,
+        primary_text: "AURORA | Playlist".to_string(),
+        secondary_text: "rowIndex=1".to_string(),
+        query_value: "1".to_string(),
+        coordinate_space: "global-logical".to_string(),
+        bounds: Some(AppRect {
+          x: 10,
+          y: 20,
+          width: 120,
+          height: 24,
+        }),
+        click_point: Some(AppPoint { x: 70, y: 32 }),
+        confidence: None,
+        evidence_step_id: "ocr-sample".to_string(),
+        candidate_query: Some(CandidateQuery {
+          query_id: "visible-row-1".to_string(),
+          selector: SurfaceSelector {
+            any_of: vec![SurfaceSelectorClause::Row {
+              row_index: Some(1),
+              contains_text: Some("AURORA".to_string()),
+              region_hint: None,
+            }],
+            within: SelectorScope::TargetWindow,
+            require_visible: true,
+          },
+          output_kind: Some("row".to_string()),
+          known_limits: vec!["row only".to_string()],
+        }),
+        evidence_refs: vec![ArtifactRef {
+          run_id: crate::trace::RunId::new("run_probe"),
+          span_id: crate::trace::SpanId::new("span_probe"),
+          artifact_id: crate::trace::ArtifactId::new("artifact_0001"),
+          captured_event_id: Some(crate::trace::EventId::new("event_probe")),
+        }],
+        promotion_gate: Some(AppCandidatePromotionGate {
+          status: AppCandidatePromotionStatus::Blocked,
+          missing_gates: vec![
+            "row_action_contract".to_string(),
+            "semantic_verification_contract".to_string(),
+          ],
+          notes: vec!["row candidate stays structural".to_string()],
+        }),
+        input_bindings: BTreeMap::from([("row_index".to_string(), "1".to_string())]),
+        compatibility: candidate_compatibility(
+          &[],
+          &["result-selection.ocr-anchor.pointer-click.capture-evidence"],
+        ),
+        notes: vec!["sample row candidate".to_string()],
+      }],
+      known_boundaries: vec![
+        "Grouped visible rows remain surface candidates until a row action exists.".to_string(),
+      ],
+      recommended_strategies: vec![],
+    };
+
+    let report = render_app_analysis_report(&analysis);
+
+    assert!(report.contains("`visible-row-1`: area=`result-selection`, kind=`row`"));
+    assert!(report.contains("candidateQuery: `visible-row-1` sources=`row`"));
+    assert!(report.contains("evidenceRefs:"));
+    assert!(report.contains("promotionGate: `blocked`"));
+    assert!(report.contains("`row_action_contract`"));
+    assert!(report.contains("`semantic_verification_contract`"));
+    assert!(report.contains("contextTaxonomyIds:"));
+    assert!(report.contains("`result-selection.ocr-anchor.pointer-click.capture-evidence`"));
+    assert!(report.contains("Grouped visible rows remain surface candidates"));
+  }
+
+  #[test]
   fn result_selection_grounding_ignores_row_only_candidates() {
     let analysis = AppAnalysis {
       analysis_version: APP_ANALYSIS_VERSION.to_string(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3606,6 +3606,90 @@ mod tests {
   }
 
   #[test]
+  fn app_distillation_json_round_trip_preserves_row_review_only_fields() {
+    let root = temp_dir("app-distillation-round-trip");
+    let distillation_path = root.join("distillation.json");
+    let distillation = AppDistillation {
+      distill_version: APP_DISTILL_VERSION.to_string(),
+      created_at_millis: 0,
+      source_analysis_path: PathBuf::from("/tmp/analysis.json"),
+      app_identity: AppIdentity {
+        bundle_id: "com.example.App".to_string(),
+        app_name: "Example".to_string(),
+        app_path: Some(PathBuf::from("/Applications/Example.app")),
+        main_executable_path: None,
+        version: "1.0".to_string(),
+        build_version: "100".to_string(),
+        url_schemes: vec![],
+        apple_script_addressable: false,
+        launch_services_resolved: true,
+        resolution_notes: vec![],
+      },
+      candidates: vec![AppDistilledCandidate {
+        recipe_id: "test.result.selection".to_string(),
+        taxonomy_id: "result-selection.ocr-anchor.pointer-click.capture-evidence".to_string(),
+        status: AssessmentStatus::Candidate,
+        rationale: "row suggestions stay review-only".to_string(),
+        suggested_annotation_ids: vec!["visible-row-1".to_string()],
+        candidate_shape: AppDistilledCandidateShape {
+          direct_candidate_ids: Vec::new(),
+          context_candidate_ids: vec!["visible-row-1".to_string()],
+          provided_inputs: BTreeMap::new(),
+          notes: vec![
+            "No direct candidate shape was available for taxonomy result-selection.ocr-anchor.pointer-click.capture-evidence during distill.".to_string(),
+            "Context-only candidates were recorded for later review, but they did not project directly into recipe inputs.".to_string(),
+          ],
+        },
+        recipe_path: PathBuf::from("/tmp/result-selection.recipe.json"),
+        case_matrix_path: PathBuf::from("/tmp/result-selection.cases.json"),
+      }],
+      known_boundaries: vec![
+        "Grouped visible rows remain surface candidates until a row action exists."
+          .to_string(),
+      ],
+    };
+
+    write_pretty_json(&distillation_path, &distillation).expect("distillation should write");
+
+    let reloaded: AppDistillation =
+      read_json(&distillation_path).expect("distillation should read");
+    let candidate = &reloaded.candidates[0];
+
+    assert_eq!(
+      candidate.suggested_annotation_ids,
+      vec!["visible-row-1".to_string()]
+    );
+    assert!(candidate.candidate_shape.direct_candidate_ids.is_empty());
+    assert_eq!(
+      candidate.candidate_shape.context_candidate_ids,
+      vec!["visible-row-1".to_string()]
+    );
+    assert!(candidate.candidate_shape.provided_inputs.is_empty());
+    assert!(
+      candidate
+        .candidate_shape
+        .notes
+        .iter()
+        .any(|note| note.contains("No direct candidate shape was available"))
+    );
+    assert!(
+      candidate
+        .candidate_shape
+        .notes
+        .iter()
+        .any(|note| note.contains("Context-only candidates were recorded"))
+    );
+    assert!(
+      reloaded
+        .known_boundaries
+        .iter()
+        .any(|note| note.contains("Grouped visible rows remain surface candidates"))
+    );
+
+    let _ = fs::remove_dir_all(root);
+  }
+
+  #[test]
   fn build_probe_evidence_refs_resolves_artifact_records_from_probe_steps() {
     let root = temp_dir("probe-evidence-refs");
     let run_dir = root.join(".auv").join("runs").join("run_fixture");

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -375,6 +375,8 @@ pub struct AppSurfaceCandidate {
   pub evidence_step_id: String,
   #[serde(default, skip_serializing_if = "Option::is_none")]
   pub candidate_query: Option<crate::contract::CandidateQuery>,
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  pub evidence_refs: Vec<crate::contract::ArtifactRef>,
   #[serde(default)]
   pub input_bindings: BTreeMap<String, String>,
   #[serde(default)]
@@ -1120,7 +1122,8 @@ fn default_distill_output_dir(analysis_path: &Path, analysis: &AppAnalysis) -> P
 mod tests {
   use super::analysis::{
     apply_candidate_grounding, build_annotation_candidates, build_app_analysis,
-    build_distilled_candidate_shape, candidate_compatibility, recommended_strategy,
+    build_distilled_candidate_shape, build_probe_evidence_refs, candidate_compatibility,
+    recommended_strategy,
   };
   use super::infra::{
     invoke_probe_step, read_json, resolve_distillation_path, resolve_probe_path, write_pretty_json,
@@ -1132,7 +1135,9 @@ mod tests {
   };
   use super::*;
   use crate::catalog::CommandCatalog;
-  use crate::contract::{CandidateQuery, SelectorScope, SurfaceSelector, SurfaceSelectorClause};
+  use crate::contract::{
+    ArtifactRef, CandidateQuery, SelectorScope, SurfaceSelector, SurfaceSelectorClause,
+  };
   use crate::driver::{Driver, DriverRegistry};
   use crate::driver::{ObservedAxNode, ObservedAxTreeSnapshot, ObservedRect, OcrTextSnapshot};
   use crate::model::RunStatus;
@@ -1447,6 +1452,12 @@ mod tests {
           output_kind: Some("focus-query".to_string()),
           known_limits: vec!["test query".to_string()],
         }),
+        evidence_refs: vec![ArtifactRef {
+          run_id: crate::trace::RunId::new("run_probe"),
+          span_id: crate::trace::SpanId::new("span_probe"),
+          artifact_id: crate::trace::ArtifactId::new("artifact_0001"),
+          captured_event_id: Some(crate::trace::EventId::new("event_probe")),
+        }],
         input_bindings: BTreeMap::from([("focus_query".to_string(), "Search".to_string())]),
         compatibility: candidate_compatibility(
           &["search-entry.ax-text-input.clipboard-submit.capture-evidence"],
@@ -1476,6 +1487,7 @@ mod tests {
     assert!(report.contains("coordinateSpace"));
     assert!(report.contains("candidateQuery"));
     assert!(report.contains("sources=`ax`"));
+    assert!(report.contains("evidenceRefs"));
     assert!(report.contains("inputBindings"));
     assert!(report.contains("## 5. Control Strategy"));
     assert!(report.contains("## 6. Verification Assessment"));
@@ -1568,6 +1580,7 @@ mod tests {
       confidence: None,
       evidence_step_id: "observe-window-tree".to_string(),
       candidate_query: None,
+      evidence_refs: Vec::new(),
       input_bindings: BTreeMap::from([
         ("window_bounds".to_string(), "100,200,800,600".to_string()),
         ("relative_x".to_string(), "0.500000".to_string()),
@@ -1646,6 +1659,7 @@ mod tests {
       confidence: None,
       evidence_step_id: "capture-ax-tree".to_string(),
       candidate_query: None,
+      evidence_refs: Vec::new(),
       input_bindings: BTreeMap::from([
         ("window_bounds".to_string(), "100,200,800,600".to_string()),
         ("relative_x".to_string(), "0.500000".to_string()),
@@ -1891,6 +1905,7 @@ mod tests {
       confidence: None,
       evidence_step_id: "capture-ax-tree".to_string(),
       candidate_query: None,
+      evidence_refs: Vec::new(),
       input_bindings: BTreeMap::from([
         ("window_bounds".to_string(), "100,200,800,600".to_string()),
         ("relative_x".to_string(), "0.500000".to_string()),
@@ -2237,8 +2252,24 @@ mod tests {
       ],
     };
 
-    let candidates =
-      build_annotation_candidates(&app, None, None, &ax_snapshot, &ocr_snapshot, true);
+    let evidence_refs = BTreeMap::from([(
+      "ocr-sample".to_string(),
+      vec![ArtifactRef {
+        run_id: crate::trace::RunId::new("run_probe"),
+        span_id: crate::trace::SpanId::new("span_probe"),
+        artifact_id: crate::trace::ArtifactId::new("artifact_0001"),
+        captured_event_id: Some(crate::trace::EventId::new("event_probe")),
+      }],
+    )]);
+    let candidates = build_annotation_candidates(
+      &app,
+      None,
+      None,
+      &ax_snapshot,
+      &ocr_snapshot,
+      true,
+      &evidence_refs,
+    );
     let ocr_candidates = candidates
       .iter()
       .filter(|candidate| candidate.source == "ocr" && candidate.kind == "anchor-text")
@@ -2247,6 +2278,7 @@ mod tests {
     for candidate in ocr_candidates {
       assert_eq!(candidate.area, "ocr-visible-text");
       assert!(candidate.compatibility.direct_taxonomy_ids.is_empty());
+      assert_eq!(candidate.evidence_refs, evidence_refs["ocr-sample"]);
       assert!(
         candidate
           .notes
@@ -2273,6 +2305,7 @@ mod tests {
       .candidate_query
       .as_ref()
       .expect("row candidate should expose selector query");
+    assert_eq!(row_candidates[0].evidence_refs, evidence_refs["ocr-sample"]);
     assert!(matches!(
       row_query.selector.any_of.as_slice(),
       [SurfaceSelectorClause::Row {
@@ -2280,6 +2313,76 @@ mod tests {
         ..
       }]
     ));
+  }
+
+  #[test]
+  fn build_probe_evidence_refs_resolves_artifact_records_from_probe_steps() {
+    let root = temp_dir("probe-evidence-refs");
+    let run_dir = root.join(".auv").join("runs").join("run_fixture");
+    let artifact_dir = run_dir.join("artifacts");
+    fs::create_dir_all(&artifact_dir).expect("artifact dir should be creatable");
+    let artifact_path = artifact_dir.join("artifact_0001_ocr-sample.txt");
+    fs::write(&artifact_path, "query=Cure For Me\nmatchCount=0\n").expect("artifact should write");
+    let artifact_record = crate::trace::ArtifactRecordV1Alpha1 {
+      api_version: crate::trace::ARTIFACT_API_VERSION.to_string(),
+      artifact_id: crate::trace::ArtifactId::new("artifact_0001"),
+      span_id: crate::trace::SpanId::new("span_probe"),
+      event_id: Some(crate::trace::EventId::new("event_probe")),
+      role: "text".to_string(),
+      mime_type: "text/plain".to_string(),
+      path: "artifacts/artifact_0001_ocr-sample.txt".to_string(),
+      sha256: None,
+      attributes: BTreeMap::new(),
+      summary: Some("OCR sample".to_string()),
+    };
+    fs::write(
+      run_dir.join("artifacts.jsonl"),
+      format!(
+        "{}\n",
+        serde_json::to_string(&artifact_record).expect("record should serialize")
+      ),
+    )
+    .expect("artifacts jsonl should write");
+
+    let probe = AppProbe {
+      probe_version: APP_PROBE_VERSION.to_string(),
+      created_at_millis: 0,
+      project_root: root.clone(),
+      output_dir: root.clone(),
+      app: AppIdentity {
+        bundle_id: "com.example.music".to_string(),
+        app_name: "ExampleMusic".to_string(),
+        app_path: None,
+        main_executable_path: None,
+        version: "1.0".to_string(),
+        build_version: "100".to_string(),
+        url_schemes: Vec::new(),
+        apple_script_addressable: false,
+        launch_services_resolved: true,
+        resolution_notes: Vec::new(),
+      },
+      steps: vec![probe_step_fixture(
+        "ocr-sample",
+        "debug.findWindowText",
+        vec![artifact_path],
+      )],
+    };
+
+    let refs = build_probe_evidence_refs(&probe);
+    assert_eq!(refs["ocr-sample"].len(), 1);
+    let reference = &refs["ocr-sample"][0];
+    assert_eq!(reference.run_id.as_str(), "run_fixture");
+    assert_eq!(reference.span_id.as_str(), "span_probe");
+    assert_eq!(reference.artifact_id.as_str(), "artifact_0001");
+    assert_eq!(
+      reference
+        .captured_event_id
+        .as_ref()
+        .map(|event| event.as_str()),
+      Some("event_probe")
+    );
+
+    let _ = fs::remove_dir_all(root);
   }
 
   #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2446,10 +2446,36 @@ mod tests {
     analysis.probe_path = root.join("missing-probe.json");
     write_pretty_json(&analysis_path, &analysis).expect("analysis should write");
 
-    write_pretty_json(&recipe_path, &test_candidate_manifest_value())
-      .expect("candidate recipe should write");
-    write_pretty_json(&case_matrix_path, &test_candidate_matrix_value())
-      .expect("candidate matrix should write");
+    let strategy = recommended_strategy(
+      "native-text",
+      "ax-text",
+      "pointer-focus-clipboard-paste",
+      "verifyAxText",
+      AssessmentStatus::Candidate,
+      "test",
+    )
+    .expect("strategy should render");
+    let candidate_shape = AppDistilledCandidateShape {
+      direct_candidate_ids: Vec::new(),
+      context_candidate_ids: vec!["visible-row-1".to_string()],
+      provided_inputs: BTreeMap::new(),
+      notes: vec![
+        "No direct candidate shape was available for taxonomy native-text.ax-text.pointer-focus-clipboard-paste.verify-ax-text during distill.".to_string(),
+        "Context-only candidates were recorded for later review, but they did not project directly into recipe inputs.".to_string(),
+      ],
+    };
+    write_pretty_json(
+      &recipe_path,
+      &render_candidate_recipe(&analysis, &strategy, &candidate_shape)
+        .expect("candidate recipe should render"),
+    )
+    .expect("candidate recipe should write");
+    write_pretty_json(
+      &case_matrix_path,
+      &render_candidate_case_matrix(&analysis, &strategy, &candidate_shape)
+        .expect("candidate matrix should render"),
+    )
+    .expect("candidate matrix should write");
     let distillation = AppDistillation {
       distill_version: APP_DISTILL_VERSION.to_string(),
       created_at_millis: 0,
@@ -2851,6 +2877,199 @@ mod tests {
         .get("relative_y"),
       Some(&"0.500000".to_string())
     );
+
+    let _ = fs::remove_dir_all(root);
+  }
+
+  #[test]
+  fn validate_app_distillation_keeps_row_context_candidates_review_only() {
+    let root = temp_dir("app-validate-row-context-only");
+    let runtime = test_runtime(root.clone());
+    let analysis_path = root.join("analysis.json");
+    let distillation_path = root.join("distillation.json");
+    let recipe_path = root.join("result-selection.recipe.json");
+    let case_matrix_path = root.join("result-selection.cases.json");
+
+    let analysis = AppAnalysis {
+      analysis_version: APP_ANALYSIS_VERSION.to_string(),
+      created_at_millis: 0,
+      probe_path: root.join("missing-probe.json"),
+      app_identity: AppIdentity {
+        bundle_id: "com.example.App".to_string(),
+        app_name: "Example".to_string(),
+        app_path: Some(PathBuf::from("/Applications/Example.app")),
+        main_executable_path: None,
+        version: "1.0".to_string(),
+        build_version: "100".to_string(),
+        url_schemes: vec![],
+        apple_script_addressable: false,
+        launch_services_resolved: true,
+        resolution_notes: vec![],
+      },
+      window_context: AppWindowContext {
+        observed_window_count: 1,
+        observed_at: "2026-05-18T00:00:00Z".to_string(),
+        frontmost_app_name: "Example".to_string(),
+        frontmost_window_title: "Example".to_string(),
+        primary_window_title: "Example".to_string(),
+        primary_window_bounds: Some(AppRect {
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 100,
+        }),
+        primary_window_display_scale: Some(2.0),
+      },
+      permissions: AppPermissionState {
+        screen_recording: "granted".to_string(),
+        accessibility: "granted".to_string(),
+        automation_to_system_events: "granted".to_string(),
+        launch_host_process: "Atlas".to_string(),
+      },
+      available_surfaces: AppAvailableSurfaces {
+        accessibility_tree: AssessmentStatus::Candidate,
+        menu_surface: AssessmentStatus::Unknown,
+        shortcut_surface: AssessmentStatus::Candidate,
+        apple_script_surface: AssessmentStatus::Unavailable,
+        url_scheme_surface: AssessmentStatus::Unavailable,
+        keyboard_first_surface: AssessmentStatus::Candidate,
+        pointer_fallback_surface: AssessmentStatus::Likely,
+      },
+      grounding_assessment: AppGroundingAssessment {
+        ocr_sample_query: "Example".to_string(),
+        ocr_sample_status: AssessmentStatus::Candidate,
+        ocr_sample_match_count: 1,
+        stable_anchor_candidates: vec![],
+        stable_region_candidates: vec![],
+        overlay_debug_artifacts_recommended: false,
+      },
+      control_assessment: AppControlAssessment {
+        preferred_path: "non-pointer first".to_string(),
+        non_pointer_path: AssessmentStatus::Candidate,
+        keyboard_path: AssessmentStatus::Candidate,
+        pointer_fallback: AssessmentStatus::Likely,
+        notes: vec![],
+      },
+      verification_assessment: AppVerificationAssessment {
+        ax_verify: AssessmentStatus::Candidate,
+        image_verify: AssessmentStatus::Candidate,
+        ui_state_verify: AssessmentStatus::Candidate,
+        semantic_success: AssessmentStatus::Unknown,
+        notes: vec![],
+      },
+      disturbance_profile: AppDisturbanceProfile {
+        observation: vec!["none".to_string()],
+        non_pointer_control: vec!["keyboard".to_string()],
+        pointer_fallback: vec!["pointer".to_string()],
+      },
+      annotation_candidates: vec![AppSurfaceCandidate {
+        candidate_id: "visible-row-1".to_string(),
+        area: "result-selection".to_string(),
+        kind: "row".to_string(),
+        source: "ocr-text".to_string(),
+        status: AssessmentStatus::Candidate,
+        primary_text: "AURORA | Playlist".to_string(),
+        secondary_text: "rowIndex=1".to_string(),
+        query_value: "1".to_string(),
+        coordinate_space: "global-logical".to_string(),
+        bounds: Some(AppRect {
+          x: 10,
+          y: 20,
+          width: 120,
+          height: 24,
+        }),
+        click_point: Some(AppPoint { x: 70, y: 32 }),
+        confidence: None,
+        evidence_step_id: "ocr-sample".to_string(),
+        candidate_query: Some(CandidateQuery {
+          query_id: "visible-row-1".to_string(),
+          selector: SurfaceSelector {
+            any_of: vec![SurfaceSelectorClause::Row {
+              row_index: Some(1),
+              contains_text: Some("AURORA".to_string()),
+              region_hint: None,
+            }],
+            within: SelectorScope::TargetWindow,
+            require_visible: true,
+          },
+          output_kind: Some("row".to_string()),
+          known_limits: vec!["row only".to_string()],
+        }),
+        evidence_refs: Vec::new(),
+        promotion_gate: Some(AppCandidatePromotionGate {
+          status: AppCandidatePromotionStatus::Blocked,
+          missing_gates: vec![
+            "row_action_contract".to_string(),
+            "semantic_verification_contract".to_string(),
+          ],
+          notes: vec!["row candidate stays structural".to_string()],
+        }),
+        input_bindings: BTreeMap::from([("row_index".to_string(), "1".to_string())]),
+        compatibility: candidate_compatibility(
+          &[],
+          &["result-selection.ocr-anchor.pointer-click.capture-evidence"],
+        ),
+        notes: vec!["sample row candidate".to_string()],
+      }],
+      known_boundaries: vec![],
+      recommended_strategies: vec![],
+    };
+    write_pretty_json(&analysis_path, &analysis).expect("analysis should write");
+
+    let strategy = recommended_strategy(
+      "native-text",
+      "ax-text",
+      "pointer-focus-clipboard-paste",
+      "verifyAxText",
+      AssessmentStatus::Candidate,
+      "test",
+    )
+    .expect("strategy should render");
+    let candidate_shape = AppDistilledCandidateShape {
+      direct_candidate_ids: Vec::new(),
+      context_candidate_ids: vec!["visible-row-1".to_string()],
+      provided_inputs: BTreeMap::new(),
+      notes: vec![
+        "No direct candidate shape was available for taxonomy native-text.ax-text.pointer-focus-clipboard-paste.verify-ax-text during distill.".to_string(),
+        "Context-only candidates were recorded for later review, but they did not project directly into recipe inputs.".to_string(),
+      ],
+    };
+    write_pretty_json(
+      &recipe_path,
+      &render_candidate_recipe(&analysis, &strategy, &candidate_shape)
+        .expect("candidate recipe should render"),
+    )
+    .expect("candidate recipe should write");
+    write_pretty_json(
+      &case_matrix_path,
+      &render_candidate_case_matrix(&analysis, &strategy, &candidate_shape)
+        .expect("candidate matrix should render"),
+    )
+    .expect("candidate matrix should write");
+    let distillation = AppDistillation {
+      distill_version: APP_DISTILL_VERSION.to_string(),
+      created_at_millis: 0,
+      source_analysis_path: analysis_path,
+      app_identity: analysis.app_identity.clone(),
+      candidates: vec![AppDistilledCandidate {
+        recipe_id: "test.recorded.skill".to_string(),
+        taxonomy_id: "native-text.ax-text.pointer-focus-clipboard-paste.verify-ax-text".to_string(),
+        status: AssessmentStatus::Candidate,
+        rationale: "test".to_string(),
+        suggested_annotation_ids: vec!["visible-row-1".to_string()],
+        candidate_shape: candidate_shape.clone(),
+        recipe_path,
+        case_matrix_path,
+      }],
+      known_boundaries: Vec::new(),
+    };
+    write_pretty_json(&distillation_path, &distillation).expect("distillation should write");
+
+    let error = validate_app_distillation(&runtime, &distillation_path)
+      .expect_err("row context-only distillation should fail validation");
+    assert!(error.contains("candidate grounding left unresolved inputs"));
+    assert!(error.contains("test.recorded.skill"));
+    assert!(error.contains("focus_query"));
 
     let _ = fs::remove_dir_all(root);
   }

--- a/src/app/report.rs
+++ b/src/app/report.rs
@@ -210,6 +210,20 @@ pub(crate) fn render_app_analysis_report(analysis: &AppAnalysis) -> String {
         "  - evidenceStep: `{}`",
         candidate.evidence_step_id
       ));
+      if !candidate.evidence_refs.is_empty() {
+        lines.push("  - evidenceRefs:".to_string());
+        for reference in &candidate.evidence_refs {
+          let event = reference
+            .captured_event_id
+            .as_ref()
+            .map(|value| value.as_str())
+            .unwrap_or("none");
+          lines.push(format!(
+            "    - run=`{}` span=`{}` artifact=`{}` event=`{}`",
+            reference.run_id, reference.span_id, reference.artifact_id, event
+          ));
+        }
+      }
       if !candidate.input_bindings.is_empty() {
         lines.push("  - inputBindings:".to_string());
         for (key, value) in &candidate.input_bindings {

--- a/src/app/report.rs
+++ b/src/app/report.rs
@@ -224,6 +224,18 @@ pub(crate) fn render_app_analysis_report(analysis: &AppAnalysis) -> String {
           ));
         }
       }
+      if let Some(gate) = &candidate.promotion_gate {
+        lines.push(format!("  - promotionGate: `{}`", gate.status.as_str()));
+        if !gate.missing_gates.is_empty() {
+          lines.push("    - missing:".to_string());
+          for item in &gate.missing_gates {
+            lines.push(format!("      - `{item}`"));
+          }
+        }
+        for note in &gate.notes {
+          lines.push(format!("    - note: {note}"));
+        }
+      }
       if !candidate.input_bindings.is_empty() {
         lines.push("  - inputBindings:".to_string());
         for (key, value) in &candidate.input_bindings {


### PR DESCRIPTION
## Summary
- attach `ArtifactRef`-backed evidence refs and selector queries to surface analyze candidates
- add machine-readable promotion gates and keep OCR/row candidates as non-promoted review-only surfaces
- lock the row/context-only boundary across analyze, distill, validate, reports, and persisted JSON
- add a closure note documenting what is actually closed versus what remains future work

## Boundary Closed In This PR
- `AppSurfaceCandidate` now carries typed evidence, selectors, compatibility metadata, and promotion blockers
- row/list grouping remains structural evidence rather than executable candidate input
- OCR visible text remains evidence-first rather than semantic result selection
- distillation/validation/report/JSON layers now preserve review-only semantics instead of implying execution safety

## Explicitly Not In This PR
- `AppSurfaceCandidate -> contract::Candidate` promotion
- row action contract or semantic row verification
- OCR-anchor semantic success contract
- `ViewObservation` / `ViewReconstruction` / `ViewProjection` work from the newer view-parser docs on `main`

## Reference Docs
- `docs/ai/references/2026-05-28-surface-analyze-v0.md`
- `docs/ai/references/2026-05-28-pr8-surface-analyze-handoff.md`
- `docs/ai/references/2026-05-28-surface-analyze-closure.md`

## Verification
- `cargo fmt --check`
- `cargo check`
- `cargo test`
- `git diff --check`
- `cargo run --quiet -- list-commands`
- `cargo run --quiet -- skill cases list`
- `cargo run --quiet -- skill bundle list`
