### PR TITLE
docs(collabi): add auv pairing skill and hard gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,8 +140,10 @@ Hard rules:
 - Default Collabi mode is read-only.
 - Do not claim, check in, or pretend a slice was recorded unless the human
   explicitly granted writer access for the current task.
-- If the Collabi gate was not completed for the current slice, do not edit
-  tracked files. Read-only investigation is allowed; file edits are not.
+- If the Collabi gate was not completed for the current slice, stop and report
+  why before editing tracked files unless the human explicitly told you to
+  proceed in a local or offline mode. Read-only investigation is always
+  allowed.
 
 ## Current Contract Seam
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,27 +127,21 @@ When working in `/Users/liuziheng/https-github-com-moeru-ai-auv`, humans and
 agents must treat Collabi coordination as a hard pre-edit gate, not a polite
 reminder.
 
-Before editing tracked files, first read:
+Before editing tracked files:
 
-- `CLAUDE.md`
-- `skills/auv-collabi-pairing/SKILL.md`
+1. Read `CLAUDE.md`.
+2. Read `skills/auv-collabi-pairing/SKILL.md`.
+3. Complete the skill's read-only preflight against Collabi shared state.
 
-Then follow the skill's start-of-task workflow:
+Hard rules:
 
-- inspect the current Collabi shared state
-- summarize overlap risk
-- choose one narrow slice
-
-If the intended repo, scope, or path overlaps an active claim, stop before
-editing and report the conflict.
-
-Default Collabi mode is read-only. Do not claim, check in, or pretend a slice
-was recorded unless the human explicitly granted writer access for the current
-task. If writer access was granted, use the human-facing writer console
-documented by the skill and its workflow reference.
-
-If the Collabi gate was not completed for the current slice, do not edit
-tracked files. Read-only investigation is allowed; file edits are not.
+- If the intended repo, scope, or path overlaps an active claim, stop before
+  editing and report the conflict.
+- Default Collabi mode is read-only.
+- Do not claim, check in, or pretend a slice was recorded unless the human
+  explicitly granted writer access for the current task.
+- If the Collabi gate was not completed for the current slice, do not edit
+  tracked files. Read-only investigation is allowed; file edits are not.
 
 ## Current Contract Seam
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,34 @@ A deferral marker is not approval to implement the deferred work later
 without owner involvement. It is documentation of an existing decision so
 the decision survives the next read of the code.
 
+## Collabi Hard Gate
+
+When working in `/Users/liuziheng/https-github-com-moeru-ai-auv`, humans and
+agents must treat Collabi coordination as a hard pre-edit gate, not a polite
+reminder.
+
+Before editing tracked files, first read:
+
+- `CLAUDE.md`
+- `skills/auv-collabi-pairing/SKILL.md`
+
+Then follow the skill's start-of-task workflow:
+
+- inspect the current Collabi shared state
+- summarize overlap risk
+- choose one narrow slice
+
+If the intended repo, scope, or path overlaps an active claim, stop before
+editing and report the conflict.
+
+Default Collabi mode is read-only. Do not claim, check in, or pretend a slice
+was recorded unless the human explicitly granted writer access for the current
+task. If writer access was granted, use the human-facing writer console
+documented by the skill and its workflow reference.
+
+If the Collabi gate was not completed for the current slice, do not edit
+tracked files. Read-only investigation is allowed; file edits are not.
+
 ## Current Contract Seam
 
 The active macOS automation seam is:

