### PR TITLE
Route macOS scroll through typed input policy

### DIFF
--- a/crates/auv-driver-macos/src/session.rs
+++ b/crates/auv-driver-macos/src/session.rs
@@ -10,7 +10,7 @@ use auv_driver::geometry::{CoordinateSpace, Point, RatioRect, Rect, ScreenPoint,
 use auv_driver::input::{
   ActivationPolicy, Click, ClickOptions, DisturbanceLevel, InputActionResult, InputAttempt,
   InputDeliveryPath, InputPolicy, InputPreparationLease, PasteTextOptions, PrepareForInputOptions,
-  TextSubmit, TypeTextOptions, WaitOptions, WindowClickStrategy,
+  Scroll, ScrollOptions, TextSubmit, TypeTextOptions, WaitOptions, WindowClickStrategy,
 };
 use auv_driver::selector::{AppSelector, TextMatcher, WindowSelector};
 use auv_driver::vision::{RecognizedText, TextRecognition};
@@ -370,6 +370,26 @@ impl InputApi<'_> {
       Click::Double { interval } => (2, duration_millis(interval)?),
     };
     crate::native::pointer::click_point(point.x, point.y, 0, count, interval).map_err(backend)
+  }
+
+  pub fn scroll_at(
+    &self,
+    point: Point,
+    scroll: Scroll,
+    options: ScrollOptions,
+  ) -> DriverResult<InputActionResult> {
+    let _ = self.session;
+    if options.policy == InputPolicy::BackgroundOnly {
+      return Err(DriverError::unsupported("background_scroll"));
+    }
+    crate::native::pointer::scroll_point(point.x, point.y, scroll.delta_x, scroll.delta_y)
+      .map_err(backend)?;
+    if !options.settle.is_zero() {
+      thread::sleep(options.settle);
+    }
+    Ok(InputActionResult::single_success(
+      InputDeliveryPath::ForegroundSystemEvents,
+    ))
   }
 
   pub fn copy(&self) -> DriverResult<()> {

--- a/crates/auv-driver-macos/src/support/selector.rs
+++ b/crates/auv-driver-macos/src/support/selector.rs
@@ -199,6 +199,43 @@ pub fn resolve_window_candidate(
     })
 }
 
+pub fn resolve_window_candidate_for_input(
+  snapshot: &ObservedWindowSnapshot,
+  resolved_app: &ResolvedAppRef,
+  displays: &[DisplayDescriptor],
+  selection: &WindowSelection,
+) -> AuvResult<WindowCandidate> {
+  let candidates = build_window_candidates(snapshot, resolved_app, displays)?;
+  if selection.has_selector() {
+    let filtered = filter_window_candidates(&candidates, selection);
+    if filtered.len() == 1 {
+      return Ok(filtered[0].clone());
+    }
+    if filtered.len() > 1 {
+      let selector_detail = if selection.title.is_some() {
+        "title"
+      } else if selection.window_ref.is_some() {
+        "window_ref"
+      } else if selection.native_window_id.is_some() {
+        "native_window_id"
+      } else {
+        "selector"
+      };
+      return Err(format!(
+        "multiple window candidates matched {selector_detail}; inspect `debug.listWindows` and provide --window_ref or --native_window_id"
+      ));
+    }
+    return Err(
+      "no window candidate matched the explicit selector; inspect `debug.listWindows` and refresh --window_ref, --native_window_id, or --title"
+        .to_string(),
+    );
+  }
+
+  candidates.into_iter().next().ok_or_else(|| {
+    "could not resolve a visible window for input; inspect `debug.listWindows`".to_string()
+  })
+}
+
 pub fn retry_window_capture_operation<T, F>(mut operation: F) -> AuvResult<T>
 where
   F: FnMut() -> AuvResult<T>,
@@ -368,4 +405,113 @@ fn containing_display<'a>(
 
 fn render_observed_rect_compact(rect: &ObservedRect) -> String {
   format!("{},{},{},{}", rect.x, rect.y, rect.width, rect.height)
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::capture::types::{CaptureBackend, DisplayDescriptor, Rect, Scale2D, Size};
+  use crate::types::{
+    AppSelector, ObservedRect, ObservedWindow, ObservedWindowSnapshot, ResolvedAppRef,
+    WindowSelection,
+  };
+
+  use super::{resolve_window_candidate, resolve_window_candidate_for_input};
+
+  #[test]
+  fn input_window_candidate_allows_partially_visible_default_window() {
+    let displays = sample_displays();
+    let snapshot = sample_snapshot_with_partial_main_window();
+    let resolved = sample_resolved_app();
+
+    let candidate = resolve_window_candidate_for_input(
+      &snapshot,
+      &resolved,
+      &displays,
+      &WindowSelection::default(),
+    )
+    .expect("scroll/input candidate should resolve");
+
+    assert_eq!(candidate.window_ref.window_number, 42);
+    assert!(!candidate.is_fully_contained_in_display);
+    assert_eq!(candidate.selection_reason, "largest-visible-normal-window");
+  }
+
+  #[test]
+  fn capture_window_candidate_still_requires_fully_contained_default_window() {
+    let displays = sample_displays();
+    let snapshot = sample_snapshot_with_partial_main_window();
+    let resolved = sample_resolved_app();
+
+    let error =
+      resolve_window_candidate(&snapshot, &resolved, &displays, &WindowSelection::default())
+        .expect_err("capture candidate should reject partial windows");
+
+    assert!(error.contains("fully contained visible window"));
+  }
+
+  fn sample_resolved_app() -> ResolvedAppRef {
+    ResolvedAppRef {
+      selector: AppSelector {
+        raw: "com.example.music".to_string(),
+        bundle_id: Some("com.example.music".to_string()),
+        app_name_hint: None,
+      },
+      resolved_bundle_id: Some("com.example.music".to_string()),
+      resolved_app_name: "ExampleMusic".to_string(),
+      owner_pids: vec![10],
+      match_strategy: "bundle-id-exact".to_string(),
+    }
+  }
+
+  fn sample_snapshot_with_partial_main_window() -> ObservedWindowSnapshot {
+    ObservedWindowSnapshot {
+      frontmost_app_name: "ExampleMusic".to_string(),
+      frontmost_app_bundle_id: "com.example.music".to_string(),
+      frontmost_window_title: "Main".to_string(),
+      observed_at: "test".to_string(),
+      windows: vec![ObservedWindow {
+        window_number: 42,
+        app_name: "ExampleMusic".to_string(),
+        owner_pid: 10,
+        owner_bundle_id: "com.example.music".to_string(),
+        layer: 0,
+        title: "Main".to_string(),
+        bounds: ObservedRect {
+          x: 1500,
+          y: 50,
+          width: 1200,
+          height: 800,
+        },
+      }],
+    }
+  }
+
+  fn sample_displays() -> Vec<DisplayDescriptor> {
+    vec![DisplayDescriptor {
+      display_ref: "display_1".to_string(),
+      is_main: true,
+      is_builtin: true,
+      global_logical_bounds: Rect {
+        x: 0.0,
+        y: 0.0,
+        width: 1512.0,
+        height: 982.0,
+      },
+      visible_logical_bounds: Rect {
+        x: 0.0,
+        y: 0.0,
+        width: 1512.0,
+        height: 982.0,
+      },
+      physical_pixel_size: Size {
+        width: 3024.0,
+        height: 1964.0,
+      },
+      scale_factor: 2.0,
+      pixel_to_logical_scale: Scale2D { x: 0.5, y: 0.5 },
+      logical_to_pixel_scale: Scale2D { x: 2.0, y: 2.0 },
+      native_display_id: "1".to_string(),
+      capture_backend: CaptureBackend::XcapMacos,
+    }]
+  }
 }

