### PR TITLE
Add freshness & consent validation and audit metadata to candidate promotion gate

### DIFF
--- a/src/candidate_promotion.rs
+++ b/src/candidate_promotion.rs
@@ -70,11 +70,17 @@ pub struct ActionConsentRecord {
   pub recognition_id: String,
   pub run_id: crate::trace::RunId,
   pub scope: ActionConsentScope,
-  pub approved_action: String,
+  pub approved_action: ActionConsentAction,
   pub target_item_id: String,
   pub approved_at_millis: u64,
   pub expires_at_millis: Option<u64>,
   pub evidence_note: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ActionConsentAction {
+  CandidatePromotion,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -95,8 +101,6 @@ pub struct PromotionAudit {
   pub projection_kind: String,
   pub stability_observed_frames: Option<u32>,
 }
-
-const APPROVED_ACTION_CANDIDATE_PROMOTION: &str = "candidate_promotion";
 
 /// 闸门决定。不是 action-result schema。
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -241,7 +245,9 @@ fn validate_freshness(
     });
   };
   let Some(capture_artifact) = recognition.scope.capture_artifact.as_ref() else {
-    return Ok(());
+    return Err(PromotionRefusal::FreshnessStale {
+      reason: "recognition capture_artifact is missing".to_string(),
+    });
   };
   if source_artifact != capture_artifact {
     return Err(PromotionRefusal::FreshnessStale {
@@ -295,10 +301,20 @@ fn validate_permission(
       reason: "permission granted_by is missing".to_string(),
     });
   }
+  if permission.scope_note.trim().is_empty() {
+    return Err(PromotionRefusal::PermissionInvalid {
+      reason: "permission scope_note is missing".to_string(),
+    });
+  }
   let consent = &permission.consent;
   if consent.consent_id.trim().is_empty() {
     return Err(PromotionRefusal::PermissionInvalid {
       reason: "consent_id is missing".to_string(),
+    });
+  }
+  if consent.evidence_note.trim().is_empty() {
+    return Err(PromotionRefusal::PermissionInvalid {
+      reason: "consent evidence_note is missing".to_string(),
     });
   }
   if consent.recognition_id != recognition.recognition_id {
@@ -307,7 +323,9 @@ fn validate_permission(
     });
   }
   let Some(capture_artifact) = recognition.scope.capture_artifact.as_ref() else {
-    return Ok(());
+    return Err(PromotionRefusal::PermissionInvalid {
+      reason: "recognition capture_artifact is missing".to_string(),
+    });
   };
   if consent.run_id != capture_artifact.run_id {
     return Err(PromotionRefusal::PermissionInvalid {
@@ -319,7 +337,7 @@ fn validate_permission(
       reason: "consent scope does not match recognition scope".to_string(),
     });
   }
-  if consent.approved_action != APPROVED_ACTION_CANDIDATE_PROMOTION {
+  if consent.approved_action != ActionConsentAction::CandidatePromotion {
     return Err(PromotionRefusal::PermissionInvalid {
       reason: "consent approved_action is not candidate_promotion".to_string(),
     });
@@ -409,9 +427,9 @@ mod tests {
   use serde_json::json;
 
   use super::{
-    ActionConsentRecord, ActionConsentScope, ActionPermission, CandidatePromotion,
-    PromotionContext, PromotionFreshness, PromotionProjection, PromotionRefusal, StabilityInput,
-    promote_recognition_to_candidates,
+    ActionConsentAction, ActionConsentRecord, ActionConsentScope, ActionPermission,
+    CandidatePromotion, PromotionContext, PromotionFreshness, PromotionProjection,
+    PromotionRefusal, StabilityInput, promote_recognition_to_candidates,
   };
   use crate::contract::{
     ArtifactRef, Candidate, RecognitionBox, RecognitionResult, RecognitionScope, RecognitionSource,
@@ -527,7 +545,7 @@ mod tests {
           window_title: Some("Slay the Spire".to_string()),
           window_number: Some(7),
         },
-        approved_action: "candidate_promotion".to_string(),
+        approved_action: ActionConsentAction::CandidatePromotion,
         target_item_id: "item_1".to_string(),
         approved_at_millis: 1_000,
         expires_at_millis: Some(1_500),
@@ -812,6 +830,68 @@ mod tests {
       ),
       PromotionRefusal::PermissionInvalid {
         reason: "consent scope does not match recognition scope".to_string(),
+      },
+    );
+  }
+
+  #[test]
+  fn permission_without_scope_note_refuses() {
+    let recognition = sample_recognition();
+    let mut permission = sample_permission();
+    permission.scope_note = "   ".to_string();
+
+    assert_refusal_contains(
+      promote_recognition_to_candidates(
+        &recognition,
+        &PromotionContext {
+          permission: Some(permission),
+          ..sample_context()
+        },
+      ),
+      PromotionRefusal::PermissionInvalid {
+        reason: "permission scope_note is missing".to_string(),
+      },
+    );
+  }
+
+  #[test]
+  fn consent_without_evidence_note_refuses() {
+    let recognition = sample_recognition();
+    let mut permission = sample_permission();
+    permission.consent.evidence_note = "   ".to_string();
+
+    assert_refusal_contains(
+      promote_recognition_to_candidates(
+        &recognition,
+        &PromotionContext {
+          permission: Some(permission),
+          ..sample_context()
+        },
+      ),
+      PromotionRefusal::PermissionInvalid {
+        reason: "consent evidence_note is missing".to_string(),
+      },
+    );
+  }
+
+  #[test]
+  fn missing_capture_does_not_make_freshness_or_permission_valid() {
+    let mut recognition = sample_recognition();
+    recognition.scope.capture_artifact = None;
+
+    let decision = promote_recognition_to_candidates(&recognition, &sample_context());
+
+    assert_refusal_contains(decision.clone(), PromotionRefusal::MissingCaptureArtifact);
+    assert_refusal_contains(
+      decision.clone(),
+      PromotionRefusal::FreshnessStale {
+        reason: "recognition capture_artifact is missing".to_string(),
+      },
+    );
+    assert_refusal_contains(
+      decision,
+      PromotionRefusal::PermissionInvalid {
+        reason: "recognition capture_artifact is missing".to_string(),
       },
     );
   }

--- a/src/candidate_promotion.rs
+++ b/src/candidate_promotion.rs
@@ -8,9 +8,8 @@
 use serde::{Deserialize, Serialize};
 
 use crate::contract::{
-  Candidate, CandidateEvidence, CandidateLiveness, ControlRequirements, FreshnessBasis,
-  LivenessPreconditions, RecognitionResult, RecognitionScope, TargetGrounding, TargetSpec,
-  WindowRefPrecondition,
+  Candidate, CandidateEvidence, CandidateLiveness, ControlRequirements, LivenessPreconditions,
+  RecognitionResult, RecognitionScope, TargetGrounding, TargetSpec, WindowRefPrecondition,
 };
 
 /// 必须由调用方显式提供的过墙前置。缺任何一项 => 拒绝。
@@ -18,8 +17,11 @@ use crate::contract::{
 pub struct PromotionContext {
   pub projection: PromotionProjection,
   pub stability: StabilityInput,
-  pub freshness: Option<FreshnessBasis>,
+  pub freshness: Option<PromotionFreshness>,
   pub permission: Option<ActionPermission>,
+  /// Caller-provided wall-clock used to evaluate freshness and consent expiry.
+  /// Keep time outside the pure gate so tests and replay stay deterministic.
+  pub checked_at_millis: u64,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -47,10 +49,54 @@ pub enum StabilityInput {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PromotionFreshness {
+  pub source_artifact: Option<crate::contract::ArtifactRef>,
+  pub source_operation_id: Option<String>,
+  pub observed_at_millis: Option<u64>,
+  pub max_age_ms: Option<u64>,
+  pub notes: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ActionPermission {
   pub granted_by: String,
   pub scope_note: String,
+  pub consent: ActionConsentRecord,
 }
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ActionConsentRecord {
+  pub consent_id: String,
+  pub recognition_id: String,
+  pub run_id: crate::trace::RunId,
+  pub scope: ActionConsentScope,
+  pub approved_action: String,
+  pub target_item_id: String,
+  pub approved_at_millis: u64,
+  pub expires_at_millis: Option<u64>,
+  pub evidence_note: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ActionConsentScope {
+  pub surface: crate::contract::RecognitionSurface,
+  pub app_bundle_id: Option<String>,
+  pub window_title: Option<String>,
+  pub window_number: Option<i64>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct PromotionAudit {
+  pub freshness_source_artifact: Option<crate::contract::ArtifactRef>,
+  pub freshness_source_operation_id: Option<String>,
+  pub consent_id: String,
+  pub consent_scope: ActionConsentScope,
+  pub consent_granted_by: String,
+  pub projection_kind: String,
+  pub stability_observed_frames: Option<u32>,
+}
+
+const APPROVED_ACTION_CANDIDATE_PROMOTION: &str = "candidate_promotion";
 
 /// 闸门决定。不是 action-result schema。
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -62,6 +108,7 @@ pub enum CandidatePromotion {
   Promoted {
     candidates: Vec<Candidate>,
     residual_known_limits: Vec<String>,
+    audit: PromotionAudit,
   },
 }
 
@@ -75,7 +122,9 @@ pub enum PromotionRefusal {
   ProjectionUnavailable { reason: String },
   StabilityUnproven { reason: String },
   FreshnessUnknown,
+  FreshnessStale { reason: String },
   PermissionMissing,
+  PermissionInvalid { reason: String },
 }
 
 /// 唯一公共入口。纯函数,无副作用,不落盘,不碰 driver。
@@ -107,10 +156,18 @@ pub fn promote_recognition_to_candidates(
       reason: reason.clone(),
     });
   }
-  if context.freshness.is_none() {
-    reasons.push(PromotionRefusal::FreshnessUnknown);
+  match validate_freshness(recognition, context) {
+    Ok(()) => {}
+    Err(PromotionRefusal::FreshnessUnknown) => reasons.push(PromotionRefusal::FreshnessUnknown),
+    Err(reason) => reasons.push(reason),
   }
-  if context.permission.is_none() {
+  if let Some(best) = recognition.best.as_ref() {
+    match validate_permission(recognition, best, context) {
+      Ok(()) => {}
+      Err(PromotionRefusal::PermissionMissing) => reasons.push(PromotionRefusal::PermissionMissing),
+      Err(reason) => reasons.push(reason),
+    }
+  } else if context.permission.is_none() {
     reasons.push(PromotionRefusal::PermissionMissing);
   }
 
@@ -167,6 +224,174 @@ pub fn promote_recognition_to_candidates(
   CandidatePromotion::Promoted {
     candidates: vec![candidate],
     residual_known_limits: known_limits,
+    audit: promotion_audit(context),
+  }
+}
+
+fn validate_freshness(
+  recognition: &RecognitionResult,
+  context: &PromotionContext,
+) -> Result<(), PromotionRefusal> {
+  let Some(freshness) = context.freshness.as_ref() else {
+    return Err(PromotionRefusal::FreshnessUnknown);
+  };
+  let Some(source_artifact) = freshness.source_artifact.as_ref() else {
+    return Err(PromotionRefusal::FreshnessStale {
+      reason: "freshness source_artifact is missing".to_string(),
+    });
+  };
+  let Some(capture_artifact) = recognition.scope.capture_artifact.as_ref() else {
+    return Ok(());
+  };
+  if source_artifact != capture_artifact {
+    return Err(PromotionRefusal::FreshnessStale {
+      reason: "freshness source_artifact does not match recognition capture_artifact".to_string(),
+    });
+  }
+  if freshness
+    .source_operation_id
+    .as_deref()
+    .map(str::trim)
+    .unwrap_or_default()
+    .is_empty()
+  {
+    return Err(PromotionRefusal::FreshnessStale {
+      reason: "freshness source_operation_id is missing".to_string(),
+    });
+  }
+  let Some(observed_at_millis) = freshness.observed_at_millis else {
+    return Err(PromotionRefusal::FreshnessStale {
+      reason: "freshness observed_at_millis is missing".to_string(),
+    });
+  };
+  if observed_at_millis > context.checked_at_millis {
+    return Err(PromotionRefusal::FreshnessStale {
+      reason: "freshness observed_at_millis is in the future".to_string(),
+    });
+  }
+  let Some(max_age_ms) = freshness.max_age_ms else {
+    return Err(PromotionRefusal::FreshnessStale {
+      reason: "freshness max_age_ms is missing".to_string(),
+    });
+  };
+  if context.checked_at_millis - observed_at_millis > max_age_ms {
+    return Err(PromotionRefusal::FreshnessStale {
+      reason: "freshness evidence is stale".to_string(),
+    });
+  }
+  Ok(())
+}
+
+fn validate_permission(
+  recognition: &RecognitionResult,
+  best: &crate::contract::RecognizedItem,
+  context: &PromotionContext,
+) -> Result<(), PromotionRefusal> {
+  let Some(permission) = context.permission.as_ref() else {
+    return Err(PromotionRefusal::PermissionMissing);
+  };
+  if permission.granted_by.trim().is_empty() {
+    return Err(PromotionRefusal::PermissionInvalid {
+      reason: "permission granted_by is missing".to_string(),
+    });
+  }
+  let consent = &permission.consent;
+  if consent.consent_id.trim().is_empty() {
+    return Err(PromotionRefusal::PermissionInvalid {
+      reason: "consent_id is missing".to_string(),
+    });
+  }
+  if consent.recognition_id != recognition.recognition_id {
+    return Err(PromotionRefusal::PermissionInvalid {
+      reason: "consent recognition_id does not match promotion recognition_id".to_string(),
+    });
+  }
+  let Some(capture_artifact) = recognition.scope.capture_artifact.as_ref() else {
+    return Ok(());
+  };
+  if consent.run_id != capture_artifact.run_id {
+    return Err(PromotionRefusal::PermissionInvalid {
+      reason: "consent run_id does not match capture artifact run_id".to_string(),
+    });
+  }
+  if consent.scope != consent_scope_from_recognition(recognition) {
+    return Err(PromotionRefusal::PermissionInvalid {
+      reason: "consent scope does not match recognition scope".to_string(),
+    });
+  }
+  if consent.approved_action != APPROVED_ACTION_CANDIDATE_PROMOTION {
+    return Err(PromotionRefusal::PermissionInvalid {
+      reason: "consent approved_action is not candidate_promotion".to_string(),
+    });
+  }
+  if consent.target_item_id != best.item_id {
+    return Err(PromotionRefusal::PermissionInvalid {
+      reason: "consent target_item_id does not match recognized item".to_string(),
+    });
+  }
+  if consent.approved_at_millis > context.checked_at_millis {
+    return Err(PromotionRefusal::PermissionInvalid {
+      reason: "consent approved_at_millis is in the future".to_string(),
+    });
+  }
+  let Some(expires_at_millis) = consent.expires_at_millis else {
+    return Err(PromotionRefusal::PermissionInvalid {
+      reason: "consent expires_at_millis is missing".to_string(),
+    });
+  };
+  if expires_at_millis <= context.checked_at_millis {
+    return Err(PromotionRefusal::PermissionInvalid {
+      reason: "consent is expired".to_string(),
+    });
+  }
+  if consent.approved_at_millis >= expires_at_millis {
+    return Err(PromotionRefusal::PermissionInvalid {
+      reason: "consent expires before or at approval time".to_string(),
+    });
+  }
+  Ok(())
+}
+
+fn consent_scope_from_recognition(recognition: &RecognitionResult) -> ActionConsentScope {
+  ActionConsentScope {
+    surface: recognition.scope.surface,
+    app_bundle_id: recognition.scope.app_bundle_id.clone(),
+    window_title: recognition.scope.window_title.clone(),
+    window_number: recognition.scope.window_number,
+  }
+}
+
+fn promotion_audit(context: &PromotionContext) -> PromotionAudit {
+  let freshness = context
+    .freshness
+    .as_ref()
+    .expect("freshness is present when promotion is audited");
+  let permission = context
+    .permission
+    .as_ref()
+    .expect("permission is present when promotion is audited");
+  PromotionAudit {
+    freshness_source_artifact: freshness.source_artifact.clone(),
+    freshness_source_operation_id: freshness.source_operation_id.clone(),
+    consent_id: permission.consent.consent_id.clone(),
+    consent_scope: permission.consent.scope.clone(),
+    consent_granted_by: permission.granted_by.clone(),
+    projection_kind: projection_kind(&context.projection),
+    stability_observed_frames: stability_observed_frames(&context.stability),
+  }
+}
+
+fn projection_kind(projection: &PromotionProjection) -> String {
+  match projection {
+    PromotionProjection::Unavailable { .. } => "unavailable".to_string(),
+    PromotionProjection::IdentityWindowAddressable => "identity_window_addressable".to_string(),
+  }
+}
+
+fn stability_observed_frames(stability: &StabilityInput) -> Option<u32> {
+  match stability {
+    StabilityInput::Unproven { .. } => None,
+    StabilityInput::Proven { observed_frames } => Some(*observed_frames),
   }
 }
 
@@ -184,12 +409,13 @@ mod tests {
   use serde_json::json;
 
   use super::{
-    ActionPermission, CandidatePromotion, PromotionContext, PromotionProjection, PromotionRefusal,
-    StabilityInput, promote_recognition_to_candidates,
+    ActionConsentRecord, ActionConsentScope, ActionPermission, CandidatePromotion,
+    PromotionContext, PromotionFreshness, PromotionProjection, PromotionRefusal, StabilityInput,
+    promote_recognition_to_candidates,
   };
   use crate::contract::{
-    ArtifactRef, Candidate, FreshnessBasis, RecognitionBox, RecognitionResult, RecognitionScope,
-    RecognitionSource, RecognitionSurface, RecognizedItem,
+    ArtifactRef, Candidate, RecognitionBox, RecognitionResult, RecognitionScope, RecognitionSource,
+    RecognitionSurface, RecognizedItem,
   };
   use crate::trace::{ArtifactId, EventId, RunId, SpanId};
 
@@ -275,15 +501,38 @@ mod tests {
     PromotionContext {
       projection: PromotionProjection::IdentityWindowAddressable,
       stability: StabilityInput::Proven { observed_frames: 3 },
-      freshness: Some(FreshnessBasis {
+      freshness: Some(PromotionFreshness {
         source_artifact: Some(sample_artifact_ref()),
         source_operation_id: Some("observe.slay.fixture".to_string()),
+        observed_at_millis: Some(1_000),
+        max_age_ms: Some(500),
         notes: vec!["same-frame fixture".to_string()],
       }),
-      permission: Some(ActionPermission {
-        granted_by: "unit-test".to_string(),
-        scope_note: "synthetic promotion proof".to_string(),
-      }),
+      permission: Some(sample_permission()),
+      checked_at_millis: 1_100,
+    }
+  }
+
+  fn sample_permission() -> ActionPermission {
+    ActionPermission {
+      granted_by: "unit-test".to_string(),
+      scope_note: "synthetic promotion proof".to_string(),
+      consent: ActionConsentRecord {
+        consent_id: "consent_candidate_promotion".to_string(),
+        recognition_id: "recognition_candidate_promotion".to_string(),
+        run_id: sample_artifact_ref().run_id,
+        scope: ActionConsentScope {
+          surface: RecognitionSurface::Region,
+          app_bundle_id: Some("com.megacrit.cardcrawl".to_string()),
+          window_title: Some("Slay the Spire".to_string()),
+          window_number: Some(7),
+        },
+        approved_action: "candidate_promotion".to_string(),
+        target_item_id: "item_1".to_string(),
+        approved_at_millis: 1_000,
+        expires_at_millis: Some(1_500),
+        evidence_note: "unit test approval".to_string(),
+      },
     }
   }
 
@@ -370,6 +619,7 @@ mod tests {
         },
         freshness: None,
         permission: None,
+        checked_at_millis: 1_100,
       },
     );
 
@@ -436,6 +686,192 @@ mod tests {
     );
   }
 
+  fn assert_refusal_contains(decision: CandidatePromotion, expected: PromotionRefusal) {
+    match decision {
+      CandidatePromotion::Refused { reasons } => assert!(
+        reasons.contains(&expected),
+        "expected refusal {expected:?}, got {reasons:?}"
+      ),
+      CandidatePromotion::Promoted { .. } => panic!("expected refusal, got promoted"),
+    }
+  }
+
+  #[test]
+  fn expired_consent_refuses() {
+    let recognition = sample_recognition();
+    let mut permission = sample_permission();
+    permission.consent.expires_at_millis = Some(1_050);
+
+    assert_refusal_contains(
+      promote_recognition_to_candidates(
+        &recognition,
+        &PromotionContext {
+          permission: Some(permission),
+          ..sample_context()
+        },
+      ),
+      PromotionRefusal::PermissionInvalid {
+        reason: "consent is expired".to_string(),
+      },
+    );
+  }
+
+  #[test]
+  fn future_consent_approval_refuses() {
+    let recognition = sample_recognition();
+    let mut permission = sample_permission();
+    permission.consent.approved_at_millis = 1_200;
+
+    assert_refusal_contains(
+      promote_recognition_to_candidates(
+        &recognition,
+        &PromotionContext {
+          permission: Some(permission),
+          ..sample_context()
+        },
+      ),
+      PromotionRefusal::PermissionInvalid {
+        reason: "consent approved_at_millis is in the future".to_string(),
+      },
+    );
+  }
+
+  #[test]
+  fn consent_for_different_item_refuses() {
+    let recognition = sample_recognition();
+    let mut permission = sample_permission();
+    permission.consent.target_item_id = "item_2".to_string();
+
+    assert_refusal_contains(
+      promote_recognition_to_candidates(
+        &recognition,
+        &PromotionContext {
+          permission: Some(permission),
+          ..sample_context()
+        },
+      ),
+      PromotionRefusal::PermissionInvalid {
+        reason: "consent target_item_id does not match recognized item".to_string(),
+      },
+    );
+  }
+
+  #[test]
+  fn consent_for_different_recognition_refuses() {
+    let recognition = sample_recognition();
+    let mut permission = sample_permission();
+    permission.consent.recognition_id = "recognition_other".to_string();
+
+    assert_refusal_contains(
+      promote_recognition_to_candidates(
+        &recognition,
+        &PromotionContext {
+          permission: Some(permission),
+          ..sample_context()
+        },
+      ),
+      PromotionRefusal::PermissionInvalid {
+        reason: "consent recognition_id does not match promotion recognition_id".to_string(),
+      },
+    );
+  }
+
+  #[test]
+  fn consent_for_different_run_refuses() {
+    let recognition = sample_recognition();
+    let mut permission = sample_permission();
+    permission.consent.run_id = RunId::new("run_other");
+
+    assert_refusal_contains(
+      promote_recognition_to_candidates(
+        &recognition,
+        &PromotionContext {
+          permission: Some(permission),
+          ..sample_context()
+        },
+      ),
+      PromotionRefusal::PermissionInvalid {
+        reason: "consent run_id does not match capture artifact run_id".to_string(),
+      },
+    );
+  }
+
+  #[test]
+  fn consent_for_different_scope_refuses() {
+    let recognition = sample_recognition();
+    let mut permission = sample_permission();
+    permission.consent.scope.window_title = Some("Other Window".to_string());
+
+    assert_refusal_contains(
+      promote_recognition_to_candidates(
+        &recognition,
+        &PromotionContext {
+          permission: Some(permission),
+          ..sample_context()
+        },
+      ),
+      PromotionRefusal::PermissionInvalid {
+        reason: "consent scope does not match recognition scope".to_string(),
+      },
+    );
+  }
+
+  #[test]
+  fn stale_freshness_refuses() {
+    let recognition = sample_recognition();
+    let mut context = sample_context();
+    context
+      .freshness
+      .as_mut()
+      .expect("freshness")
+      .observed_at_millis = Some(500);
+
+    assert_refusal_contains(
+      promote_recognition_to_candidates(&recognition, &context),
+      PromotionRefusal::FreshnessStale {
+        reason: "freshness evidence is stale".to_string(),
+      },
+    );
+  }
+
+  #[test]
+  fn freshness_for_different_capture_refuses() {
+    let recognition = sample_recognition();
+    let mut context = sample_context();
+    let freshness = context.freshness.as_mut().expect("freshness");
+    freshness.source_artifact = Some(ArtifactRef {
+      run_id: RunId::new("run_other"),
+      artifact_id: ArtifactId::new("artifact_other"),
+      span_id: SpanId::new("span_other"),
+      captured_event_id: None,
+    });
+
+    assert_refusal_contains(
+      promote_recognition_to_candidates(&recognition, &context),
+      PromotionRefusal::FreshnessStale {
+        reason: "freshness source_artifact does not match recognition capture_artifact".to_string(),
+      },
+    );
+  }
+
+  #[test]
+  fn freshness_without_operation_id_refuses() {
+    let recognition = sample_recognition();
+    let mut context = sample_context();
+    context
+      .freshness
+      .as_mut()
+      .expect("freshness")
+      .source_operation_id = Some("   ".to_string());
+
+    assert_refusal_contains(
+      promote_recognition_to_candidates(&recognition, &context),
+      PromotionRefusal::FreshnessStale {
+        reason: "freshness source_operation_id is missing".to_string(),
+      },
+    );
+  }
+
   #[test]
   fn proven_context_promotes_single_candidate_without_new_parallel_types() {
     let recognition = sample_recognition();
@@ -445,6 +881,7 @@ mod tests {
       CandidatePromotion::Promoted {
         candidates,
         residual_known_limits,
+        audit,
       } => {
         assert_eq!(candidates.len(), 1);
         assert_promoted_candidate(&candidates[0]);
@@ -454,6 +891,13 @@ mod tests {
               .to_string()
           )
         );
+        assert_eq!(audit.consent_id, "consent_candidate_promotion");
+        assert_eq!(audit.freshness_source_artifact, Some(sample_artifact_ref()));
+        assert_eq!(
+          audit.freshness_source_operation_id.as_deref(),
+          Some("observe.slay.fixture")
+        );
+        assert_eq!(audit.stability_observed_frames, Some(3));
       }
       other => panic!("expected Promoted, got {other:?}"),
     }

--- a/src/candidate_promotion_recording.rs
+++ b/src/candidate_promotion_recording.rs
@@ -287,8 +287,8 @@ mod tests {
   };
   use crate::build_runtime_with_store_root;
   use crate::candidate_promotion::{
-    ActionConsentRecord, ActionConsentScope, ActionPermission, CandidatePromotion,
-    PromotionFreshness, PromotionProjection,
+    ActionConsentAction, ActionConsentRecord, ActionConsentScope, ActionPermission,
+    CandidatePromotion, PromotionFreshness, PromotionProjection,
   };
   use crate::contract::{
     ArtifactRef, RecognitionBox, RecognitionResult, RecognitionScope, RecognitionSource,
@@ -425,7 +425,7 @@ mod tests {
             window_title: Some("Slay the Spire".to_string()),
             window_number: Some(7),
           },
-          approved_action: "candidate_promotion".to_string(),
+          approved_action: ActionConsentAction::CandidatePromotion,
           target_item_id: "item_end_turn".to_string(),
           approved_at_millis: 2_000,
           expires_at_millis: Some(2_500),

--- a/src/candidate_promotion_recording.rs
+++ b/src/candidate_promotion_recording.rs
@@ -4,10 +4,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::candidate_promotion::{
-  ActionPermission, CandidatePromotion, PromotionContext, PromotionProjection,
+  ActionPermission, CandidatePromotion, PromotionContext, PromotionFreshness, PromotionProjection,
   promote_recognition_to_candidates,
 };
-use crate::contract::{ArtifactRef, FreshnessBasis, RecognitionResult};
+use crate::contract::{ArtifactRef, RecognitionResult};
 use crate::model::{AuvResult, now_millis};
 use crate::recorded_operation::RecordedOperationContext;
 use crate::stability::{StabilityAssessment, StabilityPolicy, assess_stability};
@@ -21,8 +21,9 @@ pub struct CandidatePromotionArtifactRequest {
   pub source_recognition_artifact: Option<ArtifactRef>,
   pub stability_policy: StabilityPolicy,
   pub projection: PromotionProjection,
-  pub freshness: Option<FreshnessBasis>,
+  pub freshness: Option<PromotionFreshness>,
   pub permission: Option<ActionPermission>,
+  pub checked_at_millis: u64,
   pub artifact_role: String,
   pub artifact_label: String,
   pub artifact_note: String,
@@ -44,6 +45,7 @@ impl CandidatePromotionArtifactRequest {
       },
       freshness: None,
       permission: None,
+      checked_at_millis: now_millis(),
       artifact_role: CANDIDATE_PROMOTION_ARTIFACT_ROLE.to_string(),
       artifact_label: artifact_label.into(),
       artifact_note: "Candidate-promotion gate decision runtime artifact.".to_string(),
@@ -103,6 +105,7 @@ pub fn build_candidate_promotion_artifact(
     stability: stability_assessment.to_promotion_stability_input(),
     freshness: request.freshness.clone(),
     permission: request.permission.clone(),
+    checked_at_millis: request.checked_at_millis,
   };
   let decision = promote_recognition_to_candidates(recognition, &promotion_context);
 
@@ -284,11 +287,12 @@ mod tests {
   };
   use crate::build_runtime_with_store_root;
   use crate::candidate_promotion::{
-    ActionPermission, CandidatePromotion, PromotionProjection, PromotionRefusal,
+    ActionConsentRecord, ActionConsentScope, ActionPermission, CandidatePromotion,
+    PromotionFreshness, PromotionProjection,
   };
   use crate::contract::{
-    ArtifactRef, FreshnessBasis, RecognitionBox, RecognitionResult, RecognitionScope,
-    RecognitionSource, RecognitionSurface, RecognizedItem,
+    ArtifactRef, RecognitionBox, RecognitionResult, RecognitionScope, RecognitionSource,
+    RecognitionSurface, RecognizedItem,
   };
   use crate::run_builder::RunSpec;
   use crate::stability::StabilityPolicy;
@@ -401,15 +405,34 @@ mod tests {
         require_stable_text: true,
       },
       projection: PromotionProjection::IdentityWindowAddressable,
-      freshness: Some(FreshnessBasis {
+      freshness: Some(PromotionFreshness {
         source_artifact: Some(sample_artifact_ref()),
         source_operation_id: Some("observe.window.capture".to_string()),
+        observed_at_millis: Some(2_000),
+        max_age_ms: Some(500),
         notes: vec!["fixture freshness seed".to_string()],
       }),
       permission: Some(ActionPermission {
         granted_by: "human-review".to_string(),
         scope_note: "single end-turn action".to_string(),
+        consent: ActionConsentRecord {
+          consent_id: "consent_end_turn".to_string(),
+          recognition_id: "recognition_frame_3".to_string(),
+          run_id: sample_artifact_ref().run_id,
+          scope: ActionConsentScope {
+            surface: RecognitionSurface::Window,
+            app_bundle_id: Some("com.megacrit.cardcrawl".to_string()),
+            window_title: Some("Slay the Spire".to_string()),
+            window_number: Some(7),
+          },
+          approved_action: "candidate_promotion".to_string(),
+          target_item_id: "item_end_turn".to_string(),
+          approved_at_millis: 2_000,
+          expires_at_millis: Some(2_500),
+          evidence_note: "fixture approval".to_string(),
+        },
       }),
+      checked_at_millis: 2_100,
       artifact_role: "candidate-promotion".to_string(),
       artifact_label: "slay-the-spire-end-turn-promotion".to_string(),
       artifact_note: "Candidate-promotion gate decision for Slay the Spire fixture.".to_string(),
@@ -625,21 +648,24 @@ mod tests {
     match artifact.decision {
       CandidatePromotion::Refused { reasons } => {
         assert!(
-          !reasons
-            .iter()
-            .any(|reason| matches!(reason, PromotionRefusal::ProjectionUnavailable { .. })),
+          !reasons.iter().any(|reason| matches!(
+            reason,
+            crate::candidate_promotion::PromotionRefusal::ProjectionUnavailable { .. }
+          )),
           "AX projection should not remain refused: {reasons:?}"
         );
         assert!(
-          reasons
-            .iter()
-            .any(|reason| matches!(reason, PromotionRefusal::FreshnessUnknown)),
+          reasons.iter().any(|reason| matches!(
+            reason,
+            crate::candidate_promotion::PromotionRefusal::FreshnessUnknown
+          )),
           "freshness remains intentionally deferred for the next slice"
         );
         assert!(
-          reasons
-            .iter()
-            .any(|reason| matches!(reason, PromotionRefusal::PermissionMissing)),
+          reasons.iter().any(|reason| matches!(
+            reason,
+            crate::candidate_promotion::PromotionRefusal::PermissionMissing
+          )),
           "permission remains intentionally deferred for the next slice"
         );
       }

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -211,6 +211,30 @@ pub fn render_text(
       if let Some(stability_reason) = &lineage.stability_reason {
         output.push_str(&format!("  stability_reason={stability_reason}\n"));
       }
+      if lineage.freshness_source_operation_id.is_some()
+        || lineage.consent_id.is_some()
+        || lineage.consent_granted_by.is_some()
+      {
+        output.push_str(&format!(
+          "  audit freshness_operation={} freshness_artifact={} consent_id={} consent_granted_by={} consent_scope_window={}\n",
+          lineage
+            .freshness_source_operation_id
+            .as_deref()
+            .unwrap_or("n/a"),
+          lineage
+            .freshness_source_artifact
+            .as_ref()
+            .and_then(|artifact| artifact.path.as_deref())
+            .unwrap_or("n/a"),
+          lineage.consent_id.as_deref().unwrap_or("n/a"),
+          lineage.consent_granted_by.as_deref().unwrap_or("n/a"),
+          lineage
+            .consent_scope
+            .as_ref()
+            .and_then(|scope| scope.window_title.as_deref())
+            .unwrap_or("n/a")
+        ));
+      }
       if !lineage.known_limits.is_empty() {
         output.push_str(&format!(
           "  known_limits={}\n",
@@ -333,6 +357,7 @@ mod tests {
   use std::collections::BTreeMap;
 
   use super::render_text;
+  use crate::candidate_promotion::ActionConsentScope;
   use crate::contract::{
     OBSERVATION_SNAPSHOT_API_VERSION, ObservationSnapshot, ObservationSource, RecognitionScope,
     RecognitionSource, RecognitionSurface, VERIFICATION_RESULT_API_VERSION, VerificationMethod,
@@ -571,7 +596,26 @@ mod tests {
       stability_observed_frames: Some(2),
       stability_reason: None,
       freshness_present: Some(true),
+      freshness_source_artifact: Some(ArtifactRefLineage {
+        run_id: run_id.clone(),
+        artifact_id: ArtifactId::new("artifact_capture"),
+        span_id: SpanId::new("span_root"),
+        captured_event_id: Some(EventId::new("event_capture")),
+        role: Some("capture-image".to_string()),
+        path: Some("artifacts/capture.png".to_string()),
+        summary: Some("capture".to_string()),
+        resolved: true,
+      }),
+      freshness_source_operation_id: Some("observe.window.capture".to_string()),
       permission_granted: Some(true),
+      consent_id: Some("consent_end_turn".to_string()),
+      consent_scope: Some(ActionConsentScope {
+        surface: RecognitionSurface::Window,
+        app_bundle_id: Some("com.megacrit.cardcrawl".to_string()),
+        window_title: Some("Slay the Spire".to_string()),
+        window_number: Some(7),
+      }),
+      consent_granted_by: Some("human-review".to_string()),
       decision_kind: Some("promoted".to_string()),
       refusal_reasons: Vec::new(),
       promoted_candidate_local_ids: vec!["promoted-item_end_turn".to_string()],
@@ -613,6 +657,9 @@ mod tests {
     assert!(output.contains("decision=promoted"));
     assert!(output.contains("projection=identity_window_addressable"));
     assert!(output.contains("source_recognition=artifacts/detector-recognition.json"));
+    assert!(output.contains("freshness_operation=observe.window.capture"));
+    assert!(output.contains("consent_id=consent_end_turn"));
+    assert!(output.contains("consent_granted_by=human-review"));
     assert!(output.contains("Validation Lineage:"));
     assert!(
       output

--- a/src/inspect_server/mod.rs
+++ b/src/inspect_server/mod.rs
@@ -889,8 +889,9 @@ mod tests {
     AppIdentity, AppValidatedCandidate, AppValidation, AppValidationStatus, AppVerificationMode,
   };
   use crate::candidate_promotion::{
-    ActionConsentRecord, ActionConsentScope, ActionPermission, CandidatePromotion, PromotionAudit,
-    PromotionContext, PromotionFreshness, PromotionProjection, StabilityInput,
+    ActionConsentAction, ActionConsentRecord, ActionConsentScope, ActionPermission,
+    CandidatePromotion, PromotionAudit, PromotionContext, PromotionFreshness, PromotionProjection,
+    StabilityInput,
   };
   use crate::candidate_promotion_recording::CandidatePromotionArtifact;
   use crate::contract::{
@@ -1879,6 +1880,22 @@ mod tests {
     assert_eq!(
       run["candidate_promotion_lineage"][0]["promoted_candidate_local_ids"][0],
       "promoted-item_end_turn"
+    );
+    assert_eq!(
+      run["candidate_promotion_lineage"][0]["freshness_source_operation_id"],
+      "observe.window.capture"
+    );
+    assert_eq!(
+      run["candidate_promotion_lineage"][0]["consent_id"],
+      "consent_end_turn"
+    );
+    assert_eq!(
+      run["candidate_promotion_lineage"][0]["consent_granted_by"],
+      "human-review"
+    );
+    assert_eq!(
+      run["candidate_promotion_lineage"][0]["consent_scope"]["window_title"],
+      "Balatro"
     );
     assert!(
       run.get("spans").is_none(),
@@ -2934,7 +2951,7 @@ mod tests {
                   window_title: Some("Balatro".to_string()),
                   window_number: Some(7),
                 },
-                approved_action: "candidate_promotion".to_string(),
+                approved_action: ActionConsentAction::CandidatePromotion,
                 target_item_id: "item_end_turn".to_string(),
                 approved_at_millis: 2_000,
                 expires_at_millis: Some(2_500),

--- a/src/inspect_server/mod.rs
+++ b/src/inspect_server/mod.rs
@@ -889,7 +889,8 @@ mod tests {
     AppIdentity, AppValidatedCandidate, AppValidation, AppValidationStatus, AppVerificationMode,
   };
   use crate::candidate_promotion::{
-    ActionPermission, CandidatePromotion, PromotionContext, PromotionProjection, StabilityInput,
+    ActionConsentRecord, ActionConsentScope, ActionPermission, CandidatePromotion, PromotionAudit,
+    PromotionContext, PromotionFreshness, PromotionProjection, StabilityInput,
   };
   use crate::candidate_promotion_recording::CandidatePromotionArtifact;
   use crate::contract::{
@@ -2908,7 +2909,7 @@ mod tests {
             stability: StabilityInput::Proven {
               observed_frames: 2,
             },
-            freshness: Some(crate::contract::FreshnessBasis {
+            freshness: Some(PromotionFreshness {
               source_artifact: Some(ArtifactRef {
                 run_id: run_id.clone(),
                 artifact_id: ArtifactId::new("artifact_0004"),
@@ -2916,12 +2917,31 @@ mod tests {
                 captured_event_id: None,
               }),
               source_operation_id: Some("observe.window.capture".to_string()),
+              observed_at_millis: Some(2_000),
+              max_age_ms: Some(500),
               notes: vec!["fixture freshness".to_string()],
             }),
             permission: Some(ActionPermission {
               granted_by: "human-review".to_string(),
               scope_note: "single end-turn action".to_string(),
+              consent: ActionConsentRecord {
+                consent_id: "consent_end_turn".to_string(),
+                recognition_id: "recognition_detector_server_test".to_string(),
+                run_id: run_id.clone(),
+                scope: ActionConsentScope {
+                  surface: RecognitionSurface::Region,
+                  app_bundle_id: Some("com.playstack.balatro".to_string()),
+                  window_title: Some("Balatro".to_string()),
+                  window_number: Some(7),
+                },
+                approved_action: "candidate_promotion".to_string(),
+                target_item_id: "item_end_turn".to_string(),
+                approved_at_millis: 2_000,
+                expires_at_millis: Some(2_500),
+                evidence_note: "fixture consent".to_string(),
+              },
             }),
+            checked_at_millis: 2_100,
           },
           decision: CandidatePromotion::Promoted {
             candidates: vec![crate::contract::Candidate {
@@ -2961,6 +2981,25 @@ mod tests {
               known_limits: vec!["fixture-backed candidate".to_string()],
             }],
             residual_known_limits: vec!["fixture-backed candidate".to_string()],
+            audit: PromotionAudit {
+              freshness_source_artifact: Some(ArtifactRef {
+                run_id: run_id.clone(),
+                artifact_id: ArtifactId::new("artifact_0004"),
+                span_id: span_id.clone(),
+                captured_event_id: None,
+              }),
+              freshness_source_operation_id: Some("observe.window.capture".to_string()),
+              consent_id: "consent_end_turn".to_string(),
+              consent_scope: ActionConsentScope {
+                surface: RecognitionSurface::Region,
+                app_bundle_id: Some("com.playstack.balatro".to_string()),
+                window_title: Some("Balatro".to_string()),
+                window_number: Some(7),
+              },
+              consent_granted_by: "human-review".to_string(),
+              projection_kind: "identity_window_addressable".to_string(),
+              stability_observed_frames: Some(2),
+            },
           },
           recognition: RecognitionResult {
             recognition_id: "recognition_detector_server_test".to_string(),

--- a/src/run_read.rs
+++ b/src/run_read.rs
@@ -707,7 +707,9 @@ fn promotion_refusal_string(reason: &PromotionRefusal) -> String {
       format!("stability_unproven: {reason}")
     }
     PromotionRefusal::FreshnessUnknown => "freshness_unknown".to_string(),
+    PromotionRefusal::FreshnessStale { reason } => format!("freshness_stale: {reason}"),
     PromotionRefusal::PermissionMissing => "permission_missing".to_string(),
+    PromotionRefusal::PermissionInvalid { reason } => format!("permission_invalid: {reason}"),
   }
 }
 
@@ -771,8 +773,8 @@ mod tests {
     AppIdentity, AppValidatedCandidate, AppValidation, AppValidationStatus, AppVerificationMode,
   };
   use crate::candidate_promotion::{
-    ActionPermission, CandidatePromotion, PromotionContext, PromotionProjection, PromotionRefusal,
-    StabilityInput,
+    ActionConsentRecord, ActionConsentScope, ActionPermission, CandidatePromotion, PromotionAudit,
+    PromotionContext, PromotionFreshness, PromotionProjection, PromotionRefusal, StabilityInput,
   };
   use crate::candidate_promotion_recording::CandidatePromotionArtifact;
   use crate::contract::{
@@ -1269,6 +1271,25 @@ mod tests {
           "promoted-item_end_turn",
         )],
         residual_known_limits: vec!["fixture-backed candidate".to_string()],
+        audit: PromotionAudit {
+          freshness_source_artifact: Some(ArtifactRef {
+            run_id: run.run_id.clone(),
+            artifact_id: capture_artifact.artifact_id.clone(),
+            span_id: span.span_id.clone(),
+            captured_event_id: capture_artifact.event_id.clone(),
+          }),
+          freshness_source_operation_id: Some("observe.window.capture".to_string()),
+          consent_id: "consent_promotion_ready".to_string(),
+          consent_scope: ActionConsentScope {
+            surface: RecognitionSurface::Window,
+            app_bundle_id: Some("com.megacrit.cardcrawl".to_string()),
+            window_title: Some("Slay the Spire".to_string()),
+            window_number: Some(7),
+          },
+          consent_granted_by: "human-review".to_string(),
+          projection_kind: "identity_window_addressable".to_string(),
+          stability_observed_frames: Some(2),
+        },
       },
       "promotion_ready",
     );
@@ -1806,15 +1827,34 @@ mod tests {
       promotion_context: PromotionContext {
         projection,
         stability: stability_input,
-        freshness: Some(crate::contract::FreshnessBasis {
+        freshness: Some(PromotionFreshness {
           source_artifact: capture_artifact.clone(),
           source_operation_id: Some("observe.window.capture".to_string()),
+          observed_at_millis: Some(2_000),
+          max_age_ms: Some(500),
           notes: vec!["fixture freshness".to_string()],
         }),
         permission: Some(ActionPermission {
           granted_by: "human-review".to_string(),
           scope_note: "fixture promotion".to_string(),
+          consent: ActionConsentRecord {
+            consent_id: format!("consent_{promotion_id}"),
+            recognition_id: format!("{promotion_id}_frame_1"),
+            run_id: run_id.clone(),
+            scope: ActionConsentScope {
+              surface: RecognitionSurface::Window,
+              app_bundle_id: Some("com.megacrit.cardcrawl".to_string()),
+              window_title: Some("Slay the Spire".to_string()),
+              window_number: Some(7),
+            },
+            approved_action: "candidate_promotion".to_string(),
+            target_item_id: "item_end_turn".to_string(),
+            approved_at_millis: 2_000,
+            expires_at_millis: Some(2_500),
+            evidence_note: "fixture consent".to_string(),
+          },
         }),
+        checked_at_millis: 2_100,
       },
       decision,
       recognition: RecognitionResult {

--- a/src/run_read.rs
+++ b/src/run_read.rs
@@ -14,7 +14,9 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 
 use crate::app::AppValidation;
-use crate::candidate_promotion::{CandidatePromotion, PromotionProjection, PromotionRefusal};
+use crate::candidate_promotion::{
+  ActionConsentScope, CandidatePromotion, PromotionProjection, PromotionRefusal,
+};
 use crate::candidate_promotion_recording::CandidatePromotionArtifact;
 use crate::contract::{
   ArtifactRef, ObservationSnapshot, OperationOutput, OperationResult, RecognitionResult,
@@ -116,7 +118,12 @@ pub struct CandidatePromotionLineage {
   pub stability_observed_frames: Option<u32>,
   pub stability_reason: Option<String>,
   pub freshness_present: Option<bool>,
+  pub freshness_source_artifact: Option<ArtifactRefLineage>,
+  pub freshness_source_operation_id: Option<String>,
   pub permission_granted: Option<bool>,
+  pub consent_id: Option<String>,
+  pub consent_scope: Option<ActionConsentScope>,
+  pub consent_granted_by: Option<String>,
   pub decision_kind: Option<String>,
   pub refusal_reasons: Vec<String>,
   pub promoted_candidate_local_ids: Vec<String>,
@@ -344,7 +351,12 @@ pub(crate) fn extract_candidate_promotion_lineage(
         stability_observed_frames: None,
         stability_reason: None,
         freshness_present: None,
+        freshness_source_artifact: None,
+        freshness_source_operation_id: None,
         permission_granted: None,
+        consent_id: None,
+        consent_scope: None,
+        consent_granted_by: None,
         decision_kind: None,
         refusal_reasons: Vec::new(),
         promoted_candidate_local_ids: Vec::new(),
@@ -390,7 +402,12 @@ pub(crate) fn extract_candidate_promotion_lineage(
         stability_observed_frames: None,
         stability_reason: None,
         freshness_present: None,
+        freshness_source_artifact: None,
+        freshness_source_operation_id: None,
         permission_granted: None,
+        consent_id: None,
+        consent_scope: None,
+        consent_granted_by: None,
         decision_kind: None,
         refusal_reasons: Vec::new(),
         promoted_candidate_local_ids: Vec::new(),
@@ -481,6 +498,13 @@ fn candidate_promotion_lineage_entry(
   );
   let (decision_kind, refusal_reasons, promoted_candidate_local_ids) =
     promotion_decision_summary(&promotion.decision);
+  let (
+    freshness_source_artifact,
+    freshness_source_operation_id,
+    consent_id,
+    consent_scope,
+    consent_granted_by,
+  ) = promotion_audit_summary(run, &promotion.decision);
   let (stability_kind, stability_observed_frames, stability_reason) =
     stability_summary(&promotion.stability_assessment);
 
@@ -498,7 +522,12 @@ fn candidate_promotion_lineage_entry(
     stability_observed_frames,
     stability_reason,
     freshness_present: Some(promotion.promotion_context.freshness.is_some()),
+    freshness_source_artifact,
+    freshness_source_operation_id,
     permission_granted: Some(promotion.promotion_context.permission.is_some()),
+    consent_id,
+    consent_scope,
+    consent_granted_by,
     decision_kind: Some(decision_kind),
     refusal_reasons,
     promoted_candidate_local_ids,
@@ -676,6 +705,31 @@ fn stability_rejection_string(reason: &StabilityRejection) -> String {
   }
 }
 
+fn promotion_audit_summary(
+  run: &CanonicalRun,
+  decision: &CandidatePromotion,
+) -> (
+  Option<ArtifactRefLineage>,
+  Option<String>,
+  Option<String>,
+  Option<ActionConsentScope>,
+  Option<String>,
+) {
+  match decision {
+    CandidatePromotion::Promoted { audit, .. } => (
+      audit
+        .freshness_source_artifact
+        .as_ref()
+        .map(|reference| resolve_artifact_ref(run, reference)),
+      audit.freshness_source_operation_id.clone(),
+      Some(audit.consent_id.clone()),
+      Some(audit.consent_scope.clone()),
+      Some(audit.consent_granted_by.clone()),
+    ),
+    CandidatePromotion::Refused { .. } => (None, None, None, None, None),
+  }
+}
+
 fn promotion_decision_summary(decision: &CandidatePromotion) -> (String, Vec<String>, Vec<String>) {
   match decision {
     CandidatePromotion::Refused { reasons } => (
@@ -773,8 +827,9 @@ mod tests {
     AppIdentity, AppValidatedCandidate, AppValidation, AppValidationStatus, AppVerificationMode,
   };
   use crate::candidate_promotion::{
-    ActionConsentRecord, ActionConsentScope, ActionPermission, CandidatePromotion, PromotionAudit,
-    PromotionContext, PromotionFreshness, PromotionProjection, PromotionRefusal, StabilityInput,
+    ActionConsentAction, ActionConsentRecord, ActionConsentScope, ActionPermission,
+    CandidatePromotion, PromotionAudit, PromotionContext, PromotionFreshness, PromotionProjection,
+    PromotionRefusal, StabilityInput,
   };
   use crate::candidate_promotion_recording::CandidatePromotionArtifact;
   use crate::contract::{
@@ -1447,6 +1502,32 @@ mod tests {
       extracted[0].promoted_candidate_local_ids,
       vec!["promoted-item_end_turn".to_string()]
     );
+    assert_eq!(
+      extracted[0].freshness_source_operation_id.as_deref(),
+      Some("observe.window.capture")
+    );
+    assert_eq!(
+      extracted[0]
+        .freshness_source_artifact
+        .as_ref()
+        .and_then(|artifact| artifact.role.as_deref()),
+      Some("capture-image")
+    );
+    assert_eq!(
+      extracted[0].consent_id.as_deref(),
+      Some("consent_promotion_ready")
+    );
+    assert_eq!(
+      extracted[0].consent_granted_by.as_deref(),
+      Some("human-review")
+    );
+    assert_eq!(
+      extracted[0]
+        .consent_scope
+        .as_ref()
+        .and_then(|scope| scope.window_title.as_deref()),
+      Some("Slay the Spire")
+    );
     assert_eq!(extracted[1].status, CandidatePromotionLineageStatus::Ready);
     assert_eq!(extracted[1].decision_kind.as_deref(), Some("refused"));
     assert_eq!(
@@ -1847,7 +1928,7 @@ mod tests {
               window_title: Some("Slay the Spire".to_string()),
               window_number: Some(7),
             },
-            approved_action: "candidate_promotion".to_string(),
+            approved_action: ActionConsentAction::CandidatePromotion,
             target_item_id: "item_end_turn".to_string(),
             approved_at_millis: 2_000,
             expires_at_millis: Some(2_500),


### PR DESCRIPTION
### Motivation
- Strengthen the candidate-promotion gate by validating runtime freshness and explicit human consent before promoting a recognition into a candidate. 
- Provide structured audit metadata for promoted decisions so downstream systems can inspect provenance of freshness and consent. 
- Surface more specific refusal reasons when freshness or permission checks fail to aid debugging and telemetry.

### Description
- Replace the optional `FreshnessBasis` with `PromotionFreshness` and extend `ActionPermission` to include a structured `ActionConsentRecord` and `ActionConsentScope`, add `checked_at_millis` to `PromotionContext`, and add a `PromotionAudit` record carried on `CandidatePromotion::Promoted`.
- Implement `validate_freshness` and `validate_permission` functions that perform detailed checks (artifact/run/id/scope matching, timestamps, expiry, and approved action), add new refusal variants `FreshnessStale` and `PermissionInvalid`, and wire these validations into `promote_recognition_to_candidates` to produce refusal-first behavior.
- Emit an audit summary via `promotion_audit` for successful promotions and add helpers `projection_kind` and `stability_observed_frames`; update callers and artifact builders to populate `checked_at_millis`, freshness, consent, and to include the audit in artifacts and test fixtures.

### Testing
- Ran the unit test suite via `cargo test`, exercising the updated `candidate_promotion` unit tests including `refusal_collects_all_missing_prerequisites`, `missing_permission_refuses`, `expired_consent_refuses`, `future_consent_approval_refuses`, `consent_for_different_item_refuses`, `consent_for_different_recognition_refuses`, `consent_for_different_run_refuses`, `consent_for_different_scope_refuses`, `stale_freshness_refuses`, `freshness_for_different_capture_refuses`, `freshness_without_operation_id_refuses`, and `proven_context_promotes_single_candidate_without_new_parallel_types` along with updated recording and integration tests in `candidate_promotion_recording`, `inspect_server`, and `run_read`. 
- All automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a254e7d4188832f8c28be620802b01e)