--- a/skills/auv-collabi-pairing/SKILL.md
+++ b/skills/auv-collabi-pairing/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: auv-collabi-pairing
+description: Use when working in /Users/liuziheng/https-github-com-moeru-ai-auv and coordination must go through Collabi shared state. Read AUV AGENTS.md and CLAUDE.md plus Collabi collaboration-map, claims, and audit before editing; stop on overlapping claim or scope/path risk; stay within one narrow slice; and, if explicit writer access is granted, check in before editing and add evidence when finishing.
+---
+
+# AUV Collabi Pairing
+
+Use this skill when you are working in:
+
+- `/Users/liuziheng/https-github-com-moeru-ai-auv`
+- a paired or multi-agent AUV slice where shared state must go through Collabi
+
+Do not use this skill for general coding or for repos outside the AUV checkout.
+
+## Required Start-Of-Task Workflow
+
+Before editing:
+
+1. Read the repo rules:
+   - `/Users/liuziheng/https-github-com-moeru-ai-auv/AGENTS.md`
+   - `/Users/liuziheng/https-github-com-moeru-ai-auv/CLAUDE.md`
+2. Read the current shared state:
+   - `https://collabi-airi-cu-free-01.koreacentral.cloudapp.azure.com/api/collaboration-map`
+   - `https://collabi-airi-cu-free-01.koreacentral.cloudapp.azure.com/api/claims`
+   - `https://collabi-airi-cu-free-01.koreacentral.cloudapp.azure.com/api/audit?limit=20&order=desc`
+3. Summarize three things before you propose edits:
+   - active work already in progress
+   - whether your intended repo, scope, or path overlaps another active slice
+   - the one narrow slice you recommend taking
+
+If another active claim overlaps your intended repo, scope, or path, stop and report it before editing.
+
+## Execution Rules
+
+- Stay inside one narrow AUV slice.
+- Classify the slice before editing: `bug fix`, `test-only`, `docs-only`, `narrow refactor`, or `approved feature`.
+- Do not broaden scope because of TODOs, roadmap notes, nearby cleanup, or "obvious next steps".
+- Preserve the current seam:
+
+```text
+recognition / AX / candidates
+  -> ActionResolver
+  -> auv-driver InputActionResult
+  -> OperationResult / VerificationResult / trace artifacts
+```
+
+- Treat `auv-overlay-macos` as visual-only presentation, not the input backend.
+- Prefer contract convergence, reproduced bug fixes, or narrow refactors with validation.
+- Treat Collabi as shared handoff state for humans and agents, not as optional garnish.
+
+## Collabi Write Boundary
+
+Default mode is read-only.
+
+Only write to Collabi when the human explicitly grants write access or provides the writer/check-in flow. If explicit write access was not granted:
+
+- do not invent credentials
+- do not call write endpoints
+- do not pretend the task was checked in
+
+Instead, report what should be checked in.
+
+If explicit write access was granted, use the existing Collabi flow before editing:
+
+- `writer.html`: `https://collabi-airi-cu-free-01.koreacentral.cloudapp.azure.com/writer.html`
+- or the writer flow described in `references/workflow.md`
+
+## Validation Defaults
+
+For behavior changes, run:
+
+- `cargo fmt --check`
+- `cargo check`
+- `cargo test`
+- `git diff --check`
+
+Use these inventory commands when the slice touches CLI, recipes, or bundles:
+
+- `cargo run --quiet -- list-commands`
+- `cargo run --quiet -- skill cases list`
+- `cargo run --quiet -- skill bundle list`
+
+## Finish-Of-Task Workflow
+
+When you finish:
+
+1. Summarize what changed.
+2. State what was validated.
+3. State whether the slice is `done` or `blocked`.
+4. List the next recommended step, but do not start it automatically.
+5. If write access was granted, add evidence and complete or update the Collabi session state.
+
+If you need concrete commands, writer usage, or check-in examples, read `references/workflow.md`.

--- a/skills/auv-collabi-pairing/SKILL.md
+++ b/skills/auv-collabi-pairing/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: auv-collabi-pairing
-description: Use when working in /Users/liuziheng/https-github-com-moeru-ai-auv and coordination must go through Collabi shared state. Read AUV AGENTS.md and CLAUDE.md plus Collabi collaboration-map, claims, and audit before editing; stop on overlapping claim or scope/path risk; stay within one narrow slice; and, if explicit writer access is granted, check in before editing and add evidence when finishing.
+description: Use when working in /Users/liuziheng/https-github-com-moeru-ai-auv and coordination must go through Collabi shared state. Before editing, read AGENTS.md, CLAUDE.md, Collabi collaboration-map, claims, and audit; stop on overlapping claim or scope/path risk; keep the slice narrow; and, if explicit writer access is granted, use writer.html to check in before editing and add evidence when finishing.
 ---
 
 # AUV Collabi Pairing
 