--- a/crates/auv-driver/src/input.rs
+++ b/crates/auv-driver/src/input.rs
@@ -170,6 +170,33 @@ impl Default for TypeTextOptions {
   }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Scroll {
+  pub delta_x: f64,
+  pub delta_y: f64,
+}
+
+impl Scroll {
+  pub const fn new(delta_x: f64, delta_y: f64) -> Self {
+    Self { delta_x, delta_y }
+  }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScrollOptions {
+  pub policy: InputPolicy,
+  pub settle: Duration,
+}
+
+impl Default for ScrollOptions {
+  fn default() -> Self {
+    Self {
+      policy: InputPolicy::BackgroundPreferred,
+      settle: Duration::ZERO,
+    }
+  }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum InputDeliveryPath {
@@ -273,6 +300,24 @@ mod tests {
     let encoded = serde_json::to_string(&options).expect("serialize click options");
     let decoded: ClickOptions = serde_json::from_str(&encoded).expect("deserialize click options");
     assert_eq!(decoded, options);
+  }
+
+  #[test]
+  fn scroll_serde_roundtrip() {
+    let scroll = Scroll::new(12.5, -42.0);
+
+    let encoded = serde_json::to_string(&scroll).expect("serialize scroll");
+    let decoded: Scroll = serde_json::from_str(&encoded).expect("deserialize scroll");
+
+    assert_eq!(decoded, scroll);
+  }
+
+  #[test]
+  fn scroll_options_default_to_background_preferred() {
+    let options = ScrollOptions::default();
+
+    assert_eq!(options.policy, InputPolicy::BackgroundPreferred);
+    assert_eq!(options.settle, Duration::ZERO);
   }
 
   #[test]

--- a/crates/auv-driver/src/lib.rs
+++ b/crates/auv-driver/src/lib.rs
@@ -15,7 +15,7 @@ pub use geometry::{CoordinateSpace, Point, RatioRect, Rect, ScreenPoint, Size, W
 pub use input::{
   ActivationPolicy, Click, ClickOptions, DisturbanceLevel, InputActionResult, InputAttempt,
   InputDeliveryPath, InputPolicy, InputPreparationLease, PasteTextOptions, PrepareForInputOptions,
-  TextSubmit, TypeTextOptions, WaitOptions, WindowClickStrategy,
+  Scroll, ScrollOptions, TextSubmit, TypeTextOptions, WaitOptions, WindowClickStrategy,
 };
 pub use selector::{App, AppSelector, TextMatcher, WindowSelector};
 pub use traits::{Driver, DriverDescriptor, DriverSession, PlatformKind};
@@ -29,7 +29,7 @@ mod tests {
   use crate::{
     ActivationPolicy, Click, ClickOptions, DisturbanceLevel, InputActionResult, InputAttempt,
     InputDeliveryPath, InputPolicy, InputPreparationLease, PrepareForInputOptions, ScreenPoint,
-    TextSubmit, TypeTextOptions, WindowClickStrategy, WindowPoint,
+    Scroll, ScrollOptions, TextSubmit, TypeTextOptions, WindowClickStrategy, WindowPoint,
     capture::{Activation, Capture, CaptureOptions, ImageView},
     display::{Display, ObservedDisplays},
     error::{DriverError, DriverResult},
@@ -82,6 +82,8 @@ mod tests {
     let _lease = InputPreparationLease::noop();
     let _attempt = InputAttempt::success(InputDeliveryPath::WindowTargetedKeyboard);
     let _result = InputActionResult::single_success(InputDeliveryPath::WindowTargetedKeyboard);
+    let _scroll = Scroll::new(0.0, -120.0);
+    let _scroll_options = ScrollOptions::default();
     let _ = DisturbanceLevel::None;
     let _ = ActivationPolicy::Background;
     let _ = ActivationPolicy::FocusWithoutRaise;
@@ -103,6 +105,8 @@ mod tests {
     let _ = std::any::type_name::<Rect>();
     let _ = std::any::type_name::<Size>();
     let _ = std::any::type_name::<PasteTextOptions>();
+    let _ = std::any::type_name::<Scroll>();
+    let _ = std::any::type_name::<ScrollOptions>();
     let _ = std::any::type_name::<TextSubmit>();
     let _ = std::any::type_name::<WaitOptions>();
     let _ = std::any::type_name::<AppSelector>();

--- a/docs/ai/references/2026-05-28-view-parser-ir-netease-playlist-example-design.md
+++ b/docs/ai/references/2026-05-28-view-parser-ir-netease-playlist-example-design.md
@@ -397,6 +397,10 @@ These should be answered during implementation, not guessed in the spec:
   hybrid?
 - Which generic types should be promoted from the example after the first
   parser works?
+- 2026-05-28 implementation note: `auv-driver-macos WindowApi` did not expose
+  `a public typed region/window scroll method`. The NetEase example keeps parser
+  logic in `examples/` and records this as a framework gap instead of adding
+  NetEase-specific code to core.
 
 ## Follow-Ups
 

--- a/docs/ai/references/2026-05-28-view-parser-ir-netease-playlist-example-implementation-plan.md
+++ b/docs/ai/references/2026-05-28-view-parser-ir-netease-playlist-example-implementation-plan.md
@@ -1,0 +1,2106 @@
+# View Parser IR NetEase Playlist Example Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build an example-only `netease_playlist_ls` CLI that uses existing AUV macOS driver APIs to produce a structured NetEase playlist sidebar scan artifact.
+
+**Architecture:** Keep NetEase-specific logic in `examples/netease_playlist_ls.rs`. The example owns parser heuristics, structured artifact types, sidebar region detection, reconstruction, and human rendering. AUV framework crates remain app-agnostic; any missing driver capability discovered during implementation must be recorded as a gap instead of moving NetEase logic into core.
+
+**Tech Stack:** Rust 2024, `auv-driver`, `auv-driver-macos`, `serde`, `serde_json`, `cargo test --example`, macOS-only live execution.
+
+---
+
+## Scope And File Structure
+
+This plan intentionally touches only the NetEase playlist example and reference docs.
+
+**Create:**
+
+- `examples/netease_playlist_ls.rs`
+  - Example binary.
+  - Contains CLI parsing, example-local `View*` structs, parser, reconstruction, pure tests, live driver adapter, structured JSON output, and human rendering.
+
+**Modify:**
+
+- `docs/ai/references/2026-05-28-view-parser-ir-netease-playlist-example-design.md`
+  - Only if implementation discovers a real framework gap or adjusts terminology.
+
+**Do not modify in this plan:**
+
+- `src/catalog.rs`
+- `src/runtime.rs`
+- `src/driver/**`
+- `crates/auv-driver/**`
+- `crates/auv-driver-macos/**`
+- `src/inspect_server/**`
+
+If the example cannot be implemented with the existing typed APIs, stop and record the exact missing API. Do not add NetEase-specific framework code.
+
+## Validation Commands
+
+Run these after relevant tasks:
+
+```bash
+cargo fmt --check
+cargo test --example netease_playlist_ls
+cargo check --example netease_playlist_ls
+git diff --check
+```
+
+Live manual command, only after pure tests pass and NetEase Cloud Music is open:
+
+```bash
+cargo run --example netease_playlist_ls -- --json-out /tmp/auv-netease-playlist-ls.json
+```
+
+Expected live behavior: prints a human-readable playlist summary and writes structured JSON. If the sidebar is absent/collapsed or a modal blocks the window, it exits with a structured error message.
+
+---
+
+### Task 1: Example Skeleton And CLI Contract
+
+**Files:**
+
+- Create: `examples/netease_playlist_ls.rs`
+
+- [ ] **Step 1: Write the failing CLI parsing tests**
+
+Create `examples/netease_playlist_ls.rs` with this initial content:
+
+```rust
+use std::path::PathBuf;
+
+const DEFAULT_APP_ID: &str = "com.netease.163music";
+
+#[derive(Clone, Debug, PartialEq)]
+struct Inputs {
+  app_id: String,
+  json_out: Option<PathBuf>,
+  max_pages: usize,
+  max_scrolls: usize,
+  scroll_amount: f64,
+  sidebar_region: Option<RatioRegion>,
+  print_json: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct RatioRegion {
+  x: f64,
+  y: f64,
+  width: f64,
+  height: f64,
+}
+
+impl RatioRegion {
+  const fn new(x: f64, y: f64, width: f64, height: f64) -> Self {
+    Self {
+      x,
+      y,
+      width,
+      height,
+    }
+  }
+}
+
+fn main() {
+  if let Err(error) = run() {
+    eprintln!("{error}");
+    std::process::exit(1);
+  }
+}
+
+fn run() -> Result<(), String> {
+  let _inputs = parse_inputs(std::env::args().skip(1).collect())?;
+  Err("live implementation is added in later tasks".to_string())
+}
+
+fn parse_inputs(args: Vec<String>) -> Result<Inputs, String> {
+  let _ = args;
+  Err("parse_inputs not implemented".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn parse_inputs_uses_safe_defaults() {
+    let inputs = parse_inputs(Vec::new()).expect("defaults should parse");
+
+    assert_eq!(inputs.app_id, DEFAULT_APP_ID);
+    assert_eq!(inputs.json_out, None);
+    assert_eq!(inputs.max_pages, 24);
+    assert_eq!(inputs.max_scrolls, 48);
+    assert_eq!(inputs.scroll_amount, 6.0);
+    assert_eq!(inputs.sidebar_region, None);
+    assert!(!inputs.print_json);
+  }
+
+  #[test]
+  fn parse_inputs_accepts_json_and_scan_options() {
+    let inputs = parse_inputs(vec![
+      "--app-id".to_string(),
+      "com.example.music".to_string(),
+      "--json-out".to_string(),
+      "/tmp/scan.json".to_string(),
+      "--max-pages".to_string(),
+      "7".to_string(),
+      "--max-scrolls".to_string(),
+      "9".to_string(),
+      "--scroll-amount".to_string(),
+      "3.5".to_string(),
+      "--sidebar-region".to_string(),
+      "0.0,0.1,0.25,0.8".to_string(),
+      "--print-json".to_string(),
+    ])
+    .expect("arguments should parse");
+
+    assert_eq!(inputs.app_id, "com.example.music");
+    assert_eq!(inputs.json_out, Some(PathBuf::from("/tmp/scan.json")));
+    assert_eq!(inputs.max_pages, 7);
+    assert_eq!(inputs.max_scrolls, 9);
+    assert_eq!(inputs.scroll_amount, 3.5);
+    assert_eq!(
+      inputs.sidebar_region,
+      Some(RatioRegion::new(0.0, 0.1, 0.25, 0.8))
+    );
+    assert!(inputs.print_json);
+  }
+
+  #[test]
+  fn parse_inputs_rejects_unknown_flag() {
+    let error = parse_inputs(vec!["--bogus".to_string()])
+      .expect_err("unknown flag should fail");
+
+    assert!(error.contains("unknown argument --bogus"));
+  }
+}
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run:
+
+```bash
+cargo test --example netease_playlist_ls parse_inputs_ -- --nocapture
+```
+
+Expected: tests compile but fail because `parse_inputs` returns `parse_inputs not implemented`.
+
+- [ ] **Step 3: Implement minimal CLI parsing**
+
+Replace `parse_inputs` and add helpers below it:
+
+```rust
+fn parse_inputs(args: Vec<String>) -> Result<Inputs, String> {
+  let mut inputs = Inputs {
+    app_id: DEFAULT_APP_ID.to_string(),
+    json_out: None,
+    max_pages: 24,
+    max_scrolls: 48,
+    scroll_amount: 6.0,
+    sidebar_region: None,
+    print_json: false,
+  };
+
+  let mut index = 0;
+  while index < args.len() {
+    let flag = &args[index];
+    match flag.as_str() {
+      "--app-id" => {
+        inputs.app_id = required_value(&args, &mut index, flag)?;
+      }
+      "--json-out" => {
+        inputs.json_out = Some(PathBuf::from(required_value(&args, &mut index, flag)?));
+      }
+      "--max-pages" => {
+        inputs.max_pages = parse_usize(&required_value(&args, &mut index, flag)?, flag)?;
+      }
+      "--max-scrolls" => {
+        inputs.max_scrolls = parse_usize(&required_value(&args, &mut index, flag)?, flag)?;
+      }
+      "--scroll-amount" => {
+        inputs.scroll_amount = parse_f64(&required_value(&args, &mut index, flag)?, flag)?;
+      }
+      "--sidebar-region" => {
+        inputs.sidebar_region = Some(parse_ratio_region(&required_value(&args, &mut index, flag)?)?);
+      }
+      "--print-json" => {
+        inputs.print_json = true;
+      }
+      other => return Err(format!("unknown argument {other}")),
+    }
+    index += 1;
+  }
+
+  if inputs.max_pages == 0 {
+    return Err("--max-pages must be greater than zero".to_string());
+  }
+  if inputs.max_scrolls == 0 {
+    return Err("--max-scrolls must be greater than zero".to_string());
+  }
+  if inputs.scroll_amount <= 0.0 {
+    return Err("--scroll-amount must be greater than zero".to_string());
+  }
+
+  Ok(inputs)
+}
+
+fn required_value(args: &[String], index: &mut usize, flag: &str) -> Result<String, String> {
+  *index += 1;
+  args
+    .get(*index)
+    .cloned()
+    .ok_or_else(|| format!("{flag} requires a value"))
+}
+
+fn parse_usize(value: &str, flag: &str) -> Result<usize, String> {
+  value
+    .parse()
+    .map_err(|error| format!("invalid {flag}: {error}"))
+}
+
+fn parse_f64(value: &str, flag: &str) -> Result<f64, String> {
+  value
+    .parse()
+    .map_err(|error| format!("invalid {flag}: {error}"))
+}
+
+fn parse_ratio_region(value: &str) -> Result<RatioRegion, String> {
+  let parts = value
+    .split(',')
+    .map(str::trim)
+    .map(|part| {
+      part
+        .parse::<f64>()
+        .map_err(|error| format!("invalid --sidebar-region component {part:?}: {error}"))
+    })
+    .collect::<Result<Vec<_>, _>>()?;
+  let [x, y, width, height] = parts.as_slice() else {
+    return Err("--sidebar-region must use x,y,width,height".to_string());
+  };
+  if *width <= 0.0 || *height <= 0.0 {
+    return Err("--sidebar-region width and height must be positive".to_string());
+  }
+  Ok(RatioRegion::new(*x, *y, *width, *height))
+}
+```
+
+- [ ] **Step 4: Run the tests and verify they pass**
+
+Run:
+
+```bash
+cargo test --example netease_playlist_ls parse_inputs_ -- --nocapture
+```
+
+Expected: all `parse_inputs_` tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add examples/netease_playlist_ls.rs
+git commit -m "feat(examples): add netease playlist ls skeleton"
+```
+
+---
+
+### Task 2: Example-Local View IR And Structured Artifact Types
+
+**Files:**
+
+- Modify: `examples/netease_playlist_ls.rs`
+
+- [ ] **Step 1: Write failing serialization and tree tests**
+
+Add these imports at the top:
+
+```rust
+use serde::{Deserialize, Serialize};
+```
+
+Add this test module content below existing tests:
+
+```rust
+  #[test]
+  fn view_reconstruction_serializes_tree_with_scrollable_collection() {
+    let reconstruction = sample_reconstruction();
+    let rendered = serde_json::to_value(&reconstruction).expect("reconstruction serializes");
+
+    assert_eq!(rendered["root"]["kind"], "collection");
+    assert_eq!(rendered["root"]["layout"], "v_stack");
+    assert_eq!(rendered["root"]["scrollable"]["axis"], "vertical");
+    assert_eq!(rendered["root"]["children"][0]["kind"], "section");
+    assert_eq!(rendered["root"]["children"][0]["children"][0]["kind"], "item");
+    assert_eq!(rendered["root"]["children"][0]["children"][0]["children"][0]["kind"], "text");
+    assert_eq!(
+      rendered["root"]["children"][0]["children"][0]["anchors"][0]["label"],
+      "Coding BGM"
+    );
+  }
+
+  #[test]
+  fn playlist_sidebar_scan_uses_reconstruction_plus_projection() {
+    let scan = PlaylistSidebarScan {
+      app: ScanAppContext {
+        bundle_id: DEFAULT_APP_ID.to_string(),
+      },
+      window: ScanWindowContext {
+        title: Some("NetEase".to_string()),
+        window_id: "42".to_string(),
+      },
+      sidebar_region: Some(ViewRegionRecord {
+        name: "playlist_sidebar".to_string(),
+        bounds: ViewBounds::new(0.0, 0.1, 0.25, 0.8),
+        coordinate_space: "window_ratio".to_string(),
+      }),
+      observations: Vec::new(),
+      reconstruction: sample_reconstruction(),
+      projection: PlaylistSidebarProjection {
+        sections: vec![SidebarSection {
+          node_id: "section.my".to_string(),
+          label: "创建的歌单".to_string(),
+          kind: SidebarSectionKind::MyPlaylists,
+          confidence: Confidence::High,
+        }],
+        items: vec![PlaylistSidebarItem {
+          node_id: "item.coding".to_string(),
+          item_id: "playlist.coding".to_string(),
+          label: "Coding BGM".to_string(),
+          section_hint: Some(SidebarSectionKind::MyPlaylists),
+          bounds: ViewBounds::new(12.0, 50.0, 150.0, 28.0),
+          source_text: "Coding BGM".to_string(),
+          observation_index: 0,
+          confidence: Confidence::High,
+          diagnostics: Vec::new(),
+        }],
+      },
+      boundary: ScrollBoundarySummary::default(),
+      diagnostics: Vec::new(),
+      known_limits: Vec::new(),
+    };
+
+    let rendered = serde_json::to_string_pretty(&scan).expect("scan serializes");
+
+    assert!(rendered.contains("\"reconstruction\""));
+    assert!(rendered.contains("\"projection\""));
+    assert!(rendered.contains("\"Coding BGM\""));
+  }
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run:
+
+```bash
+cargo test --example netease_playlist_ls view_reconstruction_serializes_tree_with_scrollable_collection playlist_sidebar_scan_uses_reconstruction_plus_projection -- --nocapture
+```
+
+Expected: compile fails because the `View*`, scan, and helper types are not defined.
+
+- [ ] **Step 3: Add the example-local structured types**
+
+Add these types above `fn main()`:
+
+```rust
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+struct PlaylistSidebarScan {
+  app: ScanAppContext,
+  window: ScanWindowContext,
+  sidebar_region: Option<ViewRegionRecord>,
+  observations: Vec<SidebarViewportObservation>,
+  reconstruction: ViewReconstructionRecord,
+  projection: PlaylistSidebarProjection,
+  boundary: ScrollBoundarySummary,
+  diagnostics: Vec<ParserDiagnostic>,
+  known_limits: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct ScanAppContext {
+  bundle_id: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct ScanWindowContext {
+  title: Option<String>,
+  window_id: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+struct ViewRegionRecord {
+  name: String,
+  bounds: ViewBounds,
+  coordinate_space: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+struct SidebarViewportObservation {
+  observation_index: usize,
+  viewport: ViewViewportRecord,
+  source_artifacts: Vec<String>,
+  evidence_nodes: Vec<ViewEvidenceNode>,
+  candidates: Vec<SidebarViewportCandidate>,
+  viewport_fingerprint: String,
+  parser_notes: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+struct ViewViewportRecord {
+  bounds: ViewBounds,
+  axis: ViewAxis,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+struct ViewEvidenceNode {
+  evidence_id: String,
+  source: ViewEvidenceSource,
+  label: Option<String>,
+  bounds: ViewBounds,
+  confidence: Confidence,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ViewEvidenceSource {
+  OcrText,
+  AxNode,
+  IconMatch,
+  Visual,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+struct SidebarViewportCandidate {
+  candidate_id: String,
+  kind: SidebarCandidateKind,
+  label: String,
+  bounds: ViewBounds,
+  confidence: Confidence,
+  evidence_ids: Vec<String>,
+  diagnostics: Vec<ParserDiagnostic>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum SidebarCandidateKind {
+  SectionHeader,
+  PlaylistItem,
+  NavigationItem,
+  Unknown,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+struct ViewReconstructionRecord {
+  root: ViewNodeRecord,
+  anchor_index: Vec<ViewAnchor>,
+  landmark_index: Vec<ViewLandmark>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+struct ViewNodeRecord {
+  node_id: String,
+  kind: ViewNodeKind,
+  domain_kind: Option<String>,
+  layout: Option<ViewLayout>,
+  label: Option<String>,
+  bounds: Option<ViewBounds>,
+  scrollable: Option<ViewScrollable>,
+  children: Vec<ViewNodeRecord>,
+  anchors: Vec<ViewAnchor>,
+  landmarks: Vec<ViewLandmark>,
+  actions: Vec<ViewAction>,
+  source_evidence_ids: Vec<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ViewNodeKind {
+  Container,
+  Collection,
+  Section,
+  Item,
+  Text,
+  Icon,
+  Unknown,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ViewLayout {
+  VStack,
+  HStack,
+  Group,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ViewAxis {
+  Vertical,
+  Horizontal,
+  Both,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+struct ViewScrollable {
+  axis: ViewAxis,
+  boundary: ScrollBoundarySummary,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct ViewAnchor {
+  anchor_id: String,
+  label: String,
+  strength: AnchorStrength,
+  evidence_ids: Vec<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum AnchorStrength {
+  Strong,
+  Medium,
+  Weak,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct ViewLandmark {
+  landmark_id: String,
+  label: String,
+  use_for: Vec<LandmarkUse>,
+  evidence_ids: Vec<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum LandmarkUse {
+  ViewportPose,
+  BoundaryDetection,
+  AnchorReacquire,
+  SectionAssignment,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ViewAction {
+  Open,
+  Select,
+  Scroll,
+  ObserveOnly,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+struct ScrollBoundarySummary {
+  top: BoundaryConfidence,
+  bottom: BoundaryConfidence,
+  left: BoundaryConfidence,
+  right: BoundaryConfidence,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum BoundaryConfidence {
+  Confirmed,
+  Likely,
+  #[default]
+  Unknown,
+  Contradicted,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+struct PlaylistSidebarProjection {
+  sections: Vec<SidebarSection>,
+  items: Vec<PlaylistSidebarItem>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct SidebarSection {
+  node_id: String,
+  label: String,
+  kind: SidebarSectionKind,
+  confidence: Confidence,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum SidebarSectionKind {
+  FeatureNav,
+  PlaylistNav,
+  MyPlaylists,
+  FavoritedPlaylists,
+  Unknown,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+struct PlaylistSidebarItem {
+  node_id: String,
+  item_id: String,
+  label: String,
+  section_hint: Option<SidebarSectionKind>,
+  bounds: ViewBounds,
+  source_text: String,
+  observation_index: usize,
+  confidence: Confidence,
+  diagnostics: Vec<ParserDiagnostic>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum Confidence {
+  High,
+  Medium,
+  Low,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct ParserDiagnostic {
+  code: String,
+  message: String,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+struct ViewBounds {
+  x: f64,
+  y: f64,
+  width: f64,
+  height: f64,
+}
+
+impl ViewBounds {
+  const fn new(x: f64, y: f64, width: f64, height: f64) -> Self {
+    Self {
+      x,
+      y,
+      width,
+      height,
+    }
+  }
+}
+```
+
+Add this helper near the tests, outside the `tests` module if needed by implementation:
+
+```rust
+fn sample_reconstruction() -> ViewReconstructionRecord {
+  let anchor = ViewAnchor {
+    anchor_id: "anchor.coding".to_string(),
+    label: "Coding BGM".to_string(),
+    strength: AnchorStrength::Strong,
+    evidence_ids: vec!["ocr.coding".to_string()],
+  };
+  let landmark = ViewLandmark {
+    landmark_id: "landmark.my".to_string(),
+    label: "创建的歌单".to_string(),
+    use_for: vec![LandmarkUse::ViewportPose, LandmarkUse::SectionAssignment],
+    evidence_ids: vec!["ocr.my".to_string()],
+  };
+  ViewReconstructionRecord {
+    root: ViewNodeRecord {
+      node_id: "root.sidebar".to_string(),
+      kind: ViewNodeKind::Collection,
+      domain_kind: Some("netease.sidebar_playlist_collection".to_string()),
+      layout: Some(ViewLayout::VStack),
+      label: None,
+      bounds: Some(ViewBounds::new(0.0, 0.0, 240.0, 700.0)),
+      scrollable: Some(ViewScrollable {
+        axis: ViewAxis::Vertical,
+        boundary: ScrollBoundarySummary::default(),
+      }),
+      children: vec![ViewNodeRecord {
+        node_id: "section.my".to_string(),
+        kind: ViewNodeKind::Section,
+        domain_kind: Some("netease.my_playlists".to_string()),
+        layout: Some(ViewLayout::VStack),
+        label: Some("创建的歌单".to_string()),
+        bounds: Some(ViewBounds::new(0.0, 20.0, 240.0, 32.0)),
+        scrollable: None,
+        children: vec![ViewNodeRecord {
+          node_id: "item.coding".to_string(),
+          kind: ViewNodeKind::Item,
+          domain_kind: Some("netease.playlist_item".to_string()),
+          layout: Some(ViewLayout::HStack),
+          label: Some("Coding BGM".to_string()),
+          bounds: Some(ViewBounds::new(0.0, 50.0, 240.0, 32.0)),
+          scrollable: None,
+          children: vec![ViewNodeRecord {
+            node_id: "item.coding.text".to_string(),
+            kind: ViewNodeKind::Text,
+            domain_kind: None,
+            layout: None,
+            label: Some("Coding BGM".to_string()),
+            bounds: Some(ViewBounds::new(30.0, 56.0, 120.0, 20.0)),
+            scrollable: None,
+            children: Vec::new(),
+            anchors: Vec::new(),
+            landmarks: Vec::new(),
+            actions: vec![ViewAction::ObserveOnly],
+            source_evidence_ids: vec!["ocr.coding".to_string()],
+          }],
+          anchors: vec![anchor.clone()],
+          landmarks: Vec::new(),
+          actions: vec![ViewAction::Open, ViewAction::Select],
+          source_evidence_ids: vec!["ocr.coding".to_string()],
+        }],
+        anchors: Vec::new(),
+        landmarks: vec![landmark.clone()],
+        actions: vec![ViewAction::ObserveOnly],
+        source_evidence_ids: vec!["ocr.my".to_string()],
+      }],
+      anchors: Vec::new(),
+      landmarks: Vec::new(),
+      actions: vec![ViewAction::Scroll],
+      source_evidence_ids: Vec::new(),
+    },
+    anchor_index: vec![anchor],
+    landmark_index: vec![landmark],
+  }
+}
+```
+
+- [ ] **Step 4: Run the tests and verify they pass**
+
+Run:
+
+```bash
+cargo test --example netease_playlist_ls view_reconstruction_serializes_tree_with_scrollable_collection playlist_sidebar_scan_uses_reconstruction_plus_projection -- --nocapture
+```
+
+Expected: both tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add examples/netease_playlist_ls.rs
+git commit -m "feat(examples): define playlist scan artifact"
+```
+
+---
+
+### Task 3: One-Viewport Parser From OCR Evidence
+
+**Files:**
+
+- Modify: `examples/netease_playlist_ls.rs`
+
+- [ ] **Step 1: Write failing parser tests**
+
+Add these tests:
+
+```rust
+  #[test]
+  fn parse_viewport_classifies_sections_and_playlist_items() {
+    let recognition = fake_recognition(vec![
+      ("推荐", 8.0, 8.0, 80.0, 20.0),
+      ("创建的歌单", 8.0, 42.0, 110.0, 20.0),
+      ("Coding BGM", 32.0, 78.0, 140.0, 20.0),
+      ("Jazz", 32.0, 112.0, 90.0, 20.0),
+    ]);
+    let observation = parse_sidebar_viewport(0, ViewBounds::new(0.0, 0.0, 240.0, 400.0), &recognition);
+
+    assert_eq!(observation.candidates.len(), 4);
+    assert_eq!(observation.candidates[1].kind, SidebarCandidateKind::SectionHeader);
+    assert_eq!(observation.candidates[1].label, "创建的歌单");
+    assert_eq!(observation.candidates[2].kind, SidebarCandidateKind::PlaylistItem);
+    assert_eq!(observation.candidates[2].label, "Coding BGM");
+    assert_eq!(observation.evidence_nodes[2].source, ViewEvidenceSource::OcrText);
+  }
+
+  #[test]
+  fn parse_viewport_keeps_unknown_short_noise_as_evidence_not_item() {
+    let recognition = fake_recognition(vec![
+      ("创建的歌单", 8.0, 42.0, 110.0, 20.0),
+      ("·", 12.0, 74.0, 8.0, 8.0),
+    ]);
+    let observation = parse_sidebar_viewport(0, ViewBounds::new(0.0, 0.0, 240.0, 400.0), &recognition);
+
+    assert_eq!(observation.evidence_nodes.len(), 2);
+    assert_eq!(observation.candidates.len(), 1);
+    assert_eq!(observation.candidates[0].kind, SidebarCandidateKind::SectionHeader);
+  }
+```
+
+Add this helper inside the test module:
+
+```rust
+  fn fake_recognition(rows: Vec<(&str, f64, f64, f64, f64)>) -> auv_driver::vision::TextRecognition {
+    auv_driver::vision::TextRecognition {
+      text: rows
+        .iter()
+        .map(|(text, _, _, _, _)| *text)
+        .collect::<Vec<_>>()
+        .join("\n"),
+      regions: rows
+        .into_iter()
+        .map(|(text, x, y, width, height)| auv_driver::vision::RecognizedText {
+          text: text.to_string(),
+          bounds: auv_driver::Rect::new(x, y, width, height),
+          confidence: Some(0.92),
+        })
+        .collect(),
+    }
+  }
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```bash
+cargo test --example netease_playlist_ls parse_viewport_ -- --nocapture
+```
+
+Expected: compile fails because `parse_sidebar_viewport` is not defined.
+
+- [ ] **Step 3: Add one-viewport OCR parser**
+
+Add imports at the top:
+
+```rust
+use auv_driver::vision::TextRecognition;
+```
+
+Add this implementation below the type definitions:
+
+```rust
+fn parse_sidebar_viewport(
+  observation_index: usize,
+  viewport_bounds: ViewBounds,
+  recognition: &TextRecognition,
+) -> SidebarViewportObservation {
+  let mut evidence_nodes = recognition
+    .regions
+    .iter()
+    .enumerate()
+    .map(|(index, text)| ViewEvidenceNode {
+      evidence_id: format!("obs{observation_index}.ocr{index}"),
+      source: ViewEvidenceSource::OcrText,
+      label: Some(text.text.trim().to_string()),
+      bounds: ViewBounds::new(
+        text.bounds.origin.x,
+        text.bounds.origin.y,
+        text.bounds.size.width,
+        text.bounds.size.height,
+      ),
+      confidence: confidence_from_ocr(text.confidence),
+    })
+    .collect::<Vec<_>>();
+  evidence_nodes.sort_by(|left, right| {
+    left
+      .bounds
+      .y
+      .partial_cmp(&right.bounds.y)
+      .unwrap_or(std::cmp::Ordering::Equal)
+      .then_with(|| {
+        left
+          .bounds
+          .x
+          .partial_cmp(&right.bounds.x)
+          .unwrap_or(std::cmp::Ordering::Equal)
+      })
+  });
+
+  let candidates = evidence_nodes
+    .iter()
+    .filter_map(|node| candidate_from_evidence(observation_index, node))
+    .collect::<Vec<_>>();
+
+  SidebarViewportObservation {
+    observation_index,
+    viewport: ViewViewportRecord {
+      bounds: viewport_bounds,
+      axis: ViewAxis::Vertical,
+    },
+    source_artifacts: Vec::new(),
+    viewport_fingerprint: viewport_fingerprint(&evidence_nodes),
+    evidence_nodes,
+    candidates,
+    parser_notes: Vec::new(),
+  }
+}
+
+fn confidence_from_ocr(confidence: Option<f32>) -> Confidence {
+  match confidence {
+    Some(value) if value >= 0.85 => Confidence::High,
+    Some(value) if value >= 0.65 => Confidence::Medium,
+    _ => Confidence::Low,
+  }
+}
+
+fn candidate_from_evidence(
+  observation_index: usize,
+  node: &ViewEvidenceNode,
+) -> Option<SidebarViewportCandidate> {
+  let label = node.label.as_deref()?.trim();
+  if label.chars().count() < 2 {
+    return None;
+  }
+  let kind = classify_sidebar_text(label, node.bounds.x);
+  if kind == SidebarCandidateKind::Unknown {
+    return None;
+  }
+  Some(SidebarViewportCandidate {
+    candidate_id: format!("obs{observation_index}.candidate.{}", slug(label)),
+    kind,
+    label: label.to_string(),
+    bounds: node.bounds,
+    confidence: node.confidence,
+    evidence_ids: vec![node.evidence_id.clone()],
+    diagnostics: Vec::new(),
+  })
+}
+
+fn classify_sidebar_text(label: &str, x: f64) -> SidebarCandidateKind {
+  if section_kind_from_label(label) != SidebarSectionKind::Unknown {
+    return SidebarCandidateKind::SectionHeader;
+  }
+  if x >= 24.0 {
+    return SidebarCandidateKind::PlaylistItem;
+  }
+  if matches!(label, "推荐" | "发现音乐" | "播客" | "私人漫游" | "最近播放") {
+    return SidebarCandidateKind::NavigationItem;
+  }
+  SidebarCandidateKind::Unknown
+}
+
+fn section_kind_from_label(label: &str) -> SidebarSectionKind {
+  if label.contains("创建") || label.contains("我的歌单") {
+    SidebarSectionKind::MyPlaylists
+  } else if label.contains("收藏") {
+    SidebarSectionKind::FavoritedPlaylists
+  } else if label.contains("歌单") {
+    SidebarSectionKind::PlaylistNav
+  } else if matches!(label, "推荐" | "音乐服务") {
+    SidebarSectionKind::FeatureNav
+  } else {
+    SidebarSectionKind::Unknown
+  }
+}
+
+fn viewport_fingerprint(nodes: &[ViewEvidenceNode]) -> String {
+  nodes
+    .iter()
+    .filter_map(|node| node.label.as_deref())
+    .map(normalize_identity)
+    .collect::<Vec<_>>()
+    .join("|")
+}
+
+fn normalize_identity(value: &str) -> String {
+  value
+    .trim()
+    .to_lowercase()
+    .chars()
+    .filter(|ch| !ch.is_whitespace())
+    .collect()
+}
+
+fn slug(value: &str) -> String {
+  normalize_identity(value)
+    .chars()
+    .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '_' })
+    .collect()
+}
+```
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+Run:
+
+```bash
+cargo test --example netease_playlist_ls parse_viewport_ -- --nocapture
+```
+
+Expected: both parser tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add examples/netease_playlist_ls.rs
+git commit -m "feat(examples): parse netease sidebar viewport"
+```
+
+---
+
+### Task 4: Reconstruction From Viewport Candidates
+
+**Files:**
+
+- Modify: `examples/netease_playlist_ls.rs`
+
+- [ ] **Step 1: Write failing reconstruction tests**
+
+Add tests:
+
+```rust
+  #[test]
+  fn reconstruct_sidebar_groups_items_under_carried_section() {
+    let page0 = parse_sidebar_viewport(
+      0,
+      ViewBounds::new(0.0, 0.0, 240.0, 400.0),
+      &fake_recognition(vec![
+        ("创建的歌单", 8.0, 42.0, 110.0, 20.0),
+        ("Coding BGM", 32.0, 78.0, 140.0, 20.0),
+      ]),
+    );
+    let page1 = parse_sidebar_viewport(
+      1,
+      ViewBounds::new(0.0, 0.0, 240.0, 400.0),
+      &fake_recognition(vec![
+        ("Jazz", 32.0, 44.0, 90.0, 20.0),
+        ("收藏的歌单", 8.0, 82.0, 110.0, 20.0),
+        ("Road Trip", 32.0, 118.0, 130.0, 20.0),
+      ]),
+    );
+
+    let scan = reconstruct_playlist_sidebar(
+      ScanAppContext {
+        bundle_id: DEFAULT_APP_ID.to_string(),
+      },
+      ScanWindowContext {
+        title: Some("NetEase".to_string()),
+        window_id: "42".to_string(),
+      },
+      Some(ViewRegionRecord {
+        name: "playlist_sidebar".to_string(),
+        bounds: ViewBounds::new(0.0, 0.0, 240.0, 400.0),
+        coordinate_space: "window".to_string(),
+      }),
+      vec![page0, page1],
+    );
+
+    assert_eq!(scan.projection.sections.len(), 2);
+    assert_eq!(scan.projection.items.len(), 3);
+    assert_eq!(scan.projection.items[0].label, "Coding BGM");
+    assert_eq!(scan.projection.items[1].section_hint, Some(SidebarSectionKind::MyPlaylists));
+    assert_eq!(
+      scan.projection.items[2].section_hint,
+      Some(SidebarSectionKind::FavoritedPlaylists)
+    );
+    assert_eq!(scan.reconstruction.root.kind, ViewNodeKind::Collection);
+    assert_eq!(scan.reconstruction.root.children.len(), 2);
+  }
+
+  #[test]
+  fn reconstruct_sidebar_deduplicates_repeated_item_labels_in_same_section() {
+    let page0 = parse_sidebar_viewport(
+      0,
+      ViewBounds::new(0.0, 0.0, 240.0, 400.0),
+      &fake_recognition(vec![
+        ("创建的歌单", 8.0, 42.0, 110.0, 20.0),
+        ("Coding BGM", 32.0, 78.0, 140.0, 20.0),
+      ]),
+    );
+    let page1 = parse_sidebar_viewport(
+      1,
+      ViewBounds::new(0.0, 0.0, 240.0, 400.0),
+      &fake_recognition(vec![("Coding BGM", 32.0, 44.0, 140.0, 20.0)]),
+    );
+
+    let scan = reconstruct_playlist_sidebar(
+      ScanAppContext {
+        bundle_id: DEFAULT_APP_ID.to_string(),
+      },
+      ScanWindowContext {
+        title: None,
+        window_id: "42".to_string(),
+      },
+      None,
+      vec![page0, page1],
+    );
+
+    assert_eq!(scan.projection.items.len(), 1);
+    assert!(scan.diagnostics.iter().any(|diagnostic| diagnostic.code == "deduplicated_item"));
+  }
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```bash
+cargo test --example netease_playlist_ls reconstruct_sidebar_ -- --nocapture
+```
+
+Expected: compile fails because `reconstruct_playlist_sidebar` is not defined.
+
+- [ ] **Step 3: Implement reconstruction and projection**
+
+Add:
+
+```rust
+fn reconstruct_playlist_sidebar(
+  app: ScanAppContext,
+  window: ScanWindowContext,
+  sidebar_region: Option<ViewRegionRecord>,
+  observations: Vec<SidebarViewportObservation>,
+) -> PlaylistSidebarScan {
+  let mut sections = Vec::<SidebarSection>::new();
+  let mut items = Vec::<PlaylistSidebarItem>::new();
+  let mut diagnostics = Vec::<ParserDiagnostic>::new();
+  let mut section_nodes = Vec::<ViewNodeRecord>::new();
+  let mut current_section: Option<(SidebarSectionKind, String, String)> = None;
+  let mut seen_item_keys = std::collections::BTreeSet::<String>::new();
+
+  for observation in &observations {
+    for candidate in &observation.candidates {
+      match candidate.kind {
+        SidebarCandidateKind::SectionHeader => {
+          let section_kind = section_kind_from_label(&candidate.label);
+          let node_id = format!("section.{}", slug(&candidate.label));
+          if !sections.iter().any(|section| section.node_id == node_id) {
+            sections.push(SidebarSection {
+              node_id: node_id.clone(),
+              label: candidate.label.clone(),
+              kind: section_kind,
+              confidence: candidate.confidence,
+            });
+            section_nodes.push(section_node(candidate, section_kind, observation.observation_index));
+          }
+          current_section = Some((section_kind, candidate.label.clone(), node_id));
+        }
+        SidebarCandidateKind::PlaylistItem | SidebarCandidateKind::NavigationItem => {
+          let section_hint = current_section.as_ref().map(|(kind, _, _)| *kind);
+          let section_node_id = current_section
+            .as_ref()
+            .map(|(_, _, node_id)| node_id.clone())
+            .unwrap_or_else(|| "section.unassigned".to_string());
+          let item_key = format!(
+            "{}:{}",
+            section_hint
+              .map(|kind| format!("{kind:?}"))
+              .unwrap_or_else(|| "unknown".to_string()),
+            normalize_identity(&candidate.label)
+          );
+          if !seen_item_keys.insert(item_key) {
+            diagnostics.push(ParserDiagnostic {
+              code: "deduplicated_item".to_string(),
+              message: format!("deduplicated repeated sidebar item {:?}", candidate.label),
+            });
+            continue;
+          }
+          let node_id = format!("item.{}", slug(&candidate.label));
+          items.push(PlaylistSidebarItem {
+            node_id: node_id.clone(),
+            item_id: format!("playlist.{}", slug(&candidate.label)),
+            label: candidate.label.clone(),
+            section_hint,
+            bounds: candidate.bounds,
+            source_text: candidate.label.clone(),
+            observation_index: observation.observation_index,
+            confidence: candidate.confidence,
+            diagnostics: Vec::new(),
+          });
+          attach_item_node(&mut section_nodes, &section_node_id, item_node(&node_id, candidate));
+        }
+        SidebarCandidateKind::Unknown => {}
+      }
+    }
+  }
+
+  let anchor_index = section_nodes
+    .iter()
+    .flat_map(collect_anchors)
+    .collect::<Vec<_>>();
+  let landmark_index = section_nodes
+    .iter()
+    .flat_map(collect_landmarks)
+    .collect::<Vec<_>>();
+  let boundary = boundary_summary_from_observations(&observations);
+  let root = ViewNodeRecord {
+    node_id: "root.sidebar".to_string(),
+    kind: ViewNodeKind::Collection,
+    domain_kind: Some("netease.sidebar_playlist_collection".to_string()),
+    layout: Some(ViewLayout::VStack),
+    label: None,
+    bounds: sidebar_region.as_ref().map(|region| region.bounds),
+    scrollable: Some(ViewScrollable {
+      axis: ViewAxis::Vertical,
+      boundary: boundary.clone(),
+    }),
+    children: section_nodes,
+    anchors: Vec::new(),
+    landmarks: Vec::new(),
+    actions: vec![ViewAction::Scroll],
+    source_evidence_ids: Vec::new(),
+  };
+
+  PlaylistSidebarScan {
+    app,
+    window,
+    sidebar_region,
+    observations,
+    reconstruction: ViewReconstructionRecord {
+      root,
+      anchor_index,
+      landmark_index,
+    },
+    projection: PlaylistSidebarProjection { sections, items },
+    boundary,
+    diagnostics,
+    known_limits: Vec::new(),
+  }
+}
+
+fn section_node(
+  candidate: &SidebarViewportCandidate,
+  section_kind: SidebarSectionKind,
+  observation_index: usize,
+) -> ViewNodeRecord {
+  let label = candidate.label.clone();
+  ViewNodeRecord {
+    node_id: format!("section.{}", slug(&label)),
+    kind: ViewNodeKind::Section,
+    domain_kind: Some(format!("netease.{section_kind:?}")),
+    layout: Some(ViewLayout::VStack),
+    label: Some(label.clone()),
+    bounds: Some(candidate.bounds),
+    scrollable: None,
+    children: Vec::new(),
+    anchors: vec![ViewAnchor {
+      anchor_id: format!("anchor.section.{}", slug(&label)),
+      label: label.clone(),
+      strength: AnchorStrength::Strong,
+      evidence_ids: candidate.evidence_ids.clone(),
+    }],
+    landmarks: vec![ViewLandmark {
+      landmark_id: format!("landmark.section.{}", slug(&label)),
+      label,
+      use_for: vec![LandmarkUse::ViewportPose, LandmarkUse::SectionAssignment],
+      evidence_ids: candidate.evidence_ids.clone(),
+    }],
+    actions: vec![ViewAction::ObserveOnly],
+    source_evidence_ids: candidate.evidence_ids.clone(),
+  }
+}
+
+fn item_node(node_id: &str, candidate: &SidebarViewportCandidate) -> ViewNodeRecord {
+  ViewNodeRecord {
+    node_id: node_id.to_string(),
+    kind: ViewNodeKind::Item,
+    domain_kind: Some("netease.playlist_item".to_string()),
+    layout: Some(ViewLayout::HStack),
+    label: Some(candidate.label.clone()),
+    bounds: Some(candidate.bounds),
+    scrollable: None,
+    children: vec![ViewNodeRecord {
+      node_id: format!("{node_id}.text"),
+      kind: ViewNodeKind::Text,
+      domain_kind: None,
+      layout: None,
+      label: Some(candidate.label.clone()),
+      bounds: Some(candidate.bounds),
+      scrollable: None,
+      children: Vec::new(),
+      anchors: Vec::new(),
+      landmarks: Vec::new(),
+      actions: vec![ViewAction::ObserveOnly],
+      source_evidence_ids: candidate.evidence_ids.clone(),
+    }],
+    anchors: vec![ViewAnchor {
+      anchor_id: format!("anchor.{node_id}"),
+      label: candidate.label.clone(),
+      strength: AnchorStrength::Strong,
+      evidence_ids: candidate.evidence_ids.clone(),
+    }],
+    landmarks: Vec::new(),
+    actions: vec![ViewAction::Open, ViewAction::Select],
+    source_evidence_ids: candidate.evidence_ids.clone(),
+  }
+}
+
+fn attach_item_node(sections: &mut [ViewNodeRecord], section_node_id: &str, item: ViewNodeRecord) {
+  if let Some(section) = sections
+    .iter_mut()
+    .find(|section| section.node_id == section_node_id)
+  {
+    section.children.push(item);
+  }
+}
+
+fn collect_anchors(node: &ViewNodeRecord) -> Vec<ViewAnchor> {
+  node
+    .anchors
+    .iter()
+    .cloned()
+    .chain(node.children.iter().flat_map(collect_anchors))
+    .collect()
+}
+
+fn collect_landmarks(node: &ViewNodeRecord) -> Vec<ViewLandmark> {
+  node
+    .landmarks
+    .iter()
+    .cloned()
+    .chain(node.children.iter().flat_map(collect_landmarks))
+    .collect()
+}
+
+fn boundary_summary_from_observations(observations: &[SidebarViewportObservation]) -> ScrollBoundarySummary {
+  let bottom = if observations
+    .windows(2)
+    .any(|pair| pair[0].viewport_fingerprint == pair[1].viewport_fingerprint)
+  {
+    BoundaryConfidence::Likely
+  } else {
+    BoundaryConfidence::Unknown
+  };
+  ScrollBoundarySummary {
+    bottom,
+    ..ScrollBoundarySummary::default()
+  }
+}
+```
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+Run:
+
+```bash
+cargo test --example netease_playlist_ls reconstruct_sidebar_ -- --nocapture
+```
+
+Expected: reconstruction tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add examples/netease_playlist_ls.rs
+git commit -m "feat(examples): reconstruct playlist sidebar view"
+```
+
+---
+
+### Task 5: Sidebar Region Detection And Structured Blocker Errors
+
+**Files:**
+
+- Modify: `examples/netease_playlist_ls.rs`
+
+- [ ] **Step 1: Write failing pure tests for region/blocker detection**
+
+Add tests:
+
+```rust
+  #[test]
+  fn detect_sidebar_region_uses_manual_region_when_provided() {
+    let manual = RatioRegion::new(0.0, 0.1, 0.25, 0.8);
+    let region = detect_sidebar_region(
+      Some(manual),
+      auv_driver::Size::new(1000.0, 800.0),
+      &fake_recognition(Vec::new()),
+    )
+    .expect("manual region should be accepted");
+
+    assert_eq!(region.bounds, ViewBounds::new(0.0, 80.0, 250.0, 640.0));
+  }
+
+  #[test]
+  fn detect_sidebar_region_fails_when_sidebar_markers_are_absent() {
+    let error = detect_sidebar_region(
+      None,
+      auv_driver::Size::new(1000.0, 800.0),
+      &fake_recognition(vec![("搜索", 400.0, 40.0, 80.0, 20.0)]),
+    )
+    .expect_err("missing sidebar should fail");
+
+    assert_eq!(error.code, "sidebar_region_not_found");
+  }
+
+  #[test]
+  fn detect_blocking_modal_reports_cancel_or_open_dialog_markers() {
+    let diagnostic = detect_blocking_modal(&fake_recognition(vec![
+      ("打开", 700.0, 680.0, 60.0, 24.0),
+      ("取消", 780.0, 680.0, 60.0, 24.0),
+    ]))
+    .expect("modal should be detected");
+
+    assert_eq!(diagnostic.code, "blocking_modal_dialog");
+  }
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```bash
+cargo test --example netease_playlist_ls detect_sidebar_region_ detect_blocking_modal_ -- --nocapture
+```
+
+Expected: compile fails because detection functions are not defined.
+
+- [ ] **Step 3: Add region and modal detection helpers**
+
+Add:
+
+```rust
+fn detect_sidebar_region(
+  manual: Option<RatioRegion>,
+  window_size: auv_driver::Size,
+  recognition: &TextRecognition,
+) -> Result<ViewRegionRecord, ParserDiagnostic> {
+  if let Some(region) = manual {
+    return Ok(ViewRegionRecord {
+      name: "playlist_sidebar".to_string(),
+      bounds: ratio_to_window_bounds(region, window_size),
+      coordinate_space: "window".to_string(),
+    });
+  }
+
+  let sidebar_markers = recognition
+    .regions
+    .iter()
+    .filter(|text| {
+      let label = text.text.trim();
+      text.bounds.origin.x < window_size.width * 0.38
+        && (section_kind_from_label(label) != SidebarSectionKind::Unknown
+          || matches!(label, "推荐" | "发现音乐" | "最近播放"))
+    })
+    .collect::<Vec<_>>();
+
+  if sidebar_markers.is_empty() {
+    return Err(ParserDiagnostic {
+      code: "sidebar_region_not_found".to_string(),
+      message: "could not identify NetEase sidebar markers in the left side of the window".to_string(),
+    });
+  }
+
+  let max_x = sidebar_markers
+    .iter()
+    .map(|text| text.bounds.origin.x + text.bounds.size.width)
+    .fold(0.0, f64::max)
+    .max(window_size.width * 0.18)
+    .min(window_size.width * 0.42);
+
+  Ok(ViewRegionRecord {
+    name: "playlist_sidebar".to_string(),
+    bounds: ViewBounds::new(0.0, 0.0, max_x + 48.0, window_size.height),
+    coordinate_space: "window".to_string(),
+  })
+}
+
+fn ratio_to_window_bounds(region: RatioRegion, window_size: auv_driver::Size) -> ViewBounds {
+  ViewBounds::new(
+    region.x * window_size.width,
+    region.y * window_size.height,
+    region.width * window_size.width,
+    region.height * window_size.height,
+  )
+}
+
+fn detect_blocking_modal(recognition: &TextRecognition) -> Option<ParserDiagnostic> {
+  let has_cancel = recognition.best_contains("取消").is_some();
+  let has_open = recognition.best_contains("打开").is_some() || recognition.best_contains("存储").is_some();
+  if has_cancel && has_open {
+    Some(ParserDiagnostic {
+      code: "blocking_modal_dialog".to_string(),
+      message: "detected modal/system dialog markers; sidebar scan is blocked".to_string(),
+    })
+  } else {
+    None
+  }
+}
+```
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+Run:
+
+```bash
+cargo test --example netease_playlist_ls detect_sidebar_region_ detect_blocking_modal_ -- --nocapture
+```
+
+Expected: all three tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add examples/netease_playlist_ls.rs
+git commit -m "feat(examples): detect netease sidebar region"
+```
+
+---
+
+### Task 6: Bounded Scroll Scan Loop With Fake Observer Tests
+
+**Files:**
+
+- Modify: `examples/netease_playlist_ls.rs`
+
+- [ ] **Step 1: Write failing scroll loop tests**
+
+Add tests:
+
+```rust
+  #[test]
+  fn scan_loop_stops_on_repeated_viewport_fingerprint() {
+    let observations = vec![
+      parse_sidebar_viewport(
+        0,
+        ViewBounds::new(0.0, 0.0, 240.0, 400.0),
+        &fake_recognition(vec![("创建的歌单", 8.0, 42.0, 110.0, 20.0), ("Coding", 32.0, 78.0, 100.0, 20.0)]),
+      ),
+      parse_sidebar_viewport(
+        1,
+        ViewBounds::new(0.0, 0.0, 240.0, 400.0),
+        &fake_recognition(vec![("Jazz", 32.0, 44.0, 90.0, 20.0)]),
+      ),
+      parse_sidebar_viewport(
+        2,
+        ViewBounds::new(0.0, 0.0, 240.0, 400.0),
+        &fake_recognition(vec![("Jazz", 32.0, 44.0, 90.0, 20.0)]),
+      ),
+    ];
+    let mut observer = FakeSidebarObserver::new(observations);
+    let scan = scan_sidebar_with_observer(&mut observer, ScanOptions { max_pages: 10, max_scrolls: 10 });
+
+    assert_eq!(scan.observations.len(), 3);
+    assert_eq!(scan.boundary.bottom, BoundaryConfidence::Likely);
+  }
+
+  #[test]
+  fn scan_loop_respects_page_budget() {
+    let observations = vec![
+      parse_sidebar_viewport(0, ViewBounds::new(0.0, 0.0, 240.0, 400.0), &fake_recognition(vec![("A", 32.0, 44.0, 90.0, 20.0)])),
+      parse_sidebar_viewport(1, ViewBounds::new(0.0, 0.0, 240.0, 400.0), &fake_recognition(vec![("B", 32.0, 44.0, 90.0, 20.0)])),
+    ];
+    let mut observer = FakeSidebarObserver::new(observations);
+    let scan = scan_sidebar_with_observer(&mut observer, ScanOptions { max_pages: 1, max_scrolls: 10 });
+
+    assert_eq!(scan.observations.len(), 1);
+    assert!(scan.known_limits.iter().any(|limit| limit.contains("max_pages")));
+  }
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```bash
+cargo test --example netease_playlist_ls scan_loop_ -- --nocapture
+```
+
+Expected: compile fails because scan loop types are not defined.
+
+- [ ] **Step 3: Add fake-observer-driven scan loop**
+
+Add:
+
+```rust
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ScanOptions {
+  max_pages: usize,
+  max_scrolls: usize,
+}
+
+trait SidebarObserver {
+  fn observe(&mut self, observation_index: usize) -> Result<SidebarViewportObservation, ParserDiagnostic>;
+  fn scroll_down(&mut self) -> Result<(), ParserDiagnostic>;
+}
+
+fn scan_sidebar_with_observer(
+  observer: &mut impl SidebarObserver,
+  options: ScanOptions,
+) -> PlaylistSidebarScan {
+  let mut observations = Vec::new();
+  let mut diagnostics = Vec::new();
+  let mut known_limits = Vec::new();
+  let mut previous_fingerprint: Option<String> = None;
+  let mut scrolls = 0usize;
+
+  for page_index in 0..options.max_pages {
+    let observation = match observer.observe(page_index) {
+      Ok(observation) => observation,
+      Err(error) => {
+        diagnostics.push(error);
+        break;
+      }
+    };
+    let repeated = previous_fingerprint
+      .as_ref()
+      .is_some_and(|fingerprint| *fingerprint == observation.viewport_fingerprint);
+    previous_fingerprint = Some(observation.viewport_fingerprint.clone());
+    observations.push(observation);
+    if repeated {
+      break;
+    }
+    if page_index + 1 >= options.max_pages {
+      known_limits.push(format!("stopped after max_pages={}", options.max_pages));
+      break;
+    }
+    if scrolls >= options.max_scrolls {
+      known_limits.push(format!("stopped after max_scrolls={}", options.max_scrolls));
+      break;
+    }
+    match observer.scroll_down() {
+      Ok(()) => scrolls += 1,
+      Err(error) => {
+        diagnostics.push(error);
+        break;
+      }
+    }
+  }
+
+  let mut scan = reconstruct_playlist_sidebar(
+    ScanAppContext {
+      bundle_id: DEFAULT_APP_ID.to_string(),
+    },
+    ScanWindowContext {
+      title: None,
+      window_id: "fake".to_string(),
+    },
+    None,
+    observations,
+  );
+  scan.diagnostics.extend(diagnostics);
+  scan.known_limits.extend(known_limits);
+  scan
+}
+```
+
+Add this fake observer inside the test module:
+
+```rust
+  struct FakeSidebarObserver {
+    observations: Vec<SidebarViewportObservation>,
+    cursor: usize,
+  }
+
+  impl FakeSidebarObserver {
+    fn new(observations: Vec<SidebarViewportObservation>) -> Self {
+      Self {
+        observations,
+        cursor: 0,
+      }
+    }
+  }
+
+  impl SidebarObserver for FakeSidebarObserver {
+    fn observe(&mut self, _observation_index: usize) -> Result<SidebarViewportObservation, ParserDiagnostic> {
+      self
+        .observations
+        .get(self.cursor)
+        .cloned()
+        .ok_or_else(|| ParserDiagnostic {
+          code: "no_more_fake_observations".to_string(),
+          message: "fake observer has no observation for cursor".to_string(),
+        })
+    }
+
+    fn scroll_down(&mut self) -> Result<(), ParserDiagnostic> {
+      self.cursor += 1;
+      Ok(())
+    }
+  }
+```
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+Run:
+
+```bash
+cargo test --example netease_playlist_ls scan_loop_ -- --nocapture
+```
+
+Expected: scroll loop tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add examples/netease_playlist_ls.rs
+git commit -m "feat(examples): add playlist sidebar scan loop"
+```
+
+---
+
+### Task 7: Live Driver Adapter And JSON/Human Output
+
+**Files:**
+
+- Modify: `examples/netease_playlist_ls.rs`
+
+- [ ] **Step 1: Write failing renderer tests**
+
+Add tests:
+
+```rust
+  #[test]
+  fn render_human_summary_groups_items_by_section() {
+    let scan = reconstruct_playlist_sidebar(
+      ScanAppContext {
+        bundle_id: DEFAULT_APP_ID.to_string(),
+      },
+      ScanWindowContext {
+        title: Some("NetEase".to_string()),
+        window_id: "42".to_string(),
+      },
+      None,
+      vec![parse_sidebar_viewport(
+        0,
+        ViewBounds::new(0.0, 0.0, 240.0, 400.0),
+        &fake_recognition(vec![
+          ("创建的歌单", 8.0, 42.0, 110.0, 20.0),
+          ("Coding BGM", 32.0, 78.0, 140.0, 20.0),
+        ]),
+      )],
+    );
+
+    let rendered = render_human_summary(&scan);
+
+    assert!(rendered.contains("创建的歌单"));
+    assert!(rendered.contains("Coding BGM"));
+    assert!(rendered.contains("boundary"));
+  }
+```
+
+- [ ] **Step 2: Run test and verify failure**
+
+Run:
+
+```bash
+cargo test --example netease_playlist_ls render_human_summary_groups_items_by_section -- --nocapture
+```
+
+Expected: compile fails because `render_human_summary` is not defined.
+
+- [ ] **Step 3: Add renderer, live observer, and wire `run`**
+
+Add imports at the top:
+
+```rust
+#[cfg(target_os = "macos")]
+use auv_driver::capture::Capture;
+#[cfg(target_os = "macos")]
+use auv_driver::selector::{App, Window};
+#[cfg(target_os = "macos")]
+use auv_driver::{Driver, RatioRect};
+#[cfg(target_os = "macos")]
+use auv_driver_macos::MacosDriver;
+```
+
+Replace `run` with:
+
+```rust
+fn run() -> Result<(), String> {
+  let inputs = parse_inputs(std::env::args().skip(1).collect())?;
+  let scan = run_live_scan(&inputs)?;
+  let rendered = serde_json::to_string_pretty(&scan)
+    .map_err(|error| format!("failed to serialize scan JSON: {error}"))?;
+  if let Some(path) = &inputs.json_out {
+    std::fs::write(path, rendered.as_bytes())
+      .map_err(|error| format!("failed to write {}: {error}", path.display()))?;
+  }
+  if inputs.print_json {
+    println!("{rendered}");
+  } else {
+    println!("{}", render_human_summary(&scan));
+  }
+  Ok(())
+}
+```
+
+Add:
+
+```rust
+fn render_human_summary(scan: &PlaylistSidebarScan) -> String {
+  let mut lines = vec![
+    format!("app: {}", scan.app.bundle_id),
+    format!("window: {}", scan.window.title.as_deref().unwrap_or("<untitled>")),
+    format!(
+      "boundary: top={:?} bottom={:?}",
+      scan.boundary.top, scan.boundary.bottom
+    ),
+  ];
+  for section in &scan.projection.sections {
+    lines.push(format!("\n[{}]", section.label));
+    for item in scan
+      .projection
+      .items
+      .iter()
+      .filter(|item| item.section_hint == Some(section.kind))
+    {
+      lines.push(format!("- {}", item.label));
+    }
+  }
+  if !scan.diagnostics.is_empty() {
+    lines.push("\ndiagnostics:".to_string());
+    for diagnostic in &scan.diagnostics {
+      lines.push(format!("- {}: {}", diagnostic.code, diagnostic.message));
+    }
+  }
+  if !scan.known_limits.is_empty() {
+    lines.push("\nknown limits:".to_string());
+    for limit in &scan.known_limits {
+      lines.push(format!("- {limit}"));
+    }
+  }
+  lines.join("\n")
+}
+
+#[cfg(target_os = "macos")]
+fn run_live_scan(inputs: &Inputs) -> Result<PlaylistSidebarScan, String> {
+  let driver = MacosDriver::new();
+  let session = driver.open_local().map_err(|error| error.to_string())?;
+  let window = session
+    .window()
+    .resolve(Window::main_visible().owned_by(App::bundle(inputs.app_id.clone())))
+    .map_err(|error| error.to_string())?;
+  let initial_capture = session.window().capture(&window).map_err(|error| error.to_string())?;
+  let full_region = RatioRect::new(0.0, 0.0, 1.0, 1.0);
+  let full_ocr = session
+    .vision()
+    .recognize_text_in_capture(&initial_capture, full_region)
+    .map_err(|error| error.to_string())?;
+  if let Some(blocker) = detect_blocking_modal(&full_ocr) {
+    return Ok(PlaylistSidebarScan {
+      app: ScanAppContext {
+        bundle_id: inputs.app_id.clone(),
+      },
+      window: ScanWindowContext {
+        title: window.title.clone(),
+        window_id: window.reference.id.clone(),
+      },
+      sidebar_region: None,
+      observations: Vec::new(),
+      reconstruction: ViewReconstructionRecord {
+        root: empty_root(),
+        anchor_index: Vec::new(),
+        landmark_index: Vec::new(),
+      },
+      projection: PlaylistSidebarProjection {
+        sections: Vec::new(),
+        items: Vec::new(),
+      },
+      boundary: ScrollBoundarySummary::default(),
+      diagnostics: vec![blocker],
+      known_limits: Vec::new(),
+    });
+  }
+  let sidebar_region = detect_sidebar_region(inputs.sidebar_region, initial_capture.bounds.size, &full_ocr)
+    .map_err(|diagnostic| diagnostic.message)?;
+  let mut observer = LiveSidebarObserver {
+    session: &session,
+    window: &window,
+    sidebar_region: sidebar_region.clone(),
+    scroll_amount: inputs.scroll_amount,
+  };
+  let mut scan = scan_sidebar_with_observer(
+    &mut observer,
+    ScanOptions {
+      max_pages: inputs.max_pages,
+      max_scrolls: inputs.max_scrolls,
+    },
+  );
+  scan.app.bundle_id = inputs.app_id.clone();
+  scan.window = ScanWindowContext {
+    title: window.title.clone(),
+    window_id: window.reference.id.clone(),
+  };
+  scan.sidebar_region = Some(sidebar_region);
+  Ok(scan)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn run_live_scan(_inputs: &Inputs) -> Result<PlaylistSidebarScan, String> {
+  Err("netease_playlist_ls live scan is only available on macOS".to_string())
+}
+
+fn empty_root() -> ViewNodeRecord {
+  ViewNodeRecord {
+    node_id: "root.empty".to_string(),
+    kind: ViewNodeKind::Collection,
+    domain_kind: None,
+    layout: Some(ViewLayout::VStack),
+    label: None,
+    bounds: None,
+    scrollable: Some(ViewScrollable {
+      axis: ViewAxis::Vertical,
+      boundary: ScrollBoundarySummary::default(),
+    }),
+    children: Vec::new(),
+    anchors: Vec::new(),
+    landmarks: Vec::new(),
+    actions: vec![ViewAction::ObserveOnly],
+    source_evidence_ids: Vec::new(),
+  }
+}
+```
+
+Add the live observer:
+
+```rust
+#[cfg(target_os = "macos")]
+struct LiveSidebarObserver<'a> {
+  session: &'a auv_driver_macos::MacosDriverSession,
+  window: &'a auv_driver::Window,
+  sidebar_region: ViewRegionRecord,
+  scroll_amount: f64,
+}
+
+#[cfg(target_os = "macos")]
+impl SidebarObserver for LiveSidebarObserver<'_> {
+  fn observe(&mut self, observation_index: usize) -> Result<SidebarViewportObservation, ParserDiagnostic> {
+    let capture = self.session.window().capture(self.window).map_err(|error| ParserDiagnostic {
+      code: "capture_failed".to_string(),
+      message: error.to_string(),
+    })?;
+    let region = bounds_to_ratio(self.sidebar_region.bounds, &capture);
+    let recognition = self
+      .session
+      .vision()
+      .recognize_text_in_capture(&capture, region)
+      .map_err(|error| ParserDiagnostic {
+        code: "ocr_failed".to_string(),
+        message: error.to_string(),
+      })?;
+    Ok(parse_sidebar_viewport(
+      observation_index,
+      self.sidebar_region.bounds,
+      &recognition,
+    ))
+  }
+
+  fn scroll_down(&mut self) -> Result<(), ParserDiagnostic> {
+    let center = auv_driver::WindowPoint::new(
+      self.sidebar_region.bounds.x + self.sidebar_region.bounds.width / 2.0,
+      self.sidebar_region.bounds.y + self.sidebar_region.bounds.height / 2.0,
+    );
+    let screen = self
+      .session
+      .window()
+      .to_screen_point(self.window, center)
+      .map_err(|error| ParserDiagnostic {
+        code: "scroll_point_projection_failed".to_string(),
+        message: error.to_string(),
+      })?;
+    auv_driver_macos::native::pointer::scroll_point(
+      screen.point().x,
+      screen.point().y,
+      0.0,
+      -self.scroll_amount,
+    )
+    .map_err(|error| ParserDiagnostic {
+      code: "scroll_failed".to_string(),
+      message: error.to_string(),
+    })
+  }
+}
+
+#[cfg(target_os = "macos")]
+fn bounds_to_ratio(bounds: ViewBounds, capture: &Capture) -> RatioRect {
+  RatioRect::new(
+    bounds.x / capture.bounds.size.width,
+    bounds.y / capture.bounds.size.height,
+    bounds.width / capture.bounds.size.width,
+    bounds.height / capture.bounds.size.height,
+  )
+}
+```
+
+`auv_driver_macos::native::pointer::scroll_point` is a doc-hidden compatibility surface. It is acceptable inside this example only to avoid moving NetEase logic into framework crates. Record a framework gap in the design doc noting that the typed `WindowApi` lacks a public region/window scroll method for examples.
+
+- [ ] **Step 4: Run renderer test**
+
+Run:
+
+```bash
+cargo test --example netease_playlist_ls render_human_summary_groups_items_by_section -- --nocapture
+```
+
+Expected: renderer test passes.
+
+- [ ] **Step 5: Run full example tests/check**
+
+Run:
+
+```bash
+cargo test --example netease_playlist_ls
+cargo check --example netease_playlist_ls
+```
+
+Expected: all tests pass and example checks. If compile fails because the doc-hidden scroll compatibility function is unavailable, stop and ask for design guidance with the exact compiler error instead of adding a NetEase-specific driver API.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add examples/netease_playlist_ls.rs
+git commit -m "feat(examples): wire netease playlist ls"
+```
+
+---
+
+### Task 8: Documentation Gap Notes And Final Verification
+
+**Files:**
+
+- Modify: `docs/ai/references/2026-05-28-view-parser-ir-netease-playlist-example-design.md`
+
+- [ ] **Step 1: Add implementation notes if gaps were found**
+
+If implementation found a driver/API gap, add a dated bullet under `Open Investigation Items` in the design doc. Use this exact format:
+
+```markdown
+- 2026-05-28 implementation note: `<file-or-api>` did not expose `<capability>`.
+  The NetEase example keeps parser logic in `examples/` and records this as a
+  framework gap instead of adding NetEase-specific code to core.
+```
+
+If no gap was found, add this note instead:
+
+```markdown
+- 2026-05-28 implementation note: the first example used existing typed
+  `auv-driver-macos` capture and OCR APIs. No NetEase-specific logic was moved
+  into framework crates.
+```
+
+- [ ] **Step 2: Run full verification**
+
+Run:
+
+```bash
+cargo fmt --check
+cargo test --example netease_playlist_ls
+cargo check --example netease_playlist_ls
+git diff --check
+```
+
+Expected: all commands pass.
+
+- [ ] **Step 3: Optional live smoke**
+
+Only if NetEase Cloud Music is open and screen/OCR permissions are available, run:
+
+```bash
+cargo run --example netease_playlist_ls -- --json-out /tmp/auv-netease-playlist-ls.json
+```
+
+Expected: command completes with a human-readable summary and writes `/tmp/auv-netease-playlist-ls.json`. If it exits with a structured sidebar/modal/OCR diagnostic, preserve the JSON and screenshot/OCR context before changing parser logic.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add examples/netease_playlist_ls.rs docs/ai/references/2026-05-28-view-parser-ir-netease-playlist-example-design.md
+git commit -m "docs: record netease playlist example gaps"
+```
+
+If the design doc did not change in this task, commit only the example verification fixups with:
+
+```bash
+git add examples/netease_playlist_ls.rs
+git commit -m "test(examples): verify netease playlist ls"
+```
+
+---
+
+## Self-Review
+
+Spec coverage:
+
+- Example-only NetEase logic: Tasks 1-7 keep implementation in `examples/netease_playlist_ls.rs`.
+- Structured artifact first: Tasks 2, 4, and 7 define JSON and render human output from it.
+- `ViewObservation` as evidence IR and `ViewReconstruction` as operable tree: Tasks 2-4 implement this split.
+- `ViewScrollable` as capability, not node kind: Task 2 models `scrollable: Option<ViewScrollable>`.
+- Parser supports app/view/region/item shape: Tasks 5 and 7 cover app/window, region, and item parsing inside the example.
+- Sidebar resized/missing and modal blocker: Task 5 handles region detection and modal blocker diagnostics.
+- Scroll boundary uncertainty: Tasks 4 and 6 record repeated-fingerprint boundary evidence and known limits.
+- Inspect viewer and command catalog migration excluded: Task 8 only records gaps.
+
+No W3C HTML/ARIA role taxonomy is needed for v0 because the plan intentionally keeps the node kind set minimal and does not attempt to mirror HTML or ARIA roles. Revisit W3C references only when adding roles such as button, input, dialog, grid, or link.

--- a/examples/netease_playlist_ls.rs
+++ b/examples/netease_playlist_ls.rs
@@ -3,6 +3,15 @@ use std::path::PathBuf;
 use auv_driver::vision::TextRecognition;
 use serde::{Deserialize, Serialize};
 
+#[cfg(target_os = "macos")]
+use auv_driver::capture::Capture;
+#[cfg(target_os = "macos")]
+use auv_driver::selector::{App, Window};
+#[cfg(target_os = "macos")]
+use auv_driver::{Driver, RatioRect, Size};
+#[cfg(target_os = "macos")]
+use auv_driver_macos::{MacosDriver, MacosDriverSession};
+
 const DEFAULT_APP_ID: &str = "com.netease.163music";
 
 #[derive(Clone, Debug, PartialEq)]
@@ -343,8 +352,22 @@ fn main() {
 }
 
 fn run() -> Result<(), String> {
-  let _inputs = parse_inputs(std::env::args().skip(1).collect())?;
-  Err("live implementation is added in later tasks".to_string())
+  let inputs = parse_inputs(std::env::args().skip(1).collect())?;
+  let scan = run_live_scan(&inputs)?;
+  let json = serde_json::to_string_pretty(&scan).map_err(|error| error.to_string())?;
+
+  if let Some(path) = &inputs.json_out {
+    std::fs::write(path, &json)
+      .map_err(|error| format!("failed to write {}: {error}", path.display()))?;
+  }
+
+  if inputs.print_json {
+    println!("{json}");
+  } else {
+    println!("{}", render_human_summary(&scan));
+  }
+
+  Ok(())
 }
 
 fn parse_inputs(args: Vec<String>) -> Result<Inputs, String> {
@@ -444,6 +467,193 @@ fn parse_ratio_region(value: String) -> Result<RatioRegion, String> {
   }
 
   Ok(RatioRegion::new(parts[0], parts[1], parts[2], parts[3]))
+}
+
+fn render_human_summary(scan: &PlaylistSidebarScan) -> String {
+  let mut lines = Vec::new();
+  lines.push("NetEase playlist sidebar scan".to_string());
+  lines.push(format!(
+    "app: id={} name={} version={}",
+    optional(scan.app.app_id.as_deref()),
+    optional(scan.app.name.as_deref()),
+    optional(scan.app.version.as_deref())
+  ));
+  lines.push(format!(
+    "window: id={} title={} bounds={}",
+    optional(scan.window.id.as_deref()),
+    optional(scan.window.title.as_deref()),
+    render_optional_bounds(scan.window.bounds)
+  ));
+  lines.push(format!(
+    "sidebar_region: name={} bounds={}",
+    optional(scan.sidebar_region.name.as_deref()),
+    render_optional_bounds(scan.sidebar_region.bounds)
+  ));
+  lines.push(format!(
+    "boundary: top={:?} bottom={:?} left={:?} right={:?}",
+    scan.boundary.top, scan.boundary.bottom, scan.boundary.left, scan.boundary.right
+  ));
+  lines.push(format!("observations: {}", scan.observations.len()));
+  lines.push("sections:".to_string());
+  if scan.projection.sections.is_empty() {
+    lines.push("  (none)".to_string());
+  } else {
+    for section in &scan.projection.sections {
+      lines.push(format!(
+        "  - {} [{:?}]",
+        optional(section.label.as_deref()),
+        section.kind
+      ));
+      if section.items.is_empty() {
+        lines.push("    (no items)".to_string());
+      } else {
+        for item in &section.items {
+          lines.push(format!(
+            "    - {} confidence={:?} anchor={}",
+            item.label,
+            item.confidence,
+            optional(item.anchor_id.as_deref())
+          ));
+        }
+      }
+    }
+  }
+  lines.push("diagnostics:".to_string());
+  if scan.diagnostics.is_empty() {
+    lines.push("  (none)".to_string());
+  } else {
+    for diagnostic in &scan.diagnostics {
+      lines.push(format!(
+        "  - {}: {}{}",
+        diagnostic.code,
+        diagnostic.message,
+        diagnostic
+          .node_id
+          .as_deref()
+          .map(|node_id| format!(" node={node_id}"))
+          .unwrap_or_default()
+      ));
+    }
+  }
+  lines.push("known_limits:".to_string());
+  if scan.known_limits.is_empty() {
+    lines.push("  (none)".to_string());
+  } else {
+    for limit in &scan.known_limits {
+      lines.push(format!("  - {limit}"));
+    }
+  }
+
+  lines.join("\n")
+}
+
+fn optional(value: Option<&str>) -> &str {
+  value
+    .filter(|value| !value.trim().is_empty())
+    .unwrap_or("-")
+}
+
+fn render_optional_bounds(bounds: Option<ViewBounds>) -> String {
+  bounds
+    .map(|bounds| {
+      format!(
+        "x={:.1},y={:.1},w={:.1},h={:.1}",
+        bounds.x, bounds.y, bounds.width, bounds.height
+      )
+    })
+    .unwrap_or_else(|| "-".to_string())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn run_live_scan(_inputs: &Inputs) -> Result<PlaylistSidebarScan, String> {
+  Err("live NetEase playlist sidebar scan is only supported on macOS".to_string())
+}
+
+#[cfg(target_os = "macos")]
+fn run_live_scan(inputs: &Inputs) -> Result<PlaylistSidebarScan, String> {
+  let driver = MacosDriver::new();
+  let session = driver.open_local().map_err(|error| error.to_string())?;
+  let app = App::bundle(inputs.app_id.clone());
+  let window = session
+    .window()
+    .resolve(Window::main_visible().owned_by(app))
+    .map_err(|error| error.to_string())?;
+  let capture = session
+    .window()
+    .capture(&window)
+    .map_err(|error| error.to_string())?;
+  let window_size = Size::new(window.frame.size.width, window.frame.size.height);
+  let full_window = RatioRect::new(0.0, 0.0, 1.0, 1.0);
+  let full_recognition = recognition_in_window_space(
+    session
+      .vision()
+      .recognize_text_in_capture(&capture, full_window)
+      .map_err(|error| error.to_string())?,
+    &capture,
+  );
+  let app_context = ScanAppContext {
+    app_id: window
+      .app_bundle_id
+      .clone()
+      .or_else(|| Some(inputs.app_id.clone())),
+    name: window.app_name.clone(),
+    version: None,
+  };
+  let window_context = ScanWindowContext {
+    id: Some(window.reference.id.clone()),
+    title: window.title.clone(),
+    bounds: Some(ViewBounds::new(
+      0.0,
+      0.0,
+      window.frame.size.width,
+      window.frame.size.height,
+    )),
+  };
+
+  if let Some(diagnostic) = detect_blocking_modal(&full_recognition) {
+    return Ok(PlaylistSidebarScan {
+      app: app_context,
+      window: window_context,
+      sidebar_region: ViewRegionRecord::default(),
+      observations: Vec::new(),
+      reconstruction: ViewReconstructionRecord {
+        root: empty_root(),
+        anchor_index: Vec::new(),
+        landmark_index: Vec::new(),
+      },
+      projection: PlaylistSidebarProjection::default(),
+      boundary: ScrollBoundarySummary::default(),
+      diagnostics: vec![diagnostic],
+      known_limits: vec![
+        "scan stopped before sidebar observation because a blocking modal was detected".to_string(),
+      ],
+    });
+  }
+
+  let sidebar_region = detect_sidebar_region(inputs.sidebar_region, window_size, &full_recognition)
+    .map_err(|diagnostic| format!("{}: {}", diagnostic.code, diagnostic.message))?;
+  let sidebar_bounds = sidebar_region.bounds.unwrap_or_default();
+  let sidebar_ratio = bounds_to_ratio(sidebar_bounds, &capture);
+  let mut observer = LiveSidebarObserver {
+    session,
+    window: window.clone(),
+    sidebar_bounds,
+    sidebar_ratio,
+    scroll_amount: inputs.scroll_amount,
+  };
+  let mut scan = scan_sidebar_with_observer(
+    &mut observer,
+    ScanOptions {
+      max_pages: inputs.max_pages,
+      max_scrolls: inputs.max_scrolls,
+    },
+  );
+  scan.app = app_context;
+  scan.window = window_context;
+  scan.sidebar_region = sidebar_region;
+  scan.reconstruction.root.bounds = sidebar_bounds;
+
+  Ok(scan)
 }
 
 fn detect_sidebar_region(
@@ -917,6 +1127,117 @@ fn scan_sidebar_with_observer(
   scan
 }
 
+fn empty_root() -> ViewNodeRecord {
+  ViewNodeRecord {
+    id: "root.sidebar".to_string(),
+    kind: ViewNodeKind::Collection,
+    domain_kind: Some("netease.sidebar_playlist_collection".to_string()),
+    layout: Some(ViewLayout::VStack),
+    label: None,
+    bounds: ViewBounds::default(),
+    scrollable: Some(ViewScrollable {
+      axis: ViewAxis::Vertical,
+      boundary: ScrollBoundarySummary::default(),
+    }),
+    anchors: Vec::new(),
+    landmarks: Vec::new(),
+    actions: vec![ViewAction::Scroll],
+    evidence: Vec::new(),
+    children: Vec::new(),
+  }
+}
+
+#[cfg(target_os = "macos")]
+struct LiveSidebarObserver {
+  session: MacosDriverSession,
+  window: auv_driver::Window,
+  sidebar_bounds: ViewBounds,
+  sidebar_ratio: RatioRect,
+  scroll_amount: f64,
+}
+
+#[cfg(target_os = "macos")]
+impl SidebarObserver for LiveSidebarObserver {
+  fn observe(
+    &mut self,
+    observation_index: usize,
+  ) -> Result<SidebarViewportObservation, ParserDiagnostic> {
+    let capture = self
+      .session
+      .window()
+      .capture(&self.window)
+      .map_err(|error| ParserDiagnostic {
+        code: "window_capture_failed".to_string(),
+        message: error.to_string(),
+        node_id: None,
+      })?;
+    let recognition = self
+      .session
+      .vision()
+      .recognize_text_in_capture(&capture, self.sidebar_ratio)
+      .map_err(|error| ParserDiagnostic {
+        code: "sidebar_ocr_failed".to_string(),
+        message: error.to_string(),
+        node_id: None,
+      })?;
+
+    Ok(parse_sidebar_viewport(
+      observation_index,
+      self.sidebar_bounds,
+      &recognition_in_window_space(recognition, &capture),
+    ))
+  }
+
+  fn scroll_down(&mut self) -> Result<(), ParserDiagnostic> {
+    let screen_point = self
+      .session
+      .window()
+      .to_screen_point(
+        &self.window,
+        auv_driver::WindowPoint::new(
+          self.sidebar_bounds.x + self.sidebar_bounds.width / 2.0,
+          self.sidebar_bounds.y + self.sidebar_bounds.height / 2.0,
+        ),
+      )
+      .map_err(|error| ParserDiagnostic {
+        code: "sidebar_scroll_point_failed".to_string(),
+        message: error.to_string(),
+        node_id: None,
+      })?;
+    let point = screen_point.point();
+    auv_driver_macos::native::pointer::scroll_point(point.x, point.y, 0.0, -self.scroll_amount)
+      .map_err(|error| ParserDiagnostic {
+        code: "sidebar_scroll_failed".to_string(),
+        message: error.to_string(),
+        node_id: None,
+      })
+  }
+}
+
+#[cfg(target_os = "macos")]
+fn recognition_in_window_space(
+  mut recognition: TextRecognition,
+  capture: &Capture,
+) -> TextRecognition {
+  for region in &mut recognition.regions {
+    region.bounds.origin.x -= capture.bounds.origin.x;
+    region.bounds.origin.y -= capture.bounds.origin.y;
+  }
+  recognition
+}
+
+#[cfg(target_os = "macos")]
+fn bounds_to_ratio(bounds: ViewBounds, capture: &Capture) -> RatioRect {
+  let width = capture.bounds.size.width.max(1.0);
+  let height = capture.bounds.size.height.max(1.0);
+  RatioRect::new(
+    bounds.x / width,
+    bounds.y / height,
+    bounds.width / width,
+    bounds.height / height,
+  )
+}
+
 fn section_node(
   id: &str,
   kind: SidebarSectionKind,
@@ -1056,6 +1377,7 @@ fn domain_kind_for_section(kind: SidebarSectionKind) -> String {
   .to_string()
 }
 
+#[cfg(test)]
 fn sample_reconstruction() -> ViewReconstructionRecord {
   let anchor = ViewAnchor {
     id: "anchor.coding".to_string(),
@@ -1264,6 +1586,38 @@ mod tests {
     assert!(json.contains("\"reconstruction\""));
     assert!(json.contains("\"projection\""));
     assert!(json.contains("Coding BGM"));
+  }
+
+  #[test]
+  fn render_human_summary_groups_items_by_section() {
+    let observation = parse_sidebar_viewport(
+      0,
+      ViewBounds::new(0.0, 0.0, 240.0, 400.0),
+      &fake_recognition(vec![
+        ("创建的歌单", 8.0, 42.0, 110.0, 20.0),
+        ("Coding BGM", 32.0, 74.0, 120.0, 20.0),
+      ]),
+    );
+    let scan = reconstruct_playlist_sidebar(
+      ScanAppContext {
+        app_id: Some(DEFAULT_APP_ID.to_string()),
+        name: Some("网易云音乐".to_string()),
+        version: None,
+      },
+      ScanWindowContext {
+        id: Some("window.1".to_string()),
+        title: Some("网易云音乐".to_string()),
+        bounds: Some(ViewBounds::new(0.0, 0.0, 800.0, 600.0)),
+      },
+      sidebar_region_record(ViewBounds::new(0.0, 0.0, 240.0, 600.0)),
+      vec![observation],
+    );
+
+    let rendered = render_human_summary(&scan);
+
+    assert!(rendered.contains("创建的歌单"));
+    assert!(rendered.contains("Coding BGM"));
+    assert!(rendered.contains("boundary"));
   }
 
   #[test]

--- a/examples/netease_playlist_ls.rs
+++ b/examples/netease_playlist_ls.rs
@@ -572,25 +572,48 @@ fn run_live_scan(_inputs: &Inputs) -> Result<PlaylistSidebarScan, String> {
 #[cfg(target_os = "macos")]
 fn run_live_scan(inputs: &Inputs) -> Result<PlaylistSidebarScan, String> {
   let driver = MacosDriver::new();
-  let session = driver.open_local().map_err(|error| error.to_string())?;
+  let default_app_context = ScanAppContext {
+    app_id: Some(inputs.app_id.clone()),
+    name: None,
+    version: None,
+  };
+  let session = match driver.open_local() {
+    Ok(session) => session,
+    Err(error) => {
+      return Ok(empty_diagnostic_scan(
+        default_app_context,
+        ScanWindowContext::default(),
+        ViewRegionRecord::default(),
+        ParserDiagnostic {
+          code: "driver_open_failed".to_string(),
+          message: error.to_string(),
+          node_id: None,
+        },
+        "scan stopped before sidebar observation because the macOS driver could not be opened",
+      ));
+    }
+  };
   let app = App::bundle(inputs.app_id.clone());
-  let window = session
+  let window = match session
     .window()
     .resolve(Window::main_visible().owned_by(app))
-    .map_err(|error| error.to_string())?;
-  let capture = session
-    .window()
-    .capture(&window)
-    .map_err(|error| error.to_string())?;
+  {
+    Ok(window) => window,
+    Err(error) => {
+      return Ok(empty_diagnostic_scan(
+        default_app_context,
+        ScanWindowContext::default(),
+        ViewRegionRecord::default(),
+        ParserDiagnostic {
+          code: "target_window_not_found".to_string(),
+          message: error.to_string(),
+          node_id: None,
+        },
+        "scan stopped before sidebar observation because the target window could not be resolved",
+      ));
+    }
+  };
   let window_size = Size::new(window.frame.size.width, window.frame.size.height);
-  let full_window = RatioRect::new(0.0, 0.0, 1.0, 1.0);
-  let full_recognition = recognition_in_window_space(
-    session
-      .vision()
-      .recognize_text_in_capture(&capture, full_window)
-      .map_err(|error| error.to_string())?,
-    &capture,
-  );
   let app_context = ScanAppContext {
     app_id: window
       .app_bundle_id
@@ -609,29 +632,69 @@ fn run_live_scan(inputs: &Inputs) -> Result<PlaylistSidebarScan, String> {
       window.frame.size.height,
     )),
   };
+  let capture = match session.window().capture(&window) {
+    Ok(capture) => capture,
+    Err(error) => {
+      return Ok(empty_diagnostic_scan(
+        app_context,
+        window_context,
+        ViewRegionRecord::default(),
+        ParserDiagnostic {
+          code: "window_capture_failed".to_string(),
+          message: error.to_string(),
+          node_id: None,
+        },
+        "scan stopped before sidebar observation because the target window could not be captured",
+      ));
+    }
+  };
+  let full_window = RatioRect::new(0.0, 0.0, 1.0, 1.0);
+  let full_recognition = match session
+    .vision()
+    .recognize_text_in_capture(&capture, full_window)
+  {
+    Ok(recognition) => recognition_in_window_space(recognition, &capture),
+    Err(error) => {
+      return Ok(empty_diagnostic_scan(
+        app_context,
+        window_context,
+        ViewRegionRecord::default(),
+        ParserDiagnostic {
+          code: "full_window_ocr_failed".to_string(),
+          message: error.to_string(),
+          node_id: None,
+        },
+        "scan stopped before sidebar observation because full-window OCR failed",
+      ));
+    }
+  };
 
   if let Some(diagnostic) = detect_blocking_modal(&full_recognition) {
-    return Ok(PlaylistSidebarScan {
-      app: app_context,
-      window: window_context,
-      sidebar_region: ViewRegionRecord::default(),
-      observations: Vec::new(),
-      reconstruction: ViewReconstructionRecord {
-        root: empty_root(),
-        anchor_index: Vec::new(),
-        landmark_index: Vec::new(),
-      },
-      projection: PlaylistSidebarProjection::default(),
-      boundary: ScrollBoundarySummary::default(),
-      diagnostics: vec![diagnostic],
-      known_limits: vec![
-        "scan stopped before sidebar observation because a blocking modal was detected".to_string(),
-      ],
-    });
+    return Ok(empty_diagnostic_scan(
+      app_context,
+      window_context,
+      ViewRegionRecord::default(),
+      diagnostic,
+      "scan stopped before sidebar observation because a blocking modal was detected",
+    ));
   }
 
-  let sidebar_region = detect_sidebar_region(inputs.sidebar_region, window_size, &full_recognition)
-    .map_err(|diagnostic| format!("{}: {}", diagnostic.code, diagnostic.message))?;
+  let sidebar_region = match detect_sidebar_region(
+    inputs.sidebar_region,
+    window_size,
+    &full_recognition,
+  ) {
+    Ok(sidebar_region) => sidebar_region,
+    Err(diagnostic) => {
+      return Ok(empty_diagnostic_scan(
+        app_context,
+        window_context,
+        ViewRegionRecord::default(),
+        diagnostic,
+        "scan stopped before sidebar observation because the sidebar region could not be detected",
+      ));
+    }
+  };
   let sidebar_bounds = sidebar_region.bounds.unwrap_or_default();
   let sidebar_ratio = bounds_to_ratio(sidebar_bounds, &capture);
   let mut observer = LiveSidebarObserver {
@@ -654,6 +717,35 @@ fn run_live_scan(inputs: &Inputs) -> Result<PlaylistSidebarScan, String> {
   scan.reconstruction.root.bounds = sidebar_bounds;
 
   Ok(scan)
+}
+
+fn empty_diagnostic_scan(
+  app: ScanAppContext,
+  window: ScanWindowContext,
+  sidebar_region: ViewRegionRecord,
+  diagnostic: ParserDiagnostic,
+  known_limit: &str,
+) -> PlaylistSidebarScan {
+  let mut root = empty_root();
+  if let Some(bounds) = sidebar_region.bounds {
+    root.bounds = bounds;
+  }
+
+  PlaylistSidebarScan {
+    app,
+    window,
+    sidebar_region,
+    observations: Vec::new(),
+    reconstruction: ViewReconstructionRecord {
+      root,
+      anchor_index: Vec::new(),
+      landmark_index: Vec::new(),
+    },
+    projection: PlaylistSidebarProjection::default(),
+    boundary: ScrollBoundarySummary::default(),
+    diagnostics: vec![diagnostic],
+    known_limits: vec![known_limit.to_string()],
+  }
 }
 
 fn detect_sidebar_region(
@@ -1016,6 +1108,21 @@ fn reconstruct_playlist_sidebar(
     }
   }
 
+  let has_evidence = observations
+    .iter()
+    .any(|observation| !observation.evidence_nodes.is_empty());
+  let has_candidates = observations
+    .iter()
+    .any(|observation| !observation.candidates.is_empty());
+  if has_evidence && !has_candidates && projection_sections.is_empty() {
+    diagnostics.push(ParserDiagnostic {
+      code: "parser_no_reliable_candidates".to_string(),
+      message: "OCR evidence was observed but no reliable sidebar candidates were accepted"
+        .to_string(),
+      node_id: None,
+    });
+  }
+
   let root = ViewNodeRecord {
     id: "root.sidebar".to_string(),
     kind: ViewNodeKind::Collection,
@@ -1210,7 +1317,9 @@ impl SidebarObserver for LiveSidebarObserver {
         code: "sidebar_scroll_failed".to_string(),
         message: error.to_string(),
         node_id: None,
-      })
+      })?;
+    std::thread::sleep(std::time::Duration::from_millis(150));
+    Ok(())
   }
 }
 
@@ -1821,6 +1930,37 @@ mod tests {
         .diagnostics
         .iter()
         .any(|diagnostic| diagnostic.code == "deduplicated_item")
+    );
+  }
+
+  #[test]
+  fn reconstruct_sidebar_reports_ocr_evidence_without_reliable_candidates() {
+    // ROOT CAUSE:
+    //
+    // If OCR produced evidence but every node was rejected as an unreliable
+    // sidebar candidate, reconstruction returned a clean empty projection.
+    //
+    // Before the fix, JSON consumers could not distinguish an empty sidebar
+    // from a parser rejection. The fix keeps that boundary explicit.
+    let observation = parse_sidebar_viewport(
+      0,
+      ViewBounds::new(0.0, 0.0, 240.0, 400.0),
+      &fake_recognition(vec![("搜索框占位", 8.0, 42.0, 120.0, 20.0)]),
+    );
+
+    let scan = reconstruct_playlist_sidebar(
+      ScanAppContext::default(),
+      ScanWindowContext::default(),
+      ViewRegionRecord::default(),
+      vec![observation],
+    );
+
+    assert!(scan.projection.sections.is_empty());
+    assert!(
+      scan
+        .diagnostics
+        .iter()
+        .any(|diagnostic| diagnostic.code == "parser_no_reliable_candidates")
     );
   }
 

--- a/examples/netease_playlist_ls.rs
+++ b/examples/netease_playlist_ls.rs
@@ -262,7 +262,7 @@ struct SidebarSection {
   items: Vec<PlaylistSidebarItem>,
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 enum SidebarSectionKind {
   FeatureNav,
@@ -277,6 +277,7 @@ enum SidebarSectionKind {
 struct PlaylistSidebarItem {
   id: String,
   label: String,
+  section_hint: Option<SidebarSectionKind>,
   confidence: Confidence,
   candidate_id: Option<String>,
   anchor_id: Option<String>,
@@ -584,6 +585,307 @@ fn slug(value: &str) -> String {
     .collect()
 }
 
+fn reconstruct_playlist_sidebar(
+  app: ScanAppContext,
+  window: ScanWindowContext,
+  sidebar_region: ViewRegionRecord,
+  observations: Vec<SidebarViewportObservation>,
+) -> PlaylistSidebarScan {
+  let boundary = boundary_summary_from_observations(&observations);
+  let mut section_nodes = Vec::new();
+  let mut projection_sections = Vec::new();
+  let mut diagnostics = observations
+    .iter()
+    .flat_map(|observation| observation.parser_notes.clone())
+    .collect::<Vec<_>>();
+  let mut current_section_index = None;
+  let mut section_indices = std::collections::HashMap::new();
+  let mut seen_items = std::collections::HashSet::new();
+
+  for observation in &observations {
+    for candidate in &observation.candidates {
+      match candidate.kind {
+        SidebarCandidateKind::SectionHeader => {
+          let Some(label) = candidate.label.as_deref().map(str::trim) else {
+            continue;
+          };
+          let kind = section_kind_from_label(label);
+          let section_id = format!(
+            "section.obs{}.{}.{}",
+            observation.observation_index,
+            candidate.id,
+            slug(label)
+          );
+          let section_key = (kind, normalize_identity(label));
+          if let Some(section_index) = section_indices.get(&section_key).copied() {
+            current_section_index = Some(section_index);
+          } else {
+            section_nodes.push(section_node(
+              &section_id,
+              kind,
+              label,
+              candidate,
+              observation,
+            ));
+            projection_sections.push(SidebarSection {
+              id: section_id,
+              kind,
+              label: Some(label.to_string()),
+              items: Vec::new(),
+            });
+            let section_index = section_nodes.len() - 1;
+            section_indices.insert(section_key, section_index);
+            current_section_index = Some(section_index);
+          }
+        }
+        SidebarCandidateKind::PlaylistItem | SidebarCandidateKind::NavigationItem => {
+          let Some(label) = candidate.label.as_deref().map(str::trim) else {
+            continue;
+          };
+          let section_index = current_section_index.get_or_insert_with(|| {
+            let section_id = "section.unassigned".to_string();
+            section_nodes.push(ViewNodeRecord {
+              id: section_id.clone(),
+              kind: ViewNodeKind::Section,
+              domain_kind: Some(domain_kind_for_section(SidebarSectionKind::Unknown)),
+              layout: Some(ViewLayout::VStack),
+              label: None,
+              bounds: ViewBounds::default(),
+              scrollable: None,
+              anchors: Vec::new(),
+              landmarks: Vec::new(),
+              actions: vec![ViewAction::ObserveOnly],
+              evidence: Vec::new(),
+              children: Vec::new(),
+            });
+            projection_sections.push(SidebarSection {
+              id: section_id,
+              kind: SidebarSectionKind::Unknown,
+              label: None,
+              items: Vec::new(),
+            });
+            section_nodes.len() - 1
+          });
+          let section_hint = projection_sections[*section_index].kind;
+          let dedupe_key = (section_hint, normalize_identity(label));
+
+          if !seen_items.insert(dedupe_key) {
+            diagnostics.push(ParserDiagnostic {
+              code: "deduplicated_item".to_string(),
+              message: format!(
+                "deduplicated repeated sidebar item {label:?} in section {:?}",
+                section_hint
+              ),
+              node_id: Some(candidate.id.clone()),
+            });
+            continue;
+          }
+
+          let item_id = format!(
+            "item.obs{}.{}.{}",
+            observation.observation_index,
+            candidate.id,
+            slug(label)
+          );
+          let anchor_id = format!("anchor.{item_id}");
+          let node = item_node(&item_id, &anchor_id, label, candidate, observation);
+          attach_item_node(&mut section_nodes[*section_index], node);
+          projection_sections[*section_index]
+            .items
+            .push(PlaylistSidebarItem {
+              id: item_id,
+              label: label.to_string(),
+              section_hint: Some(section_hint),
+              confidence: candidate.confidence,
+              candidate_id: Some(candidate.id.clone()),
+              anchor_id: Some(anchor_id),
+            });
+        }
+        SidebarCandidateKind::Unknown => {}
+      }
+    }
+  }
+
+  let root = ViewNodeRecord {
+    id: "root.sidebar".to_string(),
+    kind: ViewNodeKind::Collection,
+    domain_kind: Some("netease.sidebar_playlist_collection".to_string()),
+    layout: Some(ViewLayout::VStack),
+    label: None,
+    bounds: sidebar_region.bounds.unwrap_or_default(),
+    scrollable: Some(ViewScrollable {
+      axis: ViewAxis::Vertical,
+      boundary: boundary.clone(),
+    }),
+    anchors: Vec::new(),
+    landmarks: Vec::new(),
+    actions: vec![ViewAction::Scroll],
+    evidence: Vec::new(),
+    children: section_nodes,
+  };
+  let mut anchor_index = Vec::new();
+  let mut landmark_index = Vec::new();
+  collect_anchors(&root, &mut anchor_index);
+  collect_landmarks(&root, &mut landmark_index);
+
+  PlaylistSidebarScan {
+    app,
+    window,
+    sidebar_region,
+    observations,
+    reconstruction: ViewReconstructionRecord {
+      root,
+      anchor_index,
+      landmark_index,
+    },
+    projection: PlaylistSidebarProjection {
+      sections: projection_sections,
+    },
+    boundary,
+    diagnostics,
+    known_limits: Vec::new(),
+  }
+}
+
+fn section_node(
+  id: &str,
+  kind: SidebarSectionKind,
+  label: &str,
+  candidate: &SidebarViewportCandidate,
+  observation: &SidebarViewportObservation,
+) -> ViewNodeRecord {
+  ViewNodeRecord {
+    id: id.to_string(),
+    kind: ViewNodeKind::Section,
+    domain_kind: Some(domain_kind_for_section(kind)),
+    layout: Some(ViewLayout::VStack),
+    label: Some(label.to_string()),
+    bounds: candidate.bounds.unwrap_or_default(),
+    scrollable: None,
+    anchors: vec![ViewAnchor {
+      id: format!("anchor.{id}"),
+      label: label.to_string(),
+      strength: AnchorStrength::Medium,
+      bounds: candidate.bounds.unwrap_or_default(),
+      evidence_ids: candidate.evidence_ids.clone(),
+    }],
+    landmarks: vec![ViewLandmark {
+      id: format!("landmark.{id}"),
+      label: label.to_string(),
+      landmark_use: LandmarkUse::SectionAssignment,
+      bounds: candidate.bounds.unwrap_or_default(),
+      evidence_ids: candidate.evidence_ids.clone(),
+    }],
+    actions: vec![ViewAction::ObserveOnly],
+    evidence: candidate_evidence(candidate, observation),
+    children: Vec::new(),
+  }
+}
+
+fn item_node(
+  id: &str,
+  anchor_id: &str,
+  label: &str,
+  candidate: &SidebarViewportCandidate,
+  observation: &SidebarViewportObservation,
+) -> ViewNodeRecord {
+  let evidence = candidate_evidence(candidate, observation);
+  let bounds = candidate.bounds.unwrap_or_default();
+
+  ViewNodeRecord {
+    id: id.to_string(),
+    kind: ViewNodeKind::Item,
+    domain_kind: Some("netease.playlist_item".to_string()),
+    layout: Some(ViewLayout::HStack),
+    label: Some(label.to_string()),
+    bounds,
+    scrollable: None,
+    anchors: vec![ViewAnchor {
+      id: anchor_id.to_string(),
+      label: label.to_string(),
+      strength: AnchorStrength::Strong,
+      bounds,
+      evidence_ids: candidate.evidence_ids.clone(),
+    }],
+    landmarks: Vec::new(),
+    actions: vec![ViewAction::Open, ViewAction::Select],
+    evidence: Vec::new(),
+    children: vec![ViewNodeRecord {
+      id: format!("{id}.text"),
+      kind: ViewNodeKind::Text,
+      domain_kind: None,
+      layout: None,
+      label: Some(label.to_string()),
+      bounds,
+      scrollable: None,
+      anchors: Vec::new(),
+      landmarks: Vec::new(),
+      actions: vec![ViewAction::ObserveOnly],
+      evidence,
+      children: Vec::new(),
+    }],
+  }
+}
+
+fn attach_item_node(section: &mut ViewNodeRecord, item: ViewNodeRecord) {
+  section.children.push(item);
+}
+
+fn collect_anchors(node: &ViewNodeRecord, anchors: &mut Vec<ViewAnchor>) {
+  anchors.extend(node.anchors.clone());
+  for child in &node.children {
+    collect_anchors(child, anchors);
+  }
+}
+
+fn collect_landmarks(node: &ViewNodeRecord, landmarks: &mut Vec<ViewLandmark>) {
+  landmarks.extend(node.landmarks.clone());
+  for child in &node.children {
+    collect_landmarks(child, landmarks);
+  }
+}
+
+fn boundary_summary_from_observations(
+  observations: &[SidebarViewportObservation],
+) -> ScrollBoundarySummary {
+  let mut summary = ScrollBoundarySummary::default();
+  if observations
+    .windows(2)
+    .any(|pair| pair[0].viewport_fingerprint == pair[1].viewport_fingerprint)
+  {
+    summary.bottom = BoundaryConfidence::Likely;
+  }
+  summary
+}
+
+fn candidate_evidence(
+  candidate: &SidebarViewportCandidate,
+  observation: &SidebarViewportObservation,
+) -> Vec<ViewEvidenceNode> {
+  candidate
+    .evidence_ids
+    .iter()
+    .filter_map(|id| {
+      observation
+        .evidence_nodes
+        .iter()
+        .find(|node| node.id == *id)
+        .cloned()
+    })
+    .collect()
+}
+
+fn domain_kind_for_section(kind: SidebarSectionKind) -> String {
+  match kind {
+    SidebarSectionKind::FeatureNav => "netease.feature_nav",
+    SidebarSectionKind::PlaylistNav => "netease.playlist_nav",
+    SidebarSectionKind::MyPlaylists => "netease.my_playlists",
+    SidebarSectionKind::FavoritedPlaylists => "netease.favorited_playlists",
+    SidebarSectionKind::Unknown => "netease.sidebar_section",
+  }
+  .to_string()
+}
+
 fn sample_reconstruction() -> ViewReconstructionRecord {
   let anchor = ViewAnchor {
     id: "anchor.coding".to_string(),
@@ -775,6 +1077,7 @@ mod tests {
           items: vec![PlaylistSidebarItem {
             id: "item.coding".to_string(),
             label: "Coding BGM".to_string(),
+            section_hint: None,
             confidence: Confidence::High,
             candidate_id: Some("candidate.coding".to_string()),
             anchor_id: Some("anchor.coding".to_string()),
@@ -873,6 +1176,88 @@ mod tests {
       ]
     );
     assert_eq!(unique_candidate_ids.len(), observation.candidates.len());
+  }
+
+  #[test]
+  fn reconstruct_sidebar_groups_items_under_carried_section() {
+    let page0 = parse_sidebar_viewport(
+      0,
+      ViewBounds::new(0.0, 0.0, 240.0, 400.0),
+      &fake_recognition(vec![
+        ("创建的歌单", 8.0, 42.0, 110.0, 20.0),
+        ("Coding BGM", 32.0, 74.0, 120.0, 20.0),
+      ]),
+    );
+    let page1 = parse_sidebar_viewport(
+      1,
+      ViewBounds::new(0.0, 0.0, 240.0, 400.0),
+      &fake_recognition(vec![
+        ("Jazz", 32.0, 42.0, 80.0, 20.0),
+        ("收藏的歌单", 8.0, 74.0, 110.0, 20.0),
+        ("Road Trip", 32.0, 106.0, 120.0, 20.0),
+      ]),
+    );
+
+    let scan = reconstruct_playlist_sidebar(
+      ScanAppContext::default(),
+      ScanWindowContext::default(),
+      ViewRegionRecord::default(),
+      vec![page0, page1],
+    );
+
+    assert_eq!(scan.projection.sections.len(), 2);
+    assert_eq!(
+      scan
+        .projection
+        .sections
+        .iter()
+        .map(|section| section.items.len())
+        .sum::<usize>(),
+      3
+    );
+    assert_eq!(scan.projection.sections[0].items[0].label, "Coding BGM");
+    assert_eq!(
+      scan.projection.sections[0].items[1].section_hint,
+      Some(SidebarSectionKind::MyPlaylists)
+    );
+    assert_eq!(
+      scan.projection.sections[1].items[0].section_hint,
+      Some(SidebarSectionKind::FavoritedPlaylists)
+    );
+    assert_eq!(scan.reconstruction.root.kind, ViewNodeKind::Collection);
+    assert_eq!(scan.reconstruction.root.children.len(), 2);
+  }
+
+  #[test]
+  fn reconstruct_sidebar_deduplicates_repeated_item_labels_in_same_section() {
+    let page0 = parse_sidebar_viewport(
+      0,
+      ViewBounds::new(0.0, 0.0, 240.0, 400.0),
+      &fake_recognition(vec![
+        ("创建的歌单", 8.0, 42.0, 110.0, 20.0),
+        ("Coding BGM", 32.0, 74.0, 120.0, 20.0),
+      ]),
+    );
+    let page1 = parse_sidebar_viewport(
+      1,
+      ViewBounds::new(0.0, 0.0, 240.0, 400.0),
+      &fake_recognition(vec![("Coding BGM", 32.0, 42.0, 120.0, 20.0)]),
+    );
+
+    let scan = reconstruct_playlist_sidebar(
+      ScanAppContext::default(),
+      ScanWindowContext::default(),
+      ViewRegionRecord::default(),
+      vec![page0, page1],
+    );
+
+    assert_eq!(scan.projection.sections[0].items.len(), 1);
+    assert!(
+      scan
+        .diagnostics
+        .iter()
+        .any(|diagnostic| diagnostic.code == "deduplicated_item")
+    );
   }
 
   fn fake_recognition(

--- a/examples/netease_playlist_ls.rs
+++ b/examples/netease_playlist_ls.rs
@@ -905,7 +905,7 @@ fn scan_sidebar_with_observer(
       version: None,
     },
     ScanWindowContext {
-      id: Some("fake-sidebar-window".to_string()),
+      id: Some("fake".to_string()),
       title: None,
       bounds: None,
     },
@@ -1556,6 +1556,7 @@ mod tests {
       },
     );
 
+    assert_eq!(scan.window.id, Some("fake".to_string()));
     assert_eq!(scan.observations.len(), 3);
     assert_eq!(scan.boundary.bottom, BoundaryConfidence::Likely);
   }

--- a/examples/netease_playlist_ls.rs
+++ b/examples/netease_playlist_ls.rs
@@ -1,0 +1,194 @@
+use std::path::PathBuf;
+
+const DEFAULT_APP_ID: &str = "com.netease.163music";
+
+#[derive(Clone, Debug, PartialEq)]
+struct Inputs {
+  app_id: String,
+  json_out: Option<PathBuf>,
+  max_pages: usize,
+  max_scrolls: usize,
+  scroll_amount: f64,
+  sidebar_region: Option<RatioRegion>,
+  print_json: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct RatioRegion {
+  x: f64,
+  y: f64,
+  width: f64,
+  height: f64,
+}
+
+impl RatioRegion {
+  const fn new(x: f64, y: f64, width: f64, height: f64) -> Self {
+    Self {
+      x,
+      y,
+      width,
+      height,
+    }
+  }
+}
+
+fn main() {
+  if let Err(error) = run() {
+    eprintln!("{error}");
+    std::process::exit(1);
+  }
+}
+
+fn run() -> Result<(), String> {
+  let _inputs = parse_inputs(std::env::args().skip(1).collect())?;
+  Err("live implementation is added in later tasks".to_string())
+}
+
+fn parse_inputs(args: Vec<String>) -> Result<Inputs, String> {
+  let mut inputs = Inputs {
+    app_id: DEFAULT_APP_ID.to_string(),
+    json_out: None,
+    max_pages: 24,
+    max_scrolls: 48,
+    scroll_amount: 6.0,
+    sidebar_region: None,
+    print_json: false,
+  };
+
+  let mut args = args.into_iter();
+  while let Some(arg) = args.next() {
+    match arg.as_str() {
+      "--app-id" => {
+        inputs.app_id = next_value(&mut args, "--app-id")?;
+      }
+      "--json-out" => {
+        inputs.json_out = Some(PathBuf::from(next_value(&mut args, "--json-out")?));
+      }
+      "--max-pages" => {
+        inputs.max_pages = parse_usize("--max-pages", next_value(&mut args, "--max-pages")?)?;
+        if inputs.max_pages == 0 {
+          return Err("--max-pages must be greater than 0".to_string());
+        }
+      }
+      "--max-scrolls" => {
+        inputs.max_scrolls = parse_usize("--max-scrolls", next_value(&mut args, "--max-scrolls")?)?;
+        if inputs.max_scrolls == 0 {
+          return Err("--max-scrolls must be greater than 0".to_string());
+        }
+      }
+      "--scroll-amount" => {
+        inputs.scroll_amount =
+          parse_f64("--scroll-amount", next_value(&mut args, "--scroll-amount")?)?;
+        if inputs.scroll_amount <= 0.0 {
+          return Err("--scroll-amount must be greater than 0".to_string());
+        }
+      }
+      "--sidebar-region" => {
+        inputs.sidebar_region = Some(parse_ratio_region(next_value(
+          &mut args,
+          "--sidebar-region",
+        )?)?);
+      }
+      "--print-json" => {
+        inputs.print_json = true;
+      }
+      other => return Err(format!("unknown argument {other}")),
+    }
+  }
+
+  Ok(inputs)
+}
+
+fn next_value(args: &mut impl Iterator<Item = String>, flag: &str) -> Result<String, String> {
+  args.next()
+    .ok_or_else(|| format!("{flag} requires a value"))
+}
+
+fn parse_usize(flag: &str, value: String) -> Result<usize, String> {
+  value
+    .parse()
+    .map_err(|_| format!("{flag} expects a positive integer"))
+}
+
+fn parse_f64(flag: &str, value: String) -> Result<f64, String> {
+  value
+    .parse()
+    .map_err(|_| format!("{flag} expects a number"))
+}
+
+fn parse_ratio_region(value: String) -> Result<RatioRegion, String> {
+  let parts = value
+    .split(',')
+    .map(str::trim)
+    .map(|part| {
+      part
+        .parse::<f64>()
+        .map_err(|_| "--sidebar-region expects x,y,width,height".to_string())
+    })
+    .collect::<Result<Vec<_>, _>>()?;
+
+  if parts.len() != 4 {
+    return Err("--sidebar-region expects x,y,width,height".to_string());
+  }
+
+  if parts[2] <= 0.0 || parts[3] <= 0.0 {
+    return Err("--sidebar-region width and height must be greater than 0".to_string());
+  }
+
+  Ok(RatioRegion::new(parts[0], parts[1], parts[2], parts[3]))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn parse_inputs_uses_safe_defaults() {
+    let inputs = parse_inputs(Vec::new()).expect("defaults should parse");
+
+    assert_eq!(inputs.app_id, DEFAULT_APP_ID);
+    assert_eq!(inputs.json_out, None);
+    assert_eq!(inputs.max_pages, 24);
+    assert_eq!(inputs.max_scrolls, 48);
+    assert_eq!(inputs.scroll_amount, 6.0);
+    assert_eq!(inputs.sidebar_region, None);
+    assert!(!inputs.print_json);
+  }
+
+  #[test]
+  fn parse_inputs_accepts_json_and_scan_options() {
+    let inputs = parse_inputs(vec![
+      "--app-id".to_string(),
+      "com.example.music".to_string(),
+      "--json-out".to_string(),
+      "/tmp/scan.json".to_string(),
+      "--max-pages".to_string(),
+      "7".to_string(),
+      "--max-scrolls".to_string(),
+      "9".to_string(),
+      "--scroll-amount".to_string(),
+      "3.5".to_string(),
+      "--sidebar-region".to_string(),
+      "0.0,0.1,0.25,0.8".to_string(),
+      "--print-json".to_string(),
+    ])
+    .expect("arguments should parse");
+
+    assert_eq!(inputs.app_id, "com.example.music");
+    assert_eq!(inputs.json_out, Some(PathBuf::from("/tmp/scan.json")));
+    assert_eq!(inputs.max_pages, 7);
+    assert_eq!(inputs.max_scrolls, 9);
+    assert_eq!(inputs.scroll_amount, 3.5);
+    assert_eq!(
+      inputs.sidebar_region,
+      Some(RatioRegion::new(0.0, 0.1, 0.25, 0.8))
+    );
+    assert!(inputs.print_json);
+  }
+
+  #[test]
+  fn parse_inputs_rejects_unknown_flag() {
+    let error = parse_inputs(vec!["--bogus".to_string()]).expect_err("unknown flag should fail");
+    assert!(error.contains("unknown argument --bogus"));
+  }
+}

--- a/examples/netease_playlist_ls.rs
+++ b/examples/netease_playlist_ls.rs
@@ -64,7 +64,9 @@ struct ScanWindowContext {
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 struct ViewRegionRecord {
   id: Option<String>,
+  name: Option<String>,
   bounds: Option<ViewBounds>,
+  coordinate_space: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
@@ -427,6 +429,87 @@ fn parse_ratio_region(value: String) -> Result<RatioRegion, String> {
   }
 
   Ok(RatioRegion::new(parts[0], parts[1], parts[2], parts[3]))
+}
+
+fn detect_sidebar_region(
+  manual: Option<RatioRegion>,
+  window_size: auv_driver::Size,
+  recognition: &TextRecognition,
+) -> Result<ViewRegionRecord, ParserDiagnostic> {
+  if let Some(region) = manual {
+    return Ok(sidebar_region_record(ratio_to_window_bounds(
+      region,
+      window_size,
+    )));
+  }
+
+  let left_limit = window_size.width * 0.38;
+  let mut marker_right_edges = recognition
+    .regions
+    .iter()
+    .filter(|region| region.bounds.origin.x < left_limit)
+    .filter(|region| is_sidebar_marker(region.text.trim()))
+    .map(|region| region.bounds.origin.x + region.bounds.size.width)
+    .collect::<Vec<_>>();
+
+  if marker_right_edges.is_empty() {
+    return Err(ParserDiagnostic {
+      code: "sidebar_region_not_found".to_string(),
+      message: "sidebar markers could not be identified on the left side".to_string(),
+      node_id: None,
+    });
+  }
+
+  marker_right_edges
+    .sort_by(|left, right| left.partial_cmp(right).unwrap_or(std::cmp::Ordering::Equal));
+  let max_x = marker_right_edges
+    .last()
+    .copied()
+    .unwrap_or_default()
+    .max(window_size.width * 0.18)
+    .min(window_size.width * 0.42);
+
+  Ok(sidebar_region_record(ViewBounds::new(
+    0.0,
+    0.0,
+    max_x + 48.0,
+    window_size.height,
+  )))
+}
+
+fn sidebar_region_record(bounds: ViewBounds) -> ViewRegionRecord {
+  ViewRegionRecord {
+    id: None,
+    name: Some("playlist_sidebar".to_string()),
+    bounds: Some(bounds),
+    coordinate_space: Some("window".to_string()),
+  }
+}
+
+fn ratio_to_window_bounds(region: RatioRegion, window_size: auv_driver::Size) -> ViewBounds {
+  ViewBounds::new(
+    region.x * window_size.width,
+    region.y * window_size.height,
+    region.width * window_size.width,
+    region.height * window_size.height,
+  )
+}
+
+fn is_sidebar_marker(label: &str) -> bool {
+  section_kind_from_label(label) != SidebarSectionKind::Unknown
+    || matches!(label, "推荐" | "发现音乐" | "最近播放")
+}
+
+fn detect_blocking_modal(recognition: &TextRecognition) -> Option<ParserDiagnostic> {
+  let has_cancel = recognition.best_contains("取消").is_some();
+  let has_dialog_action =
+    recognition.best_contains("打开").is_some() || recognition.best_contains("存储").is_some();
+
+  (has_cancel && has_dialog_action).then(|| ParserDiagnostic {
+    code: "blocking_modal_dialog".to_string(),
+    message: "blocking open or save dialog markers were detected".to_string(),
+    node_id: None,
+  })
 }
 
 fn parse_sidebar_viewport(
@@ -1130,6 +1213,46 @@ mod tests {
       observation.evidence_nodes[2].source,
       ViewEvidenceSource::OcrText
     );
+  }
+
+  #[test]
+  fn detect_sidebar_region_uses_manual_region_when_provided() {
+    let region = detect_sidebar_region(
+      Some(RatioRegion::new(0.0, 0.1, 0.25, 0.8)),
+      auv_driver::Size::new(1000.0, 800.0),
+      &fake_recognition(Vec::new()),
+    )
+    .expect("manual sidebar region should be accepted");
+
+    assert_eq!(region.name, Some("playlist_sidebar".to_string()));
+    assert_eq!(
+      region.bounds,
+      Some(ViewBounds::new(0.0, 80.0, 250.0, 640.0))
+    );
+    assert_eq!(region.coordinate_space, Some("window".to_string()));
+  }
+
+  #[test]
+  fn detect_sidebar_region_fails_when_sidebar_markers_are_absent() {
+    let error = detect_sidebar_region(
+      None,
+      auv_driver::Size::new(1000.0, 800.0),
+      &fake_recognition(vec![("搜索", 400.0, 20.0, 60.0, 24.0)]),
+    )
+    .expect_err("missing left-side sidebar markers should fail");
+
+    assert_eq!(error.code, "sidebar_region_not_found");
+  }
+
+  #[test]
+  fn detect_blocking_modal_reports_cancel_or_open_dialog_markers() {
+    let diagnostic = detect_blocking_modal(&fake_recognition(vec![
+      ("打开", 760.0, 720.0, 80.0, 32.0),
+      ("取消", 860.0, 720.0, 80.0, 32.0),
+    ]))
+    .expect("open dialog markers should be reported as blocking modal");
+
+    assert_eq!(diagnostic.code, "blocking_modal_dialog");
   }
 
   #[test]

--- a/examples/netease_playlist_ls.rs
+++ b/examples/netease_playlist_ls.rs
@@ -511,13 +511,23 @@ fn candidate_from_evidence(
   }
 
   Some(SidebarViewportCandidate {
-    id: format!("obs{observation_index}.candidate.{}", slug(label)),
+    id: format!(
+      "obs{observation_index}.candidate.{}.{}",
+      candidate_source_component(observation_index, &node.id),
+      slug(label)
+    ),
     kind,
     label: Some(label.to_string()),
     bounds: Some(bounds),
     evidence_ids: vec![node.id.clone()],
     confidence: node.confidence,
   })
+}
+
+fn candidate_source_component(observation_index: usize, evidence_id: &str) -> &str {
+  evidence_id
+    .strip_prefix(&format!("obs{observation_index}."))
+    .unwrap_or(evidence_id)
 }
 
 fn classify_sidebar_text(label: &str, x: f64) -> SidebarCandidateKind {
@@ -832,6 +842,37 @@ mod tests {
       observation.candidates[0].kind,
       SidebarCandidateKind::SectionHeader
     );
+  }
+
+  #[test]
+  fn parse_viewport_assigns_unique_candidate_ids_for_duplicate_cjk_labels() {
+    let recognition = fake_recognition(vec![
+      ("创建的歌单", 8.0, 42.0, 110.0, 20.0),
+      ("中文歌单", 32.0, 74.0, 120.0, 20.0),
+      ("中文歌单", 32.0, 106.0, 120.0, 20.0),
+    ]);
+    let observation =
+      parse_sidebar_viewport(0, ViewBounds::new(0.0, 0.0, 240.0, 400.0), &recognition);
+    let candidate_ids = observation
+      .candidates
+      .iter()
+      .map(|candidate| candidate.id.as_str())
+      .collect::<Vec<_>>();
+    let unique_candidate_ids = candidate_ids
+      .iter()
+      .copied()
+      .collect::<std::collections::HashSet<_>>();
+
+    assert_eq!(observation.candidates.len(), 3);
+    assert_eq!(
+      candidate_ids,
+      vec![
+        "obs0.candidate.ocr0._____",
+        "obs0.candidate.ocr1.____",
+        "obs0.candidate.ocr2.____"
+      ]
+    );
+    assert_eq!(unique_candidate_ids.len(), observation.candidates.len());
   }
 
   fn fake_recognition(

--- a/examples/netease_playlist_ls.rs
+++ b/examples/netease_playlist_ls.rs
@@ -16,6 +16,12 @@ struct Inputs {
   print_json: bool,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ScanOptions {
+  max_pages: usize,
+  max_scrolls: usize,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 struct RatioRegion {
   x: f64,
@@ -57,6 +63,7 @@ struct ScanAppContext {
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 struct ScanWindowContext {
+  id: Option<String>,
   title: Option<String>,
   bounds: Option<ViewBounds>,
 }
@@ -299,6 +306,14 @@ struct ParserDiagnostic {
   code: String,
   message: String,
   node_id: Option<String>,
+}
+
+trait SidebarObserver {
+  fn observe(
+    &mut self,
+    observation_index: usize,
+  ) -> Result<SidebarViewportObservation, ParserDiagnostic>;
+  fn scroll_down(&mut self) -> Result<(), ParserDiagnostic>;
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
@@ -830,6 +845,76 @@ fn reconstruct_playlist_sidebar(
     diagnostics,
     known_limits: Vec::new(),
   }
+}
+
+fn scan_sidebar_with_observer(
+  observer: &mut impl SidebarObserver,
+  options: ScanOptions,
+) -> PlaylistSidebarScan {
+  let mut observations = Vec::new();
+  let mut diagnostics = Vec::new();
+  let mut known_limits = Vec::new();
+  let mut previous_fingerprint = None;
+  let mut scrolls = 0;
+
+  loop {
+    if observations.len() >= options.max_pages {
+      known_limits.push(format!("stopped after max_pages={}", options.max_pages));
+      break;
+    }
+
+    let observation_index = observations.len();
+    let observation = match observer.observe(observation_index) {
+      Ok(observation) => observation,
+      Err(diagnostic) => {
+        diagnostics.push(diagnostic);
+        break;
+      }
+    };
+    let repeated_fingerprint = previous_fingerprint
+      .as_deref()
+      .is_some_and(|fingerprint| fingerprint == observation.viewport_fingerprint);
+    previous_fingerprint = Some(observation.viewport_fingerprint.clone());
+    observations.push(observation);
+
+    if repeated_fingerprint {
+      break;
+    }
+
+    if observations.len() >= options.max_pages {
+      known_limits.push(format!("stopped after max_pages={}", options.max_pages));
+      break;
+    }
+
+    if scrolls >= options.max_scrolls {
+      known_limits.push(format!("stopped after max_scrolls={}", options.max_scrolls));
+      break;
+    }
+
+    if let Err(diagnostic) = observer.scroll_down() {
+      diagnostics.push(diagnostic);
+      break;
+    }
+    scrolls += 1;
+  }
+
+  let mut scan = reconstruct_playlist_sidebar(
+    ScanAppContext {
+      app_id: Some(DEFAULT_APP_ID.to_string()),
+      name: None,
+      version: None,
+    },
+    ScanWindowContext {
+      id: Some("fake-sidebar-window".to_string()),
+      title: None,
+      bounds: None,
+    },
+    ViewRegionRecord::default(),
+    observations,
+  );
+  scan.diagnostics.extend(diagnostics);
+  scan.known_limits.extend(known_limits);
+  scan
 }
 
 fn section_node(
@@ -1437,6 +1522,115 @@ mod tests {
         .count(),
       1
     );
+  }
+
+  #[test]
+  fn scan_loop_stops_on_repeated_viewport_fingerprint() {
+    let observations = vec![
+      parse_sidebar_viewport(
+        0,
+        ViewBounds::new(0.0, 0.0, 240.0, 400.0),
+        &fake_recognition(vec![
+          ("创建的歌单", 8.0, 42.0, 110.0, 20.0),
+          ("Coding BGM", 32.0, 74.0, 120.0, 20.0),
+        ]),
+      ),
+      parse_sidebar_viewport(
+        1,
+        ViewBounds::new(0.0, 0.0, 240.0, 400.0),
+        &fake_recognition(vec![("Jazz", 32.0, 42.0, 80.0, 20.0)]),
+      ),
+      parse_sidebar_viewport(
+        2,
+        ViewBounds::new(0.0, 0.0, 240.0, 400.0),
+        &fake_recognition(vec![("Jazz", 32.0, 42.0, 80.0, 20.0)]),
+      ),
+    ];
+    let mut observer = FakeSidebarObserver::new(observations);
+
+    let scan = scan_sidebar_with_observer(
+      &mut observer,
+      ScanOptions {
+        max_pages: 10,
+        max_scrolls: 10,
+      },
+    );
+
+    assert_eq!(scan.observations.len(), 3);
+    assert_eq!(scan.boundary.bottom, BoundaryConfidence::Likely);
+  }
+
+  #[test]
+  fn scan_loop_respects_page_budget() {
+    let observations = vec![
+      parse_sidebar_viewport(
+        0,
+        ViewBounds::new(0.0, 0.0, 240.0, 400.0),
+        &fake_recognition(vec![("A", 32.0, 42.0, 80.0, 20.0)]),
+      ),
+      parse_sidebar_viewport(
+        1,
+        ViewBounds::new(0.0, 0.0, 240.0, 400.0),
+        &fake_recognition(vec![("B", 32.0, 42.0, 80.0, 20.0)]),
+      ),
+    ];
+    let mut observer = FakeSidebarObserver::new(observations);
+
+    let scan = scan_sidebar_with_observer(
+      &mut observer,
+      ScanOptions {
+        max_pages: 1,
+        max_scrolls: 10,
+      },
+    );
+
+    assert_eq!(scan.observations.len(), 1);
+    assert!(
+      scan
+        .known_limits
+        .iter()
+        .any(|limit| limit.contains("max_pages"))
+    );
+  }
+
+  struct FakeSidebarObserver {
+    observations: Vec<SidebarViewportObservation>,
+    cursor: usize,
+  }
+
+  impl FakeSidebarObserver {
+    fn new(observations: Vec<SidebarViewportObservation>) -> Self {
+      Self {
+        observations,
+        cursor: 0,
+      }
+    }
+  }
+
+  impl SidebarObserver for FakeSidebarObserver {
+    fn observe(
+      &mut self,
+      observation_index: usize,
+    ) -> Result<SidebarViewportObservation, ParserDiagnostic> {
+      let mut observation =
+        self
+          .observations
+          .get(self.cursor)
+          .cloned()
+          .ok_or_else(|| ParserDiagnostic {
+            code: "no_more_fake_observations".to_string(),
+            message: "fake sidebar observer has no more observations".to_string(),
+            node_id: None,
+          })?;
+      observation.observation_index = observation_index;
+      observation.viewport.page_index = observation_index;
+      Ok(observation)
+    }
+
+    fn scroll_down(&mut self) -> Result<(), ParserDiagnostic> {
+      self.cursor += 1;
+      Ok(())
+    }
   }
 
   fn fake_recognition(

--- a/examples/netease_playlist_ls.rs
+++ b/examples/netease_playlist_ls.rs
@@ -9,7 +9,7 @@ use auv_driver::capture::Capture;
 #[cfg(target_os = "macos")]
 use auv_driver::selector::{App, Window};
 #[cfg(target_os = "macos")]
-use auv_driver::{Driver, RatioRect, Size};
+use auv_driver::{Driver, InputPolicy, RatioRect, Scroll, ScrollOptions, Size};
 #[cfg(target_os = "macos")]
 use auv_driver_macos::{MacosDriver, MacosDriverSession};
 
@@ -289,6 +289,7 @@ struct SidebarSection {
 #[serde(rename_all = "snake_case")]
 enum SidebarSectionKind {
   FeatureNav,
+  LibraryNav,
   PlaylistNav,
   MyPlaylists,
   FavoritedPlaylists,
@@ -327,6 +328,8 @@ trait SidebarObserver {
     &mut self,
     observation_index: usize,
   ) -> Result<SidebarViewportObservation, ParserDiagnostic>;
+  fn observe_probe(&mut self) -> Result<SidebarViewportObservation, ParserDiagnostic>;
+  fn scroll_up(&mut self) -> Result<(), ParserDiagnostic>;
   fn scroll_down(&mut self) -> Result<(), ParserDiagnostic>;
 }
 
@@ -586,7 +589,7 @@ fn run_live_scan(inputs: &Inputs) -> Result<PlaylistSidebarScan, String> {
     name: None,
     version: None,
   };
-  let session = match driver.open_local() {
+  let mut session = match driver.open_local() {
     Ok(session) => session,
     Err(error) => {
       return Ok(empty_diagnostic_scan(
@@ -641,7 +644,10 @@ fn run_live_scan(inputs: &Inputs) -> Result<PlaylistSidebarScan, String> {
       window.frame.size.height,
     )),
   };
-  let capture = match session.window().capture(&window) {
+  let mut pre_scan_diagnostics = Vec::new();
+  let mut pre_scan_known_limits = Vec::new();
+
+  let mut capture = match session.window().capture(&window) {
     Ok(capture) => capture,
     Err(error) => {
       return Ok(empty_diagnostic_scan(
@@ -658,7 +664,7 @@ fn run_live_scan(inputs: &Inputs) -> Result<PlaylistSidebarScan, String> {
     }
   };
   let full_window = RatioRect::new(0.0, 0.0, 1.0, 1.0);
-  let full_recognition = match session
+  let mut full_recognition = match session
     .vision()
     .recognize_text_in_capture(&capture, full_window)
   {
@@ -686,6 +692,64 @@ fn run_live_scan(inputs: &Inputs) -> Result<PlaylistSidebarScan, String> {
       diagnostic,
       "scan stopped before sidebar observation because a blocking modal was detected",
     ));
+  }
+
+  if inputs.sidebar_region.is_none() {
+    let broad_sidebar_bounds = broad_sidebar_probe_bounds(window_size);
+    let broad_sidebar_ratio = bounds_to_ratio(broad_sidebar_bounds, &capture);
+    let mut top_probe = LiveSidebarObserver {
+      session,
+      window: window.clone(),
+      sidebar_bounds: broad_sidebar_bounds,
+      sidebar_ratio: broad_sidebar_ratio,
+      artifact_dir: inputs.artifact_dir.clone(),
+      pending_artifacts: Vec::new(),
+      scroll_amount: inputs.scroll_amount,
+    };
+    let top_seek = scroll_observer_to_top(&mut top_probe, inputs.max_scrolls);
+    pre_scan_diagnostics.extend(top_seek.diagnostics);
+    pre_scan_known_limits.extend(top_seek.known_limits);
+    let LiveSidebarObserver {
+      session: probe_session,
+      ..
+    } = top_probe;
+    session = probe_session;
+
+    capture = match session.window().capture(&window) {
+      Ok(capture) => capture,
+      Err(error) => {
+        return Ok(empty_diagnostic_scan(
+          app_context,
+          window_context,
+          ViewRegionRecord::default(),
+          ParserDiagnostic {
+            code: "window_capture_failed".to_string(),
+            message: error.to_string(),
+            node_id: None,
+          },
+          "scan stopped before sidebar observation because the target window could not be captured after top seek",
+        ));
+      }
+    };
+    full_recognition = match session
+      .vision()
+      .recognize_text_in_capture(&capture, full_window)
+    {
+      Ok(recognition) => recognition_in_window_space(recognition, &capture),
+      Err(error) => {
+        return Ok(empty_diagnostic_scan(
+          app_context,
+          window_context,
+          ViewRegionRecord::default(),
+          ParserDiagnostic {
+            code: "full_window_ocr_failed".to_string(),
+            message: error.to_string(),
+            node_id: None,
+          },
+          "scan stopped before sidebar observation because full-window OCR failed after top seek",
+        ));
+      }
+    };
   }
 
   let sidebar_region = match detect_sidebar_region(
@@ -722,6 +786,8 @@ fn run_live_scan(inputs: &Inputs) -> Result<PlaylistSidebarScan, String> {
       max_scrolls: inputs.max_scrolls,
     },
   );
+  scan.diagnostics.extend(pre_scan_diagnostics);
+  scan.known_limits.extend(pre_scan_known_limits);
   scan.diagnostics.extend(observer.finish_artifacts());
   scan.app = app_context;
   scan.window = window_context;
@@ -825,7 +891,7 @@ fn detect_sidebar_region(
     0.0,
     y,
     max_x + 48.0,
-    window_size.height - y,
+    playlist_sidebar_bottom(window_size) - y,
   )))
 }
 
@@ -864,8 +930,19 @@ fn infer_visible_playlist_body_region(
     0.0,
     min_y,
     max_x + 48.0,
-    window_size.height - min_y,
+    playlist_sidebar_bottom(window_size) - min_y,
   ))
+}
+
+fn playlist_sidebar_bottom(window_size: auv_driver::Size) -> f64 {
+  (window_size.height - 82.0).clamp(0.0, window_size.height)
+}
+
+fn broad_sidebar_probe_bounds(window_size: auv_driver::Size) -> ViewBounds {
+  let width = (window_size.width * 0.24)
+    .max(280.0)
+    .min(window_size.width * 0.42);
+  ViewBounds::new(0.0, 0.0, width, playlist_sidebar_bottom(window_size))
 }
 
 fn sidebar_region_record(bounds: ViewBounds) -> ViewRegionRecord {
@@ -892,7 +969,8 @@ fn is_sidebar_marker(label: &str) -> bool {
 }
 
 fn is_playlist_section_marker(label: &str) -> bool {
-  label.contains("创建") || label.contains("我的歌单") || label.contains("收藏")
+  section_kind_from_label(label) == SidebarSectionKind::MyPlaylists
+    || section_kind_from_label(label) == SidebarSectionKind::FavoritedPlaylists
 }
 
 fn detect_blocking_modal(recognition: &TextRecognition) -> Option<ParserDiagnostic> {
@@ -916,6 +994,17 @@ fn parse_sidebar_viewport(
     .regions
     .iter()
     .enumerate()
+    .filter(|(_, region)| {
+      viewport_contains_center(
+        viewport_bounds,
+        ViewBounds::new(
+          region.bounds.origin.x,
+          region.bounds.origin.y,
+          region.bounds.size.width,
+          region.bounds.size.height,
+        ),
+      )
+    })
     .map(|(index, region)| ViewEvidenceNode {
       id: format!("obs{observation_index}.ocr{index}"),
       source: ViewEvidenceSource::OcrText,
@@ -965,6 +1054,15 @@ fn parse_sidebar_viewport(
     candidates,
     parser_notes: Vec::new(),
   }
+}
+
+fn viewport_contains_center(viewport: ViewBounds, bounds: ViewBounds) -> bool {
+  let center_x = bounds.x + bounds.width * 0.5;
+  let center_y = bounds.y + bounds.height * 0.5;
+  center_x >= viewport.x
+    && center_x <= viewport.x + viewport.width
+    && center_y >= viewport.y
+    && center_y <= viewport.y + viewport.height
 }
 
 fn confidence_from_ocr(confidence: Option<f32>) -> Confidence {
@@ -1025,17 +1123,37 @@ fn classify_sidebar_text(label: &str, x: f64) -> SidebarCandidateKind {
 }
 
 fn section_kind_from_label(label: &str) -> SidebarSectionKind {
-  if label.contains("创建") || label.contains("我的歌单") {
+  let label = normalize_section_label(label);
+  if label.contains("创建的歌单") || label.contains("我的歌单") {
     SidebarSectionKind::MyPlaylists
-  } else if label.contains("收藏") {
+  } else if label.contains("收藏的歌单") {
     SidebarSectionKind::FavoritedPlaylists
-  } else if label.contains("歌单") {
-    SidebarSectionKind::PlaylistNav
-  } else if matches!(label, "推荐" | "音乐服务") {
+  } else if label == "我的收藏" {
+    SidebarSectionKind::LibraryNav
+  } else if matches!(label.as_str(), "推荐" | "音乐服务") {
     SidebarSectionKind::FeatureNav
   } else {
     SidebarSectionKind::Unknown
   }
+}
+
+fn normalize_section_label(label: &str) -> String {
+  let label = label
+    .trim()
+    .trim_end_matches(|char: char| char.is_ascii_digit() || char.is_whitespace())
+    .trim_end_matches(|char| matches!(char, '⌃' | '⌄' | '˄' | '˅' | '^' | '∨' | '⌵' | '入'))
+    .trim_end_matches(|char: char| char.is_ascii_digit() || char.is_whitespace())
+    .trim()
+    .to_string();
+
+  strip_leading_icon_noise(label)
+}
+
+fn strip_leading_icon_noise(label: String) -> String {
+  if label.ends_with("我的收藏") && label != "我的收藏" {
+    return "我的收藏".to_string();
+  }
+  label
 }
 
 fn viewport_fingerprint(nodes: &[ViewEvidenceNode]) -> String {
@@ -1249,6 +1367,9 @@ fn scan_sidebar_with_observer(
   let mut observations = Vec::new();
   let mut diagnostics = Vec::new();
   let mut known_limits = Vec::new();
+  let top_seek = scroll_observer_to_top(observer, options.max_scrolls);
+  diagnostics.extend(top_seek.diagnostics);
+  known_limits.extend(top_seek.known_limits);
   let mut previous_fingerprint = None;
   let mut scrolls = 0;
 
@@ -1309,7 +1430,63 @@ fn scan_sidebar_with_observer(
   );
   scan.diagnostics.extend(diagnostics);
   scan.known_limits.extend(known_limits);
+  if top_seek.boundary == BoundaryConfidence::Likely {
+    apply_top_boundary(&mut scan, top_seek.boundary);
+  }
   scan
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+struct TopSeekOutcome {
+  boundary: BoundaryConfidence,
+  diagnostics: Vec<ParserDiagnostic>,
+  known_limits: Vec<String>,
+}
+
+fn scroll_observer_to_top(
+  observer: &mut impl SidebarObserver,
+  max_scrolls: usize,
+) -> TopSeekOutcome {
+  let mut outcome = TopSeekOutcome::default();
+  let mut previous_fingerprint = match observer.observe_probe() {
+    Ok(observation) => observation.viewport_fingerprint,
+    Err(diagnostic) => {
+      outcome.diagnostics.push(diagnostic);
+      return outcome;
+    }
+  };
+
+  for _ in 0..max_scrolls {
+    if let Err(diagnostic) = observer.scroll_up() {
+      outcome.diagnostics.push(diagnostic);
+      return outcome;
+    }
+
+    let observation = match observer.observe_probe() {
+      Ok(observation) => observation,
+      Err(diagnostic) => {
+        outcome.diagnostics.push(diagnostic);
+        return outcome;
+      }
+    };
+    if observation.viewport_fingerprint == previous_fingerprint {
+      outcome.boundary = BoundaryConfidence::Likely;
+      return outcome;
+    }
+    previous_fingerprint = observation.viewport_fingerprint;
+  }
+
+  outcome
+    .known_limits
+    .push(format!("top seek stopped after max_scrolls={max_scrolls}"));
+  outcome
+}
+
+fn apply_top_boundary(scan: &mut PlaylistSidebarScan, top: BoundaryConfidence) {
+  scan.boundary.top = top;
+  if let Some(scrollable) = scan.reconstruction.root.scrollable.as_mut() {
+    scrollable.boundary.top = top;
+  }
 }
 
 fn empty_root() -> ViewNodeRecord {
@@ -1345,6 +1522,36 @@ struct LiveSidebarObserver {
 
 #[cfg(target_os = "macos")]
 impl LiveSidebarObserver {
+  fn capture_observation(
+    &mut self,
+    observation_index: usize,
+  ) -> Result<(RgbaImage, TextRecognition, SidebarViewportObservation), ParserDiagnostic> {
+    let capture = self
+      .session
+      .window()
+      .capture(&self.window)
+      .map_err(|error| ParserDiagnostic {
+        code: "window_capture_failed".to_string(),
+        message: error.to_string(),
+        node_id: None,
+      })?;
+    let recognition = self
+      .session
+      .vision()
+      .recognize_text_in_capture(&capture, self.sidebar_ratio)
+      .map_err(|error| ParserDiagnostic {
+        code: "sidebar_ocr_failed".to_string(),
+        message: error.to_string(),
+        node_id: None,
+      })?;
+
+    let window_recognition = recognition_in_window_space(recognition, &capture);
+    let observation =
+      parse_sidebar_viewport(observation_index, self.sidebar_bounds, &window_recognition);
+
+    Ok((capture.image.clone(), window_recognition, observation))
+  }
+
   fn write_observation_artifacts(
     &mut self,
     observation_index: usize,
@@ -1424,31 +1631,11 @@ impl SidebarObserver for LiveSidebarObserver {
     &mut self,
     observation_index: usize,
   ) -> Result<SidebarViewportObservation, ParserDiagnostic> {
-    let capture = self
-      .session
-      .window()
-      .capture(&self.window)
-      .map_err(|error| ParserDiagnostic {
-        code: "window_capture_failed".to_string(),
-        message: error.to_string(),
-        node_id: None,
-      })?;
-    let recognition = self
-      .session
-      .vision()
-      .recognize_text_in_capture(&capture, self.sidebar_ratio)
-      .map_err(|error| ParserDiagnostic {
-        code: "sidebar_ocr_failed".to_string(),
-        message: error.to_string(),
-        node_id: None,
-      })?;
-
-    let window_recognition = recognition_in_window_space(recognition, &capture);
-    let mut observation =
-      parse_sidebar_viewport(observation_index, self.sidebar_bounds, &window_recognition);
+    let (image, window_recognition, mut observation) =
+      self.capture_observation(observation_index)?;
     observation.source_artifacts = self.write_observation_artifacts(
       observation_index,
-      capture.image.clone(),
+      image,
       window_recognition,
       observation.clone(),
     );
@@ -1456,7 +1643,23 @@ impl SidebarObserver for LiveSidebarObserver {
     Ok(observation)
   }
 
+  fn observe_probe(&mut self) -> Result<SidebarViewportObservation, ParserDiagnostic> {
+    let (_, _, observation) = self.capture_observation(0)?;
+    Ok(observation)
+  }
+
+  fn scroll_up(&mut self) -> Result<(), ParserDiagnostic> {
+    self.scroll_by(self.scroll_amount)
+  }
+
   fn scroll_down(&mut self) -> Result<(), ParserDiagnostic> {
+    self.scroll_by(-self.scroll_amount)
+  }
+}
+
+#[cfg(target_os = "macos")]
+impl LiveSidebarObserver {
+  fn scroll_by(&mut self, vertical_delta: f64) -> Result<(), ParserDiagnostic> {
     let anchor = scroll_anchor_for_bounds(self.sidebar_bounds);
     let screen_point = self
       .session
@@ -1471,13 +1674,22 @@ impl SidebarObserver for LiveSidebarObserver {
         node_id: None,
       })?;
     let point = screen_point.point();
-    auv_driver_macos::native::pointer::scroll_point(point.x, point.y, 0.0, -self.scroll_amount)
+    self
+      .session
+      .input()
+      .scroll_at(
+        point,
+        Scroll::new(0.0, vertical_delta),
+        ScrollOptions {
+          policy: InputPolicy::BackgroundPreferred,
+          settle: std::time::Duration::from_millis(LIVE_SCROLL_SETTLE_MS),
+        },
+      )
       .map_err(|error| ParserDiagnostic {
         code: "sidebar_scroll_failed".to_string(),
         message: error.to_string(),
         node_id: None,
       })?;
-    std::thread::sleep(std::time::Duration::from_millis(LIVE_SCROLL_SETTLE_MS));
     Ok(())
   }
 }
@@ -1717,97 +1929,13 @@ fn candidate_evidence(
 fn domain_kind_for_section(kind: SidebarSectionKind) -> String {
   match kind {
     SidebarSectionKind::FeatureNav => "netease.feature_nav",
+    SidebarSectionKind::LibraryNav => "netease.library_nav",
     SidebarSectionKind::PlaylistNav => "netease.playlist_nav",
     SidebarSectionKind::MyPlaylists => "netease.my_playlists",
     SidebarSectionKind::FavoritedPlaylists => "netease.favorited_playlists",
     SidebarSectionKind::Unknown => "netease.sidebar_section",
   }
   .to_string()
-}
-
-#[cfg(test)]
-fn sample_reconstruction() -> ViewReconstructionRecord {
-  let anchor = ViewAnchor {
-    id: "anchor.coding".to_string(),
-    label: "Coding BGM".to_string(),
-    strength: AnchorStrength::Strong,
-    bounds: ViewBounds::new(0.0, 50.0, 240.0, 32.0),
-    evidence_ids: vec!["ocr.coding".to_string()],
-  };
-  let landmark = ViewLandmark {
-    id: "landmark.my".to_string(),
-    label: "创建的歌单".to_string(),
-    landmark_use: LandmarkUse::SectionAssignment,
-    bounds: ViewBounds::new(0.0, 20.0, 240.0, 32.0),
-    evidence_ids: Vec::new(),
-  };
-
-  ViewReconstructionRecord {
-    root: ViewNodeRecord {
-      id: "root.sidebar".to_string(),
-      kind: ViewNodeKind::Collection,
-      domain_kind: Some("netease.sidebar_playlist_collection".to_string()),
-      layout: Some(ViewLayout::VStack),
-      label: None,
-      bounds: ViewBounds::new(0.0, 0.0, 240.0, 700.0),
-      scrollable: Some(ViewScrollable {
-        axis: ViewAxis::Vertical,
-        boundary: ScrollBoundarySummary::default(),
-      }),
-      anchors: Vec::new(),
-      landmarks: Vec::new(),
-      actions: vec![ViewAction::Scroll],
-      evidence: Vec::new(),
-      children: vec![ViewNodeRecord {
-        id: "section.my".to_string(),
-        kind: ViewNodeKind::Section,
-        domain_kind: Some("netease.my_playlists".to_string()),
-        layout: Some(ViewLayout::VStack),
-        label: Some("创建的歌单".to_string()),
-        bounds: ViewBounds::new(0.0, 20.0, 240.0, 32.0),
-        scrollable: None,
-        anchors: Vec::new(),
-        landmarks: vec![landmark.clone()],
-        actions: vec![ViewAction::ObserveOnly],
-        evidence: Vec::new(),
-        children: vec![ViewNodeRecord {
-          id: "item.coding".to_string(),
-          kind: ViewNodeKind::Item,
-          domain_kind: Some("netease.playlist_item".to_string()),
-          layout: Some(ViewLayout::HStack),
-          label: Some("Coding BGM".to_string()),
-          bounds: ViewBounds::new(0.0, 50.0, 240.0, 32.0),
-          scrollable: None,
-          anchors: vec![anchor.clone()],
-          landmarks: Vec::new(),
-          actions: vec![ViewAction::Open, ViewAction::Select],
-          evidence: Vec::new(),
-          children: vec![ViewNodeRecord {
-            id: "item.coding.text".to_string(),
-            kind: ViewNodeKind::Text,
-            domain_kind: None,
-            layout: None,
-            label: Some("Coding BGM".to_string()),
-            bounds: ViewBounds::new(30.0, 56.0, 120.0, 20.0),
-            scrollable: None,
-            anchors: Vec::new(),
-            landmarks: Vec::new(),
-            actions: vec![ViewAction::ObserveOnly],
-            evidence: vec![ViewEvidenceNode {
-              id: "ocr.coding".to_string(),
-              source: ViewEvidenceSource::OcrText,
-              label: Some("Coding BGM".to_string()),
-              bounds: Some(ViewBounds::new(30.0, 56.0, 120.0, 20.0)),
-              confidence: Confidence::High,
-            }],
-            children: Vec::new(),
-          }],
-        }],
-      }],
-    },
-    anchor_index: vec![anchor],
-    landmark_index: vec![landmark],
-  }
 }
 
 #[cfg(test)]
@@ -1863,113 +1991,26 @@ mod tests {
   }
 
   #[test]
-  fn parse_inputs_rejects_unknown_flag() {
-    let error = parse_inputs(vec!["--bogus".to_string()]).expect_err("unknown flag should fail");
-    assert!(error.contains("unknown argument --bogus"));
-  }
+  fn parse_inputs_rejects_invalid_values() {
+    let cases = [
+      (vec!["--bogus".to_string()], "unknown argument --bogus"),
+      (
+        vec!["--scroll-amount".to_string(), "NaN".to_string()],
+        "--scroll-amount must be greater than 0",
+      ),
+      (
+        vec![
+          "--sidebar-region".to_string(),
+          "0.0,NaN,0.25,0.8".to_string(),
+        ],
+        "--sidebar-region expects finite x,y,width,height",
+      ),
+    ];
 
-  #[test]
-  fn parse_inputs_rejects_non_finite_scroll_amount() {
-    let error = parse_inputs(vec!["--scroll-amount".to_string(), "NaN".to_string()])
-      .expect_err("non-finite scroll amount should fail");
-
-    assert!(error.contains("--scroll-amount must be greater than 0"));
-  }
-
-  #[test]
-  fn parse_inputs_rejects_non_finite_sidebar_region_component() {
-    let error = parse_inputs(vec![
-      "--sidebar-region".to_string(),
-      "0.0,NaN,0.25,0.8".to_string(),
-    ])
-    .expect_err("non-finite sidebar region component should fail");
-
-    assert!(error.contains("--sidebar-region expects finite x,y,width,height"));
-  }
-
-  #[test]
-  fn view_reconstruction_serializes_tree_with_scrollable_collection() {
-    let reconstruction = sample_reconstruction();
-    let value = serde_json::to_value(&reconstruction).expect("reconstruction should serialize");
-
-    assert_eq!(value["root"]["kind"], "collection");
-    assert_eq!(value["root"]["layout"], "v_stack");
-    assert_eq!(value["root"]["scrollable"]["axis"], "vertical");
-    assert_eq!(value["root"]["children"][0]["kind"], "section");
-    assert_eq!(value["root"]["children"][0]["children"][0]["kind"], "item");
-    assert_eq!(
-      value["root"]["children"][0]["children"][0]["children"][0]["kind"],
-      "text"
-    );
-    assert_eq!(value["anchor_index"][0]["label"], "Coding BGM");
-  }
-
-  #[test]
-  fn playlist_sidebar_scan_uses_reconstruction_plus_projection() {
-    let reconstruction = sample_reconstruction();
-    let scan = PlaylistSidebarScan {
-      app: ScanAppContext::default(),
-      window: ScanWindowContext::default(),
-      sidebar_region: ViewRegionRecord::default(),
-      observations: Vec::new(),
-      reconstruction,
-      projection: PlaylistSidebarProjection {
-        sections: vec![SidebarSection {
-          id: "section.my".to_string(),
-          kind: SidebarSectionKind::MyPlaylists,
-          label: Some("创建的歌单".to_string()),
-          items: vec![PlaylistSidebarItem {
-            id: "item.coding".to_string(),
-            label: "Coding BGM".to_string(),
-            section_hint: None,
-            confidence: Confidence::High,
-            candidate_id: Some("candidate.coding".to_string()),
-            anchor_id: Some("anchor.coding".to_string()),
-          }],
-        }],
-      },
-      boundary: ScrollBoundarySummary::default(),
-      diagnostics: Vec::new(),
-      known_limits: Vec::new(),
-    };
-
-    let json = serde_json::to_string_pretty(&scan).expect("scan should serialize");
-
-    assert!(json.contains("\"reconstruction\""));
-    assert!(json.contains("\"projection\""));
-    assert!(json.contains("Coding BGM"));
-  }
-
-  #[test]
-  fn render_human_summary_groups_items_by_section() {
-    let observation = parse_sidebar_viewport(
-      0,
-      ViewBounds::new(0.0, 0.0, 240.0, 400.0),
-      &fake_recognition(vec![
-        ("创建的歌单", 8.0, 42.0, 110.0, 20.0),
-        ("Coding BGM", 32.0, 74.0, 120.0, 20.0),
-      ]),
-    );
-    let scan = reconstruct_playlist_sidebar(
-      ScanAppContext {
-        app_id: Some(DEFAULT_APP_ID.to_string()),
-        name: Some("网易云音乐".to_string()),
-        version: None,
-      },
-      ScanWindowContext {
-        id: Some("window.1".to_string()),
-        title: Some("网易云音乐".to_string()),
-        bounds: Some(ViewBounds::new(0.0, 0.0, 800.0, 600.0)),
-      },
-      sidebar_region_record(ViewBounds::new(0.0, 0.0, 240.0, 600.0)),
-      vec![observation],
-    );
-
-    let rendered = render_human_summary(&scan);
-
-    assert!(rendered.contains("创建的歌单"));
-    assert!(rendered.contains("Coding BGM"));
-    assert!(rendered.contains("boundary"));
+    for (args, expected) in cases {
+      let error = parse_inputs(args).expect_err("invalid inputs should fail");
+      assert!(error.contains(expected));
+    }
   }
 
   #[test]
@@ -2027,18 +2068,52 @@ mod tests {
   fn detect_sidebar_region_starts_at_playlist_marker() {
     let region = detect_sidebar_region(
       None,
-      auv_driver::Size::new(1000.0, 800.0),
+      auv_driver::Size::new(1646.0, 1053.0),
       &fake_recognition(vec![
         ("推荐", 8.0, 20.0, 40.0, 20.0),
-        ("创建的歌单", 8.0, 160.0, 110.0, 20.0),
-        ("Coding BGM", 32.0, 192.0, 120.0, 20.0),
+        ("创建的歌单", 8.0, 443.0, 110.0, 20.0),
+        ("Coding BGM", 32.0, 485.0, 120.0, 20.0),
+        ("Reverberation", 98.0, 994.0, 160.0, 20.0),
       ]),
     )
     .expect("playlist marker should define the scroll body");
 
     assert_eq!(
       region.bounds,
-      Some(ViewBounds::new(0.0, 160.0, 228.0, 640.0))
+      Some(ViewBounds::new(0.0, 443.0, 344.28, 528.0))
+    );
+  }
+
+  #[test]
+  fn parse_viewport_ignores_bottom_player_bar_outside_sidebar_bounds() {
+    let recognition = fake_recognition(vec![
+      ("创建的歌单", 8.0, 443.0, 110.0, 20.0),
+      ("Coding BGM", 72.0, 485.0, 120.0, 20.0),
+      ("Reverberation", 98.0, 994.0, 160.0, 20.0),
+      ("1w+", 322.0, 1003.0, 19.0, 9.0),
+      ("伊藤賢", 98.0, 1018.0, 45.0, 17.0),
+    ]);
+
+    let observation =
+      parse_sidebar_viewport(0, ViewBounds::new(0.0, 443.0, 344.0, 528.0), &recognition);
+
+    assert!(
+      observation
+        .candidates
+        .iter()
+        .any(|candidate| candidate.label.as_deref() == Some("Coding BGM"))
+    );
+    assert!(
+      observation
+        .candidates
+        .iter()
+        .all(|candidate| candidate.label.as_deref() != Some("Reverberation"))
+    );
+    assert!(
+      observation
+        .candidates
+        .iter()
+        .all(|candidate| candidate.label.as_deref() != Some("1w+"))
     );
   }
 
@@ -2051,7 +2126,7 @@ mod tests {
     )
     .expect("navigation marker should preserve full sidebar fallback");
 
-    assert_eq!(region.bounds, Some(ViewBounds::new(0.0, 0.0, 228.0, 800.0)));
+    assert_eq!(region.bounds, Some(ViewBounds::new(0.0, 0.0, 228.0, 718.0)));
   }
 
   #[test]
@@ -2069,7 +2144,7 @@ mod tests {
 
     assert_eq!(
       region.bounds,
-      Some(ViewBounds::new(0.0, 300.0, 290.0, 500.0))
+      Some(ViewBounds::new(0.0, 300.0, 290.0, 418.0))
     );
   }
 
@@ -2091,7 +2166,7 @@ mod tests {
 
     assert_eq!(
       region.bounds,
-      Some(ViewBounds::new(0.0, 300.0, 290.0, 500.0))
+      Some(ViewBounds::new(0.0, 300.0, 290.0, 418.0))
     );
   }
 
@@ -2173,6 +2248,62 @@ mod tests {
       ]
     );
     assert_eq!(unique_candidate_ids.len(), observation.candidates.len());
+  }
+
+  #[test]
+  fn parse_viewport_treats_playlist_named_rows_as_items_not_sections() {
+    let recognition = fake_recognition(vec![
+      ("创建的歌单 215", 8.0, 42.0, 120.0, 20.0),
+      ("绚香猫的2025年度歌单", 72.0, 74.0, 180.0, 20.0),
+      ("猫音歌单", 72.0, 106.0, 120.0, 20.0),
+    ]);
+    let observation =
+      parse_sidebar_viewport(0, ViewBounds::new(0.0, 0.0, 280.0, 400.0), &recognition);
+
+    assert_eq!(
+      observation.candidates[0].kind,
+      SidebarCandidateKind::SectionHeader
+    );
+    assert_eq!(
+      observation.candidates[1].kind,
+      SidebarCandidateKind::PlaylistItem
+    );
+    assert_eq!(
+      observation.candidates[2].kind,
+      SidebarCandidateKind::PlaylistItem
+    );
+  }
+
+  #[test]
+  fn section_classification_uses_normalized_exact_labels() {
+    assert_eq!(
+      section_kind_from_label("创建的歌单 215"),
+      SidebarSectionKind::MyPlaylists
+    );
+    assert_eq!(
+      section_kind_from_label("收藏的歌单 12"),
+      SidebarSectionKind::FavoritedPlaylists
+    );
+    assert_eq!(
+      section_kind_from_label("我的收藏"),
+      SidebarSectionKind::LibraryNav
+    );
+    assert_eq!(
+      section_kind_from_label("食我的收藏"),
+      SidebarSectionKind::LibraryNav
+    );
+    assert_eq!(
+      section_kind_from_label("创建的歌单 215 入"),
+      SidebarSectionKind::MyPlaylists
+    );
+    assert_eq!(
+      section_kind_from_label("绚香猫的2025年度歌单"),
+      SidebarSectionKind::Unknown
+    );
+    assert_eq!(
+      section_kind_from_label("我的收藏夹"),
+      SidebarSectionKind::Unknown
+    );
   }
 
   #[test]
@@ -2412,6 +2543,38 @@ mod tests {
     );
   }
 
+  #[test]
+  fn scan_loop_rewinds_to_top_before_collecting_pages() {
+    let observations = vec![
+      parse_sidebar_viewport(
+        0,
+        ViewBounds::new(0.0, 0.0, 240.0, 400.0),
+        &fake_recognition(vec![("创建的歌单", 8.0, 42.0, 110.0, 20.0)]),
+      ),
+      parse_sidebar_viewport(
+        1,
+        ViewBounds::new(0.0, 0.0, 240.0, 400.0),
+        &fake_recognition(vec![("Middle Playlist", 32.0, 42.0, 120.0, 20.0)]),
+      ),
+    ];
+    let mut observer = FakeSidebarObserver::new_at(observations, 1);
+
+    let scan = scan_sidebar_with_observer(
+      &mut observer,
+      ScanOptions {
+        max_pages: 1,
+        max_scrolls: 10,
+      },
+    );
+
+    assert_eq!(scan.observations.len(), 1);
+    assert_eq!(
+      scan.observations[0].candidates[0].label.as_deref(),
+      Some("创建的歌单")
+    );
+    assert_eq!(scan.boundary.top, BoundaryConfidence::Likely);
+  }
+
   struct FakeSidebarObserver {
     observations: Vec<SidebarViewportObservation>,
     cursor: usize,
@@ -2422,6 +2585,13 @@ mod tests {
       Self {
         observations,
         cursor: 0,
+      }
+    }
+
+    fn new_at(observations: Vec<SidebarViewportObservation>, cursor: usize) -> Self {
+      Self {
+        observations,
+        cursor,
       }
     }
   }
@@ -2444,6 +2614,23 @@ mod tests {
       observation.observation_index = observation_index;
       observation.viewport.page_index = observation_index;
       Ok(observation)
+    }
+
+    fn observe_probe(&mut self) -> Result<SidebarViewportObservation, ParserDiagnostic> {
+      self
+        .observations
+        .get(self.cursor)
+        .cloned()
+        .ok_or_else(|| ParserDiagnostic {
+          code: "no_more_fake_observations".to_string(),
+          message: "fake sidebar observer has no more observations".to_string(),
+          node_id: None,
+        })
+    }
+
+    fn scroll_up(&mut self) -> Result<(), ParserDiagnostic> {
+      self.cursor = self.cursor.saturating_sub(1);
+      Ok(())
     }
 
     fn scroll_down(&mut self) -> Result<(), ParserDiagnostic> {

--- a/examples/netease_playlist_ls.rs
+++ b/examples/netease_playlist_ls.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use serde::{Deserialize, Serialize};
+
 const DEFAULT_APP_ID: &str = "com.netease.163music";
 
 #[derive(Clone, Debug, PartialEq)]
@@ -22,6 +24,282 @@ struct RatioRegion {
 }
 
 impl RatioRegion {
+  const fn new(x: f64, y: f64, width: f64, height: f64) -> Self {
+    Self {
+      x,
+      y,
+      width,
+      height,
+    }
+  }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+struct PlaylistSidebarScan {
+  app: ScanAppContext,
+  window: ScanWindowContext,
+  sidebar_region: ViewRegionRecord,
+  observations: Vec<SidebarViewportObservation>,
+  reconstruction: ViewReconstructionRecord,
+  projection: PlaylistSidebarProjection,
+  boundary: ScrollBoundarySummary,
+  diagnostics: Vec<ParserDiagnostic>,
+  known_limits: Vec<String>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+struct ScanAppContext {
+  app_id: Option<String>,
+  name: Option<String>,
+  version: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+struct ScanWindowContext {
+  title: Option<String>,
+  bounds: Option<ViewBounds>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+struct ViewRegionRecord {
+  id: Option<String>,
+  bounds: Option<ViewBounds>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+struct SidebarViewportObservation {
+  viewport: ViewViewportRecord,
+  evidence: Vec<ViewEvidenceNode>,
+  candidates: Vec<SidebarViewportCandidate>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+struct ViewViewportRecord {
+  page_index: usize,
+  bounds: ViewBounds,
+  scroll_offset: Option<f64>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+struct ViewEvidenceNode {
+  id: String,
+  source: ViewEvidenceSource,
+  label: Option<String>,
+  bounds: Option<ViewBounds>,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ViewEvidenceSource {
+  OcrText,
+  AxNode,
+  IconMatch,
+  #[default]
+  Visual,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+struct SidebarViewportCandidate {
+  id: String,
+  kind: SidebarCandidateKind,
+  label: Option<String>,
+  bounds: Option<ViewBounds>,
+  evidence_ids: Vec<String>,
+  confidence: Confidence,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum SidebarCandidateKind {
+  SectionHeader,
+  PlaylistItem,
+  NavigationItem,
+  #[default]
+  Unknown,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+struct ViewReconstructionRecord {
+  root: ViewNodeRecord,
+  anchor_index: Vec<ViewAnchor>,
+  landmark_index: Vec<ViewLandmark>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+struct ViewNodeRecord {
+  id: String,
+  kind: ViewNodeKind,
+  domain_kind: Option<String>,
+  layout: Option<ViewLayout>,
+  label: Option<String>,
+  bounds: ViewBounds,
+  scrollable: Option<ViewScrollable>,
+  anchors: Vec<ViewAnchor>,
+  landmarks: Vec<ViewLandmark>,
+  actions: Vec<ViewAction>,
+  evidence: Vec<ViewEvidenceNode>,
+  children: Vec<ViewNodeRecord>,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ViewNodeKind {
+  Container,
+  Collection,
+  Section,
+  Item,
+  Text,
+  Icon,
+  #[default]
+  Unknown,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ViewLayout {
+  VStack,
+  HStack,
+  Group,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ViewAxis {
+  #[default]
+  Vertical,
+  Horizontal,
+  Both,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+struct ViewScrollable {
+  axis: ViewAxis,
+  boundary: ScrollBoundarySummary,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+struct ViewAnchor {
+  id: String,
+  label: String,
+  strength: AnchorStrength,
+  bounds: ViewBounds,
+  evidence_ids: Vec<String>,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum AnchorStrength {
+  #[default]
+  Strong,
+  Medium,
+  Weak,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+struct ViewLandmark {
+  id: String,
+  label: String,
+  #[serde(rename = "use")]
+  landmark_use: LandmarkUse,
+  bounds: ViewBounds,
+  evidence_ids: Vec<String>,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum LandmarkUse {
+  ViewportPose,
+  BoundaryDetection,
+  AnchorReacquire,
+  #[default]
+  SectionAssignment,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ViewAction {
+  Open,
+  Select,
+  Scroll,
+  ObserveOnly,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+struct ScrollBoundarySummary {
+  top: BoundaryConfidence,
+  bottom: BoundaryConfidence,
+  left: BoundaryConfidence,
+  right: BoundaryConfidence,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum BoundaryConfidence {
+  Confirmed,
+  Likely,
+  #[default]
+  Unknown,
+  Contradicted,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+struct PlaylistSidebarProjection {
+  sections: Vec<SidebarSection>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct SidebarSection {
+  id: String,
+  kind: SidebarSectionKind,
+  label: Option<String>,
+  items: Vec<PlaylistSidebarItem>,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum SidebarSectionKind {
+  FeatureNav,
+  PlaylistNav,
+  MyPlaylists,
+  FavoritedPlaylists,
+  #[default]
+  Unknown,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct PlaylistSidebarItem {
+  id: String,
+  label: String,
+  confidence: Confidence,
+  candidate_id: Option<String>,
+  anchor_id: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum Confidence {
+  High,
+  Medium,
+  #[default]
+  Low,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+struct ParserDiagnostic {
+  code: String,
+  message: String,
+  node_id: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
+struct ViewBounds {
+  x: f64,
+  y: f64,
+  width: f64,
+  height: f64,
+}
+
+impl ViewBounds {
   const fn new(x: f64, y: f64, width: f64, height: f64) -> Self {
     Self {
       x,
@@ -143,6 +421,89 @@ fn parse_ratio_region(value: String) -> Result<RatioRegion, String> {
   Ok(RatioRegion::new(parts[0], parts[1], parts[2], parts[3]))
 }
 
+fn sample_reconstruction() -> ViewReconstructionRecord {
+  let anchor = ViewAnchor {
+    id: "anchor.coding".to_string(),
+    label: "Coding BGM".to_string(),
+    strength: AnchorStrength::Strong,
+    bounds: ViewBounds::new(0.0, 50.0, 240.0, 32.0),
+    evidence_ids: vec!["ocr.coding".to_string()],
+  };
+  let landmark = ViewLandmark {
+    id: "landmark.my".to_string(),
+    label: "创建的歌单".to_string(),
+    landmark_use: LandmarkUse::SectionAssignment,
+    bounds: ViewBounds::new(0.0, 20.0, 240.0, 32.0),
+    evidence_ids: Vec::new(),
+  };
+
+  ViewReconstructionRecord {
+    root: ViewNodeRecord {
+      id: "root.sidebar".to_string(),
+      kind: ViewNodeKind::Collection,
+      domain_kind: Some("netease.sidebar_playlist_collection".to_string()),
+      layout: Some(ViewLayout::VStack),
+      label: None,
+      bounds: ViewBounds::new(0.0, 0.0, 240.0, 700.0),
+      scrollable: Some(ViewScrollable {
+        axis: ViewAxis::Vertical,
+        boundary: ScrollBoundarySummary::default(),
+      }),
+      anchors: Vec::new(),
+      landmarks: Vec::new(),
+      actions: vec![ViewAction::Scroll],
+      evidence: Vec::new(),
+      children: vec![ViewNodeRecord {
+        id: "section.my".to_string(),
+        kind: ViewNodeKind::Section,
+        domain_kind: Some("netease.my_playlists".to_string()),
+        layout: Some(ViewLayout::VStack),
+        label: Some("创建的歌单".to_string()),
+        bounds: ViewBounds::new(0.0, 20.0, 240.0, 32.0),
+        scrollable: None,
+        anchors: Vec::new(),
+        landmarks: vec![landmark.clone()],
+        actions: vec![ViewAction::ObserveOnly],
+        evidence: Vec::new(),
+        children: vec![ViewNodeRecord {
+          id: "item.coding".to_string(),
+          kind: ViewNodeKind::Item,
+          domain_kind: Some("netease.playlist_item".to_string()),
+          layout: Some(ViewLayout::HStack),
+          label: Some("Coding BGM".to_string()),
+          bounds: ViewBounds::new(0.0, 50.0, 240.0, 32.0),
+          scrollable: None,
+          anchors: vec![anchor.clone()],
+          landmarks: Vec::new(),
+          actions: vec![ViewAction::Open, ViewAction::Select],
+          evidence: Vec::new(),
+          children: vec![ViewNodeRecord {
+            id: "item.coding.text".to_string(),
+            kind: ViewNodeKind::Text,
+            domain_kind: None,
+            layout: None,
+            label: Some("Coding BGM".to_string()),
+            bounds: ViewBounds::new(30.0, 56.0, 120.0, 20.0),
+            scrollable: None,
+            anchors: Vec::new(),
+            landmarks: Vec::new(),
+            actions: vec![ViewAction::ObserveOnly],
+            evidence: vec![ViewEvidenceNode {
+              id: "ocr.coding".to_string(),
+              source: ViewEvidenceSource::OcrText,
+              label: Some("Coding BGM".to_string()),
+              bounds: Some(ViewBounds::new(30.0, 56.0, 120.0, 20.0)),
+            }],
+            children: Vec::new(),
+          }],
+        }],
+      }],
+    },
+    anchor_index: vec![anchor],
+    landmark_index: vec![landmark],
+  }
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;
@@ -214,5 +575,57 @@ mod tests {
     .expect_err("non-finite sidebar region component should fail");
 
     assert!(error.contains("--sidebar-region expects finite x,y,width,height"));
+  }
+
+  #[test]
+  fn view_reconstruction_serializes_tree_with_scrollable_collection() {
+    let reconstruction = sample_reconstruction();
+    let value = serde_json::to_value(&reconstruction).expect("reconstruction should serialize");
+
+    assert_eq!(value["root"]["kind"], "collection");
+    assert_eq!(value["root"]["layout"], "v_stack");
+    assert_eq!(value["root"]["scrollable"]["axis"], "vertical");
+    assert_eq!(value["root"]["children"][0]["kind"], "section");
+    assert_eq!(value["root"]["children"][0]["children"][0]["kind"], "item");
+    assert_eq!(
+      value["root"]["children"][0]["children"][0]["children"][0]["kind"],
+      "text"
+    );
+    assert_eq!(value["anchor_index"][0]["label"], "Coding BGM");
+  }
+
+  #[test]
+  fn playlist_sidebar_scan_uses_reconstruction_plus_projection() {
+    let reconstruction = sample_reconstruction();
+    let scan = PlaylistSidebarScan {
+      app: ScanAppContext::default(),
+      window: ScanWindowContext::default(),
+      sidebar_region: ViewRegionRecord::default(),
+      observations: Vec::new(),
+      reconstruction,
+      projection: PlaylistSidebarProjection {
+        sections: vec![SidebarSection {
+          id: "section.my".to_string(),
+          kind: SidebarSectionKind::MyPlaylists,
+          label: Some("创建的歌单".to_string()),
+          items: vec![PlaylistSidebarItem {
+            id: "item.coding".to_string(),
+            label: "Coding BGM".to_string(),
+            confidence: Confidence::High,
+            candidate_id: Some("candidate.coding".to_string()),
+            anchor_id: Some("anchor.coding".to_string()),
+          }],
+        }],
+      },
+      boundary: ScrollBoundarySummary::default(),
+      diagnostics: Vec::new(),
+      known_limits: Vec::new(),
+    };
+
+    let json = serde_json::to_string_pretty(&scan).expect("scan should serialize");
+
+    assert!(json.contains("\"reconstruction\""));
+    assert!(json.contains("\"projection\""));
+    assert!(json.contains("Coding BGM"));
   }
 }

--- a/examples/netease_playlist_ls.rs
+++ b/examples/netease_playlist_ls.rs
@@ -600,7 +600,7 @@ fn reconstruct_playlist_sidebar(
     .collect::<Vec<_>>();
   let mut current_section_index = None;
   let mut section_indices = std::collections::HashMap::new();
-  let mut seen_items = std::collections::HashSet::new();
+  let mut seen_items_by_section = Vec::<std::collections::HashSet<String>>::new();
 
   for observation in &observations {
     for candidate in &observation.candidates {
@@ -633,6 +633,7 @@ fn reconstruct_playlist_sidebar(
               label: Some(label.to_string()),
               items: Vec::new(),
             });
+            seen_items_by_section.push(std::collections::HashSet::new());
             let section_index = section_nodes.len() - 1;
             section_indices.insert(section_key, section_index);
             current_section_index = Some(section_index);
@@ -664,12 +665,13 @@ fn reconstruct_playlist_sidebar(
               label: None,
               items: Vec::new(),
             });
+            seen_items_by_section.push(std::collections::HashSet::new());
             section_nodes.len() - 1
           });
           let section_hint = projection_sections[*section_index].kind;
-          let dedupe_key = (section_hint, normalize_identity(label));
+          let dedupe_key = normalize_identity(label);
 
-          if !seen_items.insert(dedupe_key) {
+          if !seen_items_by_section[*section_index].insert(dedupe_key) {
             diagnostics.push(ParserDiagnostic {
               code: "deduplicated_item".to_string(),
               message: format!(
@@ -1257,6 +1259,60 @@ mod tests {
         .diagnostics
         .iter()
         .any(|diagnostic| diagnostic.code == "deduplicated_item")
+    );
+  }
+
+  #[test]
+  fn reconstruct_sidebar_deduplicates_items_per_actual_section() {
+    let page0 = parse_sidebar_viewport(
+      0,
+      ViewBounds::new(0.0, 0.0, 240.0, 400.0),
+      &fake_recognition(vec![
+        ("创建的歌单", 8.0, 42.0, 110.0, 20.0),
+        ("Coding BGM", 32.0, 74.0, 120.0, 20.0),
+      ]),
+    );
+    let page1 = parse_sidebar_viewport(
+      1,
+      ViewBounds::new(0.0, 0.0, 240.0, 400.0),
+      &fake_recognition(vec![("Coding BGM", 32.0, 42.0, 120.0, 20.0)]),
+    );
+    let page2 = parse_sidebar_viewport(
+      2,
+      ViewBounds::new(0.0, 0.0, 240.0, 400.0),
+      &fake_recognition(vec![
+        ("我的歌单", 8.0, 42.0, 110.0, 20.0),
+        ("Coding BGM", 32.0, 74.0, 120.0, 20.0),
+      ]),
+    );
+
+    let scan = reconstruct_playlist_sidebar(
+      ScanAppContext::default(),
+      ScanWindowContext::default(),
+      ViewRegionRecord::default(),
+      vec![page0, page1, page2],
+    );
+
+    assert_eq!(scan.projection.sections.len(), 2);
+    assert_eq!(
+      scan.projection.sections[0].kind,
+      SidebarSectionKind::MyPlaylists
+    );
+    assert_eq!(scan.projection.sections[0].items.len(), 1);
+    assert_eq!(scan.projection.sections[0].items[0].label, "Coding BGM");
+    assert_eq!(
+      scan.projection.sections[1].kind,
+      SidebarSectionKind::MyPlaylists
+    );
+    assert_eq!(scan.projection.sections[1].items.len(), 1);
+    assert_eq!(scan.projection.sections[1].items[0].label, "Coding BGM");
+    assert_eq!(
+      scan
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.code == "deduplicated_item")
+        .count(),
+      1
     );
   }
 

--- a/examples/netease_playlist_ls.rs
+++ b/examples/netease_playlist_ls.rs
@@ -79,7 +79,7 @@ fn parse_inputs(args: Vec<String>) -> Result<Inputs, String> {
       "--scroll-amount" => {
         inputs.scroll_amount =
           parse_f64("--scroll-amount", next_value(&mut args, "--scroll-amount")?)?;
-        if inputs.scroll_amount <= 0.0 {
+        if !inputs.scroll_amount.is_finite() || inputs.scroll_amount <= 0.0 {
           return Err("--scroll-amount must be greater than 0".to_string());
         }
       }
@@ -100,7 +100,8 @@ fn parse_inputs(args: Vec<String>) -> Result<Inputs, String> {
 }
 
 fn next_value(args: &mut impl Iterator<Item = String>, flag: &str) -> Result<String, String> {
-  args.next()
+  args
+    .next()
     .ok_or_else(|| format!("{flag} requires a value"))
 }
 
@@ -129,6 +130,10 @@ fn parse_ratio_region(value: String) -> Result<RatioRegion, String> {
 
   if parts.len() != 4 {
     return Err("--sidebar-region expects x,y,width,height".to_string());
+  }
+
+  if parts.iter().any(|part| !part.is_finite()) {
+    return Err("--sidebar-region expects finite x,y,width,height".to_string());
   }
 
   if parts[2] <= 0.0 || parts[3] <= 0.0 {
@@ -190,5 +195,24 @@ mod tests {
   fn parse_inputs_rejects_unknown_flag() {
     let error = parse_inputs(vec!["--bogus".to_string()]).expect_err("unknown flag should fail");
     assert!(error.contains("unknown argument --bogus"));
+  }
+
+  #[test]
+  fn parse_inputs_rejects_non_finite_scroll_amount() {
+    let error = parse_inputs(vec!["--scroll-amount".to_string(), "NaN".to_string()])
+      .expect_err("non-finite scroll amount should fail");
+
+    assert!(error.contains("--scroll-amount must be greater than 0"));
+  }
+
+  #[test]
+  fn parse_inputs_rejects_non_finite_sidebar_region_component() {
+    let error = parse_inputs(vec![
+      "--sidebar-region".to_string(),
+      "0.0,NaN,0.25,0.8".to_string(),
+    ])
+    .expect_err("non-finite sidebar region component should fail");
+
+    assert!(error.contains("--sidebar-region expects finite x,y,width,height"));
   }
 }

--- a/examples/netease_playlist_ls.rs
+++ b/examples/netease_playlist_ls.rs
@@ -13,6 +13,8 @@ use auv_driver::{Driver, RatioRect, Size};
 use auv_driver_macos::{MacosDriver, MacosDriverSession};
 
 const DEFAULT_APP_ID: &str = "com.netease.163music";
+#[cfg(target_os = "macos")]
+const LIVE_SCROLL_SETTLE_MS: u64 = 500;
 
 #[derive(Clone, Debug, PartialEq)]
 struct Inputs {
@@ -761,15 +763,21 @@ fn detect_sidebar_region(
   }
 
   let left_limit = window_size.width * 0.38;
-  let mut marker_right_edges = recognition
+  let mut markers = recognition
     .regions
     .iter()
     .filter(|region| region.bounds.origin.x < left_limit)
     .filter(|region| is_sidebar_marker(region.text.trim()))
-    .map(|region| region.bounds.origin.x + region.bounds.size.width)
+    .map(|region| {
+      (
+        region.bounds.origin.x + region.bounds.size.width,
+        region.bounds.origin.y,
+        region.text.trim(),
+      )
+    })
     .collect::<Vec<_>>();
 
-  if marker_right_edges.is_empty() {
+  if markers.is_empty() {
     return Err(ParserDiagnostic {
       code: "sidebar_region_not_found".to_string(),
       message: "sidebar markers could not be identified on the left side".to_string(),
@@ -777,20 +785,31 @@ fn detect_sidebar_region(
     });
   }
 
-  marker_right_edges
-    .sort_by(|left, right| left.partial_cmp(right).unwrap_or(std::cmp::Ordering::Equal));
-  let max_x = marker_right_edges
+  markers.sort_by(|left, right| {
+    left
+      .0
+      .partial_cmp(&right.0)
+      .unwrap_or(std::cmp::Ordering::Equal)
+  });
+  let max_x = markers
     .last()
-    .copied()
+    .map(|marker| marker.0)
     .unwrap_or_default()
     .max(window_size.width * 0.18)
     .min(window_size.width * 0.42);
+  let y = markers
+    .iter()
+    .filter(|marker| is_playlist_section_marker(marker.2))
+    .map(|marker| marker.1)
+    .min_by(|left, right| left.partial_cmp(right).unwrap_or(std::cmp::Ordering::Equal))
+    .unwrap_or(0.0)
+    .clamp(0.0, window_size.height);
 
   Ok(sidebar_region_record(ViewBounds::new(
     0.0,
-    0.0,
+    y,
     max_x + 48.0,
-    window_size.height,
+    window_size.height - y,
   )))
 }
 
@@ -815,6 +834,10 @@ fn ratio_to_window_bounds(region: RatioRegion, window_size: auv_driver::Size) ->
 fn is_sidebar_marker(label: &str) -> bool {
   section_kind_from_label(label) != SidebarSectionKind::Unknown
     || matches!(label, "推荐" | "发现音乐" | "最近播放")
+}
+
+fn is_playlist_section_marker(label: &str) -> bool {
+  label.contains("创建") || label.contains("我的歌单") || label.contains("收藏")
 }
 
 fn detect_blocking_modal(recognition: &TextRecognition) -> Option<ParserDiagnostic> {
@@ -1318,7 +1341,7 @@ impl SidebarObserver for LiveSidebarObserver {
         message: error.to_string(),
         node_id: None,
       })?;
-    std::thread::sleep(std::time::Duration::from_millis(150));
+    std::thread::sleep(std::time::Duration::from_millis(LIVE_SCROLL_SETTLE_MS));
     Ok(())
   }
 }
@@ -1778,6 +1801,37 @@ mod tests {
       Some(ViewBounds::new(0.0, 80.0, 250.0, 640.0))
     );
     assert_eq!(region.coordinate_space, Some("window".to_string()));
+  }
+
+  #[test]
+  fn detect_sidebar_region_starts_at_playlist_marker() {
+    let region = detect_sidebar_region(
+      None,
+      auv_driver::Size::new(1000.0, 800.0),
+      &fake_recognition(vec![
+        ("推荐", 8.0, 20.0, 40.0, 20.0),
+        ("创建的歌单", 8.0, 160.0, 110.0, 20.0),
+        ("Coding BGM", 32.0, 192.0, 120.0, 20.0),
+      ]),
+    )
+    .expect("playlist marker should define the scroll body");
+
+    assert_eq!(
+      region.bounds,
+      Some(ViewBounds::new(0.0, 160.0, 228.0, 640.0))
+    );
+  }
+
+  #[test]
+  fn detect_sidebar_region_falls_back_to_full_sidebar_without_playlist_marker() {
+    let region = detect_sidebar_region(
+      None,
+      auv_driver::Size::new(1000.0, 800.0),
+      &fake_recognition(vec![("推荐", 8.0, 20.0, 40.0, 20.0)]),
+    )
+    .expect("navigation marker should preserve full sidebar fallback");
+
+    assert_eq!(region.bounds, Some(ViewBounds::new(0.0, 0.0, 228.0, 800.0)));
   }
 
   #[test]

--- a/examples/netease_playlist_ls.rs
+++ b/examples/netease_playlist_ls.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use auv_driver::vision::TextRecognition;
 use serde::{Deserialize, Serialize};
 
 const DEFAULT_APP_ID: &str = "com.netease.163music";
@@ -68,15 +69,20 @@ struct ViewRegionRecord {
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 struct SidebarViewportObservation {
+  observation_index: usize,
   viewport: ViewViewportRecord,
-  evidence: Vec<ViewEvidenceNode>,
+  source_artifacts: Vec<String>,
+  viewport_fingerprint: String,
+  evidence_nodes: Vec<ViewEvidenceNode>,
   candidates: Vec<SidebarViewportCandidate>,
+  parser_notes: Vec<ParserDiagnostic>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 struct ViewViewportRecord {
   page_index: usize,
   bounds: ViewBounds,
+  axis: ViewAxis,
   scroll_offset: Option<f64>,
 }
 
@@ -86,6 +92,7 @@ struct ViewEvidenceNode {
   source: ViewEvidenceSource,
   label: Option<String>,
   bounds: Option<ViewBounds>,
+  confidence: Confidence,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -421,6 +428,152 @@ fn parse_ratio_region(value: String) -> Result<RatioRegion, String> {
   Ok(RatioRegion::new(parts[0], parts[1], parts[2], parts[3]))
 }
 
+fn parse_sidebar_viewport(
+  observation_index: usize,
+  viewport_bounds: ViewBounds,
+  recognition: &TextRecognition,
+) -> SidebarViewportObservation {
+  let mut evidence_nodes = recognition
+    .regions
+    .iter()
+    .enumerate()
+    .map(|(index, region)| ViewEvidenceNode {
+      id: format!("obs{observation_index}.ocr{index}"),
+      source: ViewEvidenceSource::OcrText,
+      label: Some(region.text.trim().to_string()),
+      bounds: Some(ViewBounds::new(
+        region.bounds.origin.x,
+        region.bounds.origin.y,
+        region.bounds.size.width,
+        region.bounds.size.height,
+      )),
+      confidence: confidence_from_ocr(region.confidence),
+    })
+    .collect::<Vec<_>>();
+
+  evidence_nodes.sort_by(|left, right| {
+    let left_bounds = left.bounds.unwrap_or_default();
+    let right_bounds = right.bounds.unwrap_or_default();
+    left_bounds
+      .y
+      .partial_cmp(&right_bounds.y)
+      .unwrap_or(std::cmp::Ordering::Equal)
+      .then_with(|| {
+        left_bounds
+          .x
+          .partial_cmp(&right_bounds.x)
+          .unwrap_or(std::cmp::Ordering::Equal)
+      })
+  });
+
+  let candidates = evidence_nodes
+    .iter()
+    .filter_map(|node| candidate_from_evidence(observation_index, node))
+    .collect::<Vec<_>>();
+  let viewport_fingerprint = viewport_fingerprint(&evidence_nodes);
+
+  SidebarViewportObservation {
+    observation_index,
+    viewport: ViewViewportRecord {
+      page_index: observation_index,
+      bounds: viewport_bounds,
+      axis: ViewAxis::Vertical,
+      scroll_offset: None,
+    },
+    source_artifacts: Vec::new(),
+    viewport_fingerprint,
+    evidence_nodes,
+    candidates,
+    parser_notes: Vec::new(),
+  }
+}
+
+fn confidence_from_ocr(confidence: Option<f32>) -> Confidence {
+  match confidence {
+    Some(value) if value >= 0.85 => Confidence::High,
+    Some(value) if value >= 0.65 => Confidence::Medium,
+    _ => Confidence::Low,
+  }
+}
+
+fn candidate_from_evidence(
+  observation_index: usize,
+  node: &ViewEvidenceNode,
+) -> Option<SidebarViewportCandidate> {
+  let label = node.label.as_deref()?.trim();
+  if label.chars().count() < 2 {
+    return None;
+  }
+  let bounds = node.bounds?;
+  let kind = classify_sidebar_text(label, bounds.x);
+  if kind == SidebarCandidateKind::Unknown {
+    return None;
+  }
+
+  Some(SidebarViewportCandidate {
+    id: format!("obs{observation_index}.candidate.{}", slug(label)),
+    kind,
+    label: Some(label.to_string()),
+    bounds: Some(bounds),
+    evidence_ids: vec![node.id.clone()],
+    confidence: node.confidence,
+  })
+}
+
+fn classify_sidebar_text(label: &str, x: f64) -> SidebarCandidateKind {
+  if section_kind_from_label(label) != SidebarSectionKind::Unknown {
+    SidebarCandidateKind::SectionHeader
+  } else if x >= 24.0 {
+    SidebarCandidateKind::PlaylistItem
+  } else if matches!(
+    label,
+    "推荐" | "发现音乐" | "播客" | "私人漫游" | "最近播放"
+  ) {
+    SidebarCandidateKind::NavigationItem
+  } else {
+    SidebarCandidateKind::Unknown
+  }
+}
+
+fn section_kind_from_label(label: &str) -> SidebarSectionKind {
+  if label.contains("创建") || label.contains("我的歌单") {
+    SidebarSectionKind::MyPlaylists
+  } else if label.contains("收藏") {
+    SidebarSectionKind::FavoritedPlaylists
+  } else if label.contains("歌单") {
+    SidebarSectionKind::PlaylistNav
+  } else if matches!(label, "推荐" | "音乐服务") {
+    SidebarSectionKind::FeatureNav
+  } else {
+    SidebarSectionKind::Unknown
+  }
+}
+
+fn viewport_fingerprint(nodes: &[ViewEvidenceNode]) -> String {
+  nodes
+    .iter()
+    .filter_map(|node| node.label.as_deref())
+    .map(normalize_identity)
+    .collect::<Vec<_>>()
+    .join("|")
+}
+
+fn normalize_identity(value: &str) -> String {
+  value
+    .trim()
+    .to_lowercase()
+    .chars()
+    .filter(|ch| !ch.is_whitespace())
+    .collect()
+}
+
+fn slug(value: &str) -> String {
+  normalize_identity(value)
+    .chars()
+    .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '_' })
+    .collect()
+}
+
 fn sample_reconstruction() -> ViewReconstructionRecord {
   let anchor = ViewAnchor {
     id: "anchor.coding".to_string(),
@@ -493,6 +646,7 @@ fn sample_reconstruction() -> ViewReconstructionRecord {
               source: ViewEvidenceSource::OcrText,
               label: Some("Coding BGM".to_string()),
               bounds: Some(ViewBounds::new(30.0, 56.0, 120.0, 20.0)),
+              confidence: Confidence::High,
             }],
             children: Vec::new(),
           }],
@@ -627,5 +781,78 @@ mod tests {
     assert!(json.contains("\"reconstruction\""));
     assert!(json.contains("\"projection\""));
     assert!(json.contains("Coding BGM"));
+  }
+
+  #[test]
+  fn parse_viewport_classifies_sections_and_playlist_items() {
+    let recognition = fake_recognition(vec![
+      ("推荐", 8.0, 10.0, 40.0, 20.0),
+      ("创建的歌单", 8.0, 42.0, 110.0, 20.0),
+      ("Coding BGM", 32.0, 74.0, 120.0, 20.0),
+      ("Jazz", 32.0, 106.0, 80.0, 20.0),
+    ]);
+    let observation =
+      parse_sidebar_viewport(0, ViewBounds::new(0.0, 0.0, 240.0, 400.0), &recognition);
+
+    assert_eq!(observation.candidates.len(), 4);
+    assert_eq!(
+      observation.candidates[1].kind,
+      SidebarCandidateKind::SectionHeader
+    );
+    assert_eq!(
+      observation.candidates[1].label,
+      Some("创建的歌单".to_string())
+    );
+    assert_eq!(
+      observation.candidates[2].kind,
+      SidebarCandidateKind::PlaylistItem
+    );
+    assert_eq!(
+      observation.candidates[2].label,
+      Some("Coding BGM".to_string())
+    );
+    assert_eq!(
+      observation.evidence_nodes[2].source,
+      ViewEvidenceSource::OcrText
+    );
+  }
+
+  #[test]
+  fn parse_viewport_keeps_unknown_short_noise_as_evidence_not_item() {
+    let recognition = fake_recognition(vec![
+      ("创建的歌单", 8.0, 42.0, 110.0, 20.0),
+      ("·", 12.0, 74.0, 8.0, 8.0),
+    ]);
+    let observation =
+      parse_sidebar_viewport(0, ViewBounds::new(0.0, 0.0, 240.0, 400.0), &recognition);
+
+    assert_eq!(observation.evidence_nodes.len(), 2);
+    assert_eq!(observation.candidates.len(), 1);
+    assert_eq!(
+      observation.candidates[0].kind,
+      SidebarCandidateKind::SectionHeader
+    );
+  }
+
+  fn fake_recognition(
+    rows: Vec<(&str, f64, f64, f64, f64)>,
+  ) -> auv_driver::vision::TextRecognition {
+    auv_driver::vision::TextRecognition {
+      text: rows
+        .iter()
+        .map(|(text, _, _, _, _)| *text)
+        .collect::<Vec<_>>()
+        .join("\n"),
+      regions: rows
+        .into_iter()
+        .map(
+          |(text, x, y, width, height)| auv_driver::vision::RecognizedText {
+            text: text.to_string(),
+            bounds: auv_driver::Rect::new(x, y, width, height),
+            confidence: Some(0.92),
+          },
+        )
+        .collect(),
+    }
   }
 }

--- a/examples/netease_playlist_ls.rs
+++ b/examples/netease_playlist_ls.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use auv_driver::vision::TextRecognition;
+use image::{Rgba, RgbaImage};
 use serde::{Deserialize, Serialize};
 
 #[cfg(target_os = "macos")]
@@ -13,6 +14,7 @@ use auv_driver::{Driver, RatioRect, Size};
 use auv_driver_macos::{MacosDriver, MacosDriverSession};
 
 const DEFAULT_APP_ID: &str = "com.netease.163music";
+const DEFAULT_ARTIFACT_DIR: &str = "/tmp/auv-netease-playlist-ls-artifacts";
 #[cfg(target_os = "macos")]
 const LIVE_SCROLL_SETTLE_MS: u64 = 500;
 
@@ -20,6 +22,7 @@ const LIVE_SCROLL_SETTLE_MS: u64 = 500;
 struct Inputs {
   app_id: String,
   json_out: Option<PathBuf>,
+  artifact_dir: PathBuf,
   max_pages: usize,
   max_scrolls: usize,
   scroll_amount: f64,
@@ -376,6 +379,7 @@ fn parse_inputs(args: Vec<String>) -> Result<Inputs, String> {
   let mut inputs = Inputs {
     app_id: DEFAULT_APP_ID.to_string(),
     json_out: None,
+    artifact_dir: PathBuf::from(DEFAULT_ARTIFACT_DIR),
     max_pages: 24,
     max_scrolls: 48,
     scroll_amount: 6.0,
@@ -391,6 +395,9 @@ fn parse_inputs(args: Vec<String>) -> Result<Inputs, String> {
       }
       "--json-out" => {
         inputs.json_out = Some(PathBuf::from(next_value(&mut args, "--json-out")?));
+      }
+      "--artifact-dir" => {
+        inputs.artifact_dir = PathBuf::from(next_value(&mut args, "--artifact-dir")?);
       }
       "--max-pages" => {
         inputs.max_pages = parse_usize("--max-pages", next_value(&mut args, "--max-pages")?)?;
@@ -704,6 +711,8 @@ fn run_live_scan(inputs: &Inputs) -> Result<PlaylistSidebarScan, String> {
     window: window.clone(),
     sidebar_bounds,
     sidebar_ratio,
+    artifact_dir: inputs.artifact_dir.clone(),
+    pending_artifacts: Vec::new(),
     scroll_amount: inputs.scroll_amount,
   };
   let mut scan = scan_sidebar_with_observer(
@@ -713,6 +722,7 @@ fn run_live_scan(inputs: &Inputs) -> Result<PlaylistSidebarScan, String> {
       max_scrolls: inputs.max_scrolls,
     },
   );
+  scan.diagnostics.extend(observer.finish_artifacts());
   scan.app = app_context;
   scan.window = window_context;
   scan.sidebar_region = sidebar_region;
@@ -1328,7 +1338,84 @@ struct LiveSidebarObserver {
   window: auv_driver::Window,
   sidebar_bounds: ViewBounds,
   sidebar_ratio: RatioRect,
+  artifact_dir: PathBuf,
+  pending_artifacts: Vec<std::thread::JoinHandle<Result<(), String>>>,
   scroll_amount: f64,
+}
+
+#[cfg(target_os = "macos")]
+impl LiveSidebarObserver {
+  fn write_observation_artifacts(
+    &mut self,
+    observation_index: usize,
+    image: RgbaImage,
+    recognition: TextRecognition,
+    observation: SidebarViewportObservation,
+  ) -> Vec<String> {
+    let base = format!("obs-{observation_index:04}");
+    let screenshot = self.artifact_dir.join(format!("{base}-window.png"));
+    let overlay = self.artifact_dir.join(format!("{base}-overlay.png"));
+    let recognition_json = self.artifact_dir.join(format!("{base}-recognition.json"));
+    let observation_json = self.artifact_dir.join(format!("{base}-observation.json"));
+    let paths = vec![
+      screenshot.clone(),
+      overlay.clone(),
+      recognition_json.clone(),
+      observation_json.clone(),
+    ];
+    let artifact_dir = self.artifact_dir.clone();
+    let sidebar_bounds = self.sidebar_bounds;
+    self.pending_artifacts.push(std::thread::spawn(move || {
+      std::fs::create_dir_all(&artifact_dir)
+        .map_err(|error| format!("failed to create {}: {error}", artifact_dir.display()))?;
+      image
+        .save(&screenshot)
+        .map_err(|error| format!("failed to save {}: {error}", screenshot.display()))?;
+
+      let mut overlay_image = image.clone();
+      draw_overlay(&mut overlay_image, sidebar_bounds, &observation);
+      overlay_image
+        .save(&overlay)
+        .map_err(|error| format!("failed to save {}: {error}", overlay.display()))?;
+
+      let recognition_payload = serde_json::to_string_pretty(&recognition)
+        .map_err(|error| format!("failed to serialize recognition: {error}"))?;
+      std::fs::write(&recognition_json, recognition_payload)
+        .map_err(|error| format!("failed to write {}: {error}", recognition_json.display()))?;
+
+      let observation_payload = serde_json::to_string_pretty(&observation)
+        .map_err(|error| format!("failed to serialize observation: {error}"))?;
+      std::fs::write(&observation_json, observation_payload)
+        .map_err(|error| format!("failed to write {}: {error}", observation_json.display()))?;
+
+      Ok(())
+    }));
+
+    paths
+      .into_iter()
+      .map(|path| path.display().to_string())
+      .collect()
+  }
+
+  fn finish_artifacts(self) -> Vec<ParserDiagnostic> {
+    self
+      .pending_artifacts
+      .into_iter()
+      .filter_map(|handle| match handle.join() {
+        Ok(Ok(())) => None,
+        Ok(Err(error)) => Some(ParserDiagnostic {
+          code: "artifact_write_failed".to_string(),
+          message: error,
+          node_id: None,
+        }),
+        Err(_) => Some(ParserDiagnostic {
+          code: "artifact_write_panicked".to_string(),
+          message: "background artifact writer panicked".to_string(),
+          node_id: None,
+        }),
+      })
+      .collect()
+  }
 }
 
 #[cfg(target_os = "macos")]
@@ -1356,23 +1443,27 @@ impl SidebarObserver for LiveSidebarObserver {
         node_id: None,
       })?;
 
-    Ok(parse_sidebar_viewport(
+    let window_recognition = recognition_in_window_space(recognition, &capture);
+    let mut observation =
+      parse_sidebar_viewport(observation_index, self.sidebar_bounds, &window_recognition);
+    observation.source_artifacts = self.write_observation_artifacts(
       observation_index,
-      self.sidebar_bounds,
-      &recognition_in_window_space(recognition, &capture),
-    ))
+      capture.image.clone(),
+      window_recognition,
+      observation.clone(),
+    );
+
+    Ok(observation)
   }
 
   fn scroll_down(&mut self) -> Result<(), ParserDiagnostic> {
+    let anchor = scroll_anchor_for_bounds(self.sidebar_bounds);
     let screen_point = self
       .session
       .window()
       .to_screen_point(
         &self.window,
-        auv_driver::WindowPoint::new(
-          self.sidebar_bounds.x + self.sidebar_bounds.width / 2.0,
-          self.sidebar_bounds.y + self.sidebar_bounds.height / 2.0,
-        ),
+        auv_driver::WindowPoint::new(anchor.x, anchor.y),
       )
       .map_err(|error| ParserDiagnostic {
         code: "sidebar_scroll_point_failed".to_string(),
@@ -1392,6 +1483,14 @@ impl SidebarObserver for LiveSidebarObserver {
 }
 
 #[cfg(target_os = "macos")]
+fn scroll_anchor_for_bounds(bounds: ViewBounds) -> auv_driver::Point {
+  auv_driver::Point::new(
+    bounds.x + bounds.width * 0.5,
+    bounds.y + bounds.height * 0.75,
+  )
+}
+
+#[cfg(target_os = "macos")]
 fn recognition_in_window_space(
   mut recognition: TextRecognition,
   capture: &Capture,
@@ -1401,6 +1500,78 @@ fn recognition_in_window_space(
     region.bounds.origin.y -= capture.bounds.origin.y;
   }
   recognition
+}
+
+#[cfg(target_os = "macos")]
+fn draw_overlay(
+  image: &mut RgbaImage,
+  sidebar_bounds: ViewBounds,
+  observation: &SidebarViewportObservation,
+) {
+  draw_rect(image, sidebar_bounds, Rgba([255, 64, 64, 255]), 3);
+  for evidence in &observation.evidence_nodes {
+    if let Some(bounds) = evidence.bounds {
+      draw_rect(image, bounds, Rgba([64, 160, 255, 255]), 2);
+    }
+  }
+  for candidate in &observation.candidates {
+    if let Some(bounds) = candidate.bounds {
+      let color = match candidate.kind {
+        SidebarCandidateKind::SectionHeader => Rgba([255, 210, 64, 255]),
+        SidebarCandidateKind::PlaylistItem => Rgba([64, 230, 120, 255]),
+        SidebarCandidateKind::NavigationItem => Rgba([200, 120, 255, 255]),
+        SidebarCandidateKind::Unknown => Rgba([160, 160, 160, 255]),
+      };
+      draw_rect(image, bounds, color, 3);
+    }
+  }
+}
+
+#[cfg(target_os = "macos")]
+fn draw_rect(image: &mut RgbaImage, bounds: ViewBounds, color: Rgba<u8>, stroke: i64) {
+  let x0 = bounds.x.round() as i64;
+  let y0 = bounds.y.round() as i64;
+  let x1 = (bounds.x + bounds.width).round() as i64;
+  let y1 = (bounds.y + bounds.height).round() as i64;
+  for offset in 0..stroke {
+    draw_line(image, x0, y0 + offset, x1, y0 + offset, color);
+    draw_line(image, x0, y1 - offset, x1, y1 - offset, color);
+    draw_line(image, x0 + offset, y0, x0 + offset, y1, color);
+    draw_line(image, x1 - offset, y0, x1 - offset, y1, color);
+  }
+}
+
+#[cfg(target_os = "macos")]
+fn draw_line(image: &mut RgbaImage, mut x0: i64, mut y0: i64, x1: i64, y1: i64, color: Rgba<u8>) {
+  let dx = (x1 - x0).abs();
+  let sx = if x0 < x1 { 1 } else { -1 };
+  let dy = -(y1 - y0).abs();
+  let sy = if y0 < y1 { 1 } else { -1 };
+  let mut error = dx + dy;
+
+  loop {
+    put_pixel(image, x0, y0, color);
+    if x0 == x1 && y0 == y1 {
+      break;
+    }
+    let doubled = error * 2;
+    if doubled >= dy {
+      error += dy;
+      x0 += sx;
+    }
+    if doubled <= dx {
+      error += dx;
+      y0 += sy;
+    }
+  }
+}
+
+#[cfg(target_os = "macos")]
+fn put_pixel(image: &mut RgbaImage, x: i64, y: i64, color: Rgba<u8>) {
+  if x < 0 || y < 0 || x >= image.width() as i64 || y >= image.height() as i64 {
+    return;
+  }
+  image.put_pixel(x as u32, y as u32, color);
 }
 
 #[cfg(target_os = "macos")]
@@ -1649,6 +1820,7 @@ mod tests {
 
     assert_eq!(inputs.app_id, DEFAULT_APP_ID);
     assert_eq!(inputs.json_out, None);
+    assert_eq!(inputs.artifact_dir, PathBuf::from(DEFAULT_ARTIFACT_DIR));
     assert_eq!(inputs.max_pages, 24);
     assert_eq!(inputs.max_scrolls, 48);
     assert_eq!(inputs.scroll_amount, 6.0);
@@ -1663,6 +1835,8 @@ mod tests {
       "com.example.music".to_string(),
       "--json-out".to_string(),
       "/tmp/scan.json".to_string(),
+      "--artifact-dir".to_string(),
+      "/tmp/scan-artifacts".to_string(),
       "--max-pages".to_string(),
       "7".to_string(),
       "--max-scrolls".to_string(),
@@ -1677,6 +1851,7 @@ mod tests {
 
     assert_eq!(inputs.app_id, "com.example.music");
     assert_eq!(inputs.json_out, Some(PathBuf::from("/tmp/scan.json")));
+    assert_eq!(inputs.artifact_dir, PathBuf::from("/tmp/scan-artifacts"));
     assert_eq!(inputs.max_pages, 7);
     assert_eq!(inputs.max_scrolls, 9);
     assert_eq!(inputs.scroll_amount, 3.5);
@@ -1941,6 +2116,15 @@ mod tests {
     .expect("open dialog markers should be reported as blocking modal");
 
     assert_eq!(diagnostic.code, "blocking_modal_dialog");
+  }
+
+  #[cfg(target_os = "macos")]
+  #[test]
+  fn scroll_anchor_uses_lower_playlist_body_hit_area() {
+    let anchor = scroll_anchor_for_bounds(ViewBounds::new(0.0, 146.0, 344.0, 908.0));
+
+    assert_eq!(anchor.x, 172.0);
+    assert_eq!(anchor.y, 827.0);
   }
 
   #[test]

--- a/examples/netease_playlist_ls.rs
+++ b/examples/netease_playlist_ls.rs
@@ -763,10 +763,13 @@ fn detect_sidebar_region(
   }
 
   let left_limit = window_size.width * 0.38;
-  let mut markers = recognition
+  let left_regions = recognition
     .regions
     .iter()
     .filter(|region| region.bounds.origin.x < left_limit)
+    .collect::<Vec<_>>();
+  let mut markers = left_regions
+    .iter()
     .filter(|region| is_sidebar_marker(region.text.trim()))
     .map(|region| {
       (
@@ -778,6 +781,9 @@ fn detect_sidebar_region(
     .collect::<Vec<_>>();
 
   if markers.is_empty() {
+    if let Some(region) = infer_visible_playlist_body_region(&left_regions, window_size) {
+      return Ok(sidebar_region_record(region));
+    }
     return Err(ParserDiagnostic {
       code: "sidebar_region_not_found".to_string(),
       message: "sidebar markers could not be identified on the left side".to_string(),
@@ -811,6 +817,45 @@ fn detect_sidebar_region(
     max_x + 48.0,
     window_size.height - y,
   )))
+}
+
+fn infer_visible_playlist_body_region(
+  left_regions: &[&auv_driver::vision::RecognizedText],
+  window_size: auv_driver::Size,
+) -> Option<ViewBounds> {
+  let rows = left_regions
+    .iter()
+    .filter(|region| {
+      let label = region.text.trim();
+      label.chars().count() >= 2
+        && region.bounds.origin.x >= 48.0
+        && region.bounds.origin.x <= window_size.width * 0.24
+        && region.bounds.origin.y >= window_size.height * 0.25
+    })
+    .collect::<Vec<_>>();
+  if rows.len() < 3 {
+    return None;
+  }
+
+  let min_y = (rows
+    .iter()
+    .map(|region| region.bounds.origin.y)
+    .fold(f64::INFINITY, f64::min)
+    - 20.0)
+    .clamp(0.0, window_size.height);
+  let max_x = rows
+    .iter()
+    .map(|region| region.bounds.origin.x + region.bounds.size.width)
+    .fold(0.0, f64::max)
+    .max(window_size.width * 0.18)
+    .min(window_size.width * 0.42);
+
+  Some(ViewBounds::new(
+    0.0,
+    min_y,
+    max_x + 48.0,
+    window_size.height - min_y,
+  ))
 }
 
 fn sidebar_region_record(bounds: ViewBounds) -> ViewRegionRecord {
@@ -1832,6 +1877,47 @@ mod tests {
     .expect("navigation marker should preserve full sidebar fallback");
 
     assert_eq!(region.bounds, Some(ViewBounds::new(0.0, 0.0, 228.0, 800.0)));
+  }
+
+  #[test]
+  fn detect_sidebar_region_infers_visible_playlist_body_without_section_marker() {
+    let region = detect_sidebar_region(
+      None,
+      auv_driver::Size::new(1000.0, 800.0),
+      &fake_recognition(vec![
+        ("Future Garage", 72.0, 320.0, 140.0, 20.0),
+        ("Progressive House", 72.0, 366.0, 170.0, 20.0),
+        ("Trance", 72.0, 412.0, 80.0, 20.0),
+      ]),
+    )
+    .expect("visible playlist rows should infer the scroll body");
+
+    assert_eq!(
+      region.bounds,
+      Some(ViewBounds::new(0.0, 300.0, 290.0, 500.0))
+    );
+  }
+
+  #[test]
+  fn detect_sidebar_region_ignores_main_content_when_inferring_playlist_body() {
+    let region = detect_sidebar_region(
+      None,
+      auv_driver::Size::new(1000.0, 800.0),
+      &fake_recognition(vec![
+        ("网易云音乐", 52.0, 40.0, 100.0, 20.0),
+        ("Future Garage", 72.0, 320.0, 140.0, 20.0),
+        ("Progressive House", 72.0, 366.0, 170.0, 20.0),
+        ("Trance", 72.0, 412.0, 80.0, 20.0),
+        ("每日推荐", 430.0, 300.0, 120.0, 30.0),
+        ("推荐歌单", 520.0, 520.0, 150.0, 30.0),
+      ]),
+    )
+    .expect("visible playlist rows should infer the scroll body");
+
+    assert_eq!(
+      region.bounds,
+      Some(ViewBounds::new(0.0, 300.0, 290.0, 500.0))
+    );
   }
 
   #[test]

--- a/src/driver/macos/control/common.rs
+++ b/src/driver/macos/control/common.rs
@@ -25,6 +25,26 @@ pub(super) fn activate_app_if_needed(app: &str) -> AuvResult<()> {
   Ok(())
 }
 
+pub(crate) fn parse_input_policy(call: &DriverCall) -> AuvResult<auv_driver::InputPolicy> {
+  match optional_string(call, "policy")
+    .unwrap_or_else(|| "foreground_preferred".to_string())
+    .trim()
+    .to_ascii_lowercase()
+    .as_str()
+  {
+    "background_only" | "background-only" => Ok(auv_driver::InputPolicy::BackgroundOnly),
+    "background_preferred" | "background-preferred" => {
+      Ok(auv_driver::InputPolicy::BackgroundPreferred)
+    }
+    "foreground_preferred" | "foreground-preferred" => {
+      Ok(auv_driver::InputPolicy::ForegroundPreferred)
+    }
+    other => Err(format!(
+      "invalid --policy value {other:?}; expected background_only, background_preferred, or foreground_preferred"
+    )),
+  }
+}
+
 pub(crate) fn resolve_click_interval_ms(call: &DriverCall) -> AuvResult<u64> {
   let value =
     optional_positive_u64(call, "click_interval_ms")?.unwrap_or(DEFAULT_CLICK_INTERVAL_MS);

--- a/src/driver/macos/control/pointer.rs
+++ b/src/driver/macos/control/pointer.rs
@@ -3,7 +3,7 @@ use std::thread;
 use std::time::Duration;
 
 use super::super::*;
-use super::common::{activate_app_if_needed, resolve_click_interval_ms};
+use super::common::{activate_app_if_needed, parse_input_policy, resolve_click_interval_ms};
 
 pub(crate) fn click_point(call: &DriverCall) -> AuvResult<DriverResponse> {
   let x = required_f64(call, "x")?;
@@ -85,12 +85,22 @@ pub(crate) fn scroll_point(call: &DriverCall) -> AuvResult<DriverResponse> {
   let x = required_f64(call, "x")?;
   let y = required_f64(call, "y")?;
   let (delta_x, delta_y, normalized_scroll) = resolve_scroll_deltas(call)?;
+  let input_policy = parse_input_policy(call)?;
   let snapshot = enumerate_displays()?;
   let resolution = resolve_display_point(&snapshot, x, y)
     .ok_or_else(|| format!("logical point ({x:.3}, {y:.3}) is outside all connected displays"))?;
 
-  activate_app_if_needed(&app_identifier(call).unwrap_or_default())?;
-  crate::driver::macos::native::pointer::scroll_point(x, y, delta_x, delta_y)?;
+  if input_policy == auv_driver::InputPolicy::ForegroundPreferred {
+    activate_app_if_needed(&app_identifier(call).unwrap_or_default())?;
+  }
+  let scroll_outcome = crate::driver::macos::typed::session::scroll_point_bridge(
+    x,
+    y,
+    delta_x,
+    delta_y,
+    input_policy,
+    0,
+  )?;
 
   let report = [
     format!("capturedAt={}", snapshot.captured_at),
@@ -103,6 +113,9 @@ pub(crate) fn scroll_point(call: &DriverCall) -> AuvResult<DriverResponse> {
     format!("deltaX={delta_x:.0}"),
     format!("deltaY={delta_y:.0}"),
     format!("normalizedScroll={normalized_scroll}"),
+    format!("inputPolicy={}", scroll_outcome.input_policy),
+    format!("inputBridge={}", scroll_outcome.input_bridge),
+    format!("selectedPath={}", scroll_outcome.selected_path),
     "coordinateSpace=global-logical".to_string(),
     "cursorAfter=restored-to-original".to_string(),
   ]
@@ -125,13 +138,16 @@ pub(crate) fn scroll_point(call: &DriverCall) -> AuvResult<DriverResponse> {
       "Scrolled at global logical point ({x:.3}, {y:.3}) on display #{} with {}.",
       resolution.display.display_id, normalized_scroll
     ),
-    backend: Some("macos.swift.quartz-scroll".to_string()),
+    backend: Some("macos.typed.input.scroll".to_string()),
     signals: std::collections::BTreeMap::new(),
     notes: vec![
       "coordinateSpace=global-logical".to_string(),
       format!("deltaX={delta_x:.0}"),
       format!("deltaY={delta_y:.0}"),
       format!("normalizedScroll={normalized_scroll}"),
+      format!("inputPolicy={}", scroll_outcome.input_policy),
+      format!("inputBridge={}", scroll_outcome.input_bridge),
+      format!("selectedPath={}", scroll_outcome.selected_path),
       format!(
         "backingPixelPoint={},{}",
         resolution.backing_pixel_x, resolution.backing_pixel_y

--- a/src/driver/macos/control/region.rs
+++ b/src/driver/macos/control/region.rs
@@ -11,6 +11,7 @@
 use std::collections::BTreeMap;
 
 use super::super::*;
+use super::common::parse_input_policy;
 
 pub(crate) fn observe_window_region(call: &DriverCall) -> AuvResult<DriverResponse> {
   let label = optional_string(call, "label").unwrap_or_else(|| "window-region-observe".to_string());
@@ -210,14 +211,17 @@ pub(crate) fn scroll_window_region(call: &DriverCall) -> AuvResult<DriverRespons
   let direction = normalize_scroll_direction(&raw_direction)?.to_string();
   let amount = optional_f64(call, "amount")?.unwrap_or(6.0).max(1.0);
   let settle_ms = optional_positive_u64(call, "settle_ms")?.unwrap_or(250);
+  let input_policy = parse_input_policy(call)?;
   let region = region_ratios_from_call(call)?;
-  activate_target_app(&app)?;
+  if input_policy == auv_driver::InputPolicy::ForegroundPreferred {
+    activate_target_app(&app)?;
+  }
   let snapshot = super::super::observe::observe_windows_snapshot(24, &app)?;
   let xcap_displays = super::super::capture::xcap_backend::list_displays()?;
   let display_snapshot = enumerate_displays()?;
   let selector = parse_app_selector(&app)?;
   let resolved_app = resolve_app_ref(&snapshot, &selector)?;
-  let candidate = resolve_window_candidate(
+  let candidate = resolve_window_candidate_for_input(
     &snapshot,
     &resolved_app,
     &xcap_displays,
@@ -232,10 +236,14 @@ pub(crate) fn scroll_window_region(call: &DriverCall) -> AuvResult<DriverRespons
     format!("resolved scroll point ({x:.3}, {y:.3}) is outside all connected displays")
   })?;
   let (delta_x, delta_y) = scan_scroll_delta(&direction, amount)?;
-  crate::driver::macos::native::pointer::scroll_point(x, y, delta_x, delta_y)?;
-  if settle_ms > 0 {
-    std::thread::sleep(std::time::Duration::from_millis(settle_ms));
-  }
+  let scroll_outcome = crate::driver::macos::typed::session::scroll_point_bridge(
+    x,
+    y,
+    delta_x,
+    delta_y,
+    input_policy,
+    settle_ms,
+  )?;
 
   let report = [
     "coordinateSpace=global-logical".to_string(),
@@ -292,6 +300,9 @@ pub(crate) fn scroll_window_region(call: &DriverCall) -> AuvResult<DriverRespons
     format!("amount={amount:.3}"),
     format!("deltaX={delta_x:.0}"),
     format!("deltaY={delta_y:.0}"),
+    format!("inputPolicy={}", scroll_outcome.input_policy),
+    format!("inputBridge={}", scroll_outcome.input_bridge),
+    format!("selectedPath={}", scroll_outcome.selected_path),
     format!("settleMs={settle_ms}"),
   ]
   .join("\n");
@@ -305,7 +316,7 @@ pub(crate) fn scroll_window_region(call: &DriverCall) -> AuvResult<DriverRespons
 
   Ok(DriverResponse {
     summary: format!("Scrolled window region {direction} by amount {amount:.3}."),
-    backend: Some("macos.swift.quartz-scroll-window-region".to_string()),
+    backend: Some("macos.typed.input.scroll-window-region".to_string()),
     signals: BTreeMap::from([
       ("scroll.direction".to_string(), direction),
       ("scroll.amount".to_string(), format!("{amount:.3}")),
@@ -328,6 +339,9 @@ pub(crate) fn scroll_window_region(call: &DriverCall) -> AuvResult<DriverRespons
       format!("selectionReason={}", candidate.selection_reason),
       format!("deltaX={delta_x:.0}"),
       format!("deltaY={delta_y:.0}"),
+      format!("inputPolicy={}", scroll_outcome.input_policy),
+      format!("inputBridge={}", scroll_outcome.input_bridge),
+      format!("selectedPath={}", scroll_outcome.selected_path),
       format!("settleMs={settle_ms}"),
     ],
     artifacts: vec![artifact],

--- a/src/driver/macos/support/mod.rs
+++ b/src/driver/macos/support/mod.rs
@@ -21,8 +21,8 @@ pub(crate) use auv_driver_macos::support::{
   ax_node_center, build_window_candidates, find_ax_node_at_point, find_best_ax_node,
   find_now_playing_ax_node, no_matching_ax_node_error, parse_app_selector, parse_bool_flag,
   parse_f64, parse_i64, parse_observed_ax_tree, render_ax_interaction_report, report_value,
-  resolve_app_ref, resolve_window_candidate, retry_window_capture_operation,
-  window_capture_readiness_diagnostic,
+  resolve_app_ref, resolve_window_candidate, resolve_window_candidate_for_input,
+  retry_window_capture_operation, window_capture_readiness_diagnostic,
 };
 
 #[cfg(test)]

--- a/src/driver/macos/tests.rs
+++ b/src/driver/macos/tests.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 
 use super::{
   OcrTextMatch, ScreenshotDimensions,
+  control::common::parse_input_policy,
   control::common::{ClickPointCallOptions, build_click_point_call},
   support::{
     TextMatchCommandReport, app_contains_window, assess_coordinate_readiness,
@@ -156,6 +157,36 @@ fn resolve_scroll_deltas_accepts_explicit_deltas() {
   assert_eq!(delta_x, 40.0);
   assert_eq!(delta_y, -120.0);
   assert!(summary.contains("delta_x=40"));
+}
+
+#[test]
+fn parse_input_policy_defaults_to_foreground_preferred() {
+  let call = build_call([]);
+
+  assert_eq!(
+    parse_input_policy(&call).expect("policy"),
+    auv_driver::InputPolicy::ForegroundPreferred
+  );
+}
+
+#[test]
+fn parse_input_policy_accepts_all_shared_policy_values() {
+  let cases = [
+    ("background_only", auv_driver::InputPolicy::BackgroundOnly),
+    (
+      "background-preferred",
+      auv_driver::InputPolicy::BackgroundPreferred,
+    ),
+    (
+      "foreground_preferred",
+      auv_driver::InputPolicy::ForegroundPreferred,
+    ),
+  ];
+
+  for (raw, expected) in cases {
+    let call = build_call([("policy", raw)]);
+    assert_eq!(parse_input_policy(&call).expect(raw), expected);
+  }
 }
 
 #[test]

--- a/src/driver/macos/typed.rs
+++ b/src/driver/macos/typed.rs
@@ -1,6 +1,8 @@
 use std::time::Duration;
 
-use auv_driver::{Driver as TypedDriver, PasteTextOptions, TextSubmit};
+use auv_driver::{
+  Driver as TypedDriver, InputPolicy, PasteTextOptions, Point, Scroll, ScrollOptions, TextSubmit,
+};
 
 use crate::model::AuvResult;
 
@@ -34,6 +36,23 @@ pub(crate) mod session {
   pub(crate) enum PasteTextBridgeOutcome {
     UsedTypedSession,
     NeedsLegacyFallback { reason: &'static str },
+  }
+
+  #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+  pub(crate) struct ScrollPointBridgeOutcome {
+    pub(crate) input_bridge: &'static str,
+    pub(crate) selected_path: &'static str,
+    pub(crate) input_policy: &'static str,
+  }
+
+  impl ScrollPointBridgeOutcome {
+    pub(crate) fn used_typed_session(policy: InputPolicy) -> Self {
+      Self {
+        input_bridge: "typed-session",
+        selected_path: "foreground_system_events",
+        input_policy: input_policy_name(policy),
+      }
+    }
   }
 
   impl PasteTextBridgeOutcome {
@@ -83,9 +102,45 @@ pub(crate) mod session {
     Ok(PasteTextBridgeOutcome::UsedTypedSession)
   }
 
+  pub(crate) fn scroll_point_bridge(
+    x: f64,
+    y: f64,
+    delta_x: f64,
+    delta_y: f64,
+    policy: InputPolicy,
+    settle_ms: u64,
+  ) -> AuvResult<ScrollPointBridgeOutcome> {
+    let driver = auv_driver_macos::MacosDriver::new();
+    let session = driver
+      .open_local()
+      .map_err(|error| format!("failed to open typed macOS driver session: {error}"))?;
+    session
+      .input()
+      .scroll_at(
+        Point::new(x, y),
+        Scroll::new(delta_x, delta_y),
+        ScrollOptions {
+          policy,
+          settle: Duration::from_millis(settle_ms),
+        },
+      )
+      .map_err(|error| format!("typed macOS scroll_at adapter failed: {error}"))?;
+    Ok(ScrollPointBridgeOutcome::used_typed_session(policy))
+  }
+
+  pub(crate) fn input_policy_name(policy: InputPolicy) -> &'static str {
+    match policy {
+      InputPolicy::BackgroundOnly => "background_only",
+      InputPolicy::BackgroundPreferred => "background_preferred",
+      InputPolicy::ForegroundPreferred => "foreground_preferred",
+    }
+  }
+
   #[cfg(test)]
   mod tests {
-    use super::PasteTextBridgeOutcome;
+    use auv_driver::InputPolicy;
+
+    use super::{PasteTextBridgeOutcome, ScrollPointBridgeOutcome};
 
     #[test]
     fn paste_text_bridge_outcome_exposes_signal_values() {
@@ -100,6 +155,15 @@ pub(crate) mod session {
       assert_eq!(fallback.input_bridge(), "legacy-clipboard");
       assert_eq!(fallback.reason(), "unsupported-submit-key");
       assert!(fallback.needs_legacy_fallback());
+    }
+
+    #[test]
+    fn scroll_point_bridge_outcome_exposes_signal_values() {
+      let outcome = ScrollPointBridgeOutcome::used_typed_session(InputPolicy::ForegroundPreferred);
+
+      assert_eq!(outcome.input_bridge, "typed-session");
+      assert_eq!(outcome.selected_path, "foreground_system_events");
+      assert_eq!(outcome.input_policy, "foreground_preferred");
     }
   }
 }


### PR DESCRIPTION
## Summary
- routes debug scroll commands through the typed auv-driver input API and shared InputPolicy parsing
- relaxes input window resolution for partially visible windows while preserving strict capture selection
- improves the NetEase playlist example with typed scrolling, top-seek scan setup, artifact capture, tighter sidebar classification, and trimmed focused tests

## Test Plan
- cargo test --example netease_playlist_ls
- cargo fmt --check
- cargo check
- git diff --check
- cargo run --quiet --example netease_playlist_ls -- --app-id com.netease.163music --max-pages 2 --max-scrolls 5 --scroll-amount 600 --artifact-dir /tmp/auv-netease-pr-check --json-out /tmp/auv-netease-pr-check.json