### PR TITLE
feat(auv-netease-music): add playback status probe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccaf7e9dfbb6ab22c82e473cd1a8a7bd313c19a5b7e40970f3d89ef5a5c9e81e"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.1.14",
  "yansi-term",
 ]
 
@@ -399,6 +399,7 @@ dependencies = [
  "auv-media-macos",
  "auv-view",
  "clap",
+ "comfy-table",
  "image",
  "serde",
  "serde_json",
@@ -794,6 +795,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "comfy-table"
+version = "7.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+dependencies = [
+ "crossterm",
+ "unicode-segmentation",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -888,6 +900,29 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.11.1",
+ "crossterm_winapi",
+ "document-features",
+ "parking_lot",
+ "rustix 1.1.4",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crunchy"
@@ -2107,7 +2142,7 @@ dependencies = [
  "bitflags 2.11.1",
  "libc",
  "plain",
- "redox_syscall",
+ "redox_syscall 0.8.1",
 ]
 
 [[package]]
@@ -2188,6 +2223,15 @@ name = "litrs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -2967,6 +3011,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.18",
+ "smallvec",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3400,6 +3467,15 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -4396,6 +4472,12 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"

--- a/crates/auv-netease-music/Cargo.toml
+++ b/crates/auv-netease-music/Cargo.toml
@@ -19,6 +19,7 @@ auv-driver = { path = "../auv-driver" }
 auv-media-macos = { path = "../auv-media-macos" }
 auv-view = { path = "../auv-view" }
 clap = { version = "4.5", features = ["derive"] }
+comfy-table = "7"
 serde.workspace = true
 serde_json.workspace = true
 image.workspace = true

--- a/crates/auv-netease-music/src/cli.rs
+++ b/crates/auv-netease-music/src/cli.rs
@@ -10,8 +10,9 @@ use clap::{Args, Parser, Subcommand};
 
 use crate::output::build_playlist_json_output;
 use crate::{
-  DailyRecommendedPlayInputs, Inputs, PlaylistCategory, SongListInputs, run_daily_recommended_play,
-  run_daily_recommended_songs_scan, run_live_scan,
+  DailyRecommendedPlayInputs, Inputs, PlaybackStatusInputs, PlaylistCategory, SongListInputs,
+  run_daily_recommended_play, run_daily_recommended_songs_scan, run_live_scan,
+  run_playback_status_probe,
 };
 
 pub(crate) fn positive_scroll_amount(raw: &str) -> Result<f64, String> {
@@ -129,6 +130,13 @@ pub(crate) struct DailyRecommendedPlayCommand {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+pub(crate) struct PlaybackStatusCommand {
+  pub inputs: PlaybackStatusInputs,
+  pub output: OutputMode,
+  pub wide: bool,
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub(crate) struct SongsLsCommand {
   pub inputs: SongListInputs,
   pub target: SongsLsTarget,
@@ -166,6 +174,7 @@ pub(crate) enum Command {
   PlaylistLs(PlaylistCommand),
   PlaylistPlayDailyRecommended(DailyRecommendedPlayCommand),
   PlaylistSongsLs(SongsLsCommand),
+  PlaybackStatus(PlaybackStatusCommand),
   NowPlaying(NowPlayingCommand),
   Control(ControlCommand),
   Seek(SeekCommand),
@@ -186,6 +195,46 @@ struct CliArgs {
 enum CliSubcommand {
   /// Work with NetEase Cloud Music playlists.
   Playlist(PlaylistArgs),
+  /// Experimental current playback probes.
+  Playback(PlaybackArgs),
+}
+
+#[derive(Clone, Debug, Args)]
+struct PlaybackArgs {
+  #[command(subcommand)]
+  command: PlaybackSubcommand,
+}
+
+#[derive(Clone, Debug, Subcommand)]
+enum PlaybackSubcommand {
+  /// Open the current song detail view and read the source label.
+  Status(PlaybackStatusArgs),
+}
+
+#[derive(Clone, Debug, Args)]
+struct PlaybackStatusArgs {
+  #[arg(long = "json")]
+  json: bool,
+  #[arg(long = "json-out")]
+  json_out: Option<PathBuf>,
+  #[arg(long = "app-id")]
+  app_id: Option<String>,
+  #[arg(long = "artifact-dir")]
+  artifact_dir: Option<PathBuf>,
+  #[arg(long = "settle-ms")]
+  settle_ms: Option<u64>,
+  #[arg(long = "wide", alias = "detailed")]
+  wide: bool,
+  #[arg(long = "hint-ocr-custom-word")]
+  custom_words: Vec<String>,
+  #[arg(long = "hint-ocr-custom-words")]
+  custom_word_csvs: Vec<String>,
+  #[arg(long = "hint-ocr-custom-words-file")]
+  custom_word_files: Vec<PathBuf>,
+  #[arg(long = "hint-ocr-language")]
+  ocr_languages: Vec<String>,
+  #[arg(long = "hint-ocr-languages")]
+  ocr_language_csvs: Vec<String>,
   /// Read the system now-playing state (via the macOS media API).
   #[command(name = "now-playing")]
   NowPlaying(NowPlayingArgs),
@@ -377,6 +426,13 @@ struct PlaylistLsArgs {
 fn command_from_args(parsed: CliArgs) -> Result<Command, String> {
   match parsed.command {
     CliSubcommand::Playlist(args) => parse_playlist(args),
+    CliSubcommand::Playback(args) => parse_playback(args),
+  }
+}
+
+fn parse_playback(args: PlaybackArgs) -> Result<Command, String> {
+  match args.command {
+    PlaybackSubcommand::Status(args) => parse_playback_status(args).map(Command::PlaybackStatus),
     CliSubcommand::NowPlaying(args) => parse_now_playing(args),
     CliSubcommand::Play(args) => Ok(control(auv_media_macos::MediaCommand::Play, args)),
     CliSubcommand::Pause(args) => Ok(control(auv_media_macos::MediaCommand::Pause, args)),
@@ -622,6 +678,47 @@ fn parse_daily_recommended(
   Ok(DailyRecommendedPlayCommand { inputs, output })
 }
 
+fn parse_playback_status(args: PlaybackStatusArgs) -> Result<PlaybackStatusCommand, String> {
+  let mut inputs = PlaybackStatusInputs::with_defaults();
+  if let Some(app_id) = args.app_id {
+    inputs.app_id = app_id;
+  }
+  if let Some(artifact_dir) = args.artifact_dir {
+    inputs.artifact_dir = artifact_dir;
+  }
+  if let Some(settle_ms) = args.settle_ms {
+    inputs.settle_ms = settle_ms;
+  }
+  for word in args.custom_words {
+    push_trimmed(&mut inputs.ocr_options.custom_words, word);
+  }
+  for csv in args.custom_word_csvs {
+    push_csv(&mut inputs.ocr_options.custom_words, &csv);
+  }
+  for path in args.custom_word_files {
+    load_custom_words_file(&mut inputs.ocr_options.custom_words, path)?;
+  }
+  for language in args.ocr_languages {
+    push_ocr_language(&mut inputs.ocr_options, language);
+  }
+  for csv in args.ocr_language_csvs {
+    for language in split_csv(&csv) {
+      push_ocr_language(&mut inputs.ocr_options, language);
+    }
+  }
+
+  let output = match args.json_out {
+    Some(path) => OutputMode::JsonFile(path),
+    None if args.json => OutputMode::Json,
+    None => OutputMode::Human,
+  };
+  Ok(PlaybackStatusCommand {
+    inputs,
+    output,
+    wide: args.wide,
+  })
+}
+
 /// Entry point for the `auv-netease-music` binary.
 pub fn run() -> ExitCode {
   let parsed = match CliArgs::try_parse_from(std::env::args()) {
@@ -641,6 +738,7 @@ pub fn run() -> ExitCode {
     Ok(Command::PlaylistLs(cmd)) => run_playlist(cmd),
     Ok(Command::PlaylistPlayDailyRecommended(cmd)) => run_daily_recommended(cmd),
     Ok(Command::PlaylistSongsLs(cmd)) => run_songs_ls(cmd),
+    Ok(Command::PlaybackStatus(cmd)) => run_playback_status(cmd),
     Ok(Command::NowPlaying(cmd)) => run_now_playing(cmd),
     Ok(Command::Control(cmd)) => run_control(cmd),
     Ok(Command::Seek(cmd)) => run_seek(cmd),
@@ -711,6 +809,14 @@ mod tests {
     match command_from_args(parsed).expect("songs ls command should parse") {
       Command::PlaylistSongsLs(command) => command,
       other => panic!("expected songs ls command, got {other:?}"),
+    }
+  }
+
+  fn parse_playback_status_command(argv: &[&str]) -> PlaybackStatusCommand {
+    let parsed = CliArgs::try_parse_from(argv).expect("CLI args should parse");
+    match command_from_args(parsed).expect("playback status command should parse") {
+      Command::PlaybackStatus(command) => command,
+      other => panic!("expected playback status command, got {other:?}"),
     }
   }
 
@@ -972,6 +1078,35 @@ mod tests {
   }
 
   #[test]
+  fn clap_playback_status_maps_flags() {
+    let command = parse_playback_status_command(&[
+      "auv-netease-music",
+      "playback",
+      "status",
+      "--json-out",
+      "/tmp/playback-status.json",
+      "--settle-ms",
+      "250",
+      "--wide",
+    ]);
+
+    assert_eq!(
+      command.output,
+      OutputMode::JsonFile(PathBuf::from("/tmp/playback-status.json"))
+    );
+    assert_eq!(command.inputs.settle_ms, 250);
+    assert!(command.wide);
+  }
+
+  #[test]
+  fn clap_playback_status_accepts_detailed_alias_for_wide_output() {
+    let command =
+      parse_playback_status_command(&["auv-netease-music", "playback", "status", "--detailed"]);
+
+    assert!(command.wide);
+  }
+
+  #[test]
   fn playlist_songs_ls_rejects_unknown_target() {
     let parsed =
       CliArgs::try_parse_from(["auv-netease-music", "playlist", "songs", "ls", "current"])
@@ -1057,7 +1192,7 @@ fn run_playlist(cmd: PlaylistCommand) -> ExitCode {
 
   match &cmd.output {
     OutputMode::Human => {
-      println!("{}", scan.human_summary());
+      println!("{}", scan.to_human_readable());
       ExitCode::SUCCESS
     }
     OutputMode::Json => match serde_json::to_string_pretty(&output) {
@@ -1237,7 +1372,7 @@ fn run_daily_recommended(cmd: DailyRecommendedPlayCommand) -> ExitCode {
 
   match &cmd.output {
     OutputMode::Human => {
-      println!("{}", result.human_summary());
+      println!("{}", result.to_human_readable());
       ExitCode::SUCCESS
     }
     OutputMode::Json => match serde_json::to_string_pretty(&result) {
@@ -1252,6 +1387,47 @@ fn run_daily_recommended(cmd: DailyRecommendedPlayCommand) -> ExitCode {
     },
     OutputMode::JsonFile(path) => {
       let json = match serde_json::to_string_pretty(&result) {
+        Ok(json) => json,
+        Err(error) => {
+          eprintln!("encode failed: {error}");
+          return ExitCode::from(1);
+        }
+      };
+      if let Err(error) = std::fs::write(path, json) {
+        eprintln!("failed to write {}: {error}", path.display());
+        return ExitCode::from(1);
+      }
+      ExitCode::SUCCESS
+    }
+  }
+}
+
+fn run_playback_status(cmd: PlaybackStatusCommand) -> ExitCode {
+  let result = match run_playback_status_probe(&cmd.inputs) {
+    Ok(result) => result,
+    Err(error) => {
+      eprintln!("playback status probe failed: {error}");
+      return ExitCode::from(1);
+    }
+  };
+
+  match &cmd.output {
+    OutputMode::Human => {
+      println!("{}", result.to_human_readable(cmd.wide));
+      ExitCode::SUCCESS
+    }
+    OutputMode::Json => match serde_json::to_string_pretty(&result.to_json()) {
+      Ok(json) => {
+        println!("{json}");
+        ExitCode::SUCCESS
+      }
+      Err(error) => {
+        eprintln!("encode failed: {error}");
+        ExitCode::from(1)
+      }
+    },
+    OutputMode::JsonFile(path) => {
+      let json = match serde_json::to_string_pretty(&result.to_json()) {
         Ok(json) => json,
         Err(error) => {
           eprintln!("encode failed: {error}");

--- a/crates/auv-netease-music/src/commands/mod.rs
+++ b/crates/auv-netease-music/src/commands/mod.rs
@@ -1,1 +1,2 @@
 pub mod daily_recommended;
+pub mod playback;

--- a/crates/auv-netease-music/src/commands/playback.rs
+++ b/crates/auv-netease-music/src/commands/playback.rs
@@ -1,0 +1,639 @@
+use std::fmt;
+use std::path::PathBuf;
+
+use auv_driver::vision::TextRecognitionOptions;
+use auv_view::{ParserDiagnostic, ScanAppContext, ScanWindowContext, ViewBounds};
+use comfy_table::{Cell, Table, presets::NOTHING};
+use serde::{Deserialize, Serialize};
+
+use crate::DEFAULT_APP_ID;
+use crate::views::player::PlaybackControlState;
+
+// NOTICE(netease-playback-status-visual-fallback): this command is a
+// NetEase-specific OCR/detail-screen probe, not the future `now-playing-v0`
+// contract. Generic title/artist/album/rate reads are deferred to
+// `auv-media-macos`; see
+// `docs/ai/references/2026-06-04-media-macos-now-playing-design.md`.
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct PlaybackStatusInputs {
+  pub app_id: String,
+  pub artifact_dir: PathBuf,
+  pub settle_ms: u64,
+  pub ocr_options: TextRecognitionOptions,
+}
+
+impl PlaybackStatusInputs {
+  pub fn with_defaults() -> Self {
+    Self {
+      app_id: DEFAULT_APP_ID.to_string(),
+      artifact_dir: PathBuf::from("/tmp/auv-netease-playback-status-artifacts"),
+      settle_ms: 350,
+      ocr_options: TextRecognitionOptions::default(),
+    }
+  }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct PlaybackStatus {
+  /// Local experimental shape for `auv-netease-music playback status`.
+  ///
+  /// TODO(media-now-playing-v0): do not extend this into a parallel generic
+  /// now-playing contract. When `auv-media-macos` lands, add/delegate
+  /// `auv-netease-music now-playing` to its `now-playing-v0` output instead.
+  pub command: String,
+  pub app: ScanAppContext,
+  pub window: ScanWindowContext,
+  pub playback_exists: bool,
+  pub was_playing: bool,
+  pub control_state: Option<PlaybackControlState>,
+  pub click_point: Option<auv_driver::Point>,
+  pub detail_screen_detected: bool,
+  pub source: Option<String>,
+  pub artifacts: Vec<String>,
+  pub diagnostics: Vec<ParserDiagnostic>,
+  pub known_limits: Vec<String>,
+}
+
+impl PlaybackStatus {
+  pub fn to_human_readable(&self, wide: bool) -> PlaybackStatusHumanReadable<'_> {
+    PlaybackStatusHumanReadable { result: self, wide }
+  }
+
+  pub fn to_json(&self) -> PlaybackStatusJson<'_> {
+    PlaybackStatusJson {
+      command: &self.command,
+      app: &self.app,
+      window: &self.window,
+      playback_exists: self.playback_exists,
+      was_playing: self.was_playing,
+      control_state: self.control_state,
+      click_point: self.click_point,
+      detail_screen_detected: self.detail_screen_detected,
+      source: self.source.as_deref(),
+      artifacts: &self.artifacts,
+      diagnostics: &self.diagnostics,
+      known_limits: &self.known_limits,
+    }
+  }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct PlaybackStatusHumanReadable<'a> {
+  result: &'a PlaybackStatus,
+  wide: bool,
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+pub struct PlaybackStatusJson<'a> {
+  pub command: &'a str,
+  pub app: &'a ScanAppContext,
+  pub window: &'a ScanWindowContext,
+  pub playback_exists: bool,
+  pub was_playing: bool,
+  pub control_state: Option<PlaybackControlState>,
+  pub click_point: Option<auv_driver::Point>,
+  pub detail_screen_detected: bool,
+  pub source: Option<&'a str>,
+  pub artifacts: &'a [String],
+  pub diagnostics: &'a [ParserDiagnostic],
+  pub known_limits: &'a [String],
+}
+
+impl fmt::Display for PlaybackStatusHumanReadable<'_> {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    let result = self.result;
+    let mut status = Table::new();
+    status.load_preset(NOTHING);
+    if self.wide {
+      status.set_header([
+        "PLAYBACK",
+        "SCREEN",
+        "PLAYING",
+        "CONTROL",
+        "CLICK",
+        "ARTIFACTS",
+        "SOURCE",
+      ]);
+      status.add_row([
+        Cell::new(playback_cell(result.playback_exists)),
+        Cell::new(screen_cell(result.detail_screen_detected)),
+        Cell::new(playing_cell(result.was_playing, result.control_state)),
+        Cell::new(control_state_cell(result.control_state)),
+        Cell::new(click_point_cell(result.click_point)),
+        Cell::new(result.artifacts.len()),
+        Cell::new(result.source.as_deref().unwrap_or("-")),
+      ]);
+    } else {
+      status.set_header(["PLAYBACK", "SCREEN", "SOURCE"]);
+      status.add_row([
+        playback_cell(result.playback_exists),
+        screen_cell(result.detail_screen_detected),
+        result.source.as_deref().unwrap_or("-"),
+      ]);
+    }
+    write!(f, "{}", render_table(status))?;
+
+    if !result.known_limits.is_empty() {
+      writeln!(f)?;
+      writeln!(f)?;
+      let mut limits = Table::new();
+      limits.load_preset(NOTHING);
+      limits.set_header(["KNOWN LIMITS"]);
+      for limit in &result.known_limits {
+        limits.add_row([limit]);
+      }
+      write!(f, "{}", render_table(limits))?;
+    }
+
+    if !result.diagnostics.is_empty() {
+      writeln!(f)?;
+      writeln!(f)?;
+      let mut diagnostics = Table::new();
+      diagnostics.load_preset(NOTHING);
+      diagnostics.set_header(["DIAGNOSTIC", "MESSAGE"]);
+      for diagnostic in &result.diagnostics {
+        diagnostics.add_row([Cell::new(&diagnostic.code), Cell::new(&diagnostic.message)]);
+      }
+      write!(f, "{}", render_table(diagnostics))?;
+    }
+
+    Ok(())
+  }
+}
+
+fn playback_cell(value: bool) -> &'static str {
+  if value { "Detected" } else { "N/A" }
+}
+
+fn screen_cell(value: bool) -> &'static str {
+  if value { "Details" } else { "N/A" }
+}
+
+fn playing_cell(is_playing: bool, control_state: Option<PlaybackControlState>) -> &'static str {
+  if is_playing {
+    "Playing"
+  } else if control_state == Some(PlaybackControlState::PlayVisible) {
+    "Paused"
+  } else {
+    "N/A"
+  }
+}
+
+fn control_state_cell(value: Option<PlaybackControlState>) -> &'static str {
+  match value {
+    Some(PlaybackControlState::PlayVisible) => "play_visible",
+    Some(PlaybackControlState::PauseVisible) => "pause_visible",
+    Some(PlaybackControlState::Unknown) => "unknown",
+    None => "-",
+  }
+}
+
+fn click_point_cell(value: Option<auv_driver::Point>) -> String {
+  value
+    .map(|point| format!("{:.1},{:.1}", point.x, point.y))
+    .unwrap_or_else(|| "-".to_string())
+}
+
+fn render_table(table: Table) -> String {
+  table
+    .to_string()
+    .lines()
+    .map(str::trim)
+    .collect::<Vec<_>>()
+    .join("\n")
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn run_playback_status_probe(_inputs: &PlaybackStatusInputs) -> Result<PlaybackStatus, String> {
+  Err("live NetEase playback status probe is only supported on macOS".to_string())
+}
+
+#[cfg(target_os = "macos")]
+pub fn run_playback_status_probe(inputs: &PlaybackStatusInputs) -> Result<PlaybackStatus, String> {
+  use crate::views::player::PlayerView;
+  use crate::views::player::classify_bottom_playback_control_state;
+  use crate::views::screen;
+  use auv_driver::selector::{App, Window};
+  use auv_driver::{
+    ActivationPolicy, Click, ClickOptions, Driver, InputPolicy, PrepareForInputOptions, RatioRect,
+    Size, WindowClickStrategy, WindowPoint,
+  };
+  use auv_driver_macos::MacosDriver;
+
+  std::fs::create_dir_all(&inputs.artifact_dir).map_err(|error| {
+    format!(
+      "failed to create {}: {error}",
+      inputs.artifact_dir.display()
+    )
+  })?;
+
+  let mut artifacts = Vec::new();
+  let mut diagnostics = Vec::new();
+  let mut known_limits = Vec::new();
+
+  let driver = MacosDriver::new();
+  let session = driver
+    .open_local()
+    .map_err(|error| format!("failed to open macOS driver: {error}"))?;
+  let window = session
+    .window()
+    .resolve(Window::main_visible().owned_by(App::bundle(inputs.app_id.clone())))
+    .map_err(|error| format!("failed to resolve NetEase window: {error}"))?;
+  let app = ScanAppContext {
+    app_id: window
+      .app_bundle_id
+      .clone()
+      .or_else(|| Some(inputs.app_id.clone())),
+    name: window.app_name.clone(),
+    version: None,
+  };
+  let window_context = ScanWindowContext {
+    id: Some(window.reference.id.clone()),
+    title: window.title.clone(),
+    bounds: Some(ViewBounds::new(
+      0.0,
+      0.0,
+      window.frame.size.width,
+      window.frame.size.height,
+    )),
+  };
+  let window_size = Size::new(window.frame.size.width, window.frame.size.height);
+
+  let before_capture = session
+    .window()
+    .capture(&window)
+    .map_err(|error| format!("initial playback capture failed: {error}"))?;
+  artifacts.push(write_capture_artifact(
+    &inputs.artifact_dir,
+    "playback-status-before",
+    &before_capture,
+  )?);
+  let before_recognition = session
+    .vision()
+    .recognize_text_in_capture_with_options(
+      &before_capture,
+      RatioRect::new(0.0, 0.0, 1.0, 1.0),
+      inputs.ocr_options.clone(),
+    )
+    .map_err(|error| format!("initial playback OCR failed: {error}"))?;
+  let before_recognition = recognition_in_window_space(before_recognition, &before_capture);
+  let before_screen = screen::classify_screen(&before_recognition, window_size);
+  let control_state = classify_bottom_playback_control_state(&before_capture.image);
+  let mut player = PlayerView::from_control_state(control_state);
+  if let Some(text) = bottom_bar_text(&before_recognition, window_size) {
+    player = player.with_observed_text(text);
+  }
+
+  if before_screen.is_playing_song_detail() {
+    let source = screen::song_detail_source(&before_recognition, window_size);
+    if source.is_none() {
+      known_limits.push(
+        "song detail screen was already open, but OCR did not identify the upper-right source label"
+          .to_string(),
+      );
+    }
+    return Ok(PlaybackStatus {
+      command: "playback.status".to_string(),
+      app,
+      window: window_context,
+      playback_exists: player.exists() || source.is_some(),
+      was_playing: player.is_playing(),
+      control_state: Some(control_state),
+      click_point: None,
+      detail_screen_detected: true,
+      source,
+      artifacts,
+      diagnostics,
+      known_limits,
+    });
+  }
+
+  let Some(click_point) = player.song_detail_click_point(window_size) else {
+    known_limits
+      .push("bottom playback bar was not detected; status probe did not click".to_string());
+    return Ok(PlaybackStatus {
+      command: "playback.status".to_string(),
+      app,
+      window: window_context,
+      playback_exists: false,
+      was_playing: false,
+      control_state: Some(control_state),
+      click_point: None,
+      detail_screen_detected: false,
+      source: None,
+      artifacts,
+      diagnostics,
+      known_limits,
+    });
+  };
+
+  let click_result = session
+    .window()
+    .click(
+      &window,
+      WindowPoint::new(click_point.x, click_point.y),
+      ClickOptions {
+        policy: InputPolicy::BackgroundPreferred,
+        click: Click::Single,
+        window_strategy: WindowClickStrategy::ChromiumCompatible,
+      },
+    )
+    .map_err(|error| format!("playback bar click failed: {error}"))?;
+  if let Some(reason) = click_result.fallback_reason {
+    known_limits.push(format!("playback bar click fallback: {reason}"));
+  }
+  if inputs.settle_ms > 0 {
+    std::thread::sleep(std::time::Duration::from_millis(inputs.settle_ms));
+  }
+
+  let mut after_capture = session
+    .window()
+    .capture(&window)
+    .map_err(|error| format!("post-click detail capture failed: {error}"))?;
+  artifacts.push(write_capture_artifact(
+    &inputs.artifact_dir,
+    "playback-status-after-click",
+    &after_capture,
+  )?);
+  let mut recognition = session
+    .vision()
+    .recognize_text_in_capture_with_options(
+      &after_capture,
+      RatioRect::new(0.0, 0.0, 1.0, 1.0),
+      inputs.ocr_options.clone(),
+    )
+    .map_err(|error| format!("post-click detail OCR failed: {error}"))?;
+  recognition = recognition_in_window_space(recognition, &after_capture);
+  let mut screen = screen::classify_screen(&recognition, window_size);
+  let mut detail_screen_detected = screen.is_playing_song_detail();
+  if !detail_screen_detected {
+    known_limits.push(
+      "background playback bar click did not reveal song detail; retried with foreground click"
+        .to_string(),
+    );
+    let lease = session
+      .window()
+      .prepare_for_input(
+        &window,
+        PrepareForInputOptions {
+          activation: ActivationPolicy::Foreground {
+            settle: std::time::Duration::from_millis(inputs.settle_ms),
+          },
+          preserve_frontmost: false,
+          install_focus_guard: false,
+          settle: std::time::Duration::ZERO,
+        },
+      )
+      .map_err(|error| format!("playback bar foreground preparation failed: {error}"))?;
+    let click_result = auv_driver_macos::native::pointer::click_point(
+      window.frame.origin.x + click_point.x,
+      window.frame.origin.y + click_point.y,
+      0,
+      1,
+      80,
+    );
+    let restore_result = session.window().restore_input(lease);
+    click_result.map_err(|error| format!("playback bar foreground click failed: {error}"))?;
+    restore_result.map_err(|error| format!("playback bar foreground restore failed: {error}"))?;
+    if inputs.settle_ms > 0 {
+      std::thread::sleep(std::time::Duration::from_millis(inputs.settle_ms));
+    }
+
+    after_capture = session
+      .window()
+      .capture(&window)
+      .map_err(|error| format!("post-foreground-click detail capture failed: {error}"))?;
+    artifacts.push(write_capture_artifact(
+      &inputs.artifact_dir,
+      "playback-status-after-foreground-click",
+      &after_capture,
+    )?);
+    recognition = session
+      .vision()
+      .recognize_text_in_capture_with_options(
+        &after_capture,
+        RatioRect::new(0.0, 0.0, 1.0, 1.0),
+        inputs.ocr_options.clone(),
+      )
+      .map_err(|error| format!("post-foreground-click detail OCR failed: {error}"))?;
+    recognition = recognition_in_window_space(recognition, &after_capture);
+    screen = screen::classify_screen(&recognition, window_size);
+    detail_screen_detected = screen.is_playing_song_detail();
+  }
+  if !detail_screen_detected {
+    diagnostics.push(ParserDiagnostic {
+      code: "song_detail_not_detected".to_string(),
+      message: "playback bar click did not reveal NetEase song detail markers".to_string(),
+      node_id: None,
+    });
+  }
+  let source = screen::song_detail_source(&recognition, window_size);
+  if detail_screen_detected && source.is_none() {
+    known_limits.push(
+      "song detail screen was detected, but OCR did not identify the upper-right source label"
+        .to_string(),
+    );
+  }
+
+  Ok(PlaybackStatus {
+    command: "playback.status".to_string(),
+    app,
+    window: window_context,
+    playback_exists: true,
+    was_playing: player.is_playing(),
+    control_state: Some(control_state),
+    click_point: Some(click_point),
+    detail_screen_detected,
+    source,
+    artifacts,
+    diagnostics,
+    known_limits,
+  })
+}
+
+#[cfg(target_os = "macos")]
+fn write_capture_artifact(
+  artifact_dir: &std::path::Path,
+  name: &str,
+  capture: &auv_driver::capture::Capture,
+) -> Result<String, String> {
+  let path = artifact_dir.join(format!("{name}.png"));
+  capture
+    .image
+    .save(&path)
+    .map_err(|error| format!("failed to save {}: {error}", path.display()))?;
+  Ok(path.display().to_string())
+}
+
+#[cfg(target_os = "macos")]
+fn recognition_in_window_space(
+  mut recognition: auv_driver::vision::TextRecognition,
+  capture: &auv_driver::capture::Capture,
+) -> auv_driver::vision::TextRecognition {
+  for region in &mut recognition.regions {
+    region.bounds.origin.x -= capture.bounds.origin.x;
+    region.bounds.origin.y -= capture.bounds.origin.y;
+  }
+  recognition
+}
+
+#[cfg(target_os = "macos")]
+fn bottom_bar_text(
+  recognition: &auv_driver::vision::TextRecognition,
+  window_size: auv_driver::Size,
+) -> Option<String> {
+  let mut regions = recognition
+    .regions
+    .iter()
+    .filter(|region| {
+      region.bounds.origin.x <= window_size.width * 0.34
+        && region.bounds.origin.y >= window_size.height * 0.88
+    })
+    .collect::<Vec<_>>();
+  regions.sort_by(|left, right| {
+    left
+      .bounds
+      .origin
+      .y
+      .partial_cmp(&right.bounds.origin.y)
+      .unwrap_or(std::cmp::Ordering::Equal)
+      .then_with(|| {
+        left
+          .bounds
+          .origin
+          .x
+          .partial_cmp(&right.bounds.origin.x)
+          .unwrap_or(std::cmp::Ordering::Equal)
+      })
+  });
+  let text = regions
+    .into_iter()
+    .map(|region| region.text.trim())
+    .filter(|text| !text.is_empty())
+    .collect::<Vec<_>>()
+    .join("\n");
+
+  (!text.trim().is_empty()).then_some(text)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn to_human_readable_renders_compact_status_table() {
+    let result = PlaybackStatus {
+      command: "playback.status".to_string(),
+      app: ScanAppContext::default(),
+      window: ScanWindowContext::default(),
+      playback_exists: true,
+      was_playing: false,
+      control_state: Some(PlaybackControlState::Unknown),
+      click_point: None,
+      detail_screen_detected: true,
+      source: Some("每日歌曲推荐".to_string()),
+      artifacts: Vec::new(),
+      diagnostics: Vec::new(),
+      known_limits: Vec::new(),
+    };
+
+    assert_eq!(
+      result.to_human_readable(false).to_string(),
+      "PLAYBACK  SCREEN   SOURCE\nDetected  Details  每日歌曲推荐"
+    );
+  }
+
+  #[test]
+  fn to_human_readable_wide_includes_control_and_click_details() {
+    let result = PlaybackStatus {
+      command: "playback.status".to_string(),
+      app: ScanAppContext::default(),
+      window: ScanWindowContext::default(),
+      playback_exists: true,
+      was_playing: true,
+      control_state: Some(PlaybackControlState::PauseVisible),
+      click_point: Some(auv_driver::Point::new(104.0, 1012.0)),
+      detail_screen_detected: true,
+      source: Some("每日歌曲推荐".to_string()),
+      artifacts: vec!["before.png".to_string(), "after.png".to_string()],
+      diagnostics: Vec::new(),
+      known_limits: Vec::new(),
+    };
+
+    assert_eq!(
+      result.to_human_readable(true).to_string(),
+      "PLAYBACK  SCREEN   PLAYING  CONTROL        CLICK         ARTIFACTS  SOURCE\nDetected  Details  Playing  pause_visible  104.0,1012.0  2          每日歌曲推荐"
+    );
+  }
+
+  #[test]
+  fn to_json_preserves_machine_output_shape() {
+    let result = PlaybackStatus {
+      command: "playback.status".to_string(),
+      app: ScanAppContext::default(),
+      window: ScanWindowContext::default(),
+      playback_exists: true,
+      was_playing: true,
+      control_state: Some(PlaybackControlState::PauseVisible),
+      click_point: Some(auv_driver::Point::new(104.0, 1012.0)),
+      detail_screen_detected: true,
+      source: Some("每日歌曲推荐".to_string()),
+      artifacts: vec!["before.png".to_string(), "after.png".to_string()],
+      diagnostics: Vec::new(),
+      known_limits: Vec::new(),
+    };
+
+    let value = serde_json::to_value(result.to_json()).expect("playback status json");
+
+    assert_eq!(value["command"], "playback.status");
+    assert_eq!(value["playback_exists"], true);
+    assert_eq!(value["was_playing"], true);
+    assert_eq!(value["control_state"], "pause_visible");
+    assert_eq!(value["detail_screen_detected"], true);
+    assert_eq!(value["source"], "每日歌曲推荐");
+    assert_eq!(
+      value["artifacts"],
+      serde_json::json!(["before.png", "after.png"])
+    );
+  }
+
+  #[test]
+  fn to_human_readable_appends_limits_and_diagnostics_as_sections() {
+    let result = PlaybackStatus {
+      command: "playback.status".to_string(),
+      app: ScanAppContext::default(),
+      window: ScanWindowContext::default(),
+      playback_exists: true,
+      was_playing: true,
+      control_state: Some(PlaybackControlState::PauseVisible),
+      click_point: Some(auv_driver::Point::new(104.0, 1012.0)),
+      detail_screen_detected: false,
+      source: None,
+      artifacts: Vec::new(),
+      diagnostics: vec![ParserDiagnostic {
+        code: "song_detail_not_detected".to_string(),
+        message: "playback bar click did not reveal NetEase song detail markers".to_string(),
+        node_id: None,
+      }],
+      known_limits: vec![
+        "background playback bar click did not reveal song detail; retried with foreground click"
+          .to_string(),
+      ],
+    };
+
+    assert_eq!(
+      result.to_human_readable(false).to_string(),
+      concat!(
+        "PLAYBACK  SCREEN  SOURCE\n",
+        "Detected  N/A     -\n",
+        "\n",
+        "KNOWN LIMITS\n",
+        "background playback bar click did not reveal song detail; retried with foreground click\n",
+        "\n",
+        "DIAGNOSTIC                MESSAGE\n",
+        "song_detail_not_detected  playback bar click did not reveal NetEase song detail markers"
+      )
+    );
+  }
+}

--- a/crates/auv-netease-music/src/lib.rs
+++ b/crates/auv-netease-music/src/lib.rs
@@ -12,6 +12,10 @@ pub mod views;
 pub use commands::daily_recommended::{
   run_daily_recommended_play, run_daily_recommended_songs_scan,
 };
+pub use commands::playback::{
+  PlaybackStatus, PlaybackStatusHumanReadable, PlaybackStatusInputs, PlaybackStatusJson,
+  run_playback_status_probe,
+};
 pub use interaction::{
   InteractionEvent, InteractionEventKind, InteractionPhase, ScrollDirection, ScrollInteraction,
 };
@@ -164,7 +168,7 @@ pub struct DailyRecommendedPlayResult {
 }
 
 impl DailyRecommendedPlayResult {
-  pub fn human_summary(&self) -> DailyRecommendedHumanSummary<'_> {
+  pub fn to_human_readable(&self) -> DailyRecommendedHumanSummary<'_> {
     DailyRecommendedHumanSummary { result: self }
   }
 }
@@ -406,7 +410,7 @@ impl PlaylistSidebarScan {
     &self.known_limits
   }
 
-  pub fn human_summary(&self) -> PlaylistSidebarHumanSummary<'_> {
+  pub fn to_human_readable(&self) -> PlaylistSidebarHumanSummary<'_> {
     PlaylistSidebarHumanSummary { scan: self }
   }
 

--- a/crates/auv-netease-music/src/views/player.rs
+++ b/crates/auv-netease-music/src/views/player.rs
@@ -59,6 +59,19 @@ impl PlayerView {
     }
   }
 
+  pub fn from_bottom_bar_text(observed_text: impl Into<String>) -> Self {
+    let observed_text = observed_text.into();
+    if observed_text.trim().is_empty() {
+      return Self::unknown();
+    }
+
+    Self {
+      state: PlayerState::Present,
+      control_state: None,
+      observed_text: Some(observed_text),
+    }
+  }
+
   /// Attach optional OCR text observed around the player bar.
   pub fn with_observed_text(mut self, observed_text: impl Into<String>) -> Self {
     self.observed_text = Some(observed_text.into());
@@ -84,6 +97,25 @@ impl PlayerView {
 
   pub fn observed_text(&self) -> Option<&str> {
     self.observed_text.as_deref()
+  }
+
+  /// Return a window-local point that should open the current song detail view.
+  pub fn song_detail_click_point(
+    &self,
+    window_size: auv_driver::Size,
+  ) -> Option<auv_driver::Point> {
+    if !self.exists() {
+      return None;
+    }
+
+    // NOTICE(netease-playback-bar-open-detail): click the artwork/title hot
+    // zone on the left side of the bottom playback bar. Wider blank areas in
+    // the bar do not open the song detail view, and centered controls toggle
+    // playback instead.
+    Some(auv_driver::Point::new(
+      window_size.width * 0.075,
+      window_size.height - 38.0,
+    ))
   }
 }
 
@@ -190,6 +222,42 @@ mod tests {
 
     assert_eq!(view.state(), PlayerState::Absent);
     assert_eq!(view.control_state(), None);
+  }
+
+  #[test]
+  fn present_player_exposes_song_detail_click_point() {
+    let view = PlayerView::from_control_state(PlaybackControlState::PauseVisible);
+
+    assert_eq!(
+      view.song_detail_click_point(auv_driver::Size::new(1200.0, 800.0)),
+      Some(auv_driver::Point::new(90.0, 762.0))
+    );
+  }
+
+  #[test]
+  fn absent_or_unknown_player_has_no_song_detail_click_point() {
+    assert_eq!(
+      PlayerView::absent().song_detail_click_point(auv_driver::Size::new(1200.0, 800.0)),
+      None
+    );
+    assert_eq!(
+      PlayerView::unknown().song_detail_click_point(auv_driver::Size::new(1200.0, 800.0)),
+      None
+    );
+  }
+
+  #[test]
+  fn bottom_bar_text_marks_player_present_without_control_state() {
+    let view = PlayerView::from_bottom_bar_text("Eos\nginkinha");
+
+    assert!(view.exists());
+    assert!(!view.is_playing());
+    assert_eq!(view.control_state(), None);
+    assert_eq!(view.observed_text(), Some("Eos\nginkinha"));
+    assert_eq!(
+      view.song_detail_click_point(auv_driver::Size::new(1200.0, 800.0)),
+      Some(auv_driver::Point::new(90.0, 762.0))
+    );
   }
 
   #[test]

--- a/crates/auv-netease-music/src/views/screen.rs
+++ b/crates/auv-netease-music/src/views/screen.rs
@@ -66,7 +66,7 @@ pub fn classify_screen(recognition: &TextRecognition, window_size: auv_driver::S
     return ScreenView::new(ScreenState::Default, None);
   }
 
-  if is_playing_song_detail(recognition) {
+  if is_playing_song_detail(recognition, window_size) {
     return ScreenView::new(
       ScreenState::PlayingSongDetail,
       Some(PLAYING_SONG_DETAIL_RESTORE_POINT),
@@ -74,6 +74,72 @@ pub fn classify_screen(recognition: &TextRecognition, window_size: auv_driver::S
   }
 
   ScreenView::new(ScreenState::Unknown, None)
+}
+
+pub fn song_detail_source(
+  recognition: &TextRecognition,
+  window_size: auv_driver::Size,
+) -> Option<String> {
+  let mut upper_right_regions = recognition
+    .regions
+    .iter()
+    .filter(|region| {
+      region.bounds.origin.x >= window_size.width * 0.55
+        && region.bounds.origin.y <= window_size.height * 0.30
+    })
+    .collect::<Vec<_>>();
+  upper_right_regions.sort_by(|left, right| {
+    left
+      .bounds
+      .origin
+      .y
+      .partial_cmp(&right.bounds.origin.y)
+      .unwrap_or(std::cmp::Ordering::Equal)
+      .then_with(|| {
+        left
+          .bounds
+          .origin
+          .x
+          .partial_cmp(&right.bounds.origin.x)
+          .unwrap_or(std::cmp::Ordering::Equal)
+      })
+  });
+
+  for region in &upper_right_regions {
+    if let Some(source) = inline_source_value(&region.text) {
+      return Some(source);
+    }
+  }
+
+  for label in upper_right_regions
+    .iter()
+    .filter(|region| is_source_label(&region.text))
+  {
+    let label_center_y = label.bounds.origin.y + label.bounds.size.height * 0.5;
+    let value = upper_right_regions
+      .iter()
+      .filter(|region| region.text != label.text || region.bounds != label.bounds)
+      .filter(|region| !is_source_label(&region.text))
+      .filter(|region| {
+        let center_y = region.bounds.origin.y + region.bounds.size.height * 0.5;
+        (center_y - label_center_y).abs() <= 28.0
+          && region.bounds.origin.x >= label.bounds.origin.x + label.bounds.size.width
+      })
+      .min_by(|left, right| {
+        left
+          .bounds
+          .origin
+          .x
+          .partial_cmp(&right.bounds.origin.x)
+          .unwrap_or(std::cmp::Ordering::Equal)
+      })?;
+    let value = value.text.trim();
+    if !value.is_empty() {
+      return Some(value.to_string());
+    }
+  }
+
+  None
 }
 
 fn is_blocking_modal(recognition: &TextRecognition) -> bool {
@@ -88,8 +154,54 @@ fn has_left_sidebar_marker(recognition: &TextRecognition, window_size: auv_drive
   })
 }
 
-fn is_playing_song_detail(recognition: &TextRecognition) -> bool {
-  contains_text(recognition, "评论") && contains_text(recognition, "收藏")
+fn is_playing_song_detail(recognition: &TextRecognition, window_size: auv_driver::Size) -> bool {
+  if contains_text(recognition, "评论") && contains_text(recognition, "收藏") {
+    return true;
+  }
+
+  if has_aligned_detail_tabs(recognition, window_size) {
+    return true;
+  }
+
+  song_detail_source(recognition, window_size).is_some()
+    && (contains_text(recognition, "歌词")
+      || contains_text(recognition, "百科")
+      || contains_text(recognition, "相似推荐"))
+}
+
+fn has_aligned_detail_tabs(recognition: &TextRecognition, window_size: auv_driver::Size) -> bool {
+  let min_x = window_size.width * 0.45;
+  let min_y = window_size.height * 0.14;
+  let max_y = window_size.height * 0.38;
+  let mut tabs = recognition
+    .regions
+    .iter()
+    .filter(|region| {
+      region.bounds.origin.x >= min_x
+        && region.bounds.origin.y >= min_y
+        && region.bounds.origin.y <= max_y
+        && matches!(
+          region.text.trim(),
+          text if text.contains("歌词") || text.contains("百科") || text.contains("相似推荐")
+        )
+    })
+    .collect::<Vec<_>>();
+  tabs.sort_by(|left, right| {
+    left
+      .bounds
+      .origin
+      .x
+      .partial_cmp(&right.bounds.origin.x)
+      .unwrap_or(std::cmp::Ordering::Equal)
+  });
+
+  tabs.iter().enumerate().any(|(index, left)| {
+    let left_center_y = left.bounds.origin.y + left.bounds.size.height * 0.5;
+    tabs.iter().skip(index + 1).any(|right| {
+      let right_center_y = right.bounds.origin.y + right.bounds.size.height * 0.5;
+      (left_center_y - right_center_y).abs() <= 18.0
+    })
+  })
 }
 
 fn contains_text(recognition: &TextRecognition, query: &str) -> bool {
@@ -97,6 +209,23 @@ fn contains_text(recognition: &TextRecognition, query: &str) -> bool {
     .regions
     .iter()
     .any(|region| region.text.contains(query))
+}
+
+fn inline_source_value(text: &str) -> Option<String> {
+  let text = text.trim();
+  for separator in ["来源：", "来源:", "来源 "] {
+    if let Some((_, value)) = text.split_once(separator) {
+      let value = value.trim();
+      if !value.is_empty() {
+        return Some(value.to_string());
+      }
+    }
+  }
+  None
+}
+
+fn is_source_label(text: &str) -> bool {
+  matches!(text.trim().trim_end_matches([':', '：']), "来源")
 }
 
 #[cfg(test)]
@@ -134,6 +263,43 @@ mod tests {
   }
 
   #[test]
+  fn classify_screen_detects_song_detail_from_source_and_lyrics_tabs() {
+    let view = classify_screen(
+      &fake_recognition(vec![
+        ("来源：每日歌曲推荐", 850.0, 118.0, 160.0, 24.0),
+        ("歌词", 700.0, 246.0, 48.0, 24.0),
+        ("百科", 760.0, 246.0, 48.0, 24.0),
+        ("相似推荐", 820.0, 246.0, 86.0, 24.0),
+      ]),
+      auv_driver::Size::new(1200.0, 800.0),
+    );
+
+    assert_eq!(view.state(), ScreenState::PlayingSongDetail);
+  }
+
+  #[test]
+  fn classify_screen_detects_song_detail_from_aligned_detail_tabs_without_source() {
+    // ROOT CAUSE:
+    //
+    // If OCR missed the low-contrast source label on an already-open song
+    // detail screen, the playback status probe classified the screen as
+    // unknown and clicked the playback bar again.
+    //
+    // The invariant is that the aligned detail tabs are enough screen evidence;
+    // source extraction should not gate detail-screen detection.
+    let view = classify_screen(
+      &fake_recognition(vec![
+        ("歌词", 700.0, 246.0, 48.0, 24.0),
+        ("百科", 760.0, 246.0, 48.0, 24.0),
+        ("相似推荐", 820.0, 246.0, 86.0, 24.0),
+      ]),
+      auv_driver::Size::new(1200.0, 800.0),
+    );
+
+    assert_eq!(view.state(), ScreenState::PlayingSongDetail);
+  }
+
+  #[test]
   fn classify_screen_detects_blocking_modal_before_default() {
     let view = classify_screen(
       &fake_recognition(vec![
@@ -158,6 +324,29 @@ mod tests {
 
     assert_eq!(view.state(), ScreenState::Unknown);
     assert_eq!(view.restore_point(), None);
+  }
+
+  #[test]
+  fn song_detail_source_reads_inline_upper_right_source_label() {
+    let source = song_detail_source(
+      &fake_recognition(vec![("来源：每日推荐", 850.0, 118.0, 160.0, 24.0)]),
+      auv_driver::Size::new(1200.0, 800.0),
+    );
+
+    assert_eq!(source.as_deref(), Some("每日推荐"));
+  }
+
+  #[test]
+  fn song_detail_source_reads_adjacent_upper_right_source_value() {
+    let source = song_detail_source(
+      &fake_recognition(vec![
+        ("来源", 850.0, 118.0, 48.0, 24.0),
+        ("我喜欢的音乐", 910.0, 118.0, 128.0, 24.0),
+      ]),
+      auv_driver::Size::new(1200.0, 800.0),
+    );
+
+    assert_eq!(source.as_deref(), Some("我喜欢的音乐"));
   }
 
   fn fake_recognition(

--- a/docs/ai/references/2026-06-04-media-macos-now-playing-design.md
+++ b/docs/ai/references/2026-06-04-media-macos-now-playing-design.md
@@ -229,6 +229,23 @@ the contract. On non-macOS it prints "only available on macOS" and exits
 non-zero. `auv-netease-music` depends on `auv-media-macos` as a
 `cfg(target_os = "macos")` dependency.
 
+### Interim NetEase Visual Status Probe
+
+As of 2026-06-05, `auv-netease-music playback status` is an interim
+NetEase-specific visual probe. It captures the NetEase window, checks the
+bottom playback bar, opens or recognizes the song-detail screen, and OCRs the
+right-side `来源` label. Its output is intentionally local and experimental:
+`playback_exists`, `was_playing`, `control_state`, `detail_screen_detected`,
+`source`, artifacts, diagnostics, and known limits.
+
+This probe is **not** the `now-playing-v0` contract and should not be expanded
+into a parallel generic now-playing surface. When `auv-media-macos` lands,
+`auv-netease-music now-playing` should delegate to that crate exactly as this
+design specifies. The visual `playback status` command may remain as a
+NetEase-only fallback for app-specific context that MediaRemote cannot provide,
+such as the in-app playlist/source label, but generic title/artist/album/rate
+fields belong to `auv-media-macos`.
+
 ### Human output (default)
 
 - Playing: `▶ <title> — <artist> [<album>]  (<source_bundle_id>)`


### PR DESCRIPTION
## Summary
- Adds `auv-netease-music playback status` to probe the current NetEase playback state and source playlist from the song detail screen.
- Adds playback bar/detail-screen detection, human table output via `PlaybackStatus::to_human_readable`, and JSON output via `PlaybackStatus::to_json`.
- Documents the interim NetEase-specific probe against the future macOS now-playing design.

## Test Plan
- [x] `cargo fmt --check -p auv-netease-music`
- [x] `cargo test -p auv-netease-music`
- [x] `git diff --check`
- [x] Live probe: `cargo run -p auv-netease-music -- playback status` returned `PLAYBACK Detected`, `SCREEN Details`, source `每日歌曲推荐`.

## Notes
- Background playback-bar click may still fall back to foreground input on the current NetEase macOS client.
- Includes one rustfmt-only formatting change in `view_parsers/sidebar/region.rs` required by `cargo fmt --check -p auv-netease-music`.