### PR TITLE
feat(auv-netease-music): now Playlist selectable and playable

### DIFF
--- a/crates/auv-netease-music/src/cli.rs
+++ b/crates/auv-netease-music/src/cli.rs
@@ -10,9 +10,10 @@ use clap::{Args, Parser, Subcommand};
 
 use crate::output::build_playlist_json_output;
 use crate::{
-  DailyRecommendedPlayInputs, Inputs, PlaybackStatusInputs, PlaylistCategory, SongListInputs,
-  run_daily_recommended_play, run_daily_recommended_songs_scan, run_live_scan,
-  run_playback_status_probe,
+  DailyRecommendedPlayInputs, Inputs, PlaybackStatusInputs, PlaylistCategory, PlaylistSidebarScan,
+  SongListInputs, run_daily_recommended_play, run_daily_recommended_songs_scan, run_live_scan,
+  run_live_scan_until_query, run_playback_status_probe, run_playlist_play,
+  run_playlist_play_candidate_id, run_playlist_select,
 };
 
 pub(crate) fn positive_scroll_amount(raw: &str) -> Result<f64, String> {
@@ -124,6 +125,26 @@ pub(crate) struct PlaylistCommand {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+pub(crate) struct PlaylistSelectCommand {
+  pub inputs: Inputs,
+  pub query: String,
+  pub output: OutputMode,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct PlaylistPlayCommand {
+  pub inputs: Inputs,
+  pub target: PlaylistPlayTarget,
+  pub output: OutputMode,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum PlaylistPlayTarget {
+  Query(String),
+  CandidateId(String),
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub(crate) struct DailyRecommendedPlayCommand {
   pub inputs: DailyRecommendedPlayInputs,
   pub output: OutputMode,
@@ -172,12 +193,14 @@ pub(crate) struct SeekCommand {
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) enum Command {
   PlaylistLs(PlaylistCommand),
+  PlaylistSelect(PlaylistSelectCommand),
+  PlaylistPlay(PlaylistPlayCommand),
   PlaylistPlayDailyRecommended(DailyRecommendedPlayCommand),
   PlaylistSongsLs(SongsLsCommand),
-  PlaybackStatus(PlaybackStatusCommand),
   NowPlaying(NowPlayingCommand),
   Control(ControlCommand),
   Seek(SeekCommand),
+  PlaybackStatus(PlaybackStatusCommand),
 }
 
 #[derive(Clone, Debug, Parser)]
@@ -195,8 +218,51 @@ struct CliArgs {
 enum CliSubcommand {
   /// Work with NetEase Cloud Music playlists.
   Playlist(PlaylistArgs),
+  /// Read the system now-playing state (via the macOS media API).
+  #[command(name = "now-playing")]
+  NowPlaying(NowPlayingArgs),
+  /// Start playback (only when NetEase owns the now-playing slot).
+  Play(ControlArgs),
+  /// Pause (only when NetEase owns the now-playing slot).
+  Pause(ControlArgs),
+  /// Toggle play/pause (only when NetEase owns the now-playing slot).
+  Toggle(ControlArgs),
+  /// Skip to the next track (only when NetEase owns the now-playing slot).
+  Next(ControlArgs),
+  /// Return to the previous track (only when NetEase owns the now-playing slot).
+  Previous(ControlArgs),
+  /// Seek to a position in seconds (only when NetEase owns the now-playing slot).
+  Seek(SeekArgs),
   /// Experimental current playback probes.
   Playback(PlaybackArgs),
+}
+
+#[derive(Clone, Debug, Args)]
+struct NowPlayingArgs {
+  /// Output format on stdout.
+  #[arg(long = "format", value_enum, default_value_t = OutputFormat::Summary)]
+  format: OutputFormat,
+  #[arg(long = "json-out")]
+  json_out: Option<PathBuf>,
+  /// Only report now-playing when this app owns the slot (default: NetEase).
+  #[arg(long = "app-id")]
+  app_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Args)]
+struct ControlArgs {
+  /// Only act when this app owns the now-playing slot (default: NetEase).
+  #[arg(long = "app-id")]
+  app_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Args)]
+struct SeekArgs {
+  #[arg(value_name = "seconds")]
+  seconds: f64,
+  /// Only act when this app owns the now-playing slot (default: NetEase).
+  #[arg(long = "app-id")]
+  app_id: Option<String>,
 }
 
 #[derive(Clone, Debug, Args)]
@@ -235,63 +301,20 @@ struct PlaybackStatusArgs {
   ocr_languages: Vec<String>,
   #[arg(long = "hint-ocr-languages")]
   ocr_language_csvs: Vec<String>,
-  /// Read the system now-playing state (via the macOS media API).
-  #[command(name = "now-playing")]
-  NowPlaying(NowPlayingArgs),
-  /// Start playback (only when NetEase owns the now-playing slot).
-  Play(ControlArgs),
-  /// Pause (only when NetEase owns the now-playing slot).
-  Pause(ControlArgs),
-  /// Toggle play/pause (only when NetEase owns the now-playing slot).
-  Toggle(ControlArgs),
-  /// Skip to the next track (only when NetEase owns the now-playing slot).
-  Next(ControlArgs),
-  /// Return to the previous track (only when NetEase owns the now-playing slot).
-  Previous(ControlArgs),
-  /// Seek to a position in seconds (only when NetEase owns the now-playing slot).
-  Seek(SeekArgs),
-}
-
-#[derive(Clone, Debug, Args)]
-struct NowPlayingArgs {
-  /// Output format on stdout.
-  #[arg(long = "format", value_enum, default_value_t = OutputFormat::Summary)]
-  format: OutputFormat,
-  #[arg(long = "json-out")]
-  json_out: Option<PathBuf>,
-  /// Only report now-playing when this app owns the slot (default: NetEase).
-  #[arg(long = "app-id")]
-  app_id: Option<String>,
-}
-
-#[derive(Clone, Debug, Args)]
-struct ControlArgs {
-  /// Only act when this app owns the now-playing slot (default: NetEase).
-  #[arg(long = "app-id")]
-  app_id: Option<String>,
-}
-
-#[derive(Clone, Debug, Args)]
-struct SeekArgs {
-  #[arg(value_name = "seconds")]
-  seconds: f64,
-  /// Only act when this app owns the now-playing slot (default: NetEase).
-  #[arg(long = "app-id")]
-  app_id: Option<String>,
 }
 
 #[derive(Clone, Debug, Args)]
 struct PlaylistArgs {
   #[command(subcommand)]
-  command: Option<PlaylistSubcommand>,
-  #[command(flatten)]
-  ls: PlaylistLsArgs,
+  command: PlaylistSubcommand,
 }
 
 #[derive(Clone, Debug, Subcommand)]
 enum PlaylistSubcommand {
   /// List NetEase Cloud Music sidebar playlists.
   Ls(PlaylistLsArgs),
+  /// Open a playlist from the sidebar without starting playback.
+  Select(PlaylistSelectArgs),
   /// Play a built-in playlist.
   Play(PlaylistPlayArgs),
   /// Scan songs from a playlist-like song table.
@@ -341,20 +364,16 @@ struct SongsLsArgs {
 }
 
 #[derive(Clone, Debug, Args)]
+#[command(
+  after_help = "Recommended playlist flow:\n  auv-netease-music playlist ls \"Trance vol.2\" --json\n  auv-netease-music playlist play --candidate-id <id>\n\n`playlist ls` writes playlist-scan-cache.json under --artifact-dir; `playlist play --candidate-id` reads that cache, so use the same --artifact-dir for both commands."
+)]
 struct PlaylistPlayArgs {
-  #[command(subcommand)]
-  command: PlaylistPlaySubcommand,
-}
-
-#[derive(Clone, Debug, Subcommand)]
-enum PlaylistPlaySubcommand {
-  /// Open Daily Recommended and press Play All.
-  #[command(name = "daily-recommended")]
-  DailyRecommended(DailyRecommendedArgs),
-}
-
-#[derive(Clone, Debug, Args)]
-struct DailyRecommendedArgs {
+  /// Playlist query. Convenience path; prefer --candidate-id after playlist ls --json for agent calls.
+  #[arg(value_name = "query")]
+  target: Option<String>,
+  /// Candidate id from `playlist ls <keyword> --json`.
+  #[arg(long = "candidate-id")]
+  candidate_id: Option<String>,
   #[arg(long = "json")]
   json: bool,
   #[arg(long = "json-out")]
@@ -363,6 +382,14 @@ struct DailyRecommendedArgs {
   app_id: Option<String>,
   #[arg(long = "artifact-dir")]
   artifact_dir: Option<PathBuf>,
+  #[arg(long = "max-scrolls")]
+  max_scrolls: Option<NonZeroUsize>,
+  #[arg(long = "scroll-amount", value_parser = positive_scroll_amount)]
+  scroll_amount: Option<f64>,
+  #[arg(long = "scroll-settle-ms")]
+  scroll_settle_ms: Option<u64>,
+  #[arg(long = "sidebar-region")]
+  sidebar_region: Option<String>,
   #[arg(long = "max-top-scrolls")]
   max_top_scrolls: Option<NonZeroUsize>,
   #[arg(long = "top-scroll-amount", value_parser = positive_scroll_amount)]
@@ -386,11 +413,13 @@ struct DailyRecommendedArgs {
 }
 
 #[derive(Clone, Debug, Args)]
+#[command(
+  after_help = "Recommended playlist flow:\n  auv-netease-music playlist ls \"Trance vol.2\" --json\n  auv-netease-music playlist play --candidate-id <id>\n\nJSON output includes matches[].candidate_id. The scan is also cached as playlist-scan-cache.json under --artifact-dir for the follow-up play command."
+)]
 struct PlaylistLsArgs {
-  #[arg(value_name = "ls|keyword")]
-  first: Option<String>,
+  /// Optional playlist keyword. When present, scanning continues until the keyword is found or the list boundary is reached.
   #[arg(value_name = "keyword")]
-  second: Option<String>,
+  keyword: Option<String>,
   #[arg(long = "category")]
   category: Option<PlaylistCategory>,
   #[arg(long = "filter")]
@@ -423,16 +452,41 @@ struct PlaylistLsArgs {
   ocr_language_csvs: Vec<String>,
 }
 
+#[derive(Clone, Debug, Args)]
+struct PlaylistSelectArgs {
+  #[arg(value_name = "query")]
+  query: String,
+  #[arg(long = "json")]
+  json: bool,
+  #[arg(long = "json-out")]
+  json_out: Option<PathBuf>,
+  #[arg(long = "app-id")]
+  app_id: Option<String>,
+  #[arg(long = "artifact-dir")]
+  artifact_dir: Option<PathBuf>,
+  #[arg(long = "max-scrolls")]
+  max_scrolls: Option<NonZeroUsize>,
+  #[arg(long = "scroll-amount", value_parser = positive_scroll_amount)]
+  scroll_amount: Option<f64>,
+  #[arg(long = "scroll-settle-ms")]
+  scroll_settle_ms: Option<u64>,
+  #[arg(long = "sidebar-region")]
+  sidebar_region: Option<String>,
+  #[arg(long = "hint-ocr-custom-word")]
+  custom_words: Vec<String>,
+  #[arg(long = "hint-ocr-custom-words")]
+  custom_word_csvs: Vec<String>,
+  #[arg(long = "hint-ocr-custom-words-file")]
+  custom_word_files: Vec<PathBuf>,
+  #[arg(long = "hint-ocr-language")]
+  ocr_languages: Vec<String>,
+  #[arg(long = "hint-ocr-languages")]
+  ocr_language_csvs: Vec<String>,
+}
+
 fn command_from_args(parsed: CliArgs) -> Result<Command, String> {
   match parsed.command {
     CliSubcommand::Playlist(args) => parse_playlist(args),
-    CliSubcommand::Playback(args) => parse_playback(args),
-  }
-}
-
-fn parse_playback(args: PlaybackArgs) -> Result<Command, String> {
-  match args.command {
-    PlaybackSubcommand::Status(args) => parse_playback_status(args).map(Command::PlaybackStatus),
     CliSubcommand::NowPlaying(args) => parse_now_playing(args),
     CliSubcommand::Play(args) => Ok(control(auv_media_macos::MediaCommand::Play, args)),
     CliSubcommand::Pause(args) => Ok(control(auv_media_macos::MediaCommand::Pause, args)),
@@ -445,6 +499,13 @@ fn parse_playback(args: PlaybackArgs) -> Result<Command, String> {
       Ok(control(auv_media_macos::MediaCommand::PreviousTrack, args))
     }
     CliSubcommand::Seek(args) => parse_seek(args),
+    CliSubcommand::Playback(args) => parse_playback(args),
+  }
+}
+
+fn parse_playback(args: PlaybackArgs) -> Result<Command, String> {
+  match args.command {
+    PlaybackSubcommand::Status(args) => parse_playback_status(args).map(Command::PlaybackStatus),
   }
 }
 
@@ -492,23 +553,18 @@ fn parse_seek(args: SeekArgs) -> Result<Command, String> {
 
 fn parse_playlist(args: PlaylistArgs) -> Result<Command, String> {
   match args.command {
-    Some(PlaylistSubcommand::Ls(ls)) => parse_playlist_ls(ls).map(Command::PlaylistLs),
-    Some(PlaylistSubcommand::Play(play)) => parse_playlist_play(play),
-    Some(PlaylistSubcommand::Songs(songs)) => parse_playlist_songs(songs),
-    None => parse_playlist_ls(args.ls).map(Command::PlaylistLs),
+    PlaylistSubcommand::Ls(ls) => parse_playlist_ls(ls).map(Command::PlaylistLs),
+    PlaylistSubcommand::Select(select) => {
+      parse_playlist_select(select).map(Command::PlaylistSelect)
+    }
+    PlaylistSubcommand::Play(play) => parse_playlist_play(play),
+    PlaylistSubcommand::Songs(songs) => parse_playlist_songs(songs),
   }
 }
 
 fn parse_playlist_ls(args: PlaylistLsArgs) -> Result<PlaylistCommand, String> {
   let mut inputs = Inputs::with_defaults();
-  let query = match (args.first.as_deref(), args.second.as_deref()) {
-    (None, None) => None,
-    (Some("ls"), None) => None,
-    (Some("ls"), Some(keyword)) => Some(keyword.to_string()),
-    (Some(keyword), None) => Some(keyword.to_string()),
-    (Some(_), Some(extra)) => return Err(format!("unexpected extra argument {extra:?}")),
-    (None, Some(_)) => unreachable!("clap fills positional arguments in order"),
-  };
+  let query = args.keyword;
 
   if let Some(app_id) = args.app_id {
     inputs.app_id = app_id;
@@ -561,12 +617,130 @@ fn parse_playlist_ls(args: PlaylistLsArgs) -> Result<PlaylistCommand, String> {
   })
 }
 
-fn parse_playlist_play(args: PlaylistPlayArgs) -> Result<Command, String> {
-  match args.command {
-    PlaylistPlaySubcommand::DailyRecommended(args) => {
-      parse_daily_recommended(args).map(Command::PlaylistPlayDailyRecommended)
+fn parse_playlist_select(args: PlaylistSelectArgs) -> Result<PlaylistSelectCommand, String> {
+  let mut inputs = Inputs::with_defaults();
+  if let Some(app_id) = args.app_id {
+    inputs.app_id = app_id;
+  }
+  if let Some(artifact_dir) = args.artifact_dir {
+    inputs.artifact_dir = artifact_dir;
+  }
+  if let Some(max_scrolls) = args.max_scrolls {
+    inputs.max_scrolls = max_scrolls.get();
+  }
+  if let Some(scroll_amount) = args.scroll_amount {
+    inputs.scroll_amount = scroll_amount;
+  }
+  if let Some(scroll_settle_ms) = args.scroll_settle_ms {
+    inputs.scroll_settle_ms = scroll_settle_ms;
+  }
+  if let Some(sidebar_region) = args.sidebar_region {
+    inputs.sidebar_region = Some(parse_ratio_region(sidebar_region)?);
+  }
+  for word in args.custom_words {
+    push_trimmed(&mut inputs.ocr_options.custom_words, word);
+  }
+  for csv in args.custom_word_csvs {
+    push_csv(&mut inputs.ocr_options.custom_words, &csv);
+  }
+  for path in args.custom_word_files {
+    load_custom_words_file(&mut inputs.ocr_options.custom_words, path)?;
+  }
+  for language in args.ocr_languages {
+    push_ocr_language(&mut inputs.ocr_options, language);
+  }
+  for csv in args.ocr_language_csvs {
+    for language in split_csv(&csv) {
+      push_ocr_language(&mut inputs.ocr_options, language);
     }
   }
+
+  let output = match args.json_out {
+    Some(path) => OutputMode::JsonFile(path),
+    None if args.json => OutputMode::Json,
+    None => OutputMode::Human,
+  };
+  Ok(PlaylistSelectCommand {
+    inputs,
+    query: args.query,
+    output,
+  })
+}
+
+fn parse_playlist_play(args: PlaylistPlayArgs) -> Result<Command, String> {
+  if args.target.as_deref() == Some("daily-recommended") && args.candidate_id.is_none() {
+    return parse_daily_recommended(args).map(Command::PlaylistPlayDailyRecommended);
+  }
+
+  parse_playlist_play_query(args).map(Command::PlaylistPlay)
+}
+
+fn parse_playlist_play_query(args: PlaylistPlayArgs) -> Result<PlaylistPlayCommand, String> {
+  let target = match (args.target.as_deref(), args.candidate_id.as_deref()) {
+    (Some(_), Some(_)) => {
+      return Err("playlist play accepts either a query or --candidate-id, not both".to_string());
+    }
+    (Some(query), None) if query.trim().is_empty() => {
+      return Err("playlist play query must not be empty".to_string());
+    }
+    (Some(query), None) => PlaylistPlayTarget::Query(query.to_string()),
+    (None, Some(candidate_id)) if candidate_id.trim().is_empty() => {
+      return Err("playlist play --candidate-id must not be empty".to_string());
+    }
+    (None, Some(candidate_id)) => PlaylistPlayTarget::CandidateId(candidate_id.to_string()),
+    (None, None) => {
+      return Err(
+        "playlist play requires a query, daily-recommended, or --candidate-id".to_string(),
+      );
+    }
+  };
+  let mut inputs = Inputs::with_defaults();
+  if let Some(app_id) = args.app_id {
+    inputs.app_id = app_id;
+  }
+  if let Some(artifact_dir) = args.artifact_dir {
+    inputs.artifact_dir = artifact_dir;
+  }
+  if let Some(max_scrolls) = args.max_scrolls {
+    inputs.max_scrolls = max_scrolls.get();
+  }
+  if let Some(scroll_amount) = args.scroll_amount {
+    inputs.scroll_amount = scroll_amount;
+  }
+  if let Some(scroll_settle_ms) = args.scroll_settle_ms {
+    inputs.scroll_settle_ms = scroll_settle_ms;
+  }
+  if let Some(sidebar_region) = args.sidebar_region {
+    inputs.sidebar_region = Some(parse_ratio_region(sidebar_region)?);
+  }
+  for word in args.custom_words {
+    push_trimmed(&mut inputs.ocr_options.custom_words, word);
+  }
+  for csv in args.custom_word_csvs {
+    push_csv(&mut inputs.ocr_options.custom_words, &csv);
+  }
+  for path in args.custom_word_files {
+    load_custom_words_file(&mut inputs.ocr_options.custom_words, path)?;
+  }
+  for language in args.ocr_languages {
+    push_ocr_language(&mut inputs.ocr_options, language);
+  }
+  for csv in args.ocr_language_csvs {
+    for language in split_csv(&csv) {
+      push_ocr_language(&mut inputs.ocr_options, language);
+    }
+  }
+
+  let output = match args.json_out {
+    Some(path) => OutputMode::JsonFile(path),
+    None if args.json => OutputMode::Json,
+    None => OutputMode::Human,
+  };
+  Ok(PlaylistPlayCommand {
+    inputs,
+    target,
+    output,
+  })
 }
 
 fn parse_playlist_songs(args: PlaylistSongsArgs) -> Result<Command, String> {
@@ -629,9 +803,7 @@ fn parse_songs_ls(args: SongsLsArgs) -> Result<SongsLsCommand, String> {
   })
 }
 
-fn parse_daily_recommended(
-  args: DailyRecommendedArgs,
-) -> Result<DailyRecommendedPlayCommand, String> {
+fn parse_daily_recommended(args: PlaylistPlayArgs) -> Result<DailyRecommendedPlayCommand, String> {
   let mut inputs = DailyRecommendedPlayInputs::with_defaults();
   if let Some(app_id) = args.app_id {
     inputs.app_id = app_id;
@@ -736,12 +908,14 @@ pub fn run() -> ExitCode {
 
   match command_from_args(parsed) {
     Ok(Command::PlaylistLs(cmd)) => run_playlist(cmd),
+    Ok(Command::PlaylistSelect(cmd)) => run_playlist_select_command(cmd),
+    Ok(Command::PlaylistPlay(cmd)) => run_playlist_play_command(cmd),
     Ok(Command::PlaylistPlayDailyRecommended(cmd)) => run_daily_recommended(cmd),
     Ok(Command::PlaylistSongsLs(cmd)) => run_songs_ls(cmd),
-    Ok(Command::PlaybackStatus(cmd)) => run_playback_status(cmd),
     Ok(Command::NowPlaying(cmd)) => run_now_playing(cmd),
     Ok(Command::Control(cmd)) => run_control(cmd),
     Ok(Command::Seek(cmd)) => run_seek(cmd),
+    Ok(Command::PlaybackStatus(cmd)) => run_playback_status(cmd),
     Err(error) => {
       if error.starts_with("error:") {
         eprint!("{error}");
@@ -761,15 +935,13 @@ mod tests {
 
   fn playlist_args() -> PlaylistArgs {
     PlaylistArgs {
-      command: None,
-      ls: playlist_ls_args(),
+      command: PlaylistSubcommand::Ls(playlist_ls_args()),
     }
   }
 
   fn playlist_ls_args() -> PlaylistLsArgs {
     PlaylistLsArgs {
-      first: None,
-      second: None,
+      keyword: None,
       category: None,
       filter: None,
       json: false,
@@ -796,11 +968,27 @@ mod tests {
     }
   }
 
+  fn parse_playlist_select_command(argv: &[&str]) -> PlaylistSelectCommand {
+    let parsed = CliArgs::try_parse_from(argv).expect("CLI args should parse");
+    match command_from_args(parsed).expect("playlist select command should parse") {
+      Command::PlaylistSelect(command) => command,
+      other => panic!("expected playlist select command, got {other:?}"),
+    }
+  }
+
   fn parse_daily_recommended_command(argv: &[&str]) -> DailyRecommendedPlayCommand {
     let parsed = CliArgs::try_parse_from(argv).expect("CLI args should parse");
     match command_from_args(parsed).expect("daily recommended command should parse") {
       Command::PlaylistPlayDailyRecommended(command) => command,
       other => panic!("expected daily recommended command, got {other:?}"),
+    }
+  }
+
+  fn parse_playlist_play_command(argv: &[&str]) -> PlaylistPlayCommand {
+    let parsed = CliArgs::try_parse_from(argv).expect("CLI args should parse");
+    match command_from_args(parsed).expect("playlist play command should parse") {
+      Command::PlaylistPlay(command) => command,
+      other => panic!("expected playlist play command, got {other:?}"),
     }
   }
 
@@ -863,7 +1051,10 @@ mod tests {
   #[test]
   fn parse_playlist_uses_positional_keyword_as_query() {
     let mut args = playlist_args();
-    args.ls.first = Some("daily".to_string());
+    match &mut args.command {
+      PlaylistSubcommand::Ls(ls) => ls.keyword = Some("daily".to_string()),
+      _ => unreachable!("playlist_args builds ls args"),
+    }
 
     let command = match parse_playlist(args).expect("playlist args should parse") {
       Command::PlaylistLs(command) => command,
@@ -876,8 +1067,13 @@ mod tests {
   #[test]
   fn parse_playlist_prefers_explicit_filter_over_positional_keyword() {
     let mut args = playlist_args();
-    args.ls.first = Some("daily".to_string());
-    args.ls.filter = Some("liked".to_string());
+    match &mut args.command {
+      PlaylistSubcommand::Ls(ls) => {
+        ls.keyword = Some("daily".to_string());
+        ls.filter = Some("liked".to_string());
+      }
+      _ => unreachable!("playlist_args builds ls args"),
+    }
 
     let command = match parse_playlist(args).expect("playlist args should parse") {
       Command::PlaylistLs(command) => command,
@@ -903,10 +1099,42 @@ mod tests {
   }
 
   #[test]
-  fn clap_playlist_legacy_keyword_still_sets_query() {
-    let command = parse_playlist_command(&["auv-netease-music", "playlist", "daily"]);
+  fn clap_playlist_select_maps_query_and_scan_flags() {
+    let command = parse_playlist_select_command(&[
+      "auv-netease-music",
+      "playlist",
+      "select",
+      "人造器械",
+      "--json",
+      "--max-scrolls",
+      "8",
+      "--scroll-settle-ms",
+      "100",
+    ]);
 
-    assert_eq!(command.query.as_deref(), Some("daily"));
+    assert_eq!(command.query, "人造器械");
+    assert_eq!(command.output, OutputMode::Json);
+    assert_eq!(command.inputs.max_scrolls, 8);
+    assert_eq!(command.inputs.scroll_settle_ms, 100);
+  }
+
+  #[test]
+  fn clap_playlist_requires_explicit_subcommand() {
+    let error = CliArgs::try_parse_from(["auv-netease-music", "playlist"])
+      .expect_err("playlist should require an explicit subcommand");
+
+    assert_eq!(
+      error.kind(),
+      clap::error::ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
+    );
+  }
+
+  #[test]
+  fn clap_playlist_rejects_legacy_keyword_without_ls() {
+    let error = CliArgs::try_parse_from(["auv-netease-music", "playlist", "daily"])
+      .expect_err("legacy playlist keyword should require explicit ls");
+
+    assert_eq!(error.kind(), clap::error::ErrorKind::InvalidSubcommand);
   }
 
   #[test]
@@ -1053,6 +1281,53 @@ mod tests {
   }
 
   #[test]
+  fn clap_playlist_play_query_maps_scan_and_output_flags() {
+    let command = parse_playlist_play_command(&[
+      "auv-netease-music",
+      "playlist",
+      "play",
+      "Trance vol.2",
+      "--json",
+      "--max-scrolls",
+      "8",
+      "--scroll-settle-ms",
+      "120",
+    ]);
+
+    assert_eq!(
+      command.target,
+      PlaylistPlayTarget::Query("Trance vol.2".to_string())
+    );
+    assert_eq!(command.output, OutputMode::Json);
+    assert_eq!(command.inputs.max_scrolls, 8);
+    assert_eq!(command.inputs.scroll_settle_ms, 120);
+  }
+
+  #[test]
+  fn clap_playlist_play_candidate_id_maps_cache_target() {
+    let command = parse_playlist_play_command(&[
+      "auv-netease-music",
+      "playlist",
+      "play",
+      "--candidate-id",
+      "obs6.candidate.ocr4.trance_vol_2",
+      "--json",
+      "--artifact-dir",
+      "/tmp/netease-playlist-cache",
+    ]);
+
+    assert_eq!(
+      command.target,
+      PlaylistPlayTarget::CandidateId("obs6.candidate.ocr4.trance_vol_2".to_string())
+    );
+    assert_eq!(command.output, OutputMode::Json);
+    assert_eq!(
+      command.inputs.artifact_dir,
+      PathBuf::from("/tmp/netease-playlist-cache")
+    );
+  }
+
+  #[test]
   fn clap_playlist_songs_ls_daily_recommended_maps_flags() {
     let command = parse_songs_ls_command(&[
       "auv-netease-music",
@@ -1136,58 +1411,29 @@ mod tests {
 
   #[test]
   fn clap_playlist_rejects_extra_positional_argument() {
-    let parsed = CliArgs::try_parse_from(["auv-netease-music", "playlist", "ls", "daily", "extra"])
-      .expect("nested ls accepts positionals before semantic parsing");
-    let error = command_from_args(parsed).expect_err("extra positional argument should fail");
+    let error = CliArgs::try_parse_from(["auv-netease-music", "playlist", "ls", "daily", "extra"])
+      .expect_err("nested ls should reject extra positionals");
 
-    assert_eq!(error, "unexpected extra argument \"extra\"");
-  }
-
-  fn seek_args(seconds: f64) -> SeekArgs {
-    SeekArgs {
-      seconds,
-      app_id: None,
-    }
-  }
-
-  #[test]
-  fn parse_seek_accepts_normal_value() {
-    let command = parse_seek(seek_args(12.5)).expect("normal seek seconds should parse");
-    match command {
-      Command::Seek(cmd) => assert_eq!(cmd.seconds, 12.5),
-      other => panic!("expected Command::Seek, got {other:?}"),
-    }
-  }
-
-  #[test]
-  fn parse_seek_rejects_negative() {
-    parse_seek(seek_args(-1.0)).expect_err("negative seek seconds must be rejected");
-  }
-
-  #[test]
-  fn parse_seek_rejects_nan_and_infinity() {
-    parse_seek(seek_args(f64::NAN)).expect_err("NaN seek seconds must be rejected");
-    parse_seek(seek_args(f64::INFINITY)).expect_err("infinity seek seconds must be rejected");
-  }
-
-  #[test]
-  fn parse_seek_rejects_overflow_past_duration_max() {
-    // `Duration::from_secs_f64` panics on values above `Duration::MAX`
-    // (~1.84e19 seconds). The pre-fix parse_seek did not check overflow,
-    // so a 1e20 input would have hit that panic during run_seek's Duration
-    // construction.
-    parse_seek(seek_args(1e20)).expect_err("overflow seek seconds must be rejected");
+    assert_eq!(error.kind(), clap::error::ErrorKind::UnknownArgument);
   }
 }
 
 fn run_playlist(cmd: PlaylistCommand) -> ExitCode {
-  let scan = match run_live_scan(&cmd.inputs) {
+  let scan = match cmd.query.as_deref() {
+    Some(query) => run_live_scan_until_query(&cmd.inputs, query),
+    None => run_live_scan(&cmd.inputs),
+  };
+  let scan = match scan {
     Ok(scan) => scan,
     Err(error) => {
       eprintln!("scan failed: {error}");
       return ExitCode::from(1);
     }
   };
+  if let Err(error) = write_playlist_scan_cache(&cmd.inputs, &scan) {
+    eprintln!("{error}");
+    return ExitCode::from(1);
+  }
   let output = build_playlist_json_output(&scan, cmd.query.as_deref());
 
   match &cmd.output {
@@ -1222,6 +1468,108 @@ fn run_playlist(cmd: PlaylistCommand) -> ExitCode {
   }
 }
 
+fn write_playlist_scan_cache(inputs: &Inputs, scan: &PlaylistSidebarScan) -> Result<(), String> {
+  std::fs::create_dir_all(&inputs.artifact_dir).map_err(|error| {
+    format!(
+      "failed to create {}: {error}",
+      inputs.artifact_dir.display()
+    )
+  })?;
+  let cache_path = inputs.artifact_dir.join(crate::PLAYLIST_SCAN_CACHE_FILE);
+  let json = serde_json::to_string_pretty(scan)
+    .map_err(|error| format!("failed to serialize playlist scan cache: {error}"))?;
+  std::fs::write(&cache_path, json)
+    .map_err(|error| format!("failed to write {}: {error}", cache_path.display()))
+}
+
+fn run_playlist_select_command(cmd: PlaylistSelectCommand) -> ExitCode {
+  let result = match run_playlist_select(&cmd.inputs, &cmd.query) {
+    Ok(result) => result,
+    Err(error) => {
+      eprintln!("playlist select failed: {error}");
+      return ExitCode::from(1);
+    }
+  };
+
+  match &cmd.output {
+    OutputMode::Human => {
+      println!("{}", result.to_human_readable());
+      ExitCode::SUCCESS
+    }
+    OutputMode::Json => match serde_json::to_string_pretty(&result) {
+      Ok(json) => {
+        println!("{json}");
+        ExitCode::SUCCESS
+      }
+      Err(error) => {
+        eprintln!("encode failed: {error}");
+        ExitCode::from(1)
+      }
+    },
+    OutputMode::JsonFile(path) => {
+      let json = match serde_json::to_string_pretty(&result) {
+        Ok(json) => json,
+        Err(error) => {
+          eprintln!("encode failed: {error}");
+          return ExitCode::from(1);
+        }
+      };
+      if let Err(error) = std::fs::write(path, json) {
+        eprintln!("failed to write {}: {error}", path.display());
+        return ExitCode::from(1);
+      }
+      ExitCode::SUCCESS
+    }
+  }
+}
+
+fn run_playlist_play_command(cmd: PlaylistPlayCommand) -> ExitCode {
+  let result = match &cmd.target {
+    PlaylistPlayTarget::Query(query) => run_playlist_play(&cmd.inputs, query),
+    PlaylistPlayTarget::CandidateId(candidate_id) => {
+      run_playlist_play_candidate_id(&cmd.inputs, candidate_id)
+    }
+  };
+  let result = match result {
+    Ok(result) => result,
+    Err(error) => {
+      eprintln!("playlist play failed: {error}");
+      return ExitCode::from(1);
+    }
+  };
+
+  match &cmd.output {
+    OutputMode::Human => {
+      println!("{}", result.to_human_readable());
+      ExitCode::SUCCESS
+    }
+    OutputMode::Json => match serde_json::to_string_pretty(&result) {
+      Ok(json) => {
+        println!("{json}");
+        ExitCode::SUCCESS
+      }
+      Err(error) => {
+        eprintln!("encode failed: {error}");
+        ExitCode::from(1)
+      }
+    },
+    OutputMode::JsonFile(path) => {
+      let json = match serde_json::to_string_pretty(&result) {
+        Ok(json) => json,
+        Err(error) => {
+          eprintln!("encode failed: {error}");
+          return ExitCode::from(1);
+        }
+      };
+      if let Err(error) = std::fs::write(path, json) {
+        eprintln!("failed to write {}: {error}", path.display());
+        return ExitCode::from(1);
+      }
+      ExitCode::SUCCESS
+    }
+  }
+}
+
 #[cfg(target_os = "macos")]
 fn run_now_playing(cmd: NowPlayingCommand) -> ExitCode {
   let state = match auv_media_macos::now_playing() {
@@ -1231,14 +1579,11 @@ fn run_now_playing(cmd: NowPlayingCommand) -> ExitCode {
       return ExitCode::from(1);
     }
   };
-  // Scope to NetEase (or the requested --app-id): when another app owns the
-  // slot, report the idle state rather than that app's track.
   let state = if state.source_bundle_id.as_deref() == Some(cmd.app_id.as_str()) {
     state
   } else {
     auv_media_macos::NowPlayingState::default()
   };
-  // netease's output omits the like fields (NetEase never reports them).
   let output = crate::output::build_now_playing_output(&state);
 
   match &cmd.output {
@@ -1279,9 +1624,6 @@ fn run_now_playing(_cmd: NowPlayingCommand) -> ExitCode {
   ExitCode::from(1)
 }
 
-/// Require that `app_id` currently owns the now-playing slot before acting on
-/// it. Returns `Err(exit_code)` (with a message) when it does not, so controls
-/// never act on some other app that happens to be playing.
 #[cfg(target_os = "macos")]
 fn require_owner(app_id: &str) -> Result<(), ExitCode> {
   let state = match auv_media_macos::now_playing() {
@@ -1330,10 +1672,6 @@ fn run_seek(cmd: SeekCommand) -> ExitCode {
   if let Err(code) = require_owner(&cmd.app_id) {
     return code;
   }
-  // Defense-in-depth: parse_seek already rejects out-of-range seconds, but
-  // a direct SeekCommand construction (tests, future callers) could still
-  // reach run_seek with overflow/NaN. `try_from_secs_f64` avoids the panic
-  // path inside `Duration::from_secs_f64`.
   let duration = match std::time::Duration::try_from_secs_f64(cmd.seconds) {
     Ok(duration) => duration,
     Err(_) => {

--- a/crates/auv-netease-music/src/commands/daily_recommended.rs
+++ b/crates/auv-netease-music/src/commands/daily_recommended.rs
@@ -640,11 +640,7 @@ impl DailyRecommendedRun<'_> {
       .click(
         &self.window,
         WindowPoint::new(point.x, point.y),
-        ClickOptions {
-          policy: InputPolicy::ForegroundPreferred,
-          click: Click::Single,
-          window_strategy: WindowClickStrategy::ChromiumCompatible,
-        },
+        daily_recommended_window_click_options(),
       )
       .map_err(|error| format!("{step_name}: click failed: {error}"))?;
     if self.inputs.settle_ms > 0 {
@@ -781,11 +777,7 @@ impl DailyRecommendedRun<'_> {
       .click(
         &self.window,
         WindowPoint::new(point.x, point.y),
-        ClickOptions {
-          policy: InputPolicy::ForegroundPreferred,
-          click: Click::Single,
-          window_strategy: WindowClickStrategy::ChromiumCompatible,
-        },
+        daily_recommended_window_click_options(),
       )
       .map_err(|error| format!("daily recommended card body click failed: {error}"))?;
     if self.inputs.settle_ms > 0 {
@@ -1005,7 +997,7 @@ impl DailyRecommendedRun<'_> {
 }
 
 #[cfg(target_os = "macos")]
-fn best_text_match(
+pub(crate) fn best_text_match(
   recognition: &TextRecognition,
   query: &str,
   window_size: Size,
@@ -1050,6 +1042,14 @@ pub(crate) fn daily_recommended_card_click_point(title_bounds: ViewBounds) -> au
   }
 }
 
+fn daily_recommended_window_click_options() -> auv_driver::ClickOptions {
+  auv_driver::ClickOptions {
+    policy: auv_driver::InputPolicy::BackgroundPreferred,
+    click: auv_driver::Click::Single,
+    window_strategy: auv_driver::WindowClickStrategy::ChromiumCompatible,
+  }
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;
@@ -1070,5 +1070,16 @@ mod tests {
     let point = daily_recommended_card_click_point(bounds);
 
     assert_eq!(point, auv_driver::Point::new(500.0, 183.0));
+  }
+
+  #[test]
+  fn daily_recommended_uses_background_preferred_window_click_by_default() {
+    let options = daily_recommended_window_click_options();
+
+    assert_eq!(options.policy, auv_driver::InputPolicy::BackgroundPreferred);
+    assert_eq!(
+      options.window_strategy,
+      auv_driver::WindowClickStrategy::ChromiumCompatible
+    );
   }
 }

--- a/crates/auv-netease-music/src/commands/mod.rs
+++ b/crates/auv-netease-music/src/commands/mod.rs
@@ -1,2 +1,3 @@
 pub mod daily_recommended;
 pub mod playback;
+pub mod playlist;

--- a/crates/auv-netease-music/src/commands/playlist.rs
+++ b/crates/auv-netease-music/src/commands/playlist.rs
@@ -1,0 +1,835 @@
+use std::fmt;
+
+use auv_view::{ParserDiagnostic, ScanAppContext, ScanWindowContext, ViewBounds};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+  Inputs, PlaybackControlState, PlaylistSelectTarget, decode_playlist_sidebar_scan_json,
+  run_live_scan_until_query,
+};
+
+const PLAYLIST_SELECT_BOTTOM_SAFE_PADDING: f64 = 128.0;
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct PlaylistSelectResult {
+  pub command: String,
+  pub query: String,
+  pub app: ScanAppContext,
+  pub window: ScanWindowContext,
+  pub target: PlaylistSelectTarget,
+  pub steps: Vec<PlaylistSelectStep>,
+  pub verification: PlaylistSelectVerification,
+  pub diagnostics: Vec<ParserDiagnostic>,
+  pub known_limits: Vec<String>,
+}
+
+impl PlaylistSelectResult {
+  pub fn to_human_readable(&self) -> PlaylistSelectHumanSummary<'_> {
+    PlaylistSelectHumanSummary { result: self }
+  }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct PlaylistSelectStep {
+  pub name: String,
+  pub target_bounds: Option<ViewBounds>,
+  pub delivery_path: Option<String>,
+  pub fallback_reason: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct PlaylistSelectVerification {
+  pub status: String,
+  pub method: String,
+  pub observed_title: Option<String>,
+  pub artifact: Option<String>,
+  pub note: Option<String>,
+}
+
+pub struct PlaylistSelectHumanSummary<'a> {
+  result: &'a PlaylistSelectResult,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct PlaylistPlayResult {
+  pub command: String,
+  pub query: String,
+  pub select: PlaylistSelectResult,
+  pub steps: Vec<PlaylistPlayStep>,
+  pub verification: PlaylistPlayVerification,
+  pub diagnostics: Vec<ParserDiagnostic>,
+  pub known_limits: Vec<String>,
+  pub artifacts: Vec<String>,
+}
+
+impl PlaylistPlayResult {
+  pub fn to_human_readable(&self) -> PlaylistPlayHumanSummary<'_> {
+    PlaylistPlayHumanSummary { result: self }
+  }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct PlaylistPlayStep {
+  pub name: String,
+  pub target_label: Option<String>,
+  pub target_bounds: Option<ViewBounds>,
+  pub delivery_path: Option<String>,
+  pub fallback_reason: Option<String>,
+  pub artifact: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct PlaylistPlayVerification {
+  pub status: String,
+  pub method: String,
+  pub control_state: Option<PlaybackControlState>,
+  pub observed_bottom_text: Option<String>,
+  pub artifact: Option<String>,
+  pub note: Option<String>,
+}
+
+pub struct PlaylistPlayHumanSummary<'a> {
+  result: &'a PlaylistPlayResult,
+}
+
+impl fmt::Display for PlaylistSelectHumanSummary<'_> {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    let result = self.result;
+    writeln!(f, "NetEase playlist select")?;
+    writeln!(f, "query: {}", result.query)?;
+    writeln!(f, "target: {}", result.target.label)?;
+    writeln!(
+      f,
+      "verification: {}{}",
+      result.verification.status,
+      result
+        .verification
+        .observed_title
+        .as_deref()
+        .map(|title| format!(" observed_title={title}"))
+        .unwrap_or_default()
+    )?;
+    if result.known_limits.is_empty() {
+      writeln!(f, "known_limits: (none)")?;
+    } else {
+      writeln!(f, "known_limits:")?;
+      for limit in &result.known_limits {
+        writeln!(f, "  - {limit}")?;
+      }
+    }
+    if result.diagnostics.is_empty() {
+      write!(f, "diagnostics: (none)")
+    } else {
+      writeln!(f, "diagnostics:")?;
+      for diagnostic in &result.diagnostics {
+        writeln!(f, "  - {}: {}", diagnostic.code, diagnostic.message)?;
+      }
+      Ok(())
+    }
+  }
+}
+
+impl fmt::Display for PlaylistPlayHumanSummary<'_> {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    let result = self.result;
+    writeln!(f, "NetEase playlist play")?;
+    writeln!(f, "query: {}", result.query)?;
+    writeln!(f, "target: {}", result.select.target.label)?;
+    writeln!(
+      f,
+      "verification: {} control={}",
+      result.verification.status,
+      result
+        .verification
+        .control_state
+        .map(|state| format!("{state:?}"))
+        .unwrap_or_else(|| "-".to_string())
+    )?;
+    if result.known_limits.is_empty() {
+      writeln!(f, "known_limits: (none)")?;
+    } else {
+      writeln!(f, "known_limits:")?;
+      for limit in &result.known_limits {
+        writeln!(f, "  - {limit}")?;
+      }
+    }
+    if result.diagnostics.is_empty() {
+      write!(f, "diagnostics: (none)")
+    } else {
+      writeln!(f, "diagnostics:")?;
+      for diagnostic in &result.diagnostics {
+        writeln!(f, "  - {}: {}", diagnostic.code, diagnostic.message)?;
+      }
+      Ok(())
+    }
+  }
+}
+
+fn playlist_select_click_options() -> auv_driver::ClickOptions {
+  auv_driver::ClickOptions {
+    policy: auv_driver::InputPolicy::BackgroundPreferred,
+    click: auv_driver::Click::Single,
+    window_strategy: auv_driver::WindowClickStrategy::ChromiumCompatible,
+  }
+}
+
+fn playlist_play_click_options() -> auv_driver::ClickOptions {
+  auv_driver::ClickOptions {
+    policy: auv_driver::InputPolicy::BackgroundPreferred,
+    click: auv_driver::Click::Single,
+    window_strategy: auv_driver::WindowClickStrategy::ChromiumCompatible,
+  }
+}
+
+fn playlist_select_bottom_padding_scroll_needed(
+  target_bounds: ViewBounds,
+  sidebar_bounds: ViewBounds,
+) -> bool {
+  target_bounds.y + target_bounds.height
+    > sidebar_bounds.y + sidebar_bounds.height - PLAYLIST_SELECT_BOTTOM_SAFE_PADDING
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn playlist_select_uses_background_preferred_window_click_by_default() {
+    let options = playlist_select_click_options();
+
+    assert_eq!(options.policy, auv_driver::InputPolicy::BackgroundPreferred);
+    assert_eq!(
+      options.window_strategy,
+      auv_driver::WindowClickStrategy::ChromiumCompatible
+    );
+  }
+
+  #[test]
+  fn playlist_play_uses_background_preferred_window_click_by_default() {
+    let options = playlist_play_click_options();
+
+    assert_eq!(options.policy, auv_driver::InputPolicy::BackgroundPreferred);
+    assert_eq!(
+      options.window_strategy,
+      auv_driver::WindowClickStrategy::ChromiumCompatible
+    );
+  }
+
+  #[test]
+  fn playlist_select_requests_bottom_padding_scroll_for_targets_inside_bottom_safe_band() {
+    let sidebar = ViewBounds::new(0.0, 0.0, 320.0, 860.0);
+    let unsafe_target = ViewBounds::new(72.0, 800.0, 154.0, 14.0);
+    let safe_target = ViewBounds::new(72.0, 620.0, 154.0, 14.0);
+
+    assert!(playlist_select_bottom_padding_scroll_needed(
+      unsafe_target,
+      sidebar
+    ));
+    assert!(!playlist_select_bottom_padding_scroll_needed(
+      safe_target,
+      sidebar
+    ));
+  }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn run_playlist_select(_inputs: &Inputs, _query: &str) -> Result<PlaylistSelectResult, String> {
+  Err("live NetEase playlist select is only supported on macOS".to_string())
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn run_playlist_play(_inputs: &Inputs, _query: &str) -> Result<PlaylistPlayResult, String> {
+  Err("live NetEase playlist play is only supported on macOS".to_string())
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn run_playlist_play_candidate_id(
+  _inputs: &Inputs,
+  _candidate_id: &str,
+) -> Result<PlaylistPlayResult, String> {
+  Err("live NetEase playlist play is only supported on macOS".to_string())
+}
+
+#[cfg(target_os = "macos")]
+pub fn run_playlist_select(inputs: &Inputs, query: &str) -> Result<PlaylistSelectResult, String> {
+  let (scan, target) = resolve_playlist_target_for_query(inputs, query)?;
+  run_playlist_select_resolved(inputs, query, scan, target)
+}
+
+#[cfg(target_os = "macos")]
+fn resolve_playlist_target_for_query(
+  inputs: &Inputs,
+  query: &str,
+) -> Result<(crate::PlaylistSidebarScan, PlaylistSelectTarget), String> {
+  std::fs::create_dir_all(&inputs.artifact_dir).map_err(|error| {
+    format!(
+      "failed to create {}: {error}",
+      inputs.artifact_dir.display()
+    )
+  })?;
+
+  let scan = run_live_scan_until_query(inputs, query)?;
+  let target = scan.select_target(query)?;
+  Ok((scan, target))
+}
+
+#[cfg(target_os = "macos")]
+fn run_playlist_select_resolved(
+  inputs: &Inputs,
+  query: &str,
+  scan: crate::PlaylistSidebarScan,
+  target: PlaylistSelectTarget,
+) -> Result<PlaylistSelectResult, String> {
+  use crate::delivery_path_label;
+  use crate::view_parsers::sidebar::region::broad_sidebar_probe_bounds;
+  use auv_driver::selector::{App, Window};
+  use auv_driver::{
+    ActivationPolicy, Click, Driver, InputPolicy, PrepareForInputOptions, Scroll, ScrollOptions,
+    Size, WindowPoint,
+  };
+  use auv_driver_macos::MacosDriver;
+
+  let target_bounds = target.bounds.ok_or_else(|| {
+    format!(
+      "playlist target {:?} did not carry live bounds; rerun playlist ls/select",
+      target.label
+    )
+  })?;
+  let target_observation_index = target.observation_index.unwrap_or(0);
+
+  let driver = MacosDriver::new();
+  let session = driver
+    .open_local()
+    .map_err(|error| format!("failed to open macOS driver: {error}"))?;
+  let app = App::bundle(inputs.app_id.clone());
+  let window = session
+    .window()
+    .resolve(Window::main_visible().owned_by(app))
+    .map_err(|error| format!("failed to resolve NetEase window: {error}"))?;
+  let window_size = Size::new(window.frame.size.width, window.frame.size.height);
+  let sidebar_bounds = broad_sidebar_probe_bounds(window_size);
+  let sidebar_anchor = WindowPoint::new(
+    sidebar_bounds.x + sidebar_bounds.width * 0.5,
+    sidebar_bounds.y + sidebar_bounds.height * 0.45,
+  );
+  let mut steps = Vec::new();
+  let mut diagnostics = scan.diagnostics().to_vec();
+  let mut known_limits = scan.known_limits().to_vec();
+
+  // NOTICE(netease-playlist-select-reacquire): selection consumes the
+  // parse-scoped bounds from the fresh scan. It rewinds to the top and replays
+  // the scan page count instead of treating stored bounds as durable across
+  // arbitrary prior app state. Replace this with view-memory reacquire once
+  // that owner-approved slice lands.
+  let top_scrolls = inputs.max_scrolls.max(target_observation_index) + 4;
+  for index in 0..top_scrolls {
+    match session.window().scroll(
+      &window,
+      sidebar_anchor,
+      Scroll::new(0.0, inputs.scroll_amount),
+      ScrollOptions {
+        policy: InputPolicy::BackgroundPreferred,
+        settle: std::time::Duration::from_millis(inputs.scroll_settle_ms),
+        ..ScrollOptions::default()
+      },
+    ) {
+      Ok(result) => steps.push(PlaylistSelectStep {
+        name: format!("scroll-sidebar-top-{index}"),
+        target_bounds: Some(sidebar_bounds),
+        delivery_path: Some(delivery_path_label(result.selected_path).to_string()),
+        fallback_reason: result.fallback_reason,
+      }),
+      Err(error) => {
+        diagnostics.push(ParserDiagnostic {
+          code: "playlist_select_top_scroll_failed".to_string(),
+          message: error.to_string(),
+          node_id: target.candidate_id.clone(),
+        });
+        known_limits.push("playlist select top seek stopped after scroll failure".to_string());
+        break;
+      }
+    }
+  }
+
+  for index in 0..target_observation_index {
+    let result = session
+      .window()
+      .scroll(
+        &window,
+        sidebar_anchor,
+        Scroll::new(0.0, -inputs.scroll_amount),
+        ScrollOptions {
+          policy: InputPolicy::BackgroundPreferred,
+          settle: std::time::Duration::from_millis(inputs.scroll_settle_ms),
+          ..ScrollOptions::default()
+        },
+      )
+      .map_err(|error| format!("playlist select page scroll failed: {error}"))?;
+    steps.push(PlaylistSelectStep {
+      name: format!("scroll-sidebar-target-page-{index}"),
+      target_bounds: Some(sidebar_bounds),
+      delivery_path: Some(delivery_path_label(result.selected_path).to_string()),
+      fallback_reason: result.fallback_reason,
+    });
+  }
+
+  let mut click_bounds = target_bounds;
+  for attempt in 0..2 {
+    if !playlist_select_bottom_padding_scroll_needed(click_bounds, sidebar_bounds) {
+      break;
+    }
+
+    let result = session
+      .window()
+      .scroll(
+        &window,
+        sidebar_anchor,
+        Scroll::new(0.0, -inputs.scroll_amount),
+        ScrollOptions {
+          policy: InputPolicy::BackgroundPreferred,
+          settle: std::time::Duration::from_millis(inputs.scroll_settle_ms),
+          ..ScrollOptions::default()
+        },
+      )
+      .map_err(|error| format!("playlist select bottom padding scroll failed: {error}"))?;
+    steps.push(PlaylistSelectStep {
+      name: format!("scroll-sidebar-bottom-padding-{attempt}"),
+      target_bounds: Some(sidebar_bounds),
+      delivery_path: Some(delivery_path_label(result.selected_path).to_string()),
+      fallback_reason: result.fallback_reason,
+    });
+
+    match current_sidebar_target_bounds(
+      &session,
+      &window,
+      sidebar_bounds,
+      inputs,
+      &target.label,
+      query,
+    ) {
+      Ok(Some(bounds)) => {
+        click_bounds = bounds;
+        steps.push(PlaylistSelectStep {
+          name: format!("reobserve-playlist-after-bottom-padding-{attempt}"),
+          target_bounds: Some(click_bounds),
+          delivery_path: None,
+          fallback_reason: None,
+        });
+      }
+      Ok(None) => {
+        diagnostics.push(ParserDiagnostic {
+          code: "playlist_select_bottom_padding_reobserve_missed_target".to_string(),
+          message: format!(
+            "target {:?} was not visible after bottom padding scroll",
+            target.label
+          ),
+          node_id: target.candidate_id.clone(),
+        });
+        known_limits.push(
+          "playlist select bottom padding could not reacquire target before click".to_string(),
+        );
+        break;
+      }
+      Err(error) => {
+        diagnostics.push(ParserDiagnostic {
+          code: "playlist_select_bottom_padding_reobserve_failed".to_string(),
+          message: error,
+          node_id: target.candidate_id.clone(),
+        });
+        known_limits.push(
+          "playlist select bottom padding could not reacquire target before click".to_string(),
+        );
+        break;
+      }
+    }
+  }
+
+  let click_point = WindowPoint::new(
+    click_bounds.x + click_bounds.width * 0.5,
+    click_bounds.y + click_bounds.height * 0.5,
+  );
+  let click = session
+    .window()
+    .click(&window, click_point, playlist_select_click_options())
+    .map_err(|error| format!("playlist select click failed: {error}"))?;
+  if inputs.scroll_settle_ms > 0 {
+    std::thread::sleep(std::time::Duration::from_millis(inputs.scroll_settle_ms));
+  }
+  steps.push(PlaylistSelectStep {
+    name: "click-playlist".to_string(),
+    target_bounds: Some(click_bounds),
+    delivery_path: Some(delivery_path_label(click.selected_path).to_string()),
+    fallback_reason: click.fallback_reason,
+  });
+
+  let verification_artifact = inputs.artifact_dir.join("playlist-select-post-click.png");
+  let mut verification = verify_playlist_select_title(
+    &session,
+    &window,
+    window_size,
+    inputs,
+    &verification_artifact,
+    &target.label,
+  )?;
+
+  if verification.status != "passed" {
+    known_limits.push(
+      "background playlist row click did not verify; retried with foreground click".to_string(),
+    );
+    let screen_point = session
+      .window()
+      .to_screen_point(&window, click_point)
+      .map_err(|error| format!("playlist select foreground point projection failed: {error}"))?;
+    let lease = session
+      .window()
+      .prepare_for_input(
+        &window,
+        PrepareForInputOptions {
+          activation: ActivationPolicy::Foreground {
+            settle: std::time::Duration::from_millis(inputs.scroll_settle_ms),
+          },
+          preserve_frontmost: false,
+          install_focus_guard: false,
+          settle: std::time::Duration::from_millis(0),
+        },
+      )
+      .map_err(|error| format!("playlist select foreground preparation failed: {error}"))?;
+    let click_result = session
+      .input()
+      .click_at(screen_point.point(), Click::Single);
+    let restore_result = session.window().restore_input(lease);
+    click_result.map_err(|error| format!("playlist select foreground click failed: {error}"))?;
+    restore_result
+      .map_err(|error| format!("playlist select foreground restore failed: {error}"))?;
+    if inputs.scroll_settle_ms > 0 {
+      std::thread::sleep(std::time::Duration::from_millis(inputs.scroll_settle_ms));
+    }
+    steps.push(PlaylistSelectStep {
+      name: "click-playlist-foreground-retry".to_string(),
+      target_bounds: Some(click_bounds),
+      delivery_path: Some("foreground_system_events".to_string()),
+      fallback_reason: Some("window-targeted click did not verify selection".to_string()),
+    });
+    verification = verify_playlist_select_title(
+      &session,
+      &window,
+      window_size,
+      inputs,
+      &verification_artifact,
+      &target.label,
+    )?;
+  }
+
+  Ok(PlaylistSelectResult {
+    command: "playlist.select".to_string(),
+    query: query.to_string(),
+    app: scan.app().clone(),
+    window: scan.window().clone(),
+    target,
+    steps,
+    verification,
+    diagnostics,
+    known_limits,
+  })
+}
+
+#[cfg(target_os = "macos")]
+fn verify_playlist_select_title(
+  session: &auv_driver_macos::MacosDriverSession,
+  window: &auv_driver::Window,
+  window_size: auv_driver::Size,
+  inputs: &Inputs,
+  verification_artifact: &std::path::Path,
+  target_label: &str,
+) -> Result<PlaylistSelectVerification, String> {
+  use auv_driver::RatioRect;
+
+  let capture = session
+    .window()
+    .capture(window)
+    .map_err(|error| format!("playlist select verification capture failed: {error}"))?;
+  capture.image.save(verification_artifact).map_err(|error| {
+    format!(
+      "failed to save {}: {error}",
+      verification_artifact.display()
+    )
+  })?;
+  let recognition = session
+    .vision()
+    .recognize_text_in_capture_with_options(
+      &capture,
+      RatioRect::new(0.24, 0.04, 0.64, 0.36),
+      inputs.ocr_options.clone(),
+    )
+    .map_err(|error| format!("playlist select verification OCR failed: {error}"))?;
+  let recognition = crate::recognition_in_window_space(recognition, &capture);
+  let observed_title = recognition
+    .regions
+    .iter()
+    .filter(|region| {
+      region.bounds.origin.x > window_size.width * 0.24
+        && region.bounds.origin.y < window_size.height * 0.36
+    })
+    .max_by(|left, right| {
+      left
+        .bounds
+        .size
+        .height
+        .partial_cmp(&right.bounds.size.height)
+        .unwrap_or(std::cmp::Ordering::Equal)
+    })
+    .map(|region| region.text.trim().to_string())
+    .filter(|text| !text.is_empty());
+  let verified = observed_title.as_deref().is_some_and(|title| {
+    crate::normalize_identity(title).contains(&crate::normalize_identity(target_label))
+  });
+
+  Ok(PlaylistSelectVerification {
+    status: if verified { "passed" } else { "failed" }.to_string(),
+    method: "main_title_ocr".to_string(),
+    observed_title,
+    artifact: Some(verification_artifact.display().to_string()),
+    note: Some(
+      "verification checks the main content title after opening the sidebar playlist".to_string(),
+    ),
+  })
+}
+
+#[cfg(target_os = "macos")]
+pub fn run_playlist_play(inputs: &Inputs, query: &str) -> Result<PlaylistPlayResult, String> {
+  let (scan, target) = resolve_playlist_target_for_query(inputs, query)?;
+  run_playlist_play_resolved(inputs, query, scan, target)
+}
+
+#[cfg(target_os = "macos")]
+pub fn run_playlist_play_candidate_id(
+  inputs: &Inputs,
+  candidate_id: &str,
+) -> Result<PlaylistPlayResult, String> {
+  let scan = load_playlist_scan_cache(inputs)?;
+  let target = scan.select_target_by_candidate_id(candidate_id)?;
+  run_playlist_play_resolved(inputs, candidate_id, scan, target)
+}
+
+#[cfg(target_os = "macos")]
+fn load_playlist_scan_cache(inputs: &Inputs) -> Result<crate::PlaylistSidebarScan, String> {
+  let cache_path = inputs.artifact_dir.join(crate::PLAYLIST_SCAN_CACHE_FILE);
+  let json = std::fs::read_to_string(&cache_path).map_err(|error| {
+    format!(
+      "failed to read playlist scan cache {}: {error}; run `playlist ls <query> --json` first with the same --artifact-dir",
+      cache_path.display()
+    )
+  })?;
+  decode_playlist_sidebar_scan_json(&json)
+}
+
+#[cfg(target_os = "macos")]
+fn run_playlist_play_resolved(
+  inputs: &Inputs,
+  query: &str,
+  scan: crate::PlaylistSidebarScan,
+  target: PlaylistSelectTarget,
+) -> Result<PlaylistPlayResult, String> {
+  use crate::commands::daily_recommended::best_text_match;
+  use crate::delivery_path_label;
+  use crate::views::player::classify_bottom_playback_control_state;
+  use auv_driver::selector::{App, Window};
+  use auv_driver::{Driver, RatioRect, Size, WindowPoint};
+  use auv_driver_macos::MacosDriver;
+
+  let select = run_playlist_select_resolved(inputs, query, scan, target)?;
+  if select.verification.status != "passed" {
+    return Err(format!(
+      "playlist select verification failed before play: observed_title={:?}",
+      select.verification.observed_title
+    ));
+  }
+
+  std::fs::create_dir_all(&inputs.artifact_dir).map_err(|error| {
+    format!(
+      "failed to create {}: {error}",
+      inputs.artifact_dir.display()
+    )
+  })?;
+
+  let driver = MacosDriver::new();
+  let session = driver
+    .open_local()
+    .map_err(|error| format!("failed to open macOS driver: {error}"))?;
+  let app = App::bundle(inputs.app_id.clone());
+  let window = session
+    .window()
+    .resolve(Window::main_visible().owned_by(app))
+    .map_err(|error| format!("failed to resolve NetEase window: {error}"))?;
+  let window_size = Size::new(window.frame.size.width, window.frame.size.height);
+  let mut steps = Vec::new();
+  let mut artifacts = Vec::new();
+  let diagnostics = select.diagnostics.clone();
+  let mut known_limits = select.known_limits.clone();
+
+  let capture = session
+    .window()
+    .capture(&window)
+    .map_err(|error| format!("playlist play-all capture failed: {error}"))?;
+  let play_all_artifact = inputs.artifact_dir.join("playlist-play-all-target.png");
+  capture
+    .image
+    .save(&play_all_artifact)
+    .map_err(|error| format!("failed to save {}: {error}", play_all_artifact.display()))?;
+  artifacts.push(play_all_artifact.display().to_string());
+  let recognition = session
+    .vision()
+    .recognize_text_in_capture_with_options(
+      &capture,
+      RatioRect::new(0.0, 0.0, 1.0, 1.0),
+      inputs.ocr_options.clone(),
+    )
+    .map_err(|error| format!("playlist play-all OCR failed: {error}"))?;
+  let recognition = crate::recognition_in_window_space(recognition, &capture);
+  let Some(target) = best_text_match(&recognition, "播放全部", window_size, |bounds, size| {
+    bounds.x > size.width * 0.18 && bounds.y > size.height * 0.12 && bounds.y < size.height * 0.55
+  }) else {
+    return Err("playlist play-all text \"播放全部\" was not found".to_string());
+  };
+  let target_bounds = ViewBounds::new(
+    target.bounds.origin.x,
+    target.bounds.origin.y,
+    target.bounds.size.width,
+    target.bounds.size.height,
+  );
+  let point = target.action_point();
+  let click = session
+    .window()
+    .click(
+      &window,
+      WindowPoint::new(point.x, point.y),
+      playlist_play_click_options(),
+    )
+    .map_err(|error| format!("playlist play-all click failed: {error}"))?;
+  if inputs.scroll_settle_ms > 0 {
+    std::thread::sleep(std::time::Duration::from_millis(inputs.scroll_settle_ms));
+  }
+  steps.push(PlaylistPlayStep {
+    name: "click-play-all".to_string(),
+    target_label: Some(target.text),
+    target_bounds: Some(target_bounds),
+    delivery_path: Some(delivery_path_label(click.selected_path).to_string()),
+    fallback_reason: click.fallback_reason,
+    artifact: Some(play_all_artifact.display().to_string()),
+  });
+
+  let capture = session
+    .window()
+    .capture(&window)
+    .map_err(|error| format!("playlist play verification capture failed: {error}"))?;
+  let screenshot = inputs
+    .artifact_dir
+    .join("playlist-play-post-click-playback-state.png");
+  capture
+    .image
+    .save(&screenshot)
+    .map_err(|error| format!("failed to save {}: {error}", screenshot.display()))?;
+  artifacts.push(screenshot.display().to_string());
+  let control_state = classify_bottom_playback_control_state(&capture.image);
+  let bottom_text = session
+    .vision()
+    .recognize_text_in_capture_with_options(
+      &capture,
+      RatioRect::new(0.0, 0.88, 0.46, 0.12),
+      inputs.ocr_options.clone(),
+    )
+    .ok()
+    .map(|recognition| recognition.text.trim().to_string())
+    .filter(|text| !text.is_empty());
+  let verification_json = inputs
+    .artifact_dir
+    .join("playlist-play-post-click-playback-state.json");
+  let payload = serde_json::json!({
+    "method": "bottom_control_icon",
+    "control_state": control_state,
+    "observed_bottom_text": bottom_text,
+    "screenshot": screenshot.display().to_string(),
+  });
+  std::fs::write(
+    &verification_json,
+    serde_json::to_string_pretty(&payload)
+      .map_err(|error| format!("failed to serialize playlist play verification: {error}"))?,
+  )
+  .map_err(|error| format!("failed to write {}: {error}", verification_json.display()))?;
+  artifacts.push(verification_json.display().to_string());
+  let verification = PlaylistPlayVerification {
+    status: if control_state == PlaybackControlState::PauseVisible {
+      "passed"
+    } else {
+      known_limits.push(
+        "playlist play-all click did not expose a pause control in the bottom player".to_string(),
+      );
+      "failed"
+    }
+    .to_string(),
+    method: "bottom_control_icon".to_string(),
+    control_state: Some(control_state),
+    observed_bottom_text: bottom_text,
+    artifact: Some(verification_json.display().to_string()),
+    note: Some(
+      "verification checks the bottom playback control after clicking playlist Play All"
+        .to_string(),
+    ),
+  };
+
+  Ok(PlaylistPlayResult {
+    command: "playlist.play".to_string(),
+    query: query.to_string(),
+    select,
+    steps,
+    verification,
+    diagnostics,
+    known_limits,
+    artifacts,
+  })
+}
+
+#[cfg(target_os = "macos")]
+fn current_sidebar_target_bounds(
+  session: &auv_driver_macos::MacosDriverSession,
+  window: &auv_driver::Window,
+  sidebar_bounds: ViewBounds,
+  inputs: &Inputs,
+  target_label: &str,
+  query: &str,
+) -> Result<Option<ViewBounds>, String> {
+  let capture = session
+    .window()
+    .capture(window)
+    .map_err(|error| format!("bottom padding capture failed: {error}"))?;
+  let recognition = session
+    .vision()
+    .recognize_text_in_capture_with_options(
+      &capture,
+      crate::bounds_to_ratio(sidebar_bounds, &capture),
+      inputs.ocr_options.clone(),
+    )
+    .map_err(|error| format!("bottom padding sidebar OCR failed: {error}"))?;
+  let recognition = crate::recognition_in_window_space(recognition, &capture);
+  let observation =
+    crate::view_parsers::sidebar::parse::parse_sidebar_viewport(0, sidebar_bounds, &recognition);
+  let target_identity = crate::normalize_identity(target_label);
+  let query_identity = crate::normalize_identity(query);
+
+  Ok(
+    observation
+      .candidates
+      .iter()
+      .filter(|candidate| candidate.kind == crate::SidebarCandidateKind::PlaylistItem)
+      .filter_map(|candidate| {
+        let label = candidate.label.as_deref()?;
+        let bounds = candidate.bounds?;
+        let label_identity = crate::normalize_identity(label);
+        let matches_target = label_identity.contains(&target_identity)
+          || target_identity.contains(&label_identity)
+          || (!query_identity.is_empty() && label_identity.contains(&query_identity));
+        matches_target.then_some(bounds)
+      })
+      .next(),
+  )
+}

--- a/crates/auv-netease-music/src/lib.rs
+++ b/crates/auv-netease-music/src/lib.rs
@@ -16,10 +16,15 @@ pub use commands::playback::{
   PlaybackStatus, PlaybackStatusHumanReadable, PlaybackStatusInputs, PlaybackStatusJson,
   run_playback_status_probe,
 };
+pub use commands::playlist::{
+  PlaylistPlayResult, PlaylistPlayStep, PlaylistPlayVerification, PlaylistSelectResult,
+  PlaylistSelectStep, PlaylistSelectVerification, run_playlist_play,
+  run_playlist_play_candidate_id, run_playlist_select,
+};
 pub use interaction::{
   InteractionEvent, InteractionEventKind, InteractionPhase, ScrollDirection, ScrollInteraction,
 };
-pub use view_parsers::sidebar::live::run_live_scan;
+pub use view_parsers::sidebar::live::{run_live_scan, run_live_scan_until_query};
 pub use views::player::PlaybackControlState;
 pub use views::sidebar::{
   PlaylistSidebarItem, PlaylistSidebarProjection, SidebarSection, SidebarSectionKind,
@@ -60,8 +65,8 @@ use auv_driver::capture::Capture;
 use auv_driver::selector::{App, Window};
 #[cfg(target_os = "macos")]
 use auv_driver::{
-  ActivationPolicy, Click, ClickOptions, Driver, InputPolicy, PrepareForInputOptions, Scroll,
-  ScrollOptions, Size, WindowClickStrategy, WindowPoint,
+  ActivationPolicy, Click, Driver, InputPolicy, PrepareForInputOptions, Scroll, ScrollOptions,
+  Size, WindowPoint,
 };
 #[cfg(target_os = "macos")]
 use auv_driver_macos::native::ax_tree::capture_ax_tree_snapshot;
@@ -72,6 +77,7 @@ use auv_driver_macos::{MacosDriver, MacosDriverSession};
 
 pub const DEFAULT_APP_ID: &str = "com.netease.163music";
 pub const DEFAULT_ARTIFACT_DIR: &str = "/tmp/auv-netease-playlist-ls-artifacts";
+pub const PLAYLIST_SCAN_CACHE_FILE: &str = "playlist-scan-cache.json";
 pub const DEFAULT_DAILY_RECOMMENDED_ARTIFACT_DIR: &str =
   "/tmp/auv-netease-play-daily-recommended-artifacts";
 // TODO(netease-scroll-completion): this conservative default is only a
@@ -335,6 +341,18 @@ pub struct PlaylistSidebarScan {
   known_limits: Vec<String>,
 }
 
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct PlaylistSelectTarget {
+  pub label: String,
+  pub section_id: String,
+  pub section_kind: SidebarSectionKind,
+  pub item_id: String,
+  pub anchor_id: Option<String>,
+  pub candidate_id: Option<String>,
+  pub observation_index: Option<usize>,
+  pub bounds: Option<ViewBounds>,
+}
+
 impl PlaylistSidebarScan {
   fn empty(
     app: ScanAppContext,
@@ -410,6 +428,84 @@ impl PlaylistSidebarScan {
     &self.known_limits
   }
 
+  pub fn select_target(&self, query: &str) -> Result<PlaylistSelectTarget, String> {
+    let query = query.trim();
+    if query.is_empty() {
+      return Err("playlist select query must not be empty".to_string());
+    }
+
+    let sidebar = crate::views::sidebar::SidebarView::from_projection(self.projection.clone());
+    let matches = sidebar.playlists(Some(query));
+    let [playlist] = matches.as_slice() else {
+      return match matches.len() {
+        0 => Err(format!("no playlist matched {query:?}")),
+        count => Err(format!(
+          "playlist query {query:?} matched {count} items; refine the query"
+        )),
+      };
+    };
+    let (observation_index, bounds) = playlist
+      .item
+      .candidate_id
+      .as_deref()
+      .and_then(|candidate_id| self.candidate_bounds(candidate_id))
+      .map(|(index, bounds)| (Some(index), Some(bounds)))
+      .unwrap_or((None, None));
+
+    Ok(PlaylistSelectTarget {
+      label: playlist.item.label.clone(),
+      section_id: playlist.section.id.clone(),
+      section_kind: playlist.section.kind,
+      item_id: playlist.item.id.clone(),
+      anchor_id: playlist.item.anchor_id.clone(),
+      candidate_id: playlist.item.candidate_id.clone(),
+      observation_index,
+      bounds,
+    })
+  }
+
+  pub fn select_target_by_candidate_id(
+    &self,
+    candidate_id: &str,
+  ) -> Result<PlaylistSelectTarget, String> {
+    let candidate_id = candidate_id.trim();
+    if candidate_id.is_empty() {
+      return Err("playlist candidate_id must not be empty".to_string());
+    }
+
+    for section in &self.projection.sections {
+      if !matches!(
+        section.kind,
+        SidebarSectionKind::MyPlaylists | SidebarSectionKind::FavoritePlaylists
+      ) {
+        continue;
+      }
+      for item in &section.items {
+        if item.candidate_id.as_deref() != Some(candidate_id) {
+          continue;
+        }
+        let (observation_index, bounds) = self
+          .candidate_bounds(candidate_id)
+          .map(|(index, bounds)| (Some(index), Some(bounds)))
+          .unwrap_or((None, None));
+        return Ok(PlaylistSelectTarget {
+          label: item.label.clone(),
+          section_id: section.id.clone(),
+          section_kind: section.kind,
+          item_id: item.id.clone(),
+          anchor_id: item.anchor_id.clone(),
+          candidate_id: item.candidate_id.clone(),
+          observation_index,
+          bounds,
+        });
+      }
+    }
+
+    Err(format!(
+      "no playlist candidate_id matched {candidate_id:?}; run `playlist ls <query> --json` first with the same --artifact-dir"
+    ))
+  }
+
   pub fn to_human_readable(&self) -> PlaylistSidebarHumanSummary<'_> {
     PlaylistSidebarHumanSummary { scan: self }
   }
@@ -423,6 +519,17 @@ impl PlaylistSidebarScan {
     );
     scan.projection = projection;
     scan
+  }
+
+  fn candidate_bounds(&self, candidate_id: &str) -> Option<(usize, ViewBounds)> {
+    self.observations.iter().find_map(|observation| {
+      observation
+        .candidates
+        .iter()
+        .find(|candidate| candidate.id == candidate_id)
+        .and_then(|candidate| candidate.bounds)
+        .map(|bounds| (observation.observation_index, bounds))
+    })
   }
 }
 
@@ -831,4 +938,94 @@ fn candidate_evidence(
         .cloned()
     })
     .collect()
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn playlist_select_target_resolves_candidate_bounds_from_scan_observation() {
+    let candidate_id = "obs2.candidate.ocr1.human_machine";
+    let bounds = ViewBounds::new(71.0, 166.0, 72.0, 15.0);
+    let mut scan = PlaylistSidebarScan::from_projection_for_tests(PlaylistSidebarProjection {
+      sections: vec![SidebarSection {
+        id: "section-created".to_string(),
+        kind: SidebarSectionKind::MyPlaylists,
+        label: Some("创建的歌单".to_string()),
+        items: vec![PlaylistSidebarItem {
+          id: "item-human-machine".to_string(),
+          label: "人造器械".to_string(),
+          section_hint: Some(SidebarSectionKind::MyPlaylists),
+          confidence: Confidence::High,
+          candidate_id: Some(candidate_id.to_string()),
+          anchor_id: Some("anchor-human-machine".to_string()),
+        }],
+      }],
+    });
+    scan.observations.push(SidebarViewportObservation {
+      observation_index: 2,
+      candidates: vec![SidebarViewportCandidate {
+        id: candidate_id.to_string(),
+        kind: SidebarCandidateKind::PlaylistItem,
+        label: Some("人造器械".to_string()),
+        bounds: Some(bounds),
+        evidence_ids: Vec::new(),
+        confidence: Confidence::High,
+      }],
+      ..SidebarViewportObservation::default()
+    });
+
+    let target = scan
+      .select_target("人造")
+      .expect("single playlist match should resolve");
+
+    assert_eq!(target.label, "人造器械");
+    assert_eq!(target.item_id, "item-human-machine");
+    assert_eq!(target.anchor_id.as_deref(), Some("anchor-human-machine"));
+    assert_eq!(target.observation_index, Some(2));
+    assert_eq!(target.bounds, Some(bounds));
+  }
+
+  #[test]
+  fn playlist_select_target_resolves_by_candidate_id() {
+    let candidate_id = "obs6.candidate.ocr4.trance_vol_2";
+    let bounds = ViewBounds::new(72.0, 492.0, 148.0, 16.0);
+    let mut scan = PlaylistSidebarScan::from_projection_for_tests(PlaylistSidebarProjection {
+      sections: vec![SidebarSection {
+        id: "section-favorite".to_string(),
+        kind: SidebarSectionKind::FavoritePlaylists,
+        label: Some("收藏的歌单".to_string()),
+        items: vec![PlaylistSidebarItem {
+          id: "item-trance-vol-2".to_string(),
+          label: "我喜欢的风格 | Trance Vol.2".to_string(),
+          section_hint: Some(SidebarSectionKind::FavoritePlaylists),
+          confidence: Confidence::High,
+          candidate_id: Some(candidate_id.to_string()),
+          anchor_id: Some("anchor-trance-vol-2".to_string()),
+        }],
+      }],
+    });
+    scan.observations.push(SidebarViewportObservation {
+      observation_index: 6,
+      candidates: vec![SidebarViewportCandidate {
+        id: candidate_id.to_string(),
+        kind: SidebarCandidateKind::PlaylistItem,
+        label: Some("我喜欢的风格 | Trance Vol.2".to_string()),
+        bounds: Some(bounds),
+        evidence_ids: Vec::new(),
+        confidence: Confidence::High,
+      }],
+      ..SidebarViewportObservation::default()
+    });
+
+    let target = scan
+      .select_target_by_candidate_id(candidate_id)
+      .expect("candidate id should resolve");
+
+    assert_eq!(target.label, "我喜欢的风格 | Trance Vol.2");
+    assert_eq!(target.candidate_id.as_deref(), Some(candidate_id));
+    assert_eq!(target.observation_index, Some(6));
+    assert_eq!(target.bounds, Some(bounds));
+  }
 }

--- a/crates/auv-netease-music/src/output.rs
+++ b/crates/auv-netease-music/src/output.rs
@@ -10,6 +10,7 @@ pub struct MatchRef {
   pub section_kind: SidebarSectionKind,
   pub item_id: String,
   pub label: String,
+  pub candidate_id: Option<String>,
   pub anchor_id: Option<String>,
 }
 
@@ -63,6 +64,7 @@ fn collect_matches_from_sidebar(sidebar: &SidebarView, keyword: Option<&str>) ->
       section_kind: playlist.section.kind,
       item_id: playlist.item.id.clone(),
       label: playlist.item.label.clone(),
+      candidate_id: playlist.item.candidate_id.clone(),
       anchor_id: playlist.item.anchor_id.clone(),
     })
     .collect()
@@ -121,7 +123,7 @@ mod tests {
             label: "Daily Mix".to_string(),
             section_hint: None,
             confidence: Confidence::High,
-            candidate_id: None,
+            candidate_id: Some("obs1.candidate.daily".to_string()),
             anchor_id: Some("a1".to_string()),
           },
           PlaylistSidebarItem {
@@ -216,6 +218,10 @@ mod tests {
     assert_eq!(output.item_count, 2);
     assert_eq!(output.match_count, 1);
     assert_eq!(output.matches[0].item_id, "i1");
+    assert_eq!(
+      output.matches[0].candidate_id.as_deref(),
+      Some("obs1.candidate.daily")
+    );
     assert!(std::ptr::eq(output.scan, &scan));
   }
 }

--- a/crates/auv-netease-music/src/view_parsers/sidebar/live.rs
+++ b/crates/auv-netease-music/src/view_parsers/sidebar/live.rs
@@ -5,8 +5,32 @@ pub fn run_live_scan(_inputs: &Inputs) -> Result<PlaylistSidebarScan, String> {
   Err("live NetEase playlist sidebar scan is only supported on macOS".to_string())
 }
 
+#[cfg(not(target_os = "macos"))]
+pub fn run_live_scan_until_query(
+  _inputs: &Inputs,
+  _query: &str,
+) -> Result<PlaylistSidebarScan, String> {
+  Err("live NetEase playlist sidebar scan is only supported on macOS".to_string())
+}
+
 #[cfg(target_os = "macos")]
 pub fn run_live_scan(inputs: &Inputs) -> Result<PlaylistSidebarScan, String> {
+  run_live_scan_inner(inputs, None)
+}
+
+#[cfg(target_os = "macos")]
+pub fn run_live_scan_until_query(
+  inputs: &Inputs,
+  query: &str,
+) -> Result<PlaylistSidebarScan, String> {
+  run_live_scan_inner(inputs, Some(query))
+}
+
+#[cfg(target_os = "macos")]
+fn run_live_scan_inner(
+  inputs: &Inputs,
+  query: Option<&str>,
+) -> Result<PlaylistSidebarScan, String> {
   let driver = MacosDriver::new();
   let default_app_context = ScanAppContext {
     app_id: Some(inputs.app_id.clone()),
@@ -359,20 +383,31 @@ pub fn run_live_scan(inputs: &Inputs) -> Result<PlaylistSidebarScan, String> {
     previous_sidebar_crop: None,
     motion_policy: MotionDetectionPolicy::default(),
   };
-  let mut scan = scan_sidebar_with_observer(
-    &mut observer,
-    ScanOptions {
-      // NOTICE: NetEase playlist listing no longer has a page completion
-      // model. This shared `auv-view::ScanOptions` field remains for other
-      // scan loops, but this crate's collection policy intentionally ignores
-      // it and stops at section landmarks or scroll boundaries.
-      max_pages: 0,
-      max_scrolls: inputs.max_scrolls,
-    },
-    inputs.category,
-    inputs.scroll_amount,
-    inputs.scroll_settle_ms,
-  );
+  let options = ScanOptions {
+    // NOTICE: NetEase playlist listing no longer has a page completion
+    // model. This shared `auv-view::ScanOptions` field remains for other
+    // scan loops, but this crate's collection policy intentionally ignores
+    // it and stops at section landmarks or scroll boundaries.
+    max_pages: 0,
+    max_scrolls: inputs.max_scrolls,
+  };
+  let mut scan = match query {
+    Some(query) => scan_sidebar_with_observer_until_query(
+      &mut observer,
+      options,
+      inputs.category,
+      inputs.scroll_amount,
+      inputs.scroll_settle_ms,
+      query,
+    ),
+    None => scan_sidebar_with_observer(
+      &mut observer,
+      options,
+      inputs.category,
+      inputs.scroll_amount,
+      inputs.scroll_settle_ms,
+    ),
+  };
   scan.diagnostics.extend(pre_scan_diagnostics);
   scan.known_limits.extend(pre_scan_known_limits);
   scan.diagnostics.extend(observer.finish_artifacts());
@@ -613,6 +648,14 @@ impl SidebarScanObserver for LiveSidebarObserver {
     observation.incoming_scroll_delivery_path = incoming_scroll_delivery_path;
     Ok(observation)
   }
+
+  fn scroll_down_for_query_recovery(&mut self) -> Result<(), ParserDiagnostic> {
+    self.scroll_by_with_policy(
+      -self.scroll_amount,
+      std::time::Duration::from_millis(self.scroll_settle_ms),
+      InputPolicy::ForegroundPreferred,
+    )
+  }
 }
 
 #[cfg(target_os = "macos")]
@@ -647,6 +690,15 @@ impl LiveSidebarObserver {
     vertical_delta: f64,
     settle: std::time::Duration,
   ) -> Result<(), ParserDiagnostic> {
+    self.scroll_by_with_policy(vertical_delta, settle, InputPolicy::BackgroundPreferred)
+  }
+
+  fn scroll_by_with_policy(
+    &mut self,
+    vertical_delta: f64,
+    settle: std::time::Duration,
+    policy: InputPolicy,
+  ) -> Result<(), ParserDiagnostic> {
     let anchor = self.scroll_anchor();
     let result = self
       .session
@@ -656,7 +708,7 @@ impl LiveSidebarObserver {
         WindowPoint::new(anchor.x, anchor.y),
         Scroll::new(0.0, vertical_delta),
         ScrollOptions {
-          policy: InputPolicy::BackgroundPreferred,
+          policy,
           settle,
           ..ScrollOptions::default()
         },

--- a/crates/auv-netease-music/src/view_parsers/sidebar/scan.rs
+++ b/crates/auv-netease-music/src/view_parsers/sidebar/scan.rs
@@ -9,7 +9,32 @@ pub(crate) fn scan_sidebar_with_observer(
 ) -> PlaylistSidebarScan {
   let top_seek = scroll_to_top_by_motion(observer, top_seek_scroll_budget(options.max_scrolls));
   observer.reset_collection_phase();
-  let loop_outcome = scan_with_collection_policy(observer, options, category);
+  let loop_outcome = scan_with_collection_policy_impl(observer, options, category, None);
+  finish_sidebar_scan(top_seek, loop_outcome, scroll_amount, scroll_settle_ms)
+}
+
+pub(crate) fn scan_sidebar_with_observer_until_query(
+  observer: &mut impl SidebarScanObserver,
+  options: ScanOptions,
+  category: PlaylistCategory,
+  scroll_amount: f64,
+  scroll_settle_ms: u64,
+  query: &str,
+) -> PlaylistSidebarScan {
+  let top_seek = scroll_to_top_by_motion(observer, top_seek_scroll_budget(options.max_scrolls));
+  observer.reset_collection_phase();
+  let normalized_query = normalize_identity(query);
+  let loop_outcome =
+    scan_with_collection_policy_impl(observer, options, category, Some(normalized_query.as_str()));
+  finish_sidebar_scan(top_seek, loop_outcome, scroll_amount, scroll_settle_ms)
+}
+
+fn finish_sidebar_scan(
+  top_seek: TopSeekOutcome,
+  loop_outcome: CollectionLoopOutcome,
+  scroll_amount: f64,
+  scroll_settle_ms: u64,
+) -> PlaylistSidebarScan {
   let interaction_events = build_standalone_interaction_events(
     &loop_outcome.observations,
     scroll_amount,
@@ -113,6 +138,10 @@ pub(crate) trait SidebarScanObserver:
   ) -> Result<SidebarViewportObservation, ParserDiagnostic> {
     self.observe(observation_index)
   }
+
+  fn scroll_down_for_query_recovery(&mut self) -> Result<(), ParserDiagnostic> {
+    self.scroll_down()
+  }
 }
 
 pub(crate) fn scroll_to_top_by_motion(
@@ -198,10 +227,11 @@ pub(crate) struct CollectionLoopOutcome {
   stop_reason: Option<String>,
 }
 
-pub(crate) fn scan_with_collection_policy(
-  observer: &mut impl ViewObserver<Observation = SidebarViewportObservation>,
+fn scan_with_collection_policy_impl(
+  observer: &mut impl SidebarScanObserver,
   options: ScanOptions,
   category: PlaylistCategory,
+  normalized_query: Option<&str>,
 ) -> CollectionLoopOutcome {
   let mut policy = CollectionPolicy::new(category);
   let mut observations = Vec::new();
@@ -212,6 +242,7 @@ pub(crate) fn scan_with_collection_policy(
   let mut consecutive_no_new_semantic_candidates_after_scroll = 0usize;
   let mut consecutive_no_motion_after_scroll = 0usize;
   let mut observed_scroll_motion_after_successful_input = false;
+  let mut query_seen = normalized_query.is_none_or(str::is_empty);
   let mut scrolls = 0;
   let mut stop_reason = None;
 
@@ -231,6 +262,11 @@ pub(crate) fn scan_with_collection_policy(
     previous_fingerprint = Some(fingerprint);
     let ax_scrollbar_boundary = observation.ax_scrollbar_boundary;
     let observation = policy.apply(observation);
+    if !query_seen {
+      if let Some(query) = normalized_query {
+        query_seen = observation_contains_query(&observation, query);
+      }
+    }
     let introduced_new_semantic_candidates =
       record_page_semantic_candidates(&observation, &mut seen_semantic_candidates);
     let reached_stop_landmark = policy.reached_stop_landmark();
@@ -273,7 +309,9 @@ pub(crate) fn scan_with_collection_policy(
     // backward-compatible loop-boundary signal, but they are no longer the only
     // scroll stop detector. Motion evidence covers the real NetEase case where
     // OCR text drifts enough that exact fingerprints do not repeat at bottom.
-    if repeated_fingerprint {
+    if repeated_fingerprint
+      && (query_seen || ax_scrollbar_boundary == Some(SidebarScrollbarBoundary::Bottom))
+    {
       stop_reason = Some(repeated_fingerprint_stop_reason(ax_scrollbar_boundary).to_string());
       break;
     }
@@ -283,7 +321,9 @@ pub(crate) fn scan_with_collection_policy(
     // motion alone because it tracks the actual playlist/sidebar IR that this
     // crate exports. It remains heuristic until a future slice corroborates it
     // with scroll-bar, AX scroll-state, or provider-reported bounds.
-    if consecutive_no_new_semantic_candidates_after_scroll >= 2 {
+    if consecutive_no_new_semantic_candidates_after_scroll >= 2
+      && (query_seen || ax_scrollbar_boundary == Some(SidebarScrollbarBoundary::Bottom))
+    {
       if let Some(reason) = heuristic_stop_reason_with_ax_corroboration(
         "scroll_no_new_semantic_candidates_after_input",
         ax_scrollbar_boundary,
@@ -298,7 +338,9 @@ pub(crate) fn scan_with_collection_policy(
     // least one prior post-scroll motion observation. This prevents launch
     // state, failed/noop input, or already-stuck captures from being promoted
     // into a false bottom boundary.
-    if consecutive_no_motion_after_scroll >= motion_stop_threshold(ax_scrollbar_boundary) {
+    if consecutive_no_motion_after_scroll >= motion_stop_threshold(ax_scrollbar_boundary)
+      && (query_seen || ax_scrollbar_boundary == Some(SidebarScrollbarBoundary::Bottom))
+    {
       if let Some(reason) = heuristic_stop_reason_with_ax_corroboration(
         "scroll_no_motion_after_input",
         ax_scrollbar_boundary,
@@ -313,7 +355,15 @@ pub(crate) fn scan_with_collection_policy(
       break;
     }
 
-    if let Err(diagnostic) = observer.scroll_down() {
+    let use_query_recovery_scroll = !query_seen
+      && (consecutive_no_motion_after_scroll > 0
+        || consecutive_no_new_semantic_candidates_after_scroll >= 2);
+    let scroll_result = if use_query_recovery_scroll {
+      observer.scroll_down_for_query_recovery()
+    } else {
+      observer.scroll_down()
+    };
+    if let Err(diagnostic) = scroll_result {
       diagnostics.push(diagnostic);
       break;
     }
@@ -332,6 +382,20 @@ pub(crate) fn scan_with_collection_policy(
     known_limits,
     stop_reason,
   }
+}
+
+fn observation_contains_query(
+  observation: &SidebarViewportObservation,
+  normalized_query: &str,
+) -> bool {
+  observation.candidates.iter().any(|candidate| {
+    candidate.kind == SidebarCandidateKind::PlaylistItem
+      && candidate.label.as_deref().is_some_and(|label| {
+        let normalized_label = normalize_identity(label);
+        normalized_label.contains(normalized_query)
+          || normalized_query.contains(normalized_label.as_str())
+      })
+  })
 }
 
 pub(crate) fn successful_scroll_delivery_path(path: Option<&str>) -> bool {

--- a/crates/auv-netease-music/src/view_parsers/sidebar/tests.rs
+++ b/crates/auv-netease-music/src/view_parsers/sidebar/tests.rs
@@ -702,6 +702,82 @@ fn scan_loop_stops_after_two_scrolls_with_no_new_semantic_candidates() {
 }
 
 #[test]
+fn query_scan_continues_past_no_new_candidates_until_query_is_visible() {
+  let mut first = parse_sidebar_viewport(
+    0,
+    ViewBounds::new(0.0, 0.0, 240.0, 400.0),
+    &fake_recognition(vec![
+      ("创建的歌单", 8.0, 42.0, 110.0, 20.0),
+      ("Coding BGM", 32.0, 74.0, 120.0, 20.0),
+    ]),
+  );
+  first.viewport_fingerprint = "page-a".to_string();
+  let mut second = parse_sidebar_viewport(
+    1,
+    ViewBounds::new(0.0, 0.0, 240.0, 400.0),
+    &fake_recognition(vec![
+      ("创建的歌单", 8.0, 42.0, 110.0, 20.0),
+      ("Coding BGM", 32.0, 106.0, 120.0, 20.0),
+    ]),
+  );
+  second.viewport_fingerprint = "page-b".to_string();
+  second.incoming_scroll_delivery_path = Some("window_targeted_wheel".to_string());
+  let mut third = parse_sidebar_viewport(
+    2,
+    ViewBounds::new(0.0, 0.0, 240.0, 400.0),
+    &fake_recognition(vec![
+      ("创建的歌单", 8.0, 42.0, 110.0, 20.0),
+      ("Coding BGM", 32.0, 138.0, 120.0, 20.0),
+    ]),
+  );
+  third.viewport_fingerprint = "page-c".to_string();
+  third.incoming_scroll_delivery_path = Some("window_targeted_wheel".to_string());
+  let mut fourth = parse_sidebar_viewport(
+    3,
+    ViewBounds::new(0.0, 0.0, 240.0, 400.0),
+    &fake_recognition(vec![
+      ("创建的歌单", 8.0, 42.0, 110.0, 20.0),
+      ("我喜欢的风格 | Trance Vol.2", 32.0, 170.0, 168.0, 20.0),
+    ]),
+  );
+  fourth.viewport_fingerprint = "page-d".to_string();
+  fourth.incoming_scroll_delivery_path = Some("window_targeted_wheel".to_string());
+  let mut observer = FakeSidebarObserver::new(vec![first, second, third, fourth]);
+
+  let scan = scan_sidebar_with_observer_until_query(
+    &mut observer,
+    ScanOptions {
+      max_pages: 10,
+      max_scrolls: 10,
+    },
+    PlaylistCategory::All,
+    300.0,
+    DEFAULT_SCROLL_SETTLE_MS,
+    "Trance Vol.2",
+  );
+
+  assert_eq!(scan.observations.len(), 4);
+  assert_eq!(scan.boundary.bottom, BoundaryConfidence::Unknown);
+  assert!(
+    !scan
+      .interaction_events
+      .iter()
+      .any(|event| event.kind == InteractionEventKind::StopDecision
+        && event.note.as_deref() == Some("scroll_no_new_semantic_candidates_after_input"))
+  );
+  assert_eq!(
+    scan
+      .projection
+      .sections
+      .iter()
+      .flat_map(|section| section.items.iter())
+      .find(|item| item.label.contains("Trance Vol.2"))
+      .map(|item| item.label.as_str()),
+    Some("我喜欢的风格 | Trance Vol.2")
+  );
+}
+
+#[test]
 fn scan_loop_ignores_scroll_no_new_semantic_candidates_from_noop_delivery() {
   let mut first = parse_sidebar_viewport(
     0,

--- a/docs/ai/references/2026-06-03-netease-cloud-music-domain-api-design.md
+++ b/docs/ai/references/2026-06-03-netease-cloud-music-domain-api-design.md
@@ -44,11 +44,7 @@ pub struct NeteaseCloudMusic {
 }
 
 pub struct NeteaseCloudMusicObservation {
-  pub screen: ScreenState,
-  pub sidebar: SidebarState,
-  pub player: PlayerState,
-  pub diagnostics: Vec<ParserDiagnostic>,
-  pub artifacts: Vec<ArtifactRef>,
+  // App-specific read views derived from the same observation/reconstruction.
 }
 ```
 
@@ -68,18 +64,21 @@ if observation.sidebar.exists() {
 ```
 
 `NeteaseCloudMusicObservation` is one immutable observation of the app window at
-a point in time. It may be backed by capture, OCR, AX, reconstruction, and
-domain classifiers, but callers should not need to understand those internals
-for common predicates such as `screen.is_default()` or `sidebar.exists()`.
+a point in time. It is not a general evidence bag. It is an app-specific read
+model derived from capture, OCR, AX, reconstruction, and domain projection data.
+Callers should not need to understand those internals for common predicates such
+as `screen().is_default()` or `sidebar().exists()`.
 
 ## Naming
 
 Use Rust module names for boundaries and state/action names for types:
 
 - `NeteaseCloudMusic`: executable app client/session.
-- `NeteaseCloudMusicObservation`: read-only observation result.
+- `NeteaseCloudMusicObservation`: read-only app view over one observation.
 - `screen`, `sidebar`, `player`: Rust modules.
-- `ScreenState`, `SidebarState`, `PlayerState`: pure state records.
+- `ScreenView`, `SidebarView`, `PlayerView`: domain read facades.
+- `ScreenState`, `SidebarState`, `PlayerState`: compact state records used by
+  those facades.
 
 Do not name public types `ScreenModule` or `SidebarModule`. If action surfaces
 become large enough to split from `NeteaseCloudMusic`, prefer handle names such
@@ -94,17 +93,23 @@ The API should make IO and UI mutation visible in method names and return types.
 Pure observation reads:
 
 ```rust
-observation.screen.is_default();
-observation.screen.is_playing_song_detail();
-observation.sidebar.exists();
-observation.player.exists();
+observation.screen().is_default();
+observation.screen().is_playing_song_detail();
+observation.sidebar().exists();
+observation.sidebar().find_playlist("daily");
+observation.player().exists();
 ```
 
 Fresh observation:
 
 ```rust
 let observation = app.observe()?;
+let refreshed = app.refresh()?;
 ```
+
+`observe()` may reuse a valid cached observation within the current app/window
+generation. `refresh()` is a shortcut for forcing a new capture/OCR/reconstruct
+pass.
 
 Actions:
 
@@ -119,6 +124,46 @@ Action methods must use `auv-driver` / `auv-driver-macos` for input delivery and
 return typed operation evidence. They should not return only `bool`, because
 callers need to inspect delivery path, fallback reason, verification result, and
 evidence artifacts.
+
+## Reconstruction And Cache Reuse
+
+`NeteaseCloudMusicObservation` should be immutable. A new capture/OCR/AX pass
+creates a new observation and, when needed, a new reconstruction. Existing
+observations remain useful as historical evidence but must not be treated as the
+current UI after an action mutates the app.
+
+The app client may cache the latest observation to avoid repeated OCR and
+reconstruction inside one orchestration step. Cache policy should be explicit:
+
+```rust
+pub struct ObserveOptions {
+  pub reuse: ObserveReuseMode,
+}
+
+pub enum ObserveReuseMode {
+  ReuseValidCache,
+  ForceRefresh,
+}
+```
+
+Default behavior may use `ReuseValidCache`. Mutating actions such as
+`restore_default_screen()`, `go_to_recommendation()`, and
+`play_daily_recommended()` must invalidate the cached observation unless they
+return a fresh post-action observation as part of their result.
+
+`SidebarView` should be derived from the reconstructed/projection data rather
+than re-running a parallel OCR heuristic:
+
+```text
+ViewObservation
+  -> ViewReconstruction
+  -> PlaylistSidebarProjection
+  -> SidebarView::exists / find_playlist / created_playlists
+```
+
+This keeps CLI, MCP, and inspect debugging aligned on one source of truth.
+`inspect` can render the underlying reconstruction and artifacts; the domain API
+can expose a smaller NetEase-specific read facade over that same data.
 
 ## Recording Boundary
 
@@ -165,6 +210,8 @@ Scope:
 - introduce `NeteaseCloudMusic` and `NeteaseCloudMusicObservation`
 - introduce `ScreenState::{Default, PlayingSongDetail, BlockingModal, Unknown}`
 - expose pure predicates on `ScreenState`
+- define `ObserveReuseMode::{ReuseValidCache, ForceRefresh}` and cache
+  invalidation rules for mutating actions
 - adapt the existing default-screen/song-detail restore detection logic to
   consume the classifier
 - preserve existing behavior and tests


### PR DESCRIPTION
## Summary
- Add explicit playlist candidate flow: `playlist ls <query> --json` now exposes `matches[].candidate_id`, writes a scan cache, and query scans continue until the requested playlist is visible or the sidebar boundary is reached.
- Add `playlist play --candidate-id <id>` to resolve from the cached scan, select the exact playlist, click Play All, and verify the bottom playback control state.
- Include related NetEase Music command surface improvements for playlist select/playback status, background-preferred input paths, bottom-player-safe sidebar selection, and help text documenting the recommended `ls` -> `play --candidate-id` flow.

## Verification
- `cargo fmt --check`
- `cargo check -p auv-netease-music`
- `cargo test -p auv-netease-music`
- `git diff --check`
- Live check: `playlist ls "Trance vol.2" --json-out /tmp/auv-netease-candidate-contract/ls.json --artifact-dir /tmp/auv-netease-candidate-contract` produced one match with `candidate_id=obs4.candidate.ocr17._______trancevol_2`.
- Live check: `playlist play --candidate-id obs4.candidate.ocr17._______trancevol_2 --artifact-dir /tmp/auv-netease-candidate-contract` passed select verification and play verification with `control_state=pause_visible`.