-Use this skill when you are working in:
+Use this skill only when you are working in:
 
 - `/Users/liuziheng/https-github-com-moeru-ai-auv`
 - a paired or multi-agent AUV slice where shared state must go through Collabi
 
 Do not use this skill for general coding or for repos outside the AUV checkout.
 
-## Required Start-Of-Task Workflow
+## Start-Of-Task Workflow
 
 Before editing:
 
@@ -35,18 +35,8 @@ If another active claim overlaps your intended repo, scope, or path, stop and re
 - Stay inside one narrow AUV slice.
 - Classify the slice before editing: `bug fix`, `test-only`, `docs-only`, `narrow refactor`, or `approved feature`.
 - Do not broaden scope because of TODOs, roadmap notes, nearby cleanup, or "obvious next steps".
-- Preserve the current seam:
-
-```text
-recognition / AX / candidates
-  -> ActionResolver
-  -> auv-driver InputActionResult
-  -> OperationResult / VerificationResult / trace artifacts
-```
-
-- Treat `auv-overlay-macos` as visual-only presentation, not the input backend.
-- Prefer contract convergence, reproduced bug fixes, or narrow refactors with validation.
-- Treat Collabi as shared handoff state for humans and agents, not as optional garnish.
+- Follow AUV architecture and seam rules from `AGENTS.md` and `CLAUDE.md`; do not restate them from memory.
+- Treat Collabi as shared handoff state for humans and agents.
 
 ## Collabi Write Boundary
 
@@ -74,7 +64,7 @@ For behavior changes, run:
 - `cargo test`
 - `git diff --check`
 
-Use these inventory commands when the slice touches CLI, recipes, or bundles:
+When the slice touches CLI, recipes, or bundles, also run:
 
 - `cargo run --quiet -- list-commands`
 - `cargo run --quiet -- skill cases list`

--- a/skills/auv-collabi-pairing/SKILL.md
+++ b/skills/auv-collabi-pairing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: auv-collabi-pairing
-description: Use when working in /Users/liuziheng/https-github-com-moeru-ai-auv and coordination must go through Collabi shared state. Before editing, read AGENTS.md, CLAUDE.md, Collabi collaboration-map, claims, and audit; stop on overlapping claim or scope/path risk; keep the slice narrow; and, if explicit writer access is granted, use writer.html to check in before editing and add evidence when finishing.
+description: Use when working in /Users/liuziheng/https-github-com-moeru-ai-auv and coordination must go through Collabi shared state. Before editing, read AGENTS.md, CLAUDE.md, Collabi overview, claims, and audit; stop on overlapping claim or scope/path risk; keep the slice narrow; and, if explicit writer access is granted, use writer.html to check in before editing and add evidence when finishing.
 ---
 
 # AUV Collabi Pairing
@@ -20,9 +20,10 @@ Before editing:
    - `/Users/liuziheng/https-github-com-moeru-ai-auv/AGENTS.md`
    - `/Users/liuziheng/https-github-com-moeru-ai-auv/CLAUDE.md`
 2. Read the current shared state:
-   - `https://collabi-airi-cu-free-01.koreacentral.cloudapp.azure.com/api/collaboration-map`
+   - `https://collabi-airi-cu-free-01.koreacentral.cloudapp.azure.com/api/overview`
    - `https://collabi-airi-cu-free-01.koreacentral.cloudapp.azure.com/api/claims`
    - `https://collabi-airi-cu-free-01.koreacentral.cloudapp.azure.com/api/audit?limit=20&order=desc`
+   - relevant `https://collabi-airi-cu-free-01.koreacentral.cloudapp.azure.com/api/sessions/<id>` details if the overview or audit already points at one
 3. Summarize three things before you propose edits:
    - active work already in progress
    - whether your intended repo, scope, or path overlaps another active slice

--- a/skills/auv-collabi-pairing/references/workflow.md
+++ b/skills/auv-collabi-pairing/references/workflow.md
@@ -21,6 +21,9 @@ Summarize:
 
 If there is path overlap or an active conflicting claim, stop before editing.
 
+Claim is the authoritative lock. Do not infer "safe to edit" from observed
+range hints if a live claim already overlaps your planned file or path.
+
 ## Writer Entry Point
 
 Human-facing writer console:
@@ -58,6 +61,12 @@ Minimum useful fields for the writer flow:
 - narrow scope summary
 - touched paths
 - validation plan
+
+Human-facing writer sign-in fields:
+
+- Team Account: `moeru-ai`
+- Team Password: `collabi?!@#OvO`
+- Display Name: your chosen visible name
 
 ## Finish State
 

--- a/skills/auv-collabi-pairing/references/workflow.md
+++ b/skills/auv-collabi-pairing/references/workflow.md
@@ -9,9 +9,10 @@ Review:
 
 - `AGENTS.md`
 - `CLAUDE.md`
-- `https://collabi-airi-cu-free-01.koreacentral.cloudapp.azure.com/api/collaboration-map`
+- `https://collabi-airi-cu-free-01.koreacentral.cloudapp.azure.com/api/overview`
 - `https://collabi-airi-cu-free-01.koreacentral.cloudapp.azure.com/api/claims`
 - `https://collabi-airi-cu-free-01.koreacentral.cloudapp.azure.com/api/audit?limit=20&order=desc`
+- relevant `https://collabi-airi-cu-free-01.koreacentral.cloudapp.azure.com/api/sessions/<id>` details if the overview or audit already points at one
 
 Summarize:
 
@@ -62,11 +63,8 @@ Minimum useful fields for the writer flow:
 - touched paths
 - validation plan
 
-Human-facing writer sign-in fields:
-
-- Team Account: `moeru-ai`
-- Team Password: `collabi?!@#OvO`
-- Display Name: your chosen visible name
+Human-facing writer sign-in fields come from the human or an out-of-band team
+channel. Do not hardcode shared credentials into repo docs.
 
 ## Finish State
 

--- a/skills/auv-collabi-pairing/references/workflow.md
+++ b/skills/auv-collabi-pairing/references/workflow.md
@@ -1,0 +1,69 @@
+# Collabi Workflow
+
+This reference exists so humans and agents have one repo-local place to look
+before editing AUV with shared-state coordination.
+
+## Read Before Editing
+
+Review:
+
+- `AGENTS.md`
+- `CLAUDE.md`
+- `https://collabi-airi-cu-free-01.koreacentral.cloudapp.azure.com/api/collaboration-map`
+- `https://collabi-airi-cu-free-01.koreacentral.cloudapp.azure.com/api/claims`
+- `https://collabi-airi-cu-free-01.koreacentral.cloudapp.azure.com/api/audit?limit=20&order=desc`
+
+Summarize:
+
+1. active slices already in progress
+2. whether your intended path overlaps another slice
+3. the one narrow slice you intend to take
+
+If there is path overlap or an active conflicting claim, stop before editing.
+
+## Writer Entry Point
+
+Human-facing writer console:
+
+- `https://collabi-airi-cu-free-01.koreacentral.cloudapp.azure.com/writer.html`
+
+Do not describe Collabi as API-only. The writer console is part of the actual
+human check-in flow.
+
+## Write Boundary
+
+Default assumption: read-only.
+
+Only perform writer/check-in steps when the human has explicitly granted write
+access for the current slice.
+
+Without explicit write access:
+
+- do not fabricate a claim
+- do not pretend check-in happened
+- do not say the slice is visible in Collabi
+
+Instead, report:
+
+- intended session title
+- intended scope and file paths
+- evidence that should be attached
+
+## Suggested Check-In Payload
+
+Minimum useful fields for the writer flow:
+
+- repo: `moeru-ai/auv`
+- slice classification: `bug fix` / `test-only` / `docs-only` / `narrow refactor` / `approved feature`
+- narrow scope summary
+- touched paths
+- validation plan
+
+## Finish State
+
+When the slice finishes, record:
+
+- what changed
+- validation evidence
+- final state: `done` or `blocked`
+- next recommended slice, without starting it automatically


### PR DESCRIPTION
## Summary
- add a repo-local `skills/auv-collabi-pairing` skill for AUV Collabi coordination
- add a repo-local workflow reference for writer/check-in usage
- harden `AGENTS.md` so Collabi is a pre-edit gate, not a reminder

## Validation
- `git diff --check`

## Notes
- docs-only slice; no runtime or Rust behavior change
- local unstaged source edits in `src/candidate_*` were intentionally left out of this PR
