### PR TITLE
feat(auv-game-balatro): now plays Balatro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "annotate-snippets"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,6 +159,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,7 +224,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 1.0.4",
  "concurrent-queue",
  "futures-io",
  "futures-lite",
@@ -243,7 +258,7 @@ dependencies = [
  "async-signal",
  "async-task",
  "blocking",
- "cfg-if",
+ "cfg-if 1.0.4",
  "event-listener",
  "futures-lite",
  "rustix 1.1.4",
@@ -269,7 +284,7 @@ dependencies = [
  "async-io",
  "async-lock",
  "atomic-waker",
- "cfg-if",
+ "cfg-if 1.0.4",
  "futures-core",
  "futures-io",
  "rustix 1.1.4",
@@ -303,9 +318,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "auv-cli"
@@ -320,7 +335,7 @@ dependencies = [
  "libc",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "reqwest",
+ "reqwest 0.12.28",
  "semver",
  "serde",
  "serde_json",
@@ -352,6 +367,25 @@ dependencies = [
  "swift-bridge",
  "swift-bridge-build",
  "xcap",
+]
+
+[[package]]
+name = "auv-game-balatro"
+version = "0.0.1"
+dependencies = [
+ "auv-driver",
+ "auv-driver-macos",
+ "auv-inference-common",
+ "auv-inference-ort",
+ "auv-inference-ultralytics",
+ "auv-view",
+ "clap",
+ "hf-hub",
+ "image",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -488,6 +522,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -621,12 +677,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if 1.0.4",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -649,6 +728,42 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "piper",
+]
+
+[[package]]
+name = "bon"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47dbe92550676ee653353c310dfb9cf6ba17ee70396e1f7cf0a2020ad49b2fe"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
+dependencies = [
+ "darling",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -734,6 +849,12 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
@@ -743,6 +864,30 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link 0.2.1",
+]
 
 [[package]]
 name = "clang-sys"
@@ -796,6 +941,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -814,6 +968,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -842,9 +1006,36 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "const-str"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18f12cc9948ed9604230cdddc7c86e270f9401ccbe3c2e98a4378c5e7632212f"
+
+[[package]]
+name = "const_panic"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e262cdaac42494e3ae34c43969f9cdeb7da178bdb4b66fa6a1ea2edb4c8ae652"
+dependencies = [
+ "typewit",
+]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "convert_case"
@@ -866,6 +1057,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -881,10 +1082,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "countio"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9702aee5d1d744c01d82f6915644f950f898e014903385464c773b96fefdecb"
+dependencies = [
+ "futures-io",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -910,7 +1129,16 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -978,12 +1206,92 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "ctor"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "424e0138278faeb2b401f174ad17e715c829512d74f3d1e81eb43365c2e0590e"
+dependencies = [
+ "ctor-proc-macro",
+ "dtor",
+]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
+
+[[package]]
 name = "cudarc"
 version = "0.19.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cea5f10a99e025c1b44ae2354c2d8326b25ddbd0baf76bde8e55cfd4018a2cc"
 dependencies = [
  "libloading 0.9.0",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1003,13 +1311,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1121,10 +1449,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "404d02eeb088a82cfd873006cb713fe411306c7d182c344905e101fb1167d301"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if 1.0.4",
+]
 
 [[package]]
 name = "endi"
@@ -1232,7 +1590,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12dd43e5011e8d8411a3215a0d57a2ec5c68282fb90eb5d7221fab0113442174"
 dependencies = [
  "bytemuck",
- "cfg-if",
+ "cfg-if 1.0.4",
  "document-features",
  "image",
  "num-traits",
@@ -1303,6 +1661,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1337,6 +1701,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1464,6 +1834,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "gearhash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8cf82cf76cd16485e56295a1377c775ce708c9f1a0be6b029076d60a245d213"
+dependencies = [
+ "cfg-if 0.1.10",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1479,10 +1858,10 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -1492,7 +1871,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "js-sys",
  "libc",
  "r-efi 5.3.0",
@@ -1506,11 +1885,14 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1521,6 +1903,26 @@ checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
 dependencies = [
  "color_quant",
  "weezl",
+]
+
+[[package]]
+name = "git-version"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad568aa3db0fcbc81f2f116137f263d7304f512a1209b35b85150d3ef88ad19"
+dependencies = [
+ "git-version-macro",
+]
+
+[[package]]
+name = "git-version-macro"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1658,12 +2060,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "crunchy",
  "num-traits",
  "zerocopy",
@@ -1690,6 +2124,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heapify"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0049b265b7f201ca9ab25475b22b47fe444060126a51abe00f77d986fc5cc52e"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1706,6 +2146,54 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hf-hub"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f89305dc8fe34e165eaf0eb12b6e294e12381d9df9a431bcc52a5809bab4319"
+dependencies = [
+ "base64",
+ "bon",
+ "bytes",
+ "futures",
+ "globset",
+ "hf-xet",
+ "hyper",
+ "pathdiff",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-retry",
+ "tokio-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hf-xet"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "430b33fa84f92796d4d263070b6c0d3ca219df7b9a0e1853ee431029b1612bcd"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "more-asserts",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+ "xet-client",
+ "xet-core-structures",
+ "xet-data",
+ "xet-runtime",
+]
 
 [[package]]
 name = "hmac-sha256"
@@ -1759,6 +2247,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1768,6 +2271,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1813,9 +2317,35 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1907,6 +2437,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1974,7 +2510,7 @@ dependencies = [
  "itertools 0.14.0",
  "nalgebra",
  "num",
- "rand",
+ "rand 0.9.4",
  "rand_distr",
  "rayon",
  "rustdct",
@@ -2004,7 +2540,7 @@ version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -2058,6 +2594,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if 1.0.4",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2082,7 +2667,7 @@ version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "futures-util",
  "once_cell",
  "wasm-bindgen",
@@ -2125,6 +2710,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
+name = "konst"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f660d5f887e3562f9ab6f4a14988795b694099d66b4f5dedc02d197ba9becb1d"
+dependencies = [
+ "const_panic",
+ "konst_proc_macros",
+ "typewit",
+]
+
+[[package]]
+name = "konst_proc_macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e037a2e1d8d5fdbd49b16a4ea09d5d6401c1f29eca5ff29d03d3824dba16256a"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2156,9 +2758,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libfuzzer-sys"
-version = "0.4.13"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
+checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
 dependencies = [
  "arbitrary",
  "cc",
@@ -2170,7 +2772,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "windows-link 0.2.1",
 ]
 
@@ -2180,7 +2782,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "windows-link 0.2.1",
 ]
 
@@ -2192,14 +2794,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "bitflags 2.11.1",
  "libc",
  "plain",
- "redox_syscall 0.7.5",
+ "redox_syscall 0.8.1",
 ]
 
 [[package]]
@@ -2292,9 +2894,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "loop9"
@@ -2321,10 +2923,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lz4_flex"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "lzma-rust2"
 version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e20f57f9918e5bd7bc58c22cdd70a6afc7375d4dd9683af5f2b34bd3d2bba619"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "matchit"
@@ -2348,15 +2968,15 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "rayon",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
@@ -2390,6 +3010,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minifb"
@@ -2443,9 +3073,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "more-asserts"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 
 [[package]]
 name = "moxcms"
@@ -2536,7 +3172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
 dependencies = [
  "bitflags 1.3.2",
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "memoffset 0.6.5",
 ]
@@ -2548,7 +3184,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
  "bitflags 2.11.1",
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
 ]
 
@@ -2587,6 +3223,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "num"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2617,6 +3271,12 @@ checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -2899,6 +3559,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-io-surface"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2944,6 +3614,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2956,13 +3635,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oneshot"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
+
+[[package]]
 name = "openssl"
 version = "0.10.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
 dependencies = [
  "bitflags 2.11.1",
- "cfg-if",
+ "cfg-if 1.0.4",
  "foreign-types",
  "libc",
  "once_cell",
@@ -3054,6 +3739,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "owned_ttf_parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3084,7 +3778,7 @@ version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "redox_syscall 0.5.18",
  "smallvec",
@@ -3102,6 +3796,12 @@ name = "pastey"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pem-rfc7468"
@@ -3126,6 +3826,26 @@ checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
 dependencies = [
  "memchr",
  "ucd-trie",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3204,7 +3924,7 @@ version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
@@ -3235,6 +3955,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -3366,10 +4092,11 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash 2.1.2",
  "rustls",
@@ -3423,7 +4150,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3433,7 +4171,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3446,13 +4184,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_distr"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -3469,7 +4213,7 @@ dependencies = [
  "av1-grain",
  "bitstream-io",
  "built",
- "cfg-if",
+ "cfg-if 1.0.4",
  "interpolate_name",
  "itertools 0.14.0",
  "libc",
@@ -3482,7 +4226,7 @@ dependencies = [
  "num-traits",
  "paste",
  "profiling",
- "rand",
+ "rand 0.9.4",
  "rand_chacha",
  "simd_helpers",
  "thiserror 2.0.18",
@@ -3538,6 +4282,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redb"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba239c1c1693315d3cc0e601db3b3965543afbf48c41730fdca2f069f510f4a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3548,9 +4301,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.5"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
+checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -3636,6 +4389,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bc3f1384cffa4f274dad2d4ddd73aed32fed8f786d96c6be8aa4e5fd3c3b58"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest 0.13.4",
+ "thiserror 2.0.18",
+ "tower-service",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3648,7 +4460,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
- "cfg-if",
+ "cfg-if 1.0.4",
  "getrandom 0.2.17",
  "libc",
  "untrusted",
@@ -3666,6 +4478,15 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustdct"
@@ -3722,6 +4543,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -3729,6 +4551,18 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -3742,11 +4576,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3765,6 +4627,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "safe-transmute"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944826ff8fa8093089aba3acb4ef44b9446a99a16f3bf4e74af3f77d340ab7d"
+
+[[package]]
 name = "safe_arch"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3780,6 +4648,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f7caad094bd561859bcd467734a720c3c1f5d1f338995351fefe2190c45efed"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -3821,7 +4698,7 @@ version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff61407fc75d4b0bbc93dc7e4d6c196439965fbef8e4a4f003a36095823eac0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "version-compare 0.1.1",
 ]
@@ -3833,7 +4710,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3887,9 +4764,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
@@ -3947,9 +4824,61 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
+ "cfg-if 1.0.4",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+ "sha2-asm",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "sha2-asm"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b845214d6175804686b2bd482bcffe96651bb2d1200742b712003504a2dac1ab"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "shellexpand"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
+dependencies = [
+ "bstr",
+ "dirs",
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -3988,6 +4917,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
 name = "simd_helpers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3995,6 +4934,12 @@ checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
 dependencies = [
  "quote",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -4034,6 +4979,22 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "statrs"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
+dependencies = [
+ "approx",
+ "num-traits",
+]
 
 [[package]]
 name = "steamlocate"
@@ -4113,6 +5074,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4152,6 +5119,41 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.62.2",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -4227,6 +5229,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if 1.0.4",
+]
+
+[[package]]
 name = "tiff"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4238,6 +5249,37 @@ dependencies = [
  "quick-error",
  "weezl",
  "zune-jpeg",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -4292,6 +5334,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-retry"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a129d95275ebf4c493ec53bf0f8cd95f5ac161bc4f381700809a54f595d4470"
+dependencies = [
+ "pin-project-lite",
+ "rand 0.10.1",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4311,6 +5364,19 @@ dependencies = [
  "log",
  "tokio",
  "tungstenite",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -4436,6 +5502,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4453,6 +5532,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -4488,16 +5610,28 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.9.4",
  "sha1",
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "typewit"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "214ca0b2191785cbc06209b9ca1861e048e39b5ba33574b3cedd58363d5bb5f6"
 
 [[package]]
 name = "ucd-trie"
@@ -4542,6 +5676,12 @@ dependencies = [
  "video-rs",
  "wide 1.4.0",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -4625,6 +5765,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf8-zero"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4648,6 +5794,7 @@ version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
+ "getrandom 0.4.2",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -4663,6 +5810,12 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -4701,6 +5854,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4714,6 +5877,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
 
 [[package]]
 name = "wasip2"
@@ -4734,12 +5906,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasite"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "once_cell",
  "rustversion",
  "serde",
@@ -4810,6 +5991,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -5030,6 +6224,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
+name = "whoami"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
+dependencies = [
+ "libc",
+ "libredox",
+ "objc2-system-configuration",
+ "wasite",
+ "web-sys",
+]
+
+[[package]]
 name = "wide"
 version = "0.7.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5072,6 +6279,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5083,11 +6299,23 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
+ "windows-collections 0.2.0",
+ "windows-core 0.61.2",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -5096,7 +6324,16 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -5108,8 +6345,21 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.1.3",
- "windows-result",
- "windows-strings",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -5118,9 +6368,20 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -5163,8 +6424,29 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -5177,12 +6459,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5261,6 +6561,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5383,7 +6692,7 @@ version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "windows-sys 0.61.2",
 ]
 
@@ -5519,13 +6828,13 @@ dependencies = [
  "objc2-foundation",
  "percent-encoding",
  "pipewire",
- "rand",
+ "rand 0.9.4",
  "scopeguard",
  "serde",
  "thiserror 2.0.18",
  "url",
  "widestring",
- "windows",
+ "windows 0.61.3",
  "xcb",
  "zbus",
 ]
@@ -5546,6 +6855,153 @@ name = "xcursor"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b"
+
+[[package]]
+name = "xet-client"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e1e496dcbe6a09017acdfaf48e1a646735e7ff5b2a49e2c7e081cca77a59bc8"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64",
+ "bytes",
+ "clap",
+ "crc32fast",
+ "futures",
+ "http",
+ "hyper",
+ "lazy_static",
+ "more-asserts",
+ "rand 0.10.1",
+ "redb",
+ "reqwest 0.13.4",
+ "reqwest-middleware",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "statrs",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-retry",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+ "urlencoding",
+ "web-time",
+ "xet-core-structures",
+ "xet-runtime",
+]
+
+[[package]]
+name = "xet-core-structures"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb838aa8eb67d730af301584cf003caad407487606058292a6750711b603fbee"
+dependencies = [
+ "async-trait",
+ "base64",
+ "blake3",
+ "bytemuck",
+ "bytes",
+ "clap",
+ "countio",
+ "csv",
+ "futures",
+ "futures-util",
+ "getrandom 0.4.2",
+ "heapify",
+ "itertools 0.14.0",
+ "lazy_static",
+ "lz4_flex",
+ "more-asserts",
+ "rand 0.10.1",
+ "regex",
+ "safe-transmute",
+ "serde",
+ "static_assertions",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+ "web-time",
+ "xet-runtime",
+]
+
+[[package]]
+name = "xet-data"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67fd409bef621411a9d9013798540bb8036cb2678f03ab39af89a5e88034ed8c"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "clap",
+ "gearhash",
+ "http",
+ "itertools 0.14.0",
+ "lazy_static",
+ "more-asserts",
+ "rand 0.10.1",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "url",
+ "uuid",
+ "walkdir",
+ "xet-client",
+ "xet-core-structures",
+ "xet-runtime",
+]
+
+[[package]]
+name = "xet-runtime"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15d8f121c33866f7648b737abe70d0e2dd9c0af4ffdd7219207531d0283aa63d"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "colored",
+ "const-str",
+ "ctor",
+ "dirs",
+ "futures",
+ "git-version",
+ "humantime",
+ "konst",
+ "lazy_static",
+ "libc",
+ "more-asserts",
+ "oneshot",
+ "pin-project",
+ "rand 0.10.1",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "shellexpand",
+ "sysinfo",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+ "whoami",
+ "winapi",
+]
 
 [[package]]
 name = "xml-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   ".",
   "crates/auv-driver",
   "crates/auv-driver-macos",
+  "crates/auv-game-balatro",
   "crates/auv-inference-common",
   "crates/auv-inference-ort",
   "crates/auv-inference-ultralytics",

--- a/crates/auv-game-balatro/Cargo.toml
+++ b/crates/auv-game-balatro/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "auv-game-balatro"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+readme.workspace = true
+license.workspace = true
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[features]
+default = []
+card-corner-onnx = ["dep:auv-inference-ort"]
+
+[dependencies]
+auv-driver = { path = "../auv-driver" }
+auv-inference-common = { path = "../auv-inference-common" }
+auv-inference-ort = { path = "../auv-inference-ort", optional = true }
+auv-inference-ultralytics = { path = "../auv-inference-ultralytics" }
+auv-view = { path = "../auv-view" }
+clap = { version = "4.5", features = ["derive"] }
+hf-hub = { version = "1.0.0-rc.1", features = ["blocking", "rustls-tls"] }
+image.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sha2 = "0.10"
+thiserror.workspace = true
+
+[target.'cfg(target_os = "macos")'.dependencies]
+auv-driver-macos = { path = "../auv-driver-macos" }

--- a/crates/auv-game-balatro/README.md
+++ b/crates/auv-game-balatro/README.md
@@ -1,0 +1,672 @@
+# auv-game-balatro Live Probe Handoff
+
+Date: 2026-06-08
+
+This README records the live Balatro operations that were first validated with
+short Python probes in `proj-airi/game-playing-ai-balatro`, then should be
+migrated into reusable `auv-game-balatro` Rust CLI operations.
+
+The Python probes were temporary evidence-gathering tools. They should not
+become the long-term automation surface. The Rust migration should keep the
+current AUV seam:
+
+```text
+recognition / candidates
+  -> target resolution
+  -> auv-driver input
+  -> operation result / verification evidence / artifacts
+```
+
+`auv-overlay-macos` is not an input backend for this crate.
+
+## Current Rust Surface
+
+`auv-game-balatro` already has the object-oriented CLI shape:
+
+```bash
+auv-game-balatro game state
+auv-game-balatro game restart --verify
+auv-game-balatro game cash-out --verify
+auv-game-balatro cards ls
+auv-game-balatro cards read --slot hand:all
+auv-game-balatro cards clear --verify
+auv-game-balatro cards select --slots hand:0,hand:2
+auv-game-balatro cards play --slots hand:0,hand:2 --verify
+auv-game-balatro cards discard --slots hand:1,hand:3 --verify
+auv-game-balatro store status
+auv-game-balatro store ls
+auv-game-balatro store read --slot store:0
+auv-game-balatro store buy --slot store:0 --verify
+auv-game-balatro store next-round --verify
+auv-game-balatro consumables read --slot consumable:0
+auv-game-balatro consumables use --slot consumable:0 --verify
+auv-game-balatro jokers read --slot joker:0
+auv-game-balatro pack read --json
+auv-game-balatro pack choose --slot pack:1 --verify
+auv-game-balatro pack skip --verify
+auv-game-balatro blinds ls
+auv-game-balatro blinds select --slot blind:0 --verify
+auv-game-balatro blinds skip --verify
+```
+
+`LOG.md` records commands, stdout/stderr, parsed JSON, screenshots copied from
+operation outputs, and the natural-language decision for each step. `SKILL.md`
+records the current reusable play policy. The current policy is intentionally
+conservative: buy early jokers first, skip unread packs until hover OCR is
+available, play flushes when confidently read, play rank groups when present,
+and use up to two weak-hand discards per blind before falling back to high-card
+play.
+
+The remaining deferred mutating operations are:
+
+```bash
+auv-game-balatro store reroll --verify
+auv-game-balatro jokers sell --slot joker:0 --verify
+```
+
+Default Balatro observation uses Hugging Face cached assets instead of an
+owner-local checkout. The entities and UI ONNX models are resolved from
+`proj-airi/games-balatro-2024-yolo-entities-detection` and
+`proj-airi/games-balatro-2024-yolo-ui-detection`; class lists are resolved from
+the matching `proj-airi/games-balatro-2024-entities-detection` and
+`proj-airi/games-balatro-2024-ui-detection` dataset repositories. The optional
+card-corner ONNX classifier resolves from
+`proj-airi/games-balatro-2024-card-corner-classifier` when the
+`card-corner-onnx` feature loads that classifier. Explicit `--entities-model`,
+`--entities-classes`, `--ui-model`, `--ui-classes`, and `--card-corner-model`
+arguments remain the highest-priority override.
+
+`cards read` can optionally use the local Balatro deck atlas as a visual
+template fallback for rank glyphs. AUV does not redistribute this game asset.
+Run setup on a machine with a valid local Steam install to extract the atlas
+into AUV's local cache:
+
+```bash
+auv-game-balatro setup
+auv-game-balatro setup --check
+```
+
+If Balatro is installed outside the default Steam location, pass
+`--app <Balatro.app>` or `--love <Balatro.love>`. Runtime atlas lookup reads the
+setup cache only; there is no owner-local fallback path and no environment
+variable override.
+
+This slice implements the P0 store and pack operations except `store reroll`
+and `jokers sell`, which remain deferred mutating commands. `store read`,
+`jokers read`, `consumables read`, and `pack read` now use live hover OCR when
+they are pointed at the running game. Image-backed reads still report static
+observation evidence because they cannot move the pointer or create a tooltip.
+The current read path keeps raw OCR text and evidence artifacts first; structured
+name/effect parsing remains a read-quality follow-up.
+
+Pack operations are now a top-level namespace because an opened card pack is an
+active modal-like game surface, not simply a store row item. Current active
+pack choice support is intentionally limited to joker, tarot, planet, and
+spectral choices. Standard Pack playing-card choices are deferred because
+`poker_card_front` also appears on persistent hand/deck cards and needs a
+separate live fixture before it is safe to target.
+
+## Live Probe Commands
+
+The probes used `ScreenCapture`, `MultiYOLODetector`, `MouseController`, and
+`CardTooltipService` from the Python repository:
+
+```bash
+cd <game-playing-ai-balatro>
+PYTHONPATH=src pixi run python
+```
+
+The local Balatro window was detected as a visible display-region capture:
+
+```json
+{
+  "top": -1094,
+  "left": -751,
+  "width": 1646,
+  "height": 963
+}
+```
+
+The negative coordinates are expected with the current multi-display layout.
+Click delivery still worked when frame coordinates were projected through the
+capture region.
+
+### Arcana Pack Hover OCR
+
+The probe captured the open Arcana Pack, selected lower-row `tarot_card`
+detections, hovered each card, ran YOLO again to find `card_description`, and
+OCRed the description crops.
+
+Representative command:
+
+```bash
+PYTHONPATH=src pixi run python - <<'PY'
+from pathlib import Path
+import cv2
+from ai_balatro.core.screen_capture import ScreenCapture
+from ai_balatro.core.multi_yolo_detector import MultiYOLODetector
+from ai_balatro.ai.actions.mouse_controller import MouseController
+from ai_balatro.services.card_tooltip_service import CardTooltipService
+
+out = Path(".runs/balatro-arcana-pack-hover-choices")
+out.mkdir(parents=True, exist_ok=True)
+
+screen = ScreenCapture()
+mouse = MouseController(screen)
+multi = MultiYOLODetector()
+tooltip = CardTooltipService(
+    screen_capture=screen,
+    mouse_controller=mouse,
+    multi_detector=multi,
+)
+
+frame = screen.capture_once()
+entities, ui = multi.detect_combined(frame, confidence_threshold=0.2)
+tarots = sorted(
+    [
+        detection
+        for detection in entities
+        if detection.class_name == "tarot_card"
+        and detection.center[1] > frame.shape[0] * 0.48
+    ],
+    key=lambda detection: detection.center[0],
+)[:5]
+
+for index, card in enumerate(tarots):
+    screen_x, screen_y = tooltip._frame_to_screen_coordinates(
+        card.center[0],
+        card.center[1] - 20,
+        frame.shape,
+    )
+    mouse.smooth_move_to(screen_x, screen_y)
+    hover_frame = screen.capture_once()
+    cv2.imwrite(str(out / f"hover-{index:02d}.png"), hover_frame)
+    hover_entities, hover_ui = multi.detect_combined(
+        hover_frame,
+        confidence_threshold=0.2,
+    )
+    for description in [
+        detection
+        for detection in hover_entities + hover_ui
+        if detection.class_name in {"card_description", "poker_card_description"}
+    ]:
+        x1, y1, x2, y2 = map(int, description.bbox)
+        crop = hover_frame[y1:y2, x1:x2]
+        print(index, tooltip._ocr_description_crop(crop))
+PY
+```
+
+Observed OCR output:
+
+```text
+正义 - 增强1张选定卡牌成为玻璃牌
+命运之轮 - 有1/4几率给一张随机小丑牌添加版本
+恋人 - 增强1张选定卡牌成为万能牌
+皇后 - 增强2张选定卡牌成为倍率牌
+战车 - 增强1张选定卡牌成为钢铁牌
+```
+
+Artifacts:
+
+```text
+.runs/balatro-arcana-pack-hover-choices/hover-scan.json
+.runs/balatro-arcana-pack-hover-choices/initial-detections.png
+.runs/balatro-arcana-pack-hover-choices/hover-00-detections.png
+.runs/balatro-arcana-pack-hover-choices/hover-01-detections.png
+.runs/balatro-arcana-pack-hover-choices/hover-02-detections.png
+.runs/balatro-arcana-pack-hover-choices/hover-03-detections.png
+.runs/balatro-arcana-pack-hover-choices/hover-04-detections.png
+```
+
+### Arcana Pack Choose
+
+The probe selected Wheel of Fortune, then clicked a layout fallback confirm
+point below the selected card. After confirmation, `button_card_pack_skip`
+disappeared and the view returned to store context.
+
+Representative command:
+
+```bash
+PYTHONPATH=src pixi run python - <<'PY'
+from pathlib import Path
+import time
+from ai_balatro.core.screen_capture import ScreenCapture
+from ai_balatro.core.multi_yolo_detector import MultiYOLODetector
+from ai_balatro.ai.actions.mouse_controller import MouseController
+
+out = Path(".runs/balatro-arcana-wheel-choice-trial")
+out.mkdir(parents=True, exist_ok=True)
+
+screen = ScreenCapture()
+mouse = MouseController(screen)
+multi = MultiYOLODetector()
+
+frame = screen.capture_once()
+entities, ui = multi.detect_combined(frame, confidence_threshold=0.2)
+tarots = sorted(
+    [d for d in entities if d.class_name == "tarot_card" and d.center[1] > frame.shape[0] * 0.48],
+    key=lambda d: d.center[0],
+)[:5]
+wheel = tarots[1]
+region = screen.get_capture_region()
+
+mouse.click_at(region["left"] + wheel.center[0], region["top"] + wheel.center[1])
+time.sleep(1.0)
+
+fallback_x = region["left"] + wheel.center[0]
+fallback_y = region["top"] + int(frame.shape[0] * 0.82)
+mouse.click_at(fallback_x, fallback_y)
+time.sleep(1.4)
+PY
+```
+
+Artifacts:
+
+```text
+.runs/balatro-arcana-wheel-choice-trial/summary.json
+.runs/balatro-arcana-wheel-choice-trial/after-click-card-detections.png
+.runs/balatro-arcana-wheel-choice-trial/after-confirm-fallback-detections.png
+```
+
+Design note: pack choice confirmation needs both a YOLO `button_use` path and a
+recorded layout fallback. The fallback must report the clicked frame point,
+screen point, and post-click detections.
+
+### Store Item Hover and Buy
+
+The probe read store products by hovering card-like detections in the shop row,
+then selected the left joker and clicked the detected `button_purchase`.
+
+Representative command:
+
+```bash
+PYTHONPATH=src pixi run python - <<'PY'
+from ai_balatro.core.screen_capture import ScreenCapture
+from ai_balatro.core.multi_yolo_detector import MultiYOLODetector
+from ai_balatro.ai.actions.mouse_controller import MouseController
+
+screen = ScreenCapture()
+mouse = MouseController(screen)
+multi = MultiYOLODetector()
+region = screen.get_capture_region()
+
+frame = screen.capture_once()
+entities, ui = multi.detect_combined(frame, confidence_threshold=0.15)
+height, width = frame.shape[:2]
+products = sorted(
+    [
+        detection
+        for detection in entities
+        if detection.class_name in {"joker_card", "planet_card", "tarot_card", "spectral_card", "card_pack"}
+        and height * 0.25 < detection.center[1] < height * 0.70
+        and width * 0.35 < detection.center[0] < width * 0.80
+    ],
+    key=lambda detection: detection.center[0],
+)
+
+target = next((d for d in products if d.class_name == "joker_card"), products[0])
+mouse.click_at(region["left"] + target.center[0], region["top"] + target.center[1])
+
+selected = screen.capture_once()
+selected_entities, selected_ui = multi.detect_combined(selected, confidence_threshold=0.15)
+purchase = max(
+    [d for d in selected_ui if d.class_name == "button_purchase"],
+    key=lambda d: d.confidence,
+)
+mouse.click_at(region["left"] + purchase.center[0], region["top"] + purchase.center[1])
+PY
+```
+
+Observed OCR:
+
+```text
+store:0 joker_card - 致胜之拳
+store:1 planet_card - 木星, 等级1, 升级同花, +2倍率, +15筹码
+```
+
+Artifacts:
+
+```text
+.runs/balatro-store-item-buy-trial/summary.json
+.runs/balatro-store-item-buy-trial/hover-00-detections.png
+.runs/balatro-store-item-buy-trial/hover-01-detections.png
+.runs/balatro-store-item-buy-trial/after-purchase-detections.png
+```
+
+Observed verification:
+
+```text
+cash: $9 -> $4
+joker slots: 1/5 -> 2/5
+```
+
+### Planet Buy and Use
+
+The probe bought Jupiter from the store, then clicked the held consumable and
+clicked `button_use`.
+
+Representative command:
+
+```bash
+PYTHONPATH=src pixi run python - <<'PY'
+from ai_balatro.core.screen_capture import ScreenCapture
+from ai_balatro.core.multi_yolo_detector import MultiYOLODetector
+from ai_balatro.ai.actions.mouse_controller import MouseController
+
+screen = ScreenCapture()
+mouse = MouseController(screen)
+multi = MultiYOLODetector()
+region = screen.get_capture_region()
+
+frame = screen.capture_once()
+entities, ui = multi.detect_combined(frame, confidence_threshold=0.15)
+planet = max(
+    [d for d in entities if d.class_name == "planet_card" and 300 < d.center[1] < 650],
+    key=lambda d: d.confidence,
+)
+mouse.click_at(region["left"] + planet.center[0], region["top"] + planet.center[1])
+
+selected = screen.capture_once()
+_, selected_ui = multi.detect_combined(selected, confidence_threshold=0.15)
+purchase = max([d for d in selected_ui if d.class_name == "button_purchase"], key=lambda d: d.confidence)
+mouse.click_at(region["left"] + purchase.center[0], region["top"] + purchase.center[1])
+
+held = screen.capture_once()
+held_entities, _ = multi.detect_combined(held, confidence_threshold=0.15)
+held_planet = max(
+    [d for d in held_entities if d.class_name == "planet_card" and d.center[0] > held.shape[1] * 0.65],
+    key=lambda d: d.confidence,
+)
+mouse.click_at(region["left"] + held_planet.center[0], region["top"] + held_planet.center[1])
+
+selected = screen.capture_once()
+_, selected_ui = multi.detect_combined(selected, confidence_threshold=0.15)
+use = max([d for d in selected_ui if d.class_name == "button_use"], key=lambda d: d.confidence)
+mouse.click_at(region["left"] + use.center[0], region["top"] + use.center[1])
+PY
+```
+
+Artifacts:
+
+```text
+.runs/balatro-buy-jupiter-trial/summary.json
+.runs/balatro-buy-jupiter-trial/after-purchase-detections.png
+.runs/balatro-use-jupiter-trial/summary.json
+.runs/balatro-use-jupiter-trial/after-use-detections.png
+```
+
+Observed verification:
+
+```text
+cash: $4 -> $1
+held consumables: 0/2 -> 1/2 -> 0/2 after use
+flush display: 同花 等级2
+score parameters after use: 50 chips, 6 mult
+```
+
+### Store Next Round Fallback and Blind Select
+
+The store next-round button was visible but YOLO missed
+`button_store_next_round` in one capture. A layout fallback clicked the known
+shop-panel button center, then verification observed blind-select controls.
+
+Representative command:
+
+```bash
+PYTHONPATH=src pixi run python - <<'PY'
+from ai_balatro.core.screen_capture import ScreenCapture
+from ai_balatro.core.multi_yolo_detector import MultiYOLODetector
+from ai_balatro.ai.actions.mouse_controller import MouseController
+
+screen = ScreenCapture()
+mouse = MouseController(screen)
+multi = MultiYOLODetector()
+region = screen.get_capture_region()
+
+# Layout fallback from the stable shop panel location.
+frame_x, frame_y = 594, 429
+mouse.click_at(region["left"] + frame_x, region["top"] + frame_y)
+
+after = screen.capture_once()
+entities, ui = multi.detect_combined(after, confidence_threshold=0.15)
+select = max([d for d in ui if d.class_name == "button_level_select"], key=lambda d: d.confidence)
+mouse.click_at(region["left"] + select.center[0], region["top"] + select.center[1])
+PY
+```
+
+Artifacts:
+
+```text
+.runs/balatro-next-round-layout-fallback-trial/summary.json
+.runs/balatro-next-round-layout-fallback-trial/after-click-detections.png
+.runs/balatro-select-next-blind-trial/summary.json
+.runs/balatro-select-next-blind-trial/after-select-detections.png
+```
+
+Observed verification:
+
+```text
+store -> blind_select -> playing
+button_level_select detected after next-round fallback
+joker cards detected after blind select: 4
+joker counter: 4/5
+```
+
+The last observation verified that the Riff-raff-like joker selected from the
+Buffoon Pack generated two common jokers when the next blind was selected.
+
+## Reusable Operation Lessons
+
+### Capture and Coordinates
+
+- Balatro can require display-region capture when window capture times out.
+- Capture frame coordinates must be projected through the current capture
+  region or window frame before input.
+- If the window moves or resizes between observation and action, old bboxes are
+  unsafe. Live operations should capture immediately before resolving targets.
+
+### Store Items
+
+- Store item detection should not use all `joker_card` / `planet_card`
+  detections blindly.
+- The top owned-joker row and right deck stack must be excluded.
+- Price detections and known shop-panel bands are useful evidence for store item
+  slots.
+- `store buy` should select the item first, then find `button_purchase` or
+  `button_use` in a fresh post-selection capture.
+
+### Packs
+
+- Packs and pack choices need hover OCR.
+- A selected pack choice may expose `button_use`, but the visible green confirm
+  button is not always stable in the UI model.
+- Pack choice operations need a fallback confirm target, with fallback reason
+  and post-click evidence in the result.
+
+### Consumables
+
+- Held tarot / planet / spectral cards should be modeled as `consumable:N`.
+- `consumables use` should click the held card, recapture, find `button_use`,
+  then click it.
+- Verification can start with state evidence and screenshots; semantic effects
+  such as `同花 等级2` should be added as OCR-backed evidence later.
+
+### Hover OCR
+
+- Joker, tarot, planet, pack, voucher, and uncertain poker cards should be
+  readable through hover plus OCR. Live joker, consumable, store-item, and pack
+  choice reads now use this path; static image reads still expose the unresolved
+  observation instead of inventing tooltip text.
+- The Rust slice uses existing AUV/macOS OCR and local recognizers only. It
+  must not guess owner-local Python repositories, import Python OCR packages,
+  or keep ad-hoc external OCR command hooks.
+- TODO(balatro-first-party-ocr): evaluate a first-party OCR tool or library
+  integration when hover text/card text quality becomes the approved slice.
+- The operation result should include raw text, OCR confidence when available,
+  tooltip bbox, object bbox, hover point, and artifact paths.
+
+### TODO: Live Hover Read Quality
+
+- Separate owned joker slots from shop joker-like detections in store phase.
+  Live `jokers read` can currently pick visible shop objects if they share the
+  same detection class and overlap the broad object filter.
+- Serialize hover-based read commands or add an explicit pointer/session guard.
+  Concurrent `store read`, `jokers read`, `consumables read`, or `pack read`
+  calls fight over the mouse and can produce empty detector results.
+- Normalize raw hover OCR into structured `name`, `edition`, `rarity`, `cost`,
+  and `effect` fields while still preserving raw OCR text and crop artifacts.
+- Tune per-object tooltip crop regions for owned jokers, held tarot/planet/
+  spectral consumables, store items, vouchers, and active pack choices.
+- Add live fixture or artifact-backed regression coverage for tarot, planet,
+  spectral, joker, store-item, pack-choice, and voucher reads.
+- Add voucher-specific read and purchase grounding. Vouchers matter
+  strategically, but their detection and buy target should not be folded into
+  generic store-card handling without evidence.
+- Keep score/current-round digit reading as a separate OCR-quality slice.
+  Recent live runs still showed score misreads, and that path should not be
+  conflated with tooltip OCR.
+
+### TODO: DebugPlus Ground Truth Adapter
+
+- Investigate the DebugPlus mod as a development-only ground-truth channel for
+  Balatro observations.
+- Add a tiny AUV DebugPlus command such as `auv_dump_state` that writes JSON
+  through `love.filesystem.write(...)` instead of changing gameplay state.
+- The dump should include current phase, dollars, hands/discards left, ante,
+  round, hand cards, jokers, consumables, shop items, pack choices, and each
+  card object's internal rank/suit/center/ability plus `T.x/T.y/T.w/T.h` when
+  available.
+- Use this only for benchmarks, labeled screenshots, OCR/CNN error-rate
+  reports, and coordinate-grounding investigations. It must not become the
+  normal CLI gameplay path, because AUV still needs to prove the unmodded
+  visual/input contract works.
+- Compare the DebugPlus dump against AUV observation output after every
+  screenshot to produce structured false-positive, false-negative, and
+  rank/suit mismatch reports.
+
+### Verification
+
+- Click success is not semantic success.
+- For cards, hand count is weak because Balatro refills the hand after play.
+  Current Rust verification accepts phase changes, hand-count changes, or
+  before/after hand fingerprint changes, and reports the evidence used.
+- `--no-cache` bypasses persisted card-reading reuse, but still keeps
+  current-frame visual fingerprints so action verification can prove state
+  changes.
+- For store buy, useful checks are cash delta, store item disappearance,
+  inventory count changes, and after-image evidence. Current Rust verification
+  reports store item, joker, consumable, and phase-change evidence.
+- For next-round and blind-select, phase transition and button-set changes are
+  useful checks.
+- Failed verification should return structured evidence instead of hiding the
+  action result.
+
+## Migration Target
+
+The next Rust slice should keep changes inside:
+
+```text
+crates/auv-game-balatro/src/cli.rs
+crates/auv-game-balatro/src/model.rs
+crates/auv-game-balatro/src/observation.rs
+crates/auv-game-balatro/tests/
+```
+
+Possible narrow order:
+
+1. Add shared object-slot parsing and selection helpers for `store:N`,
+   `joker:N`, `consumable:N`, and `pack:N`.
+2. Add `store buy --slot store:N --verify`.
+3. Add `consumables use --slot consumable:N --verify`.
+4. Harden live hover reads with owned/store zone separation, serialized pointer
+   use, and structured raw-text normalization.
+5. Add voucher-specific read/buy grounding and regression fixtures for
+   tarot/planet/spectral/joker/store/pack object reads.
+
+Do not broaden this into Balatro strategy, RL environment replication, or root
+AUV runtime/catalog integration in this slice.
+
+## Proposed Reusable Commands
+
+The command surface should stay object-oriented. The CLI resolves visible game
+objects and records evidence; an external agent decides whether an action is a
+good strategy.
+
+One naming rule is useful for packs:
+
+- Store packs remain `store:N` items before purchase.
+- The active opened pack screen can use `pack:N` choice slots after opening.
+
+| Command | Required observation | Action target | Verification | Evidence |
+| --- | --- | --- | --- | --- |
+| `store status` | Store controls and store item zones | None | Observation only | Frame, store summary, raw detections |
+| `store ls` | Store item detections; hover OCR when unread/stale | None | Observation only | Per-item bbox, hover image, OCR text, cache hint |
+| `store buy --slot store:N` | Store state, target item bbox, confirm button after selection | Store item, then `button_purchase` or `button_use` | Item disappears, cash changes, or item appears in held zone | Before/selected/after frames, target bbox, confirm button, verification evidence |
+| `store reroll` | `button_store_reroll`, item fingerprints | Reroll button | Store item fingerprints change | Before/after item list, button bbox |
+| `store next-round` | Prefer `button_store_next_round`; layout fallback if missed | Next-round button or fallback point | Store controls disappear; phase changes | Target source, fallback reason, after frame |
+| `store open-pack --slot store:N` | `store:N` is `card_pack`; pack hover OCR if unread | Buy/open target | Pack choices or skip button visible | Pack OCR, before/after frames |
+| `pack read` | Active non-Standard Pack choices, skip button, optional confirm/use button | None | Observation only | Choice bboxes, hover screenshots, OCR crops/text when live |
+| `pack choose --slot pack:N` | Active non-Standard Pack choice slot | Choice card, then confirm/use button or fallback point | Pack screen closes or selected item appears | Before/selected/after frames, confirm target source |
+| `pack skip` | `button_card_pack_skip` | Skip button | Pack screen closes | Skip button bbox, after frame |
+| `consumables ls` | Held tarot/planet/spectral zones | None | Observation only | Slot bboxes, hover OCR text, cache hint |
+| `consumables read --slot consumable:N` | Held consumable bbox | None | Reading exists or explicit uncertainty | Hover screenshot, OCR crop, text/source |
+| `consumables use --slot consumable:N` | Held consumable bbox, `button_use` after selection | Consumable, then use button or fallback point | Consumable leaves held zone or visible effect changes | Before/selected/after frames |
+| `jokers ls` | Joker zone detections | None | Observation only | Joker bboxes, hover OCR text, cache hint |
+| `jokers read --slot joker:N` | Joker bbox | None | Reading exists or explicit uncertainty | Hover screenshot, OCR crop, text/source |
+| `jokers sell --slot joker:N` | Joker bbox, sell affordance after selection | Joker, then `button_sell` | Joker removed; cash changes if readable | Before/after joker list, sell button bbox |
+| `cards read --slot hand:N` | Fresh hand detections; corner OCR/template evidence | None | Card identity is known/partial/uncertain | Frame, bbox, crop, OCR/template evidence |
+| `cards clear --verify` | Fresh hand slots and selected-state capture | Currently selected hand slots only | No selected hand slots remain | Before/after frames, per-card interaction state |
+| `cards select --slots ...` | Fresh hand slots and selected-state capture | Requested card slots, with observe-gated retry | Selected hand slot set exactly matches requested slots | Before/selected frames, clicked points, per-card interaction state |
+| `cards play --slots ...` | Fresh hand slots, exact selected-state gate, play button | Clear non-requested selected slots, select missing requested slots, then `button_play` | Exact selected-state gate passes before commit; phase, hand count, or hand fingerprint changes after commit | Before/selected/after frames, verification evidence |
+| `cards discard --slots ...` | Fresh hand slots, exact selected-state gate, discard button | Clear non-requested selected slots, select missing requested slots, then `button_discard` | Exact selected-state gate passes before commit; phase, hand count, or hand fingerprint changes after commit | Before/selected/after frames, verification evidence |
+| `game restart` | New Run play button, or Game Over layout fallback | `button_new_run_play` or fallback point | Blind-select, playing, or store phase appears | Before/intermediate/after frames, strategy |
+| `game cash-out` | `button_cash_out` | Cash-out button | Cash-out button disappears or store appears | Before/after frames, button bbox |
+
+Shared mutation result shape:
+
+```text
+operation
+target_object
+observation_before
+action_target
+driver_result
+verification
+artifacts
+fallbacks
+```
+
+Important fallback contracts:
+
+- `store next-round`: try `button_store_next_round`; if YOLO misses the visible
+  button, use deterministic store-panel layout fallback and record
+  `fallback_reason = "yolo_button_missing_visible_layout_match"`.
+- `pack choose`: try detected confirm/use button; if absent, use the green
+  confirm/use layout fallback and record the fallback target.
+- `pack read` / `pack choose`: current choice detection excludes Standard Pack
+  `poker_card_front` choices until that label can be separated from hand/deck
+  playing-card detections with live fixture evidence.
+- Hover OCR is required for jokers, tarot/planet/spectral consumables, store
+  items, pack choices, vouchers, and uncertain poker cards. The live path now
+  exists for the main object reads; remaining work is quality, structure,
+  serialization, and coverage.
+- Card actions must rebuild slot identity from a fresh observation before every
+  play/discard. Live runs showed slot assumptions drift after discards.
+
+## Smallest Next Slices
+
+The next work should not try to implement every command in the table at once.
+The current crate already has card play/discard, store next-round, blind
+select/skip, live capture fallback, macOS Vision card-corner OCR, local UI
+digit readers, and deck template rank inference.
+
+Recommended order:
+
+1. Add tests and helpers for `store:N`, `joker:N`, `consumable:N`, and `pack:N`
+   slot parsing and object selection.
+2. Harden live object reads by separating owned zones from shop zones, adding
+   hover-session serialization, and normalizing raw OCR into structured fields.
+3. Add voucher read/buy grounding with evidence distinct from generic store
+   cards.
+4. Add live fixture or artifact-backed tests for joker, tarot, planet,
+   spectral, store-item, pack-choice, and voucher reads.
+5. Improve score/current-round OCR separately from tooltip OCR.

--- a/crates/auv-game-balatro/examples/card_corner_smoke.rs
+++ b/crates/auv-game-balatro/examples/card_corner_smoke.rs
@@ -1,0 +1,82 @@
+#[cfg(feature = "card-corner-onnx")]
+use auv_game_balatro::card_corner::{
+  CARD_CORNER_MODEL_ID, CardCornerClassifier, CardCornerClassifierConfig,
+};
+#[cfg(feature = "card-corner-onnx")]
+use auv_game_balatro::config::BalatroModelAsset;
+#[cfg(feature = "card-corner-onnx")]
+use serde::Serialize;
+#[cfg(feature = "card-corner-onnx")]
+use std::path::PathBuf;
+
+#[cfg(feature = "card-corner-onnx")]
+#[derive(Debug, Serialize)]
+struct SmokeOutput {
+  model: &'static str,
+  image: String,
+  prediction: auv_game_balatro::card_corner::CardCornerPrediction,
+}
+
+#[cfg(feature = "card-corner-onnx")]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+  let args = Args::parse()?;
+  let image = image::open(&args.image)?.to_rgb8();
+  let config = match args.model {
+    Some(model) => CardCornerClassifierConfig::from_model_asset(&BalatroModelAsset::local(model))?,
+    None => CardCornerClassifierConfig::default_model()?,
+  };
+  let classifier = CardCornerClassifier::load(config)?;
+  let prediction = classifier.predict(&image)?;
+  println!(
+    "{}",
+    serde_json::to_string_pretty(&SmokeOutput {
+      model: CARD_CORNER_MODEL_ID,
+      image: args.image.display().to_string(),
+      prediction,
+    })?
+  );
+  Ok(())
+}
+
+#[cfg(not(feature = "card-corner-onnx"))]
+fn main() {
+  eprintln!("card_corner_smoke requires the `card-corner-onnx` feature");
+}
+
+#[cfg(feature = "card-corner-onnx")]
+struct Args {
+  model: Option<PathBuf>,
+  image: PathBuf,
+}
+
+#[cfg(feature = "card-corner-onnx")]
+impl Args {
+  fn parse() -> Result<Self, String> {
+    let mut model = None;
+    let mut image = None;
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+      match arg.as_str() {
+        "--model" => {
+          model = Some(PathBuf::from(
+            args
+              .next()
+              .ok_or_else(|| "--model requires a path".to_string())?,
+          ));
+        }
+        "--image" => {
+          image = Some(PathBuf::from(
+            args
+              .next()
+              .ok_or_else(|| "--image requires a path".to_string())?,
+          ));
+        }
+        _ => return Err(format!("unknown argument: {arg}")),
+      }
+    }
+    Ok(Self {
+      model,
+      image: image.ok_or_else(|| "--image is required".to_string())?,
+    })
+  }
+}

--- a/crates/auv-game-balatro/src/bin/auv-game-balatro.rs
+++ b/crates/auv-game-balatro/src/bin/auv-game-balatro.rs
@@ -1,0 +1,11 @@
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+  match auv_game_balatro::cli::run_from_env() {
+    Ok(()) => ExitCode::SUCCESS,
+    Err(error) => {
+      eprintln!("{error}");
+      ExitCode::FAILURE
+    }
+  }
+}

--- a/crates/auv-game-balatro/src/cache.rs
+++ b/crates/auv-game-balatro/src/cache.rs
@@ -1,0 +1,113 @@
+use auv_inference_common::{BoundingBox, Detection};
+use image::RgbImage;
+
+use crate::model::CacheHint;
+
+// TODO(balatro-cache-v1): Reading cache storage and invalidation policy are
+// deferred until observation/read commands need cached enrichment.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ReadingCache;
+
+pub fn cache_hint_for_detection(
+  detection: &Detection,
+  image: &RgbImage,
+  _no_cache: bool,
+) -> CacheHint {
+  // `no_cache` bypasses persisted/semantic reading reuse, not frame evidence.
+  // Live action verification still needs the current-frame fingerprint to
+  // prove that hand contents changed when Balatro refills to the same count.
+  CacheHint {
+    needs_reading: true,
+    visual_fingerprint: visual_fingerprint(detection, image),
+    changed_since_last_read: true,
+  }
+}
+
+pub fn visual_fingerprint(detection: &Detection, image: &RgbImage) -> Option<String> {
+  let bounds = bounded_crop(detection.bbox, image)?;
+  let mut hash = 0xcbf29ce484222325_u64;
+
+  for value in [
+    detection.bbox.x1.to_bits(),
+    detection.bbox.y1.to_bits(),
+    detection.bbox.x2.to_bits(),
+    detection.bbox.y2.to_bits(),
+  ] {
+    hash = fnv1a(hash, value);
+  }
+
+  let width = bounds.x2 - bounds.x1;
+  let height = bounds.y2 - bounds.y1;
+  let x_step = (width / 8).max(1);
+  let y_step = (height / 8).max(1);
+
+  let mut y = bounds.y1;
+  while y < bounds.y2 {
+    let mut x = bounds.x1;
+    while x < bounds.x2 {
+      for channel in image.get_pixel(x, y).0 {
+        hash = fnv1a(hash, channel as u32);
+      }
+      x = x.saturating_add(x_step);
+    }
+    y = y.saturating_add(y_step);
+  }
+
+  Some(format!("{hash:016x}"))
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct CropBounds {
+  x1: u32,
+  y1: u32,
+  x2: u32,
+  y2: u32,
+}
+
+fn bounded_crop(bbox: BoundingBox, image: &RgbImage) -> Option<CropBounds> {
+  let image_width = image.width();
+  let image_height = image.height();
+  if image_width == 0 || image_height == 0 {
+    return None;
+  }
+
+  let x1 = clamp_lower(bbox.x1.floor(), image_width);
+  let y1 = clamp_lower(bbox.y1.floor(), image_height);
+  let x2 = clamp_upper(bbox.x2.ceil(), image_width);
+  let y2 = clamp_upper(bbox.y2.ceil(), image_height);
+
+  if x1 >= x2 || y1 >= y2 {
+    return None;
+  }
+
+  Some(CropBounds { x1, y1, x2, y2 })
+}
+
+fn clamp_lower(value: f32, upper: u32) -> u32 {
+  if !value.is_finite() || value <= 0.0 {
+    return 0;
+  }
+
+  (value as u32).min(upper)
+}
+
+fn clamp_upper(value: f32, upper: u32) -> u32 {
+  if !value.is_finite() {
+    return 0;
+  }
+
+  if value <= 0.0 {
+    0
+  } else {
+    (value as u32).min(upper)
+  }
+}
+
+fn fnv1a(hash: u64, value: u32) -> u64 {
+  let mut hash = hash;
+  for byte in value.to_le_bytes() {
+    hash ^= byte as u64;
+    hash = hash.wrapping_mul(0x100000001b3);
+  }
+  hash
+}

--- a/crates/auv-game-balatro/src/card_corner.rs
+++ b/crates/auv-game-balatro/src/card_corner.rs
@@ -1,0 +1,214 @@
+use auv_inference_common::{InferenceError, InferenceResult};
+use auv_inference_ort::{ExecutionProvider, F32Tensor, OrtModelConfig, OrtSession, softmax, top1};
+use image::{RgbImage, imageops::FilterType};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+use crate::config::{BalatroModelAsset, BalatroModelConfig, BalatroModelConfigError};
+
+pub const CARD_CORNER_IMAGE_SIZE: u32 = 64;
+pub const CARD_CORNER_INPUT_NAME: &str = "images";
+pub const CARD_CORNER_RANK_OUTPUT_NAME: &str = "rank_logits";
+pub const CARD_CORNER_SUIT_OUTPUT_NAME: &str = "suit_logits";
+pub const CARD_CORNER_MODEL_ID: &str = "balatro-card-corner-classifier";
+
+pub const RANK_LABELS: [&str; 13] = [
+  "A", "2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K",
+];
+pub const SUIT_LABELS: [&str; 4] = ["spades", "hearts", "clubs", "diamonds"];
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CardCornerClassifierConfig {
+  pub model_path: PathBuf,
+  pub execution_provider: ExecutionProvider,
+  pub image_size: u32,
+}
+
+impl CardCornerClassifierConfig {
+  pub fn new(model_path: PathBuf) -> Self {
+    Self {
+      model_path,
+      execution_provider: ExecutionProvider::Cpu,
+      image_size: CARD_CORNER_IMAGE_SIZE,
+    }
+  }
+
+  pub fn default_model() -> Result<Self, BalatroModelConfigError> {
+    Self::from_model_asset(&BalatroModelConfig::default().card_corner_model)
+  }
+
+  pub fn from_model_asset(asset: &BalatroModelAsset) -> Result<Self, BalatroModelConfigError> {
+    Ok(Self::new(asset.resolve_path()?))
+  }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct CardCornerPrediction {
+  pub rank: String,
+  pub suit: String,
+  pub rank_confidence: f32,
+  pub suit_confidence: f32,
+}
+
+#[derive(Debug)]
+pub struct CardCornerClassifier {
+  session: OrtSession,
+  image_size: u32,
+}
+
+impl CardCornerClassifier {
+  pub fn load(config: CardCornerClassifierConfig) -> InferenceResult<Self> {
+    let session = OrtSession::load(OrtModelConfig {
+      model_path: config.model_path,
+      execution_provider: config.execution_provider,
+    })?;
+
+    Ok(Self {
+      session,
+      image_size: config.image_size,
+    })
+  }
+
+  pub fn predict(&self, image: &RgbImage) -> InferenceResult<CardCornerPrediction> {
+    let input = card_corner_input_tensor(image, self.image_size);
+    let outputs = self.session.run_f32(input)?;
+    let rank_logits = named_output(&outputs, CARD_CORNER_RANK_OUTPUT_NAME)?;
+    let suit_logits = named_output(&outputs, CARD_CORNER_SUIT_OUTPUT_NAME)?;
+
+    prediction_from_logits(rank_logits, suit_logits)
+  }
+}
+
+pub fn rank_label(index: usize) -> Option<&'static str> {
+  RANK_LABELS.get(index).copied()
+}
+
+pub fn suit_label(index: usize) -> Option<&'static str> {
+  SUIT_LABELS.get(index).copied()
+}
+
+pub fn card_corner_input_tensor(image: &RgbImage, image_size: u32) -> F32Tensor {
+  let resized = image::imageops::resize(image, image_size, image_size, FilterType::Triangle);
+  let size = image_size as usize;
+  let plane_size = size * size;
+  let mut data = vec![0.0; 3 * plane_size];
+
+  for (x, y, pixel) in resized.enumerate_pixels() {
+    let offset = y as usize * size + x as usize;
+    data[offset] = f32::from(pixel[0]) / 255.0;
+    data[plane_size + offset] = f32::from(pixel[1]) / 255.0;
+    data[plane_size * 2 + offset] = f32::from(pixel[2]) / 255.0;
+  }
+
+  F32Tensor {
+    name: CARD_CORNER_INPUT_NAME.to_string(),
+    shape: vec![1, 3, size, size],
+    data,
+  }
+}
+
+pub fn prediction_from_logits(
+  rank_logits: &F32Tensor,
+  suit_logits: &F32Tensor,
+) -> InferenceResult<CardCornerPrediction> {
+  let rank_probabilities = softmax(&rank_logits.data);
+  let suit_probabilities = softmax(&suit_logits.data);
+  let rank = top1(&rank_probabilities).ok_or_else(|| InferenceError::Backend {
+    message: "rank logits were empty".to_string(),
+  })?;
+  let suit = top1(&suit_probabilities).ok_or_else(|| InferenceError::Backend {
+    message: "suit logits were empty".to_string(),
+  })?;
+  let rank_label = rank_label(rank.index).ok_or_else(|| InferenceError::MissingClassLabel {
+    class_id: rank.index,
+  })?;
+  let suit_label = suit_label(suit.index).ok_or_else(|| InferenceError::MissingClassLabel {
+    class_id: suit.index,
+  })?;
+
+  Ok(CardCornerPrediction {
+    rank: rank_label.to_string(),
+    suit: suit_label.to_string(),
+    rank_confidence: rank.confidence,
+    suit_confidence: suit.confidence,
+  })
+}
+
+fn named_output<'a>(outputs: &'a [F32Tensor], name: &str) -> InferenceResult<&'a F32Tensor> {
+  outputs
+    .iter()
+    .find(|output| output.name == name)
+    .ok_or_else(|| InferenceError::Backend {
+      message: format!("missing ONNX output: {name}"),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+  use auv_inference_ort::F32Tensor;
+  use image::{Rgb, RgbImage};
+
+  use crate::card_corner::{
+    CardCornerPrediction, card_corner_input_tensor, prediction_from_logits, rank_label, suit_label,
+  };
+
+  #[test]
+  fn rank_and_suit_labels_match_training_order() {
+    assert_eq!(rank_label(0), Some("A"));
+    assert_eq!(rank_label(9), Some("10"));
+    assert_eq!(rank_label(12), Some("K"));
+    assert_eq!(rank_label(13), None);
+
+    assert_eq!(suit_label(0), Some("spades"));
+    assert_eq!(suit_label(1), Some("hearts"));
+    assert_eq!(suit_label(2), Some("clubs"));
+    assert_eq!(suit_label(3), Some("diamonds"));
+    assert_eq!(suit_label(4), None);
+  }
+
+  #[test]
+  fn input_tensor_resizes_and_normalizes_rgb_to_chw() {
+    let mut image = RgbImage::new(1, 1);
+    image.put_pixel(0, 0, Rgb([64, 128, 255]));
+
+    let tensor = card_corner_input_tensor(&image, 2);
+
+    assert_eq!(tensor.name, "images");
+    assert_eq!(tensor.shape, vec![1, 3, 2, 2]);
+    assert_eq!(tensor.data.len(), 12);
+    assert!((tensor.data[0] - 64.0 / 255.0).abs() < 1e-6);
+    assert!((tensor.data[4] - 128.0 / 255.0).abs() < 1e-6);
+    assert!((tensor.data[8] - 1.0).abs() < 1e-6);
+  }
+
+  #[test]
+  fn prediction_from_logits_uses_softmax_confidence() {
+    let prediction = prediction_from_logits(
+      &F32Tensor {
+        name: "rank_logits".to_string(),
+        shape: vec![1, 13],
+        data: vec![
+          0.0, 8.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+        ],
+      },
+      &F32Tensor {
+        name: "suit_logits".to_string(),
+        shape: vec![1, 4],
+        data: vec![0.0, 0.0, 9.0, 0.0],
+      },
+    )
+    .unwrap();
+
+    assert_eq!(
+      prediction,
+      CardCornerPrediction {
+        rank: "2".to_string(),
+        suit: "clubs".to_string(),
+        rank_confidence: prediction.rank_confidence,
+        suit_confidence: prediction.suit_confidence,
+      }
+    );
+    assert!(prediction.rank_confidence > 0.99);
+    assert!(prediction.suit_confidence > 0.99);
+  }
+}

--- a/crates/auv-game-balatro/src/cli.rs
+++ b/crates/auv-game-balatro/src/cli.rs
@@ -1,0 +1,5685 @@
+use std::fmt;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command as ProcessCommand;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use auv_driver::capture::{Activation, Capture, CaptureOptions};
+use auv_driver::geometry::{Point, RatioRect, Rect, WindowPoint};
+use auv_driver::input::{ClickOptions, InputPolicy};
+use auv_driver::selector::{App, Window};
+use auv_driver::vision::TextRecognitionOptions;
+use auv_inference_common::BoundingBox;
+use auv_inference_ultralytics::InferenceDevice;
+use clap::{Args, Parser, Subcommand, ValueEnum};
+use image::{ImageError, RgbaImage};
+use serde::Serialize;
+use serde_json::Value;
+use serde_json::json;
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+use crate::config::BalatroModelConfig;
+use crate::model::{
+  BalatroPhase, BalatroState, ButtonTarget, CardSlot, ConsumableSlot, JokerSlot, RoundState,
+  ScoreState, SlotId, StoreItem,
+};
+use crate::observation::{ObservationError, observe_image};
+pub use crate::output::OutputMode;
+
+const DECK_ATLAS_LOVE_PATH: &str = "resources/textures/2x/8BitDeck.png";
+const DECK_ATLAS_CACHE_FILE: &str = "8BitDeck.png";
+const SETUP_MANIFEST_FILE: &str = "setup.json";
+const SETUP_MANIFEST_SCHEMA_VERSION: &str = "auv.game.balatro.setup.v0";
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, ValueEnum)]
+pub enum Format {
+  #[default]
+  Text,
+  Json,
+}
+
+impl fmt::Display for Format {
+  fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match self {
+      Self::Text => formatter.write_str("text"),
+      Self::Json => formatter.write_str("json"),
+    }
+  }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, ValueEnum)]
+pub enum VerifyModeArg {
+  #[default]
+  Targeted,
+  Weak,
+  ActivationOnly,
+}
+
+impl fmt::Display for VerifyModeArg {
+  fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match self {
+      Self::Targeted => formatter.write_str("targeted"),
+      Self::Weak => formatter.write_str("weak"),
+      Self::ActivationOnly => formatter.write_str("activation-only"),
+    }
+  }
+}
+
+#[derive(Clone, Debug, Eq, Parser, PartialEq)]
+#[command(name = "auv-game-balatro")]
+pub struct CliArgs {
+  #[command(subcommand)]
+  pub command: Command,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Subcommand)]
+pub enum Command {
+  Game(GameArgs),
+  Objective(ObjectiveArgs),
+  Scores(ScoresArgs),
+  Rounds(RoundsArgs),
+  Cards(CardsArgs),
+  Jokers(JokersArgs),
+  Consumables(ConsumablesArgs),
+  Store(StoreArgs),
+  Pack(PackArgs),
+  Blinds(BlindsArgs),
+  Setup(SetupArgs),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Args)]
+pub struct SetupArgs {
+  #[arg(long, value_name = "PATH")]
+  pub love: Option<PathBuf>,
+  #[arg(long, value_name = "PATH")]
+  pub app: Option<PathBuf>,
+  #[arg(long, value_name = "PATH")]
+  pub cache_dir: Option<PathBuf>,
+  #[arg(long)]
+  pub check: bool,
+  #[arg(long)]
+  pub force: bool,
+  #[arg(long)]
+  pub json: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct SetupReport {
+  pub schema_version: String,
+  pub status: SetupStatus,
+  pub cache_dir: PathBuf,
+  pub deck_atlas_path: PathBuf,
+  pub manifest_path: PathBuf,
+  pub source_love_path: Option<PathBuf>,
+  pub deck_atlas_sha256: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SetupStatus {
+  Ready,
+  Reused,
+  Extracted,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+struct SetupManifest {
+  schema_version: String,
+  source_love_path: PathBuf,
+  deck_atlas_path: PathBuf,
+  deck_atlas_sha256: String,
+  extracted_at_ms: u128,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Args)]
+pub struct ObserveArgs {
+  #[arg(long, value_name = "PATH")]
+  pub image: Option<PathBuf>,
+  #[arg(long, default_value = "Balatro")]
+  pub target: String,
+  #[arg(long)]
+  pub json: bool,
+  #[arg(long, default_value_t)]
+  pub format: Format,
+  #[arg(long, value_name = "PATH")]
+  pub json_out: Option<PathBuf>,
+  #[arg(long)]
+  pub no_cache: bool,
+  #[arg(long, value_name = "PATH")]
+  pub entities_model: Option<PathBuf>,
+  #[arg(long, value_name = "PATH")]
+  pub entities_classes: Option<PathBuf>,
+  #[arg(long, value_name = "PATH")]
+  pub ui_model: Option<PathBuf>,
+  #[arg(long, value_name = "PATH")]
+  pub ui_classes: Option<PathBuf>,
+  #[arg(long, value_name = "PATH")]
+  pub card_corner_model: Option<PathBuf>,
+  #[arg(long, default_value = "cpu", value_parser = clap::value_parser!(InferenceDevice))]
+  pub device: InferenceDevice,
+}
+
+impl ObserveArgs {
+  pub fn output_mode(&self) -> OutputMode {
+    if let Some(path) = &self.json_out {
+      return OutputMode::JsonFile(path.clone());
+    }
+    if self.json || self.format == Format::Json {
+      return OutputMode::Json;
+    }
+    OutputMode::Human
+  }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Args)]
+pub struct OperationControlArgs {
+  #[arg(long, default_value = "Balatro")]
+  pub target: String,
+  #[arg(long)]
+  pub verify: bool,
+  #[arg(long, default_value_t)]
+  pub verify_mode: VerifyModeArg,
+  #[arg(long)]
+  pub timeout_ms: Option<u64>,
+  #[arg(long, alias = "detailed")]
+  pub details: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Args)]
+pub struct SlotOperationArgs {
+  #[arg(long)]
+  pub slot: String,
+  #[command(flatten)]
+  pub control: OperationControlArgs,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Args)]
+pub struct TargetSlotOperationArgs {
+  #[arg(long)]
+  pub slot: String,
+  #[arg(long, value_delimiter = ',', value_name = "TARGETS")]
+  pub targets: Vec<String>,
+  #[command(flatten)]
+  pub control: OperationControlArgs,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Args)]
+pub struct MultiSlotOperationArgs {
+  #[arg(long, value_name = "SLOTS")]
+  pub slots: String,
+  #[command(flatten)]
+  pub control: OperationControlArgs,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Args)]
+pub struct GameArgs {
+  #[command(subcommand)]
+  pub command: GameCommand,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Subcommand)]
+pub enum GameCommand {
+  State(ObserveArgs),
+  CashOut(OperationControlArgs),
+  Restart(OperationControlArgs),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Args)]
+pub struct ObjectiveArgs {
+  #[command(flatten)]
+  pub observe: ObserveArgs,
+  #[arg(long)]
+  pub include_scores: bool,
+  #[arg(long)]
+  pub include_rounds: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Args)]
+pub struct ScoresArgs {
+  #[command(subcommand)]
+  pub command: ScoresCommand,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Subcommand)]
+pub enum ScoresCommand {
+  Get(ObserveArgs),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Args)]
+pub struct RoundsArgs {
+  #[command(subcommand)]
+  pub command: RoundsCommand,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Subcommand)]
+pub enum RoundsCommand {
+  Get(ObserveArgs),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Args)]
+pub struct SlotObserveArgs {
+  #[arg(long)]
+  pub slot: String,
+  #[arg(long, value_name = "PATH")]
+  pub frame_out: Option<PathBuf>,
+  #[command(flatten)]
+  pub observe: ObserveArgs,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Args)]
+pub struct CardsArgs {
+  #[command(subcommand)]
+  pub command: CardsCommand,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Subcommand)]
+pub enum CardsCommand {
+  Ls(ObserveArgs),
+  Hand(ObserveArgs),
+  Read(SlotObserveArgs),
+  Clear(OperationControlArgs),
+  Select(MultiSlotOperationArgs),
+  Play(MultiSlotOperationArgs),
+  Discard(MultiSlotOperationArgs),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Args)]
+pub struct JokersArgs {
+  #[command(subcommand)]
+  pub command: JokersCommand,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Subcommand)]
+pub enum JokersCommand {
+  Ls(ObserveArgs),
+  Read(SlotObserveArgs),
+  Sell(SlotOperationArgs),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Args)]
+pub struct ConsumablesArgs {
+  #[command(subcommand)]
+  pub command: ConsumablesCommand,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Subcommand)]
+pub enum ConsumablesCommand {
+  Ls(ObserveArgs),
+  Read(SlotObserveArgs),
+  Sell(SlotOperationArgs),
+  Use(TargetSlotOperationArgs),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Args)]
+pub struct StoreArgs {
+  #[command(subcommand)]
+  pub command: StoreCommand,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Subcommand)]
+pub enum StoreCommand {
+  Status(ObserveArgs),
+  Ls(ObserveArgs),
+  Read(SlotObserveArgs),
+  Buy(SlotOperationArgs),
+  Reroll(OperationControlArgs),
+  NextRound(OperationControlArgs),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Args)]
+pub struct PackArgs {
+  #[command(subcommand)]
+  pub command: PackCommand,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Subcommand)]
+pub enum PackCommand {
+  Read(ObserveArgs),
+  Choose(TargetSlotOperationArgs),
+  Skip(OperationControlArgs),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Args)]
+pub struct BlindsArgs {
+  #[command(subcommand)]
+  pub command: BlindsCommand,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Subcommand)]
+pub enum BlindsCommand {
+  Ls(ObserveArgs),
+  Select(SlotOperationArgs),
+  Skip(OperationControlArgs),
+}
+
+#[derive(Debug, Error)]
+pub enum CliError {
+  #[error("Balatro command `{command}` is deferred: {reason}")]
+  Deferred {
+    command: &'static str,
+    reason: &'static str,
+  },
+  #[error(
+    "observation command requires --image until live capture dispatch lands for this surface"
+  )]
+  MissingImage,
+  #[error("observation failed: {0}")]
+  Observation(#[from] ObservationError),
+  #[error("output failed: {0}")]
+  Output(#[from] crate::output::OutputError),
+  #[error("driver error: {0}")]
+  Driver(#[from] auv_driver::error::DriverError),
+  #[error("image error: {0}")]
+  Image(#[from] ImageError),
+  #[error("io error: {0}")]
+  Io(#[from] std::io::Error),
+  #[error("json error: {0}")]
+  Json(#[from] serde_json::Error),
+  #[error("{0}")]
+  Message(String),
+}
+
+pub fn run_from_env() -> Result<(), CliError> {
+  run(CliArgs::parse())
+}
+
+pub fn run(args: CliArgs) -> Result<(), CliError> {
+  match args.command {
+    Command::Game(GameArgs {
+      command: GameCommand::State(args),
+    }) => write_observed_state(&args),
+    Command::Game(GameArgs {
+      command: GameCommand::CashOut(args),
+    }) => click_game_cash_out(args),
+    Command::Game(GameArgs {
+      command: GameCommand::Restart(args),
+    }) => click_game_restart(args),
+    Command::Objective(args) => write_observed_state(&args.observe),
+    Command::Scores(ScoresArgs {
+      command: ScoresCommand::Get(args),
+    }) => write_scores(&args),
+    Command::Rounds(RoundsArgs {
+      command: RoundsCommand::Get(args),
+    }) => write_rounds(&args),
+    Command::Cards(CardsArgs {
+      command: CardsCommand::Ls(args) | CardsCommand::Hand(args),
+    }) => write_observed_state(&args),
+    Command::Cards(CardsArgs {
+      command: CardsCommand::Read(args),
+    }) => write_card_read(&args),
+    Command::Cards(CardsArgs {
+      command: CardsCommand::Clear(args),
+    }) => click_cards_clear(args),
+    Command::Cards(CardsArgs {
+      command: CardsCommand::Select(args),
+    }) => click_cards_select(args),
+    Command::Cards(CardsArgs {
+      command: CardsCommand::Play(args),
+    }) => click_cards_commit("cards.play", "button_play", args),
+    Command::Cards(CardsArgs {
+      command: CardsCommand::Discard(args),
+    }) => click_cards_commit("cards.discard", "button_discard", args),
+    Command::Jokers(JokersArgs {
+      command: JokersCommand::Ls(args),
+    }) => write_observed_state(&args),
+    Command::Jokers(JokersArgs {
+      command: JokersCommand::Read(args),
+    }) => write_object_read(&args, ObjectReadZone::Joker),
+    Command::Jokers(JokersArgs {
+      command: JokersCommand::Sell(args),
+    }) => click_joker_sell(args),
+    Command::Consumables(ConsumablesArgs {
+      command: ConsumablesCommand::Ls(args),
+    }) => write_observed_state(&args),
+    Command::Consumables(ConsumablesArgs {
+      command: ConsumablesCommand::Read(args),
+    }) => write_object_read(&args, ObjectReadZone::Consumable),
+    Command::Consumables(ConsumablesArgs {
+      command: ConsumablesCommand::Sell(args),
+    }) => click_consumable_sell(args),
+    Command::Consumables(ConsumablesArgs {
+      command: ConsumablesCommand::Use(args),
+    }) => click_consumable_use(args),
+    Command::Store(StoreArgs {
+      command: StoreCommand::Status(args),
+    }) => write_store_status(&args),
+    Command::Store(StoreArgs {
+      command: StoreCommand::Ls(args),
+    }) => write_store_items(&args),
+    Command::Store(StoreArgs {
+      command: StoreCommand::Read(args),
+    }) => write_object_read(&args, ObjectReadZone::Store),
+    Command::Store(StoreArgs {
+      command: StoreCommand::Buy(args),
+    }) => click_store_buy(args),
+    Command::Store(StoreArgs {
+      command: StoreCommand::Reroll(args),
+    }) => click_store_reroll(args),
+    Command::Store(StoreArgs {
+      command: StoreCommand::NextRound(args),
+    }) => click_store_next_round(args),
+    Command::Pack(PackArgs {
+      command: PackCommand::Read(args),
+    }) => write_pack_read(&args),
+    Command::Pack(PackArgs {
+      command: PackCommand::Choose(args),
+    }) => click_pack_choose(args),
+    Command::Pack(PackArgs {
+      command: PackCommand::Skip(args),
+    }) => click_pack_skip(args),
+    Command::Blinds(BlindsArgs {
+      command: BlindsCommand::Ls(args),
+    }) => write_blind_buttons(&args),
+    Command::Blinds(BlindsArgs {
+      command: BlindsCommand::Select(args),
+    }) => click_blind_select(args),
+    Command::Blinds(BlindsArgs {
+      command: BlindsCommand::Skip(args),
+    }) => click_blind_skip(args),
+    Command::Setup(args) => run_setup(args),
+  }
+}
+
+fn run_setup(args: SetupArgs) -> Result<(), CliError> {
+  let report = setup_balatro_assets(&args)?;
+  if args.json {
+    println!("{}", serde_json::to_string_pretty(&report)?);
+  } else {
+    println!(
+      "Balatro setup {:?}: deck atlas {}",
+      report.status,
+      report.deck_atlas_path.display()
+    );
+  }
+  Ok(())
+}
+
+fn setup_balatro_assets(args: &SetupArgs) -> Result<SetupReport, CliError> {
+  let cache_dir = setup_cache_dir(args.cache_dir.as_deref())?;
+  let deck_atlas_path = cache_dir.join(DECK_ATLAS_CACHE_FILE);
+  let manifest_path = cache_dir.join(SETUP_MANIFEST_FILE);
+
+  if args.check {
+    let deck_atlas_sha256 = if deck_atlas_path.exists() {
+      validate_deck_atlas_path(&deck_atlas_path)?;
+      Some(sha256_file(&deck_atlas_path)?)
+    } else {
+      return Err(CliError::Message(format!(
+        "Balatro setup cache is missing {}; run `auv-game-balatro setup` first",
+        deck_atlas_path.display()
+      )));
+    };
+    return Ok(SetupReport {
+      schema_version: SETUP_MANIFEST_SCHEMA_VERSION.to_string(),
+      status: SetupStatus::Ready,
+      cache_dir,
+      deck_atlas_path,
+      manifest_path,
+      source_love_path: None,
+      deck_atlas_sha256,
+    });
+  }
+
+  if deck_atlas_path.exists() && !args.force {
+    validate_deck_atlas_path(&deck_atlas_path)?;
+    return Ok(SetupReport {
+      schema_version: SETUP_MANIFEST_SCHEMA_VERSION.to_string(),
+      status: SetupStatus::Reused,
+      cache_dir,
+      deck_atlas_path: deck_atlas_path.clone(),
+      manifest_path,
+      source_love_path: None,
+      deck_atlas_sha256: Some(sha256_file(&deck_atlas_path)?),
+    });
+  }
+
+  let love_path = resolve_setup_love_path(args)?;
+  let atlas_bytes = extract_deck_atlas_from_love(&love_path)?;
+  image::load_from_memory(&atlas_bytes)?;
+  fs::create_dir_all(&cache_dir)?;
+  fs::write(&deck_atlas_path, &atlas_bytes)?;
+  let deck_atlas_sha256 = sha256_bytes(&atlas_bytes);
+  let manifest = SetupManifest {
+    schema_version: SETUP_MANIFEST_SCHEMA_VERSION.to_string(),
+    source_love_path: love_path.clone(),
+    deck_atlas_path: deck_atlas_path.clone(),
+    deck_atlas_sha256: deck_atlas_sha256.clone(),
+    extracted_at_ms: now_millis(),
+  };
+  fs::write(
+    &manifest_path,
+    serde_json::to_string_pretty(&manifest)? + "\n",
+  )?;
+
+  Ok(SetupReport {
+    schema_version: SETUP_MANIFEST_SCHEMA_VERSION.to_string(),
+    status: SetupStatus::Extracted,
+    cache_dir,
+    deck_atlas_path,
+    manifest_path,
+    source_love_path: Some(love_path),
+    deck_atlas_sha256: Some(deck_atlas_sha256),
+  })
+}
+
+fn setup_cache_dir(explicit: Option<&Path>) -> Result<PathBuf, CliError> {
+  if let Some(path) = explicit {
+    return Ok(path.to_path_buf());
+  }
+  if let Some(home) = std::env::var_os("HOME").map(PathBuf::from) {
+    return Ok(home.join(".cache").join("auv").join("game-balatro"));
+  }
+  Err(CliError::Message(format!(
+    "could not resolve Balatro setup cache directory; pass --cache-dir"
+  )))
+}
+
+fn resolve_setup_love_path(args: &SetupArgs) -> Result<PathBuf, CliError> {
+  if let Some(path) = args.love.as_deref() {
+    return require_love_path(path);
+  }
+  if let Some(app) = args.app.as_deref() {
+    return require_love_path(&love_path_from_app(app));
+  }
+  if let Some(path) = discover_steam_love_path() {
+    return require_love_path(&path);
+  }
+  Err(CliError::Message(
+    "could not find Balatro.love; pass --love <path> or --app <Balatro.app>".to_string(),
+  ))
+}
+
+fn require_love_path(path: &Path) -> Result<PathBuf, CliError> {
+  if path.exists() {
+    Ok(path.to_path_buf())
+  } else {
+    Err(CliError::Message(format!(
+      "Balatro.love does not exist: {}",
+      path.display()
+    )))
+  }
+}
+
+fn love_path_from_app(app: &Path) -> PathBuf {
+  app.join("Contents").join("Resources").join("Balatro.love")
+}
+
+fn discover_steam_love_path() -> Option<PathBuf> {
+  let home = std::env::var_os("HOME").map(PathBuf::from)?;
+  let path = home
+    .join("Library")
+    .join("Application Support")
+    .join("Steam")
+    .join("steamapps")
+    .join("common")
+    .join("Balatro")
+    .join("Balatro.app")
+    .join("Contents")
+    .join("Resources")
+    .join("Balatro.love");
+  path.exists().then_some(path)
+}
+
+fn extract_deck_atlas_from_love(love_path: &Path) -> Result<Vec<u8>, CliError> {
+  let output = ProcessCommand::new("unzip")
+    .arg("-p")
+    .arg(love_path)
+    .arg(DECK_ATLAS_LOVE_PATH)
+    .output()?;
+  if !output.status.success() {
+    return Err(CliError::Message(format!(
+      "failed to extract {DECK_ATLAS_LOVE_PATH} from {}",
+      love_path.display()
+    )));
+  }
+  Ok(output.stdout)
+}
+
+fn validate_deck_atlas_path(path: &Path) -> Result<(), CliError> {
+  image::open(path)?;
+  Ok(())
+}
+
+fn sha256_file(path: &Path) -> Result<String, CliError> {
+  Ok(sha256_bytes(&fs::read(path)?))
+}
+
+fn sha256_bytes(bytes: &[u8]) -> String {
+  let mut hasher = Sha256::new();
+  hasher.update(bytes);
+  format!("{:x}", hasher.finalize())
+}
+
+fn now_millis() -> u128 {
+  SystemTime::now()
+    .duration_since(UNIX_EPOCH)
+    .map(|duration| duration.as_millis())
+    .unwrap_or_default()
+}
+
+fn click_store_reroll(_args: OperationControlArgs) -> Result<(), CliError> {
+  deferred(
+    "store.reroll",
+    "store reroll input is implemented after store buy",
+  )
+}
+
+#[cfg(target_os = "macos")]
+fn click_joker_sell(args: SlotOperationArgs) -> Result<(), CliError> {
+  let slot_index = parse_joker_slot_index(&args.slot)?;
+  click_sell_object(ObjectReadZone::Joker, slot_index, args)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn click_joker_sell(args: SlotOperationArgs) -> Result<(), CliError> {
+  parse_joker_slot_index(&args.slot)?;
+  Err(CliError::Message(
+    "jokers sell live operation is only available on macOS".to_string(),
+  ))
+}
+
+#[cfg(target_os = "macos")]
+fn click_consumable_sell(args: SlotOperationArgs) -> Result<(), CliError> {
+  let slot_index = parse_consumable_slot_index(&args.slot)?;
+  click_sell_object(ObjectReadZone::Consumable, slot_index, args)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn click_consumable_sell(args: SlotOperationArgs) -> Result<(), CliError> {
+  parse_consumable_slot_index(&args.slot)?;
+  Err(CliError::Message(
+    "consumables sell live operation is only available on macOS".to_string(),
+  ))
+}
+
+#[cfg(target_os = "macos")]
+fn click_sell_object(
+  zone: ObjectReadZone,
+  slot_index: u32,
+  args: SlotOperationArgs,
+) -> Result<(), CliError> {
+  use auv_driver::Driver;
+
+  let driver = auv_driver_macos::MacosDriver::new();
+  let session = driver.open_local()?;
+  let window = session
+    .window()
+    .resolve(Window::main_visible().owned_by(App::name(args.control.target.clone())))?;
+  let operation = match zone {
+    ObjectReadZone::Joker => "jokers.sell",
+    ObjectReadZone::Consumable => "consumables.sell",
+    ObjectReadZone::Store => {
+      return Err(CliError::Message(
+        "store items are not sellable through object sell".to_string(),
+      ));
+    }
+  };
+  let before_image = capture_window_to_temp(&session, &window, "object-sell-before")?;
+  let before = observe_image(&before_image, &BalatroModelConfig::default(), true)?;
+  let object_point = match zone {
+    ObjectReadZone::Joker => {
+      let joker = select_joker(&before, slot_index)?;
+      window_point_from_joker(&before, &window, joker)
+    }
+    ObjectReadZone::Consumable => {
+      let consumable = select_consumable(&before, slot_index)?;
+      window_point_from_consumable(&before, &window, consumable)
+    }
+    ObjectReadZone::Store => unreachable!("store sell is rejected above"),
+  };
+
+  click_game_point(&session, &window, object_point)?;
+  std::thread::sleep(Duration::from_millis(500));
+  let selected_image = capture_window_to_temp(&session, &window, "object-sell-selected")?;
+  let selected = observe_image(&selected_image, &BalatroModelConfig::default(), true)?;
+  let sell_button = find_button(&selected, "button_sell")?;
+  let sell_point = window_point_from_button(&selected, &window, sell_button);
+  click_game_point(&session, &window, sell_point)?;
+
+  let verification = if args.control.verify {
+    let (after_image, after_result) = capture_observable_window(
+      &session,
+      &window,
+      "object-sell-after",
+      args.control.timeout_ms.unwrap_or(1000),
+      500,
+    )?;
+    if args.control.verify_mode == VerifyModeArg::ActivationOnly {
+      Some(json!({
+        "mode": args.control.verify_mode.to_string(),
+        "profile": "activation_only",
+        "evidence": ["object_click_completed", "sell_click_completed"],
+        "passed": true,
+        "after_image": after_image,
+      }))
+    } else {
+      match after_result {
+        Ok(after) => Some(json!({
+          "mode": args.control.verify_mode.to_string(),
+          "profile": "weak",
+          "evidence": sell_operation_evidence(zone, &before, &after),
+          "before_joker_count": before.jokers.len(),
+          "after_joker_count": after.jokers.len(),
+          "before_consumable_count": before.consumables.len(),
+          "after_consumable_count": after.consumables.len(),
+          "before_cash": before.rounds.cash,
+          "after_cash": after.rounds.cash,
+          "passed": verify_sell_operation(zone, &before, &after),
+          "after_image": after_image,
+        })),
+        Err(error) => Some(json!({
+          "mode": args.control.verify_mode.to_string(),
+          "profile": "weak",
+          "evidence": Vec::<&str>::new(),
+          "before_joker_count": before.jokers.len(),
+          "before_consumable_count": before.consumables.len(),
+          "before_cash": before.rounds.cash,
+          "passed": false,
+          "after_image": after_image,
+          "error": error.to_string(),
+        })),
+      }
+    }
+  } else {
+    None
+  };
+
+  write_operation_output(
+    args.control.details,
+    json!({
+      "operation": operation,
+      "target": args.control.target,
+      "slot": args.slot,
+      "object_point": object_point,
+      "sell_button": sell_button,
+      "sell_point": sell_point,
+      "before_image": before_image,
+      "selected_image": selected_image,
+      "verification": verification,
+    }),
+  )
+}
+
+fn deferred(command: &'static str, reason: &'static str) -> Result<(), CliError> {
+  Err(CliError::Deferred { command, reason })
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+struct CardReadResult {
+  slot: crate::model::SlotId,
+  bbox: auv_inference_common::BoundingBox,
+  confidence: f32,
+  reading: CardReadValue,
+  evidence: CardReadEvidence,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum ObjectReadZone {
+  Store,
+  Joker,
+  Consumable,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+struct ObjectReadResult {
+  slot: crate::model::SlotId,
+  kind: String,
+  bbox: auv_inference_common::BoundingBox,
+  confidence: f32,
+  reading: ObjectReadValue,
+  evidence: ObjectReadEvidence,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+struct ObjectReadValue {
+  status: &'static str,
+  raw_text: Option<String>,
+  confidence: Option<f32>,
+}
+
+impl ObjectReadValue {
+  fn unread() -> Self {
+    Self {
+      status: "unread",
+      raw_text: None,
+      confidence: None,
+    }
+  }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+struct ObjectReadEvidence {
+  frame: String,
+  source: String,
+  hover_required: bool,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  hover_frame: Option<String>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  hover_ocr_region: Option<RatioRect>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  hover_error: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum ActionTargetSource {
+  YoloButton,
+  // TODO(store-object-target-v1): object-origin targets are reserved for
+  // store/pack item actions; Task 3 only resolves buttons and layout fallback.
+  #[allow(dead_code)]
+  YoloObject,
+  LayoutFallback,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+struct ResolvedActionTarget {
+  source: ActionTargetSource,
+  label: String,
+  frame_point: Point,
+  fallback_reason: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+struct PackChoice {
+  slot_index: u32,
+  kind: String,
+  detector_label: String,
+  hint: String,
+  hover_required: bool,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  hover_text: Option<String>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  hover_frame: Option<String>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  hover_ocr_region: Option<RatioRect>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  hover_error: Option<String>,
+  bbox: auv_inference_common::BoundingBox,
+  confidence: f32,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+struct PackReadOutput {
+  phase: BalatroPhase,
+  choices: Vec<PackChoice>,
+  skip_button: Option<ButtonTarget>,
+  frame: crate::model::FrameRef,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+struct CardReadValue {
+  status: &'static str,
+  raw_text: Option<String>,
+  normalized_text: Option<String>,
+  rank: Option<String>,
+  suit: Option<String>,
+  suit_symbol: Option<String>,
+  short_code: Option<String>,
+  confidence: Option<f32>,
+  valid: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+struct CardReadEvidence {
+  frame: String,
+  ocr_region: RatioRect,
+  corner_crop: Option<PathBuf>,
+  source: String,
+}
+
+fn write_observed_state(args: &ObserveArgs) -> Result<(), CliError> {
+  let state = observe_from_args(args)?;
+  write_output(args.output_mode(), &state)
+}
+
+fn write_scores(args: &ObserveArgs) -> Result<(), CliError> {
+  let state = observe_from_args(args)?;
+  write_output(args.output_mode(), &state.scores)
+}
+
+fn write_rounds(args: &ObserveArgs) -> Result<(), CliError> {
+  let state = observe_from_args(args)?;
+  write_output(args.output_mode(), &state.rounds)
+}
+
+fn write_card_read(args: &SlotObserveArgs) -> Result<(), CliError> {
+  let reads = read_cards_from_args(args)?;
+  write_output(args.observe.output_mode(), &reads)
+}
+
+fn write_object_read(args: &SlotObserveArgs, zone: ObjectReadZone) -> Result<(), CliError> {
+  if args.observe.image.is_none() {
+    let read = read_object_live(args, zone)?;
+    return write_output(args.observe.output_mode(), &read);
+  }
+
+  let state = observe_from_args(&args.observe)?;
+  let read = object_read_from_state(&state, &args.slot, zone)?;
+  write_output(args.observe.output_mode(), &read)
+}
+
+fn write_store_status(args: &ObserveArgs) -> Result<(), CliError> {
+  let state = observe_from_args(args)?;
+  write_output(args.output_mode(), &state.store)
+}
+
+fn write_store_items(args: &ObserveArgs) -> Result<(), CliError> {
+  let state = observe_from_args(args)?;
+  write_output(args.output_mode(), &state.store.items)
+}
+
+fn write_blind_buttons(args: &ObserveArgs) -> Result<(), CliError> {
+  let state = observe_from_args(args)?;
+  let buttons = blind_buttons(&state);
+  write_output(args.output_mode(), &buttons)
+}
+
+fn write_pack_read(args: &ObserveArgs) -> Result<(), CliError> {
+  #[cfg(target_os = "macos")]
+  if args.image.is_none() {
+    let output = read_pack_live(args)?;
+    return write_output(args.output_mode(), &output);
+  }
+
+  let state = observe_from_args(args)?;
+  let choices = active_pack_choices(&state);
+  write_output(
+    args.output_mode(),
+    &json!({
+      "phase": state.phase,
+      "choices": choices,
+      "skip_button": best_button(&state.buttons, "button_card_pack_skip"),
+      "frame": state.frame,
+    }),
+  )
+}
+
+#[cfg(target_os = "macos")]
+fn click_game_cash_out(args: OperationControlArgs) -> Result<(), CliError> {
+  click_single_button("game.cash_out", "button_cash_out", args)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn click_game_cash_out(_args: OperationControlArgs) -> Result<(), CliError> {
+  Err(CliError::Message(
+    "game cash-out live operation is only available on macOS".to_string(),
+  ))
+}
+
+#[cfg(target_os = "macos")]
+fn click_game_restart(args: OperationControlArgs) -> Result<(), CliError> {
+  use auv_driver::Driver;
+
+  let driver = auv_driver_macos::MacosDriver::new();
+  let session = driver.open_local()?;
+  let window = session
+    .window()
+    .resolve(Window::main_visible().owned_by(App::name(args.target.clone())))?;
+  let before_image = capture_window_to_temp(&session, &window, "game-restart-before")?;
+  let before = observe_image(&before_image, &BalatroModelConfig::default(), true).ok();
+  let first_point = before
+    .as_ref()
+    .and_then(|state| {
+      best_button(&state.buttons, "button_new_run_play").map(|button| {
+        (
+          "button_new_run_play",
+          window_point_from_button(state, &window, button),
+        )
+      })
+    })
+    .unwrap_or_else(|| {
+      if before.is_none() {
+        // NOTICE: Game Over overlays and some localized title screens are not
+        // covered by the current Balatro YOLO UI dataset, so restart may begin
+        // from a no-detection frame. Prefer the Game Over "start new run" slot
+        // first because it is the common post-run recovery path; the localized
+        // title-screen fallback below is still tried if this does not reveal an
+        // observable new-run button.
+        return (
+          "game_over_start_new_run_layout",
+          normalized_window_point(&window, 0.62, 0.805),
+        );
+      }
+      // TODO(balatro-game-over-ui-v1): replace this Game Over layout fallback
+      // with YOLO button evidence once game-over overlay buttons are in the UI
+      // dataset.
+      (
+        "game_over_start_new_run_layout",
+        normalized_window_point(&window, 0.62, 0.815),
+      )
+    });
+
+  click_game_point(&session, &window, first_point.1)?;
+  if first_point.0 == "game_over_start_new_run_layout" {
+    std::thread::sleep(Duration::from_millis(300));
+    click_game_point(&session, &window, first_point.1)?;
+  }
+
+  std::thread::sleep(Duration::from_millis(900));
+  let intermediate_image = capture_window_to_temp(&session, &window, "game-restart-intermediate")?;
+  let mut second_point = None;
+  if let Ok(intermediate) = observe_image(&intermediate_image, &BalatroModelConfig::default(), true)
+  {
+    if let Some(button) = best_button(&intermediate.buttons, "button_new_run_play") {
+      let point = window_point_from_button(&intermediate, &window, button);
+      click_game_point(&session, &window, point)?;
+      second_point = Some(point);
+    }
+  } else if first_point.0 == "game_over_start_new_run_layout" {
+    // NOTICE: If the first no-detection click did not expose the new-run
+    // screen, treat the frame as the older localized title-screen fallback.
+    // This keeps restart usable until both layouts have detector-backed button
+    // classes.
+    let point = normalized_window_point(&window, 0.31, 0.84);
+    click_game_point(&session, &window, point)?;
+    second_point = Some(point);
+  }
+
+  let verification = if args.verify {
+    let (mut after_image, mut after_result) = capture_observable_window(
+      &session,
+      &window,
+      "game-restart-after",
+      args.timeout_ms.unwrap_or(1800),
+      700,
+    )?;
+    let mut verification_retry_click_point = None;
+    if let Ok(after) = &after_result {
+      if after.phase == BalatroPhase::MainMenu {
+        if let Some(button) = best_button(&after.buttons, "button_new_run_play") {
+          let point = window_point_from_button(after, &window, button);
+          click_game_point(&session, &window, point)?;
+          verification_retry_click_point = Some(point);
+          (after_image, after_result) = capture_observable_window(
+            &session,
+            &window,
+            "game-restart-after-retry",
+            args.timeout_ms.unwrap_or(1800),
+            700,
+          )?;
+        }
+      }
+    }
+    match after_result {
+      Ok(after) => Some(json!({
+        "mode": args.verify_mode.to_string(),
+        "after_phase": after.phase,
+        "verification_retry_click_point": verification_retry_click_point,
+        "passed": matches!(after.phase, BalatroPhase::BlindSelect | BalatroPhase::Playing | BalatroPhase::Store),
+        "after_image": after_image,
+      })),
+      Err(error) => Some(json!({
+        "mode": args.verify_mode.to_string(),
+        "verification_retry_click_point": verification_retry_click_point,
+        "passed": false,
+        "after_image": after_image,
+        "error": error.to_string(),
+      })),
+    }
+  } else {
+    None
+  };
+
+  write_operation_output(
+    args.details,
+    json!({
+      "operation": "game.restart",
+      "target": args.target,
+      "strategy": first_point.0,
+      "window_point": first_point.1,
+      "intermediate_image": intermediate_image,
+      "second_click_point": second_point,
+      "before_image": before_image,
+      "verification": verification,
+    }),
+  )
+}
+
+#[cfg(not(target_os = "macos"))]
+fn click_game_restart(_args: OperationControlArgs) -> Result<(), CliError> {
+  Err(CliError::Message(
+    "game restart live operation is only available on macOS".to_string(),
+  ))
+}
+
+#[cfg(target_os = "macos")]
+fn click_store_buy(args: SlotOperationArgs) -> Result<(), CliError> {
+  use auv_driver::Driver;
+
+  let slot_index = parse_store_slot_index(&args.slot)?;
+  let driver = auv_driver_macos::MacosDriver::new();
+  let session = driver.open_local()?;
+  let window = session
+    .window()
+    .resolve(Window::main_visible().owned_by(App::name(args.control.target.clone())))?;
+  let before_image = capture_window_to_temp(&session, &window, "store-buy-before")?;
+  let before = observe_image(&before_image, &BalatroModelConfig::default(), true)?;
+  let item = select_store_item(&before, slot_index)?;
+  let item_point = window_point_from_store_item(&before, &window, item);
+
+  click_game_point(&session, &window, item_point)?;
+  std::thread::sleep(Duration::from_millis(500));
+  let selected_image = capture_window_to_temp(&session, &window, "store-buy-selected")?;
+  let selected = observe_image(&selected_image, &BalatroModelConfig::default(), true)?;
+  let confirm_button = select_store_buy_confirm_button(&selected)?;
+  let confirm_point = window_point_from_button(&selected, &window, confirm_button);
+  click_game_point(&session, &window, confirm_point)?;
+
+  let verification = if args.control.verify {
+    let (after_image, after_result) = capture_observable_window(
+      &session,
+      &window,
+      "store-buy-after",
+      args.control.timeout_ms.unwrap_or(1000),
+      500,
+    )?;
+    match after_result {
+      Ok(after) => Some(json!({
+        "mode": args.control.verify_mode.to_string(),
+        "before_phase": before.phase,
+        "after_phase": after.phase,
+        "before_store_item_count": before.store.items.len(),
+        "after_store_item_count": after.store.items.len(),
+        "before_joker_count": before.jokers.len(),
+        "after_joker_count": after.jokers.len(),
+        "before_consumable_count": before.consumables.len(),
+        "after_consumable_count": after.consumables.len(),
+        "evidence": store_buy_evidence(&before, &after),
+        "passed": verify_store_buy(&before, &after),
+        "after_image": after_image,
+      })),
+      Err(error) => Some(json!({
+        "mode": args.control.verify_mode.to_string(),
+        "before_phase": before.phase,
+        "before_store_item_count": before.store.items.len(),
+        "before_joker_count": before.jokers.len(),
+        "before_consumable_count": before.consumables.len(),
+        "evidence": Vec::<&str>::new(),
+        "passed": false,
+        "after_image": after_image,
+        "error": error.to_string(),
+      })),
+    }
+  } else {
+    None
+  };
+
+  write_operation_output(
+    args.control.details,
+    json!({
+      "operation": "store.buy",
+      "target": args.control.target,
+      "slot": args.slot,
+      "store_item": item,
+      "item_point": item_point,
+      "before_image": before_image,
+      "confirm_button": confirm_button,
+      "confirm_point": confirm_point,
+      "selected_image": selected_image,
+      "verification": verification,
+    }),
+  )
+}
+
+#[cfg(not(target_os = "macos"))]
+fn click_store_buy(args: SlotOperationArgs) -> Result<(), CliError> {
+  parse_store_slot_index(&args.slot)?;
+  Err(CliError::Message(
+    "store buy live operation is only available on macOS".to_string(),
+  ))
+}
+
+fn observe_from_args(args: &ObserveArgs) -> Result<BalatroState, CliError> {
+  let config = BalatroModelConfig::from_observe_args(args);
+  if let Some(image) = args.image.as_deref() {
+    return observe_image_with_ui_readings(image, &config, args.no_cache);
+  }
+  observe_live_target(&args.target, &config, args.no_cache)
+}
+
+fn observe_image_with_ui_readings(
+  image: &Path,
+  config: &BalatroModelConfig,
+  no_cache: bool,
+) -> Result<BalatroState, CliError> {
+  let mut state = observe_image(image, config, no_cache)?;
+  enrich_ui_numeric_readings_from_image(&mut state, image);
+  Ok(state)
+}
+
+fn read_cards_from_args(args: &SlotObserveArgs) -> Result<Vec<CardReadResult>, CliError> {
+  let requested = parse_card_read_slots(&args.slot)?;
+  let config = BalatroModelConfig::from_observe_args(&args.observe);
+  if let Some(image) = args.observe.image.as_deref() {
+    return read_cards_from_image(image, &config, args.observe.no_cache, &requested);
+  }
+  read_cards_live(
+    &args.observe.target,
+    &config,
+    args.observe.no_cache,
+    &requested,
+    args.frame_out.as_deref(),
+  )
+}
+
+#[cfg(target_os = "macos")]
+fn read_object_live(
+  args: &SlotObserveArgs,
+  zone: ObjectReadZone,
+) -> Result<ObjectReadResult, CliError> {
+  use auv_driver::Driver;
+
+  let config = BalatroModelConfig::from_observe_args(&args.observe);
+  let driver = auv_driver_macos::MacosDriver::new();
+  let session = driver.open_local()?;
+  let window = session
+    .window()
+    .resolve(Window::main_visible().owned_by(App::name(args.observe.target.clone())))?;
+  let capture = capture_window(&session, &window)?;
+  let frame = match args.frame_out.as_deref() {
+    Some(path) => save_capture_to_path(&capture, path)?,
+    None => save_capture_to_temp(&capture, "object-read")?,
+  };
+  let state = observe_image_with_ui_readings(&frame, &config, args.observe.no_cache)?;
+  let mut read = object_read_from_state(&state, &args.slot, zone)?;
+  let original_mouse = auv_driver_macos::native::pointer::current_mouse_logical_point().ok();
+
+  if let Err(error) = hover_read_object(&session, &window, &state, &mut read) {
+    read.evidence.hover_error = Some(error.to_string());
+  }
+
+  if let Some((x, y)) = original_mouse {
+    let _ = auv_driver_macos::native::pointer::move_point(x, y, 0);
+  }
+
+  Ok(read)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn read_object_live(
+  args: &SlotObserveArgs,
+  zone: ObjectReadZone,
+) -> Result<ObjectReadResult, CliError> {
+  let state = observe_from_args(&args.observe)?;
+  object_read_from_state(&state, &args.slot, zone)
+}
+
+#[cfg(target_os = "macos")]
+fn read_cards_from_image(
+  image: &Path,
+  config: &BalatroModelConfig,
+  no_cache: bool,
+  requested: &Option<Vec<u32>>,
+) -> Result<Vec<CardReadResult>, CliError> {
+  use auv_driver::Driver;
+
+  let driver = auv_driver_macos::MacosDriver::new();
+  let session = driver.open_local()?;
+  let capture = capture_from_image(image)?;
+  let state = observe_image_with_ui_readings(image, config, no_cache)?;
+  let cards = select_cards_for_read(&state, requested)?;
+  let rank_templates = load_deck_rank_templates();
+  cards
+    .into_iter()
+    .map(|card| {
+      read_card_from_capture(
+        &session,
+        &capture,
+        image,
+        &state,
+        card,
+        rank_templates.as_deref(),
+      )
+    })
+    .collect()
+}
+
+#[cfg(not(target_os = "macos"))]
+fn read_cards_from_image(
+  image: &Path,
+  config: &BalatroModelConfig,
+  no_cache: bool,
+  requested: &Option<Vec<u32>>,
+) -> Result<Vec<CardReadResult>, CliError> {
+  let state = observe_image_with_ui_readings(image, config, no_cache)?;
+  let cards = select_cards_for_read(&state, requested)?;
+  cards
+    .into_iter()
+    .map(|card| {
+      let region = ocr_region_for_card(&state, card);
+      Ok(CardReadResult {
+        slot: card.slot,
+        bbox: card.bbox,
+        confidence: card.confidence,
+        reading: CardReadValue::unread(),
+        evidence: CardReadEvidence {
+          frame: state.frame.source.clone(),
+          ocr_region: region,
+          corner_crop: None,
+          source: "image_without_ocr_non_macos".to_string(),
+        },
+      })
+    })
+    .collect()
+}
+
+fn write_output<T>(mode: OutputMode, value: &T) -> Result<(), CliError>
+where
+  T: Serialize + std::fmt::Debug,
+{
+  match mode {
+    OutputMode::Human => {
+      println!("{value:#?}");
+      Ok(())
+    }
+    OutputMode::Json => {
+      println!("{}", serde_json::to_string_pretty(value)?);
+      Ok(())
+    }
+    OutputMode::JsonFile(path) => {
+      crate::output::write_json_file(&path, value)?;
+      Ok(())
+    }
+  }
+}
+
+fn write_operation_output(details: bool, mut payload: Value) -> Result<(), CliError> {
+  if !details {
+    strip_operation_details(&mut payload);
+  }
+  write_output(OutputMode::Json, &payload)
+}
+
+fn strip_operation_details(value: &mut Value) {
+  match value {
+    Value::Object(map) => {
+      let generated_detail_keys = map
+        .keys()
+        .filter(|key| {
+          key.ends_with("_image")
+            || key.ends_with("_images")
+            || key.ends_with("_point")
+            || key.ends_with("_points")
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+      for key in generated_detail_keys {
+        map.remove(&key);
+      }
+
+      for key in [
+        "after_image",
+        "after_store",
+        "before_image",
+        "before_interactions",
+        "bbox",
+        "button",
+        "button_point",
+        "buttons",
+        "card_points",
+        "choice",
+        "choice_point",
+        "click_targets",
+        "commit_button",
+        "confirm_button",
+        "confirm_point",
+        "confirm_target",
+        "consumable",
+        "consumable_point",
+        "hand",
+        "item_point",
+        "raw_entities",
+        "raw_ui",
+        "selected_button",
+        "selected_cards",
+        "selected_image",
+        "selected_interactions",
+        "selected_target",
+        "selection_evidence",
+        "store_item",
+        "use_button",
+        "use_point",
+        "window_point",
+      ] {
+        map.remove(key);
+      }
+      for value in map.values_mut() {
+        strip_operation_details(value);
+      }
+    }
+    Value::Array(values) => {
+      for value in values {
+        strip_operation_details(value);
+      }
+    }
+    _ => {}
+  }
+}
+
+#[cfg(target_os = "macos")]
+fn click_consumable_use(args: TargetSlotOperationArgs) -> Result<(), CliError> {
+  use auv_driver::Driver;
+
+  let slot_index = parse_consumable_slot_index(&args.slot)?;
+  let target_indices = parse_hand_target_indices(&args.targets)?;
+  let driver = auv_driver_macos::MacosDriver::new();
+  let session = driver.open_local()?;
+  let window = session
+    .window()
+    .resolve(Window::main_visible().owned_by(App::name(args.control.target.clone())))?;
+  let before_image = capture_window_to_temp(&session, &window, "consumable-use-before")?;
+  let before = observe_image(&before_image, &BalatroModelConfig::default(), true)?;
+  let target_selection = if target_indices.is_empty() {
+    None
+  } else {
+    Some(click_hand_targets(
+      &session,
+      &window,
+      "consumable-use-targets",
+      &before,
+      &target_indices,
+      args.control.timeout_ms,
+    )?)
+  };
+  let consumable = select_consumable(&before, slot_index)?;
+  let consumable_point = window_point_from_consumable(&before, &window, consumable);
+
+  click_game_point(&session, &window, consumable_point)?;
+  std::thread::sleep(Duration::from_millis(500));
+  let selected_image = capture_window_to_temp(&session, &window, "consumable-use-selected")?;
+  let selected = observe_image(&selected_image, &BalatroModelConfig::default(), true)?;
+  let use_target = resolve_consumable_use_target(&selected, slot_index)?;
+  let use_point = window_point_from_frame_point(&selected, &window, use_target.frame_point);
+  click_game_point(&session, &window, use_point)?;
+
+  let verification = if args.control.verify {
+    std::thread::sleep(Duration::from_millis(
+      args.control.timeout_ms.unwrap_or(1200),
+    ));
+    let after_image = capture_window_to_temp(&session, &window, "consumable-use-after")?;
+    if args.control.verify_mode == VerifyModeArg::ActivationOnly {
+      Some(json!({
+        "mode": args.control.verify_mode.to_string(),
+        "profile": "activation_only",
+        "evidence": ["consumable_click_completed", "use_click_completed"],
+        "passed": true,
+        "after_image": after_image,
+      }))
+    } else {
+      match observe_image(&after_image, &BalatroModelConfig::default(), true) {
+        Ok(after) => Some(json!({
+          "mode": args.control.verify_mode.to_string(),
+          "profile": "weak",
+          "evidence": consumable_use_evidence(&before, &after),
+          "before_consumable_count": before.consumables.len(),
+          "after_consumable_count": after.consumables.len(),
+          "before_phase": before.phase,
+          "after_phase": after.phase,
+          "passed": verify_consumable_use(&before, &after),
+          "after_image": after_image,
+        })),
+        Err(error) => Some(json!({
+          "mode": args.control.verify_mode.to_string(),
+          "profile": "weak",
+          "evidence": Vec::<&str>::new(),
+          "before_consumable_count": before.consumables.len(),
+          "before_phase": before.phase,
+          "passed": false,
+          "after_image": after_image,
+          "error": error.to_string(),
+        })),
+      }
+    }
+  } else {
+    None
+  };
+
+  write_operation_output(
+    args.control.details,
+    json!({
+      "operation": "consumables.use",
+      "target": args.control.target,
+      "slot": args.slot,
+      "targets": args.targets,
+      "consumable": consumable,
+      "consumable_point": consumable_point,
+      "before_image": before_image,
+      "target_selection": target_selection,
+      "use_target": use_target,
+      "use_point": use_point,
+      "selected_image": selected_image,
+      "verification": verification,
+    }),
+  )
+}
+
+#[cfg(not(target_os = "macos"))]
+fn click_consumable_use(args: TargetSlotOperationArgs) -> Result<(), CliError> {
+  parse_consumable_slot_index(&args.slot)?;
+  parse_hand_target_indices(&args.targets)?;
+  Err(CliError::Message(
+    "consumables use live operation is only available on macOS".to_string(),
+  ))
+}
+
+#[cfg(target_os = "macos")]
+fn click_pack_skip(args: OperationControlArgs) -> Result<(), CliError> {
+  use auv_driver::Driver;
+
+  let driver = auv_driver_macos::MacosDriver::new();
+  let session = driver.open_local()?;
+  let window = session
+    .window()
+    .resolve(Window::main_visible().owned_by(App::name(args.target.clone())))?;
+  let before_image = capture_window_to_temp(&session, &window, "pack-skip-before")?;
+  let before = observe_image(&before_image, &BalatroModelConfig::default(), true)?;
+  let button = find_button(&before, "button_card_pack_skip")?;
+  let point = window_point_from_button(&before, &window, button);
+
+  click_game_point(&session, &window, point)?;
+
+  let verification = if args.verify {
+    std::thread::sleep(Duration::from_millis(args.timeout_ms.unwrap_or(1200)));
+    let after_image = capture_window_to_temp(&session, &window, "pack-skip-after")?;
+    match observe_image(&after_image, &BalatroModelConfig::default(), true) {
+      Ok(after) => {
+        let after_choice_count = active_pack_choices(&after).len();
+        Some(json!({
+          "mode": args.verify_mode.to_string(),
+          "before_phase": before.phase,
+          "after_phase": after.phase,
+          "before_choice_count": active_pack_choices(&before).len(),
+          "after_choice_count": after_choice_count,
+          "passed": best_button(&after.buttons, "button_card_pack_skip").is_none()
+            || after_choice_count == 0,
+          "after_image": after_image,
+        }))
+      }
+      Err(error) => Some(json!({
+        "mode": args.verify_mode.to_string(),
+        "before_phase": before.phase,
+        "before_choice_count": active_pack_choices(&before).len(),
+        "passed": false,
+        "after_image": after_image,
+        "error": error.to_string(),
+      })),
+    }
+  } else {
+    None
+  };
+
+  write_operation_output(
+    args.details,
+    json!({
+      "operation": "pack.skip",
+      "target": args.target,
+      "selected_button": button,
+      "window_point": { "x": point.x, "y": point.y },
+      "before_image": before_image,
+      "verification": verification,
+    }),
+  )
+}
+
+#[cfg(not(target_os = "macos"))]
+fn click_pack_skip(_args: OperationControlArgs) -> Result<(), CliError> {
+  Err(CliError::Message(
+    "pack skip live operation is only available on macOS".to_string(),
+  ))
+}
+
+#[cfg(target_os = "macos")]
+fn click_pack_choose(args: TargetSlotOperationArgs) -> Result<(), CliError> {
+  use auv_driver::Driver;
+
+  let slot_index = parse_pack_slot_index(&args.slot)?;
+  let target_indices = parse_hand_target_indices(&args.targets)?;
+  let driver = auv_driver_macos::MacosDriver::new();
+  let session = driver.open_local()?;
+  let window = session
+    .window()
+    .resolve(Window::main_visible().owned_by(App::name(args.control.target.clone())))?;
+  let before_image = capture_window_to_temp(&session, &window, "pack-choose-before")?;
+  let before = observe_image(&before_image, &BalatroModelConfig::default(), true)?;
+  let choices = active_pack_choices(&before);
+  let choice = select_pack_choice(&choices, slot_index)?;
+  let already_selected =
+    target_indices.is_empty() && best_button(&before.buttons, "button_use").is_some();
+  let (choice_point, selected_image, mut selected) = if already_selected {
+    (None, before_image.clone(), before.clone())
+  } else {
+    let choice_point =
+      window_point_from_frame_point(&before, &window, bbox_center_point(choice.bbox));
+
+    click_game_point(&session, &window, choice_point)?;
+    std::thread::sleep(Duration::from_millis(600));
+    let selected_image = capture_window_to_temp(&session, &window, "pack-choose-selected")?;
+    let selected = observe_image(&selected_image, &BalatroModelConfig::default(), true)?;
+    (Some(choice_point), selected_image, selected)
+  };
+  let target_selection = if target_indices.is_empty() {
+    None
+  } else {
+    let evidence = click_hand_targets(
+      &session,
+      &window,
+      "pack-choose-targets",
+      &selected,
+      &target_indices,
+      args.control.timeout_ms,
+    )?;
+    if let Some(after_targets) = evidence.state.clone() {
+      selected = after_targets;
+    }
+    Some(evidence)
+  };
+  let confirm = resolve_pack_confirm_target(&selected, choice)?;
+  let confirm_point = window_point_from_frame_point(&selected, &window, confirm.frame_point);
+  click_game_point(&session, &window, confirm_point)?;
+
+  let verification = if args.control.verify {
+    std::thread::sleep(Duration::from_millis(
+      args.control.timeout_ms.unwrap_or(1200),
+    ));
+    let after_image = capture_window_to_temp(&session, &window, "pack-choose-after")?;
+    match observe_image(&after_image, &BalatroModelConfig::default(), true) {
+      Ok(after) => {
+        let after_choice_count = active_pack_choices(&after).len();
+        Some(json!({
+          "mode": args.control.verify_mode.to_string(),
+          "before_choice_count": choices.len(),
+          "after_choice_count": after_choice_count,
+          "passed": best_button(&after.buttons, "button_card_pack_skip").is_none()
+            || after_choice_count < choices.len(),
+          "after_image": after_image,
+        }))
+      }
+      Err(error) => Some(json!({
+        "mode": args.control.verify_mode.to_string(),
+        "before_choice_count": choices.len(),
+        "passed": false,
+        "after_image": after_image,
+        "error": error.to_string(),
+      })),
+    }
+  } else {
+    None
+  };
+
+  write_operation_output(
+    args.control.details,
+    json!({
+      "operation": "pack.choose",
+      "target": args.control.target,
+      "slot": args.slot,
+      "targets": args.targets,
+      "choice": choice,
+      "choice_point": choice_point,
+      "before_image": before_image,
+      "target_selection": target_selection,
+      "confirm_target": confirm,
+      "confirm_point": confirm_point,
+      "selected_image": selected_image,
+      "verification": verification,
+    }),
+  )
+}
+
+#[cfg(not(target_os = "macos"))]
+fn click_pack_choose(args: TargetSlotOperationArgs) -> Result<(), CliError> {
+  parse_pack_slot_index(&args.slot)?;
+  parse_hand_target_indices(&args.targets)?;
+  Err(CliError::Message(
+    "pack choose live operation is only available on macOS".to_string(),
+  ))
+}
+
+#[cfg(target_os = "macos")]
+fn click_store_next_round(args: OperationControlArgs) -> Result<(), CliError> {
+  use auv_driver::Driver;
+
+  let driver = auv_driver_macos::MacosDriver::new();
+  let session = driver.open_local()?;
+  let window = session
+    .window()
+    .resolve(Window::main_visible().owned_by(App::name(args.target.clone())))?;
+  let before_image = capture_window_to_temp(&session, &window, "store-next-round-before")?;
+  let before = observe_image(&before_image, &BalatroModelConfig::default(), true)?;
+  let selected_target = resolve_store_next_round_target(&before)?;
+  let point = window_point_from_frame_point(&before, &window, selected_target.frame_point);
+
+  session.window().click(
+    &window,
+    WindowPoint::new(point.x, point.y),
+    ClickOptions {
+      policy: InputPolicy::ForegroundPreferred,
+      ..ClickOptions::default()
+    },
+  )?;
+
+  let verification = if args.verify {
+    std::thread::sleep(Duration::from_millis(args.timeout_ms.unwrap_or(1200)));
+    let after_image = capture_window_to_temp(&session, &window, "store-next-round-after")?;
+    match observe_image(&after_image, &BalatroModelConfig::default(), true) {
+      Ok(after) => Some(json!({
+        "mode": args.verify_mode.to_string(),
+        "before_phase": before.phase,
+        "after_phase": after.phase,
+        "passed": has_store_layout_evidence(&before)
+          && after.phase != BalatroPhase::Store
+          && after.phase != BalatroPhase::Unknown,
+        "after_store": after.store,
+        "after_image": after_image,
+      })),
+      Err(error) => Some(json!({
+        "mode": args.verify_mode.to_string(),
+        "before_phase": before.phase,
+        "passed": false,
+        "after_image": after_image,
+        "error": error.to_string(),
+      })),
+    }
+  } else {
+    None
+  };
+
+  write_operation_output(
+    args.details,
+    json!({
+      "operation": "store.next_round",
+      "target": args.target,
+      "selected_target": selected_target,
+      "window_point": { "x": point.x, "y": point.y },
+      "verification": verification,
+    }),
+  )
+}
+
+#[cfg(not(target_os = "macos"))]
+fn click_store_next_round(_args: OperationControlArgs) -> Result<(), CliError> {
+  Err(CliError::Message(
+    "store next-round live operation is only available on macOS".to_string(),
+  ))
+}
+
+#[cfg(target_os = "macos")]
+fn click_cards_select(args: MultiSlotOperationArgs) -> Result<(), CliError> {
+  click_cards("cards.select", None, args)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn click_cards_select(_args: MultiSlotOperationArgs) -> Result<(), CliError> {
+  Err(CliError::Message(
+    "cards select live operation is only available on macOS".to_string(),
+  ))
+}
+
+#[cfg(target_os = "macos")]
+fn click_cards_clear(args: OperationControlArgs) -> Result<(), CliError> {
+  use auv_driver::Driver;
+
+  let operation = "cards.clear";
+  let driver = auv_driver_macos::MacosDriver::new();
+  let session = driver.open_local()?;
+  let window = session
+    .window()
+    .resolve(Window::main_visible().owned_by(App::name(args.target.clone())))?;
+  let (before_image, before_result) = capture_observable_window(
+    &session,
+    &window,
+    operation,
+    args.timeout_ms.unwrap_or(1500),
+    0,
+  )?;
+  let before = before_result?;
+  let before_interactions = hand_card_interactions(&before);
+  let selected_slots = before_interactions
+    .iter()
+    .filter(|interaction| interaction.selected)
+    .map(|interaction| interaction.slot.index)
+    .collect::<Vec<_>>();
+
+  let mut click_state = before.clone();
+  let mut click_targets = Vec::new();
+  for slot_index in selected_slots {
+    let card = select_hand_card(&click_state, slot_index)?;
+    let point = window_point_from_hand_card(&click_state, &window, card);
+    click_targets.push(json!({
+      "phase": "clear_existing_selection",
+      "slot": card.slot,
+      "bbox": card.bbox,
+      "point": point,
+    }));
+    click_game_point(&session, &window, point)?;
+    std::thread::sleep(Duration::from_millis(160));
+    let (_, state_result) = capture_observable_window(
+      &session,
+      &window,
+      operation,
+      args.timeout_ms.unwrap_or(1500),
+      120,
+    )?;
+    click_state = state_result?;
+  }
+
+  let (after_image, after_result) = capture_observable_window(
+    &session,
+    &window,
+    operation,
+    args.timeout_ms.unwrap_or(1500),
+    250,
+  )?;
+  let after = after_result?;
+  let after_interactions = hand_card_interactions(&after);
+  let remaining_selected_slots = after_interactions
+    .iter()
+    .filter(|interaction| interaction.selected)
+    .map(|interaction| interaction.slot.index)
+    .collect::<Vec<_>>();
+  let passed = remaining_selected_slots.is_empty();
+
+  write_operation_output(
+    args.details,
+    json!({
+      "operation": operation,
+      "target": args.target,
+      "before_image": before_image,
+      "after_image": after_image,
+      "click_targets": click_targets,
+      "selection_evidence": {
+        "before_interactions": before_interactions,
+        "after_interactions": after_interactions,
+        "remaining_selected_slots": remaining_selected_slots,
+        "passed": passed,
+      },
+      "verification": if args.verify {
+        Some(json!({
+          "mode": args.verify_mode.to_string(),
+          "passed": passed,
+          "evidence": if passed {
+            vec!["no_selected_hand_cards_remaining"]
+          } else {
+            vec!["selected_hand_cards_remaining"]
+          },
+        }))
+      } else {
+        None
+      },
+    }),
+  )?;
+
+  if args.verify && !passed {
+    return Err(CliError::Message(
+      "card clear verification failed; selected hand cards remain".to_string(),
+    ));
+  }
+  Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn click_cards_clear(_args: OperationControlArgs) -> Result<(), CliError> {
+  Err(CliError::Message(
+    "cards clear live operation is only available on macOS".to_string(),
+  ))
+}
+
+#[cfg(target_os = "macos")]
+fn click_cards_commit(
+  operation: &str,
+  button_id: &str,
+  args: MultiSlotOperationArgs,
+) -> Result<(), CliError> {
+  click_cards(operation, Some(button_id), args)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn click_cards_commit(
+  _operation: &str,
+  _button_id: &str,
+  _args: MultiSlotOperationArgs,
+) -> Result<(), CliError> {
+  Err(CliError::Message(
+    "cards play/discard live operations are only available on macOS".to_string(),
+  ))
+}
+
+#[cfg(target_os = "macos")]
+fn click_cards(
+  operation: &str,
+  commit_button_id: Option<&str>,
+  args: MultiSlotOperationArgs,
+) -> Result<(), CliError> {
+  use auv_driver::Driver;
+
+  let slot_indices = parse_hand_slot_indices(&args.slots)?;
+  let driver = auv_driver_macos::MacosDriver::new();
+  let session = driver.open_local()?;
+  let window = session
+    .window()
+    .resolve(Window::main_visible().owned_by(App::name(args.control.target.clone())))?;
+  let (before_image, before_result) = capture_observable_window(
+    &session,
+    &window,
+    operation,
+    args.control.timeout_ms.unwrap_or(1500),
+    0,
+  )?;
+  let before = before_result?;
+  let cards = select_hand_cards(&before, &slot_indices)?;
+  let planned_card_points = cards
+    .iter()
+    .map(|card| window_point_from_hand_card(&before, &window, card))
+    .collect::<Vec<_>>();
+
+  let mut click_state = before.clone();
+  let mut click_targets = Vec::new();
+  let mut cleared_slots = Vec::new();
+  let mut kept_selected_slots = Vec::new();
+  if commit_button_id.is_some() {
+    kept_selected_slots = selected_hand_slot_indices(&click_state, &slot_indices);
+    for slot_index in selected_slots_to_clear(&click_state, &slot_indices) {
+      let card = select_hand_card(&click_state, slot_index)?;
+      let point = window_point_from_hand_card(&click_state, &window, card);
+      click_targets.push(json!({
+        "phase": "clear_existing_selection",
+        "slot": card.slot,
+        "bbox": card.bbox,
+        "point": point,
+      }));
+      click_game_point(&session, &window, point)?;
+      cleared_slots.push(slot_index);
+      std::thread::sleep(Duration::from_millis(160));
+      let (_, state_result) = capture_observable_window(
+        &session,
+        &window,
+        operation,
+        args.control.timeout_ms.unwrap_or(1500),
+        120,
+      )?;
+      click_state = state_result?;
+    }
+  }
+
+  for slot_index in requested_slots_to_select(&click_state, &slot_indices) {
+    // NOTICE: Balatro hand-card clicks can be dropped while the card hover
+    // description is appearing. Retry only after observing that the slot is
+    // still unselected; blind double-clicking would toggle a correctly selected
+    // card back off.
+    for attempt in 1..=2 {
+      if hand_slot_is_selected(&click_state, slot_index) {
+        break;
+      }
+      let card = select_hand_card(&click_state, slot_index)?;
+      let point = window_point_from_hand_card(&click_state, &window, card);
+      click_targets.push(json!({
+        "phase": "select_requested_slot",
+        "attempt": attempt,
+        "slot": card.slot,
+        "bbox": card.bbox,
+        "point": point,
+      }));
+      click_game_point(&session, &window, point)?;
+      std::thread::sleep(Duration::from_millis(180));
+      let (_, state_result) = capture_observable_window(
+        &session,
+        &window,
+        operation,
+        args.control.timeout_ms.unwrap_or(1500),
+        120,
+      )?;
+      click_state = state_result?;
+    }
+  }
+
+  // Planned hand slots are not trusted as semantic success. Balatro can move
+  // cards during selection, the window may change between capture and click,
+  // and jokers such as Hook can mutate the hand. Capture the selected state
+  // before committing so callers can inspect which cards the game actually
+  // accepted. Commit operations treat this as a hard gate: if the requested
+  // cards are not raised, the command refuses to press play/discard.
+  std::thread::sleep(Duration::from_millis(250));
+  let selected_image = capture_window_to_temp(&session, &window, operation)?;
+  let selected = observe_image(&selected_image, &BalatroModelConfig::default(), true)?;
+  let selected_interactions = hand_card_interactions(&selected);
+  let selected_slots = selected_hand_slot_indices(&selected, &hand_slot_indices(&selected));
+  let requested_selected_slots = selected_hand_slot_indices(&selected, &slot_indices);
+  let selection_passed = hand_selection_matches_requested(&selected, &slot_indices);
+  let selection_evidence = json!({
+    "selected_image": selected_image,
+    "phase": selected.phase,
+    "hand_count": selected.hand.len(),
+    "requested_slots": slot_indices,
+    "cleared_slots": cleared_slots,
+    "kept_selected_slots": kept_selected_slots,
+    "selected_slots": selected_slots,
+    "requested_selected_slots": requested_selected_slots,
+    "passed": selection_passed,
+    "selected_interactions": selected_interactions,
+    "hand": selected.hand.clone(),
+    "buttons": selected.buttons.clone(),
+  });
+
+  if commit_button_id.is_some() && !selection_passed {
+    write_operation_output(
+      args.control.details,
+      json!({
+        "operation": operation,
+        "target": args.control.target,
+        "slots": args.slots,
+        "before_image": before_image,
+        "selected_cards": cards,
+        "card_points": planned_card_points,
+        "click_targets": click_targets,
+        "selection_evidence": selection_evidence,
+        "verification": {
+          "mode": args.control.verify_mode.to_string(),
+          "passed": false,
+          "evidence": ["target_slots_not_selected_before_commit"],
+        },
+      }),
+    )?;
+    return Err(CliError::Message(
+      "card selection verification failed before commit; refusing to press play/discard"
+        .to_string(),
+    ));
+  }
+  if commit_button_id.is_none() && args.control.verify && !selection_passed {
+    write_operation_output(
+      args.control.details,
+      json!({
+        "operation": operation,
+        "target": args.control.target,
+        "slots": args.slots,
+        "before_image": before_image,
+        "selected_cards": cards,
+        "card_points": planned_card_points,
+        "click_targets": click_targets,
+        "selection_evidence": selection_evidence,
+        "verification": {
+          "mode": args.control.verify_mode.to_string(),
+          "passed": false,
+          "evidence": ["selected_hand_slots_do_not_match_requested_slots"],
+        },
+      }),
+    )?;
+    return Err(CliError::Message(
+      "card select verification failed; selected hand slots do not match requested slots"
+        .to_string(),
+    ));
+  }
+
+  let mut commit_button = None;
+  let mut button_point = None;
+  if let Some(button_id) = commit_button_id {
+    let button = find_button(&selected, button_id)?;
+    let point = window_point_from_button(&selected, &window, button);
+    session.window().click(
+      &window,
+      WindowPoint::new(point.x, point.y),
+      ClickOptions {
+        policy: InputPolicy::ForegroundPreferred,
+        ..ClickOptions::default()
+      },
+    )?;
+    commit_button = Some(button.clone());
+    button_point = Some(point);
+  }
+
+  let verification = if args.control.verify {
+    let (after_image, after_result) = capture_observable_window(
+      &session,
+      &window,
+      operation,
+      args.control.timeout_ms.unwrap_or(1500),
+      600,
+    )?;
+    match after_result {
+      Ok(after) => Some(json!({
+        "mode": args.control.verify_mode.to_string(),
+        "before_phase": before.phase,
+        "after_phase": after.phase,
+        "before_hand_count": before.hand.len(),
+        "after_hand_count": after.hand.len(),
+        "evidence": card_operation_evidence(operation, &before, &after),
+        "passed": verify_card_operation(operation, &before, &after),
+        "after_image": after_image,
+      })),
+      Err(error) => Some(json!({
+        "mode": args.control.verify_mode.to_string(),
+        "before_phase": before.phase,
+        "before_hand_count": before.hand.len(),
+        "passed": false,
+        "after_image": after_image,
+        "error": error.to_string(),
+      })),
+    }
+  } else {
+    None
+  };
+
+  write_operation_output(
+    args.control.details,
+    json!({
+      "operation": operation,
+      "target": args.control.target,
+      "slots": args.slots,
+      "before_image": before_image,
+      "selected_cards": cards,
+      "card_points": planned_card_points,
+      "click_targets": click_targets,
+      "selection_evidence": selection_evidence,
+      "commit_button": commit_button,
+      "button_point": button_point,
+      "verification": verification,
+    }),
+  )
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Debug, Serialize)]
+struct HandTargetSelection {
+  selected_image: PathBuf,
+  requested_slots: Vec<u32>,
+  selected_slots: Vec<u32>,
+  passed: bool,
+  click_targets: Vec<Value>,
+  #[serde(skip)]
+  state: Option<BalatroState>,
+}
+
+#[cfg(target_os = "macos")]
+fn click_hand_targets(
+  session: &auv_driver_macos::MacosDriverSession,
+  window: &auv_driver::window::Window,
+  operation: &str,
+  before: &BalatroState,
+  slot_indices: &[u32],
+  timeout_ms: Option<u64>,
+) -> Result<HandTargetSelection, CliError> {
+  let _cards = select_hand_cards(before, slot_indices)?;
+  let mut click_state = before.clone();
+  let mut click_targets = Vec::new();
+  for slot_index in selected_slots_to_clear(&click_state, slot_indices) {
+    let card = select_hand_card(&click_state, slot_index)?;
+    let point = window_point_from_hand_card(&click_state, window, card);
+    click_targets.push(json!({
+      "phase": "clear_existing_selection",
+      "slot": card.slot,
+      "bbox": card.bbox,
+      "point": point,
+    }));
+    click_game_point(session, window, point)?;
+    std::thread::sleep(Duration::from_millis(160));
+    let (_, state_result) =
+      capture_observable_window(session, window, operation, timeout_ms.unwrap_or(1500), 120)?;
+    click_state = state_result?;
+  }
+
+  for slot_index in requested_slots_to_select(&click_state, slot_indices) {
+    for attempt in 1..=2 {
+      if hand_slot_is_selected(&click_state, slot_index) {
+        break;
+      }
+      let card = select_hand_card(&click_state, slot_index)?;
+      let point = window_point_from_hand_card(&click_state, window, card);
+      click_targets.push(json!({
+        "phase": "select_requested_slot",
+        "attempt": attempt,
+        "slot": card.slot,
+        "bbox": card.bbox,
+        "point": point,
+      }));
+      click_game_point(session, window, point)?;
+      std::thread::sleep(Duration::from_millis(180));
+      let (_, state_result) =
+        capture_observable_window(session, window, operation, timeout_ms.unwrap_or(1500), 120)?;
+      click_state = state_result?;
+    }
+  }
+
+  std::thread::sleep(Duration::from_millis(250));
+  let selected_image = capture_window_to_temp(session, window, operation)?;
+  let selected = observe_image(&selected_image, &BalatroModelConfig::default(), true)?;
+  let selected_slots = selected_hand_slot_indices(&selected, &hand_slot_indices(&selected));
+  let passed = hand_selection_matches_requested(&selected, slot_indices);
+  if !passed {
+    return Err(CliError::Message(
+      "target hand selection verification failed; refusing to use consumable".to_string(),
+    ));
+  }
+
+  Ok(HandTargetSelection {
+    selected_image,
+    requested_slots: slot_indices.to_vec(),
+    selected_slots,
+    passed,
+    click_targets,
+    state: Some(selected),
+  })
+}
+
+#[cfg(target_os = "macos")]
+fn click_blind_select(args: SlotOperationArgs) -> Result<(), CliError> {
+  let slot_index = parse_blind_slot_index(&args.slot)?;
+  click_blind_button(
+    "blinds.select",
+    "button_level_select",
+    Some(slot_index),
+    args.control,
+  )
+}
+
+#[cfg(not(target_os = "macos"))]
+fn click_blind_select(_args: SlotOperationArgs) -> Result<(), CliError> {
+  Err(CliError::Message(
+    "blinds select live operation is only available on macOS".to_string(),
+  ))
+}
+
+#[cfg(target_os = "macos")]
+fn click_blind_skip(args: OperationControlArgs) -> Result<(), CliError> {
+  click_blind_button("blinds.skip", "button_level_skip", None, args)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn click_blind_skip(_args: OperationControlArgs) -> Result<(), CliError> {
+  Err(CliError::Message(
+    "blinds skip live operation is only available on macOS".to_string(),
+  ))
+}
+
+#[cfg(target_os = "macos")]
+fn click_blind_button(
+  operation: &str,
+  button_id: &str,
+  slot_index: Option<u32>,
+  args: OperationControlArgs,
+) -> Result<(), CliError> {
+  use auv_driver::Driver;
+
+  let driver = auv_driver_macos::MacosDriver::new();
+  let session = driver.open_local()?;
+  let window = session
+    .window()
+    .resolve(Window::main_visible().owned_by(App::name(args.target.clone())))?;
+  let before_image = capture_window_to_temp(&session, &window, operation)?;
+  let before = observe_image(&before_image, &BalatroModelConfig::default(), true)?;
+  let button = select_button_for_slot(&before.buttons, button_id, slot_index)?;
+  let point = window_point_from_button(&before, &window, button);
+
+  session.window().click(
+    &window,
+    WindowPoint::new(point.x, point.y),
+    ClickOptions {
+      policy: InputPolicy::ForegroundPreferred,
+      ..ClickOptions::default()
+    },
+  )?;
+
+  let verification = if args.verify {
+    let (after_image, after_result) = capture_observable_window(
+      &session,
+      &window,
+      operation,
+      args.timeout_ms.unwrap_or(1200),
+      500,
+    )?;
+    match after_result {
+      Ok(after) => {
+        let passed = match operation {
+          "blinds.select" => {
+            before.phase == BalatroPhase::BlindSelect
+              && (after.phase == BalatroPhase::Playing || !after.hand.is_empty())
+          }
+          "blinds.skip" => {
+            before.phase == BalatroPhase::BlindSelect && after.phase != BalatroPhase::BlindSelect
+          }
+          _ => false,
+        };
+        Some(json!({
+          "mode": args.verify_mode.to_string(),
+          "before_phase": before.phase,
+          "after_phase": after.phase,
+          "after_hand_count": after.hand.len(),
+          "passed": passed,
+          "after_image": after_image,
+        }))
+      }
+      Err(error) => Some(json!({
+        "mode": args.verify_mode.to_string(),
+        "before_phase": before.phase,
+        "passed": false,
+        "after_image": after_image,
+        "error": error.to_string(),
+      })),
+    }
+  } else {
+    None
+  };
+
+  write_operation_output(
+    args.details,
+    json!({
+      "operation": operation,
+      "target": args.target,
+      "slot_index": slot_index,
+      "selected_button": button,
+      "window_point": { "x": point.x, "y": point.y },
+      "verification": verification,
+    }),
+  )
+}
+
+#[cfg(target_os = "macos")]
+fn click_single_button(
+  operation: &str,
+  button_id: &str,
+  args: OperationControlArgs,
+) -> Result<(), CliError> {
+  use auv_driver::Driver;
+
+  let driver = auv_driver_macos::MacosDriver::new();
+  let session = driver.open_local()?;
+  let window = session
+    .window()
+    .resolve(Window::main_visible().owned_by(App::name(args.target.clone())))?;
+  let before_image = capture_window_to_temp(&session, &window, operation)?;
+  let before = observe_image(&before_image, &BalatroModelConfig::default(), true)?;
+  let button = find_button(&before, button_id)?;
+  let point = window_point_from_button(&before, &window, button);
+
+  click_game_point(&session, &window, point)?;
+
+  let verification = if args.verify {
+    let (after_image, after_result) = capture_observable_window(
+      &session,
+      &window,
+      operation,
+      args.timeout_ms.unwrap_or(1200),
+      500,
+    )?;
+    match after_result {
+      Ok(after) => Some(json!({
+        "mode": args.verify_mode.to_string(),
+        "before_phase": before.phase,
+        "after_phase": after.phase,
+        "button_still_visible": best_button(&after.buttons, button_id).is_some(),
+        "passed": verify_single_button_activation(button_id, &before, &after),
+        "after_image": after_image,
+      })),
+      Err(error) => Some(json!({
+        "mode": args.verify_mode.to_string(),
+        "before_phase": before.phase,
+        "passed": false,
+        "after_image": after_image,
+        "error": error.to_string(),
+      })),
+    }
+  } else {
+    None
+  };
+
+  write_operation_output(
+    args.details,
+    json!({
+      "operation": operation,
+      "target": args.target,
+      "button": button,
+      "window_point": point,
+      "before_image": before_image,
+      "verification": verification,
+    }),
+  )
+}
+
+#[cfg(target_os = "macos")]
+fn observe_live_target(
+  target: &str,
+  config: &BalatroModelConfig,
+  no_cache: bool,
+) -> Result<BalatroState, CliError> {
+  use auv_driver::Driver;
+
+  let driver = auv_driver_macos::MacosDriver::new();
+  let session = driver.open_local()?;
+  let window = session
+    .window()
+    .resolve(Window::main_visible().owned_by(App::name(target.to_string())))?;
+  let image = capture_window_to_temp(&session, &window, "observe-live")?;
+  observe_image_with_ui_readings(&image, config, no_cache)
+}
+
+#[cfg(target_os = "macos")]
+fn read_cards_live(
+  target: &str,
+  config: &BalatroModelConfig,
+  no_cache: bool,
+  requested: &Option<Vec<u32>>,
+  frame_out: Option<&Path>,
+) -> Result<Vec<CardReadResult>, CliError> {
+  use auv_driver::Driver;
+
+  let driver = auv_driver_macos::MacosDriver::new();
+  let session = driver.open_local()?;
+  let window = session
+    .window()
+    .resolve(Window::main_visible().owned_by(App::name(target.to_string())))?;
+  let capture = capture_window(&session, &window)?;
+  let frame = match frame_out {
+    Some(path) => save_capture_to_path(&capture, path)?,
+    None => save_capture_to_temp(&capture, "cards-read")?,
+  };
+  let state = observe_image_with_ui_readings(&frame, config, no_cache)?;
+  let cards = select_cards_for_read(&state, requested)?;
+  let rank_templates = load_deck_rank_templates();
+  let original_mouse = auv_driver_macos::native::pointer::current_mouse_logical_point().ok();
+  let mut used_hover = false;
+  let results = cards
+    .into_iter()
+    .map(|card| {
+      let mut result = read_card_from_capture(
+        &session,
+        &capture,
+        &frame,
+        &state,
+        card,
+        rank_templates.as_deref(),
+      )?;
+      if should_hover_reread_card(&result.reading)
+        && let Some(hover) = hover_reread_card(
+          &session,
+          &window,
+          config,
+          no_cache,
+          &state,
+          card,
+          rank_templates.as_deref(),
+        )?
+      {
+        used_hover = true;
+        result = better_card_read(result, hover);
+      }
+      Ok(result)
+    })
+    .collect::<Result<Vec<_>, CliError>>();
+  if used_hover && let Some((x, y)) = original_mouse {
+    let _ = auv_driver_macos::native::pointer::move_point(x, y, 0);
+  }
+  results
+}
+
+#[cfg(target_os = "macos")]
+fn read_pack_live(args: &ObserveArgs) -> Result<PackReadOutput, CliError> {
+  use auv_driver::Driver;
+
+  let config = BalatroModelConfig::from_observe_args(args);
+  let driver = auv_driver_macos::MacosDriver::new();
+  let session = driver.open_local()?;
+  let window = session
+    .window()
+    .resolve(Window::main_visible().owned_by(App::name(args.target.clone())))?;
+  let capture = capture_window(&session, &window)?;
+  let frame = save_capture_to_temp(&capture, "pack-read")?;
+  let state = observe_image_with_ui_readings(&frame, &config, args.no_cache)?;
+  let mut choices = active_pack_choices(&state);
+  let original_mouse = auv_driver_macos::native::pointer::current_mouse_logical_point().ok();
+
+  for choice in &mut choices {
+    if !choice.hover_required {
+      continue;
+    }
+    if let Err(error) = hover_read_pack_choice(&session, &window, &state, choice) {
+      choice.hover_error = Some(error.to_string());
+    }
+  }
+
+  if let Some((x, y)) = original_mouse {
+    let _ = auv_driver_macos::native::pointer::move_point(x, y, 0);
+  }
+
+  Ok(PackReadOutput {
+    phase: state.phase,
+    choices,
+    skip_button: best_button(&state.buttons, "button_card_pack_skip").cloned(),
+    frame: state.frame,
+  })
+}
+
+#[cfg(target_os = "macos")]
+fn hover_read_pack_choice(
+  session: &auv_driver_macos::MacosDriverSession,
+  window: &auv_driver::window::Window,
+  state: &BalatroState,
+  choice: &mut PackChoice,
+) -> Result<(), CliError> {
+  let point = window_point_from_frame_point(state, window, bbox_center_point(choice.bbox));
+  let screen = session
+    .window()
+    .to_screen_point(window, WindowPoint::new(point.x, point.y))?;
+  let screen = screen.point();
+  auv_driver_macos::native::pointer::move_point(screen.x, screen.y, 0)
+    .map_err(CliError::Message)?;
+  std::thread::sleep(Duration::from_millis(450));
+
+  let capture = capture_window(session, window)?;
+  let frame = save_capture_to_temp(&capture, "pack-hover-read")?;
+  let region = pack_choice_hover_ocr_region();
+  let recognition = session.vision().recognize_text_in_capture_with_options(
+    &capture,
+    region,
+    TextRecognitionOptions::default()
+      .with_recognition_languages(["zh-Hans", "en-US"])
+      .with_custom_words(pack_ocr_words()),
+  )?;
+  choice.hover_text = non_empty_trimmed_text(&recognition.text);
+  choice.hover_frame = Some(frame.display().to_string());
+  choice.hover_ocr_region = Some(region);
+  Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn hover_read_object(
+  session: &auv_driver_macos::MacosDriverSession,
+  window: &auv_driver::window::Window,
+  state: &BalatroState,
+  read: &mut ObjectReadResult,
+) -> Result<(), CliError> {
+  let point = window_point_from_frame_point(state, window, bbox_center_point(read.bbox));
+  let screen = session
+    .window()
+    .to_screen_point(window, WindowPoint::new(point.x, point.y))?;
+  let screen = screen.point();
+  auv_driver_macos::native::pointer::move_point(screen.x, screen.y, 0)
+    .map_err(CliError::Message)?;
+  std::thread::sleep(Duration::from_millis(450));
+
+  let capture = capture_window(session, window)?;
+  let frame = save_capture_to_temp(&capture, "object-hover-read")?;
+  let region = object_hover_ocr_region();
+  let recognition = session.vision().recognize_text_in_capture_with_options(
+    &capture,
+    region,
+    TextRecognitionOptions::default()
+      .with_recognition_languages(["zh-Hans", "en-US"])
+      .with_custom_words(object_ocr_words()),
+  )?;
+
+  if let Some(text) = non_empty_trimmed_text(&recognition.text) {
+    read.reading = ObjectReadValue {
+      status: "read",
+      raw_text: Some(text),
+      confidence: None,
+    };
+    read.evidence.hover_required = false;
+  }
+  read.evidence.source = "hover_ocr".to_string();
+  read.evidence.hover_frame = Some(frame.display().to_string());
+  read.evidence.hover_ocr_region = Some(region);
+  Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn click_game_point(
+  session: &auv_driver_macos::MacosDriverSession,
+  window: &auv_driver::window::Window,
+  point: Point,
+) -> Result<(), CliError> {
+  session.window().click(
+    window,
+    WindowPoint::new(point.x, point.y),
+    ClickOptions {
+      policy: InputPolicy::ForegroundPreferred,
+      ..ClickOptions::default()
+    },
+  )?;
+  Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn read_card_from_capture(
+  session: &auv_driver_macos::MacosDriverSession,
+  capture: &Capture,
+  frame: &Path,
+  state: &BalatroState,
+  card: &CardSlot,
+  rank_templates: Option<&[RankTemplate]>,
+) -> Result<CardReadResult, CliError> {
+  let region = ocr_region_for_card(state, card);
+  let corner_capture = card_corner_capture(capture, state, card);
+  let recognition = session.vision().recognize_text_in_capture_with_options(
+    &corner_capture,
+    RatioRect::new(0.0, 0.0, 1.0, 1.0),
+    TextRecognitionOptions::default()
+      .with_custom_words(card_ocr_words())
+      .with_recognition_languages(["zh-Hans", "en-US"]),
+  )?;
+  let crop = save_capture_to_temp(&corner_capture, "card-corner")?;
+  let suit = infer_suit_from_card_corner(capture, state, card);
+  let mut source = "macos_vision_corner_ocr".to_string();
+  let mut reading = parse_card_reading(&recognition.text, suit, None);
+  if reading.rank.is_none()
+    && let Some((rank, confidence)) =
+      infer_rank_from_deck_template(&corner_capture.image, rank_templates, suit)
+  {
+    apply_inferred_rank(&mut reading, rank, confidence);
+    source = format!("{source}+deck_template_rank");
+  }
+  Ok(CardReadResult {
+    slot: card.slot,
+    bbox: card.bbox,
+    confidence: card.confidence,
+    reading,
+    evidence: CardReadEvidence {
+      frame: frame.display().to_string(),
+      ocr_region: region,
+      corner_crop: Some(crop),
+      source,
+    },
+  })
+}
+
+#[cfg(target_os = "macos")]
+fn hover_reread_card(
+  session: &auv_driver_macos::MacosDriverSession,
+  window: &auv_driver::window::Window,
+  config: &BalatroModelConfig,
+  no_cache: bool,
+  state: &BalatroState,
+  card: &CardSlot,
+  rank_templates: Option<&[RankTemplate]>,
+) -> Result<Option<CardReadResult>, CliError> {
+  let point = window_point_from_frame_point(state, window, bbox_center_point(card.bbox));
+  let screen = session
+    .window()
+    .to_screen_point(window, WindowPoint::new(point.x, point.y))?;
+  let screen = screen.point();
+  auv_driver_macos::native::pointer::move_point(screen.x, screen.y, 0)
+    .map_err(CliError::Message)?;
+  std::thread::sleep(Duration::from_millis(350));
+
+  let capture = capture_window(session, window)?;
+  let frame = save_capture_to_temp(&capture, "cards-hover-read")?;
+  let hover_state = observe_image_with_ui_readings(&frame, config, no_cache)?;
+  let hover_card = match select_hand_card(&hover_state, card.slot.index) {
+    Ok(card) => card,
+    Err(_) => return Ok(None),
+  };
+  let mut result = read_card_from_capture(
+    session,
+    &capture,
+    &frame,
+    &hover_state,
+    hover_card,
+    rank_templates,
+  )?;
+  result.evidence.source = format!("{}+hover_reread", result.evidence.source);
+  Ok(Some(result))
+}
+
+fn better_card_read(original: CardReadResult, hover: CardReadResult) -> CardReadResult {
+  if card_read_score(&hover.reading) > card_read_score(&original.reading) {
+    hover
+  } else {
+    original
+  }
+}
+
+fn card_read_score(reading: &CardReadValue) -> (u8, u8) {
+  let completeness = match (
+    reading.rank.is_some(),
+    reading.suit.is_some(),
+    reading.valid,
+  ) {
+    (_, _, true) => 3,
+    (true, false, false) | (false, true, false) => 2,
+    _ => 1,
+  };
+  let confidence = reading
+    .confidence
+    .map(|confidence| (confidence.clamp(0.0, 1.0) * 100.0).round() as u8)
+    .unwrap_or(0);
+  (completeness, confidence)
+}
+
+#[cfg(target_os = "macos")]
+fn capture_observable_window(
+  session: &auv_driver_macos::MacosDriverSession,
+  window: &auv_driver::window::Window,
+  label: &str,
+  timeout_ms: u64,
+  initial_delay_ms: u64,
+) -> Result<(PathBuf, Result<BalatroState, ObservationError>), CliError> {
+  let timeout = Duration::from_millis(timeout_ms);
+  let deadline = Instant::now() + timeout;
+  let mut delay = Duration::from_millis(initial_delay_ms.min(timeout_ms));
+
+  loop {
+    if !delay.is_zero() {
+      std::thread::sleep(delay);
+    }
+
+    let image = capture_window_to_temp(session, window, label)?;
+    match observe_image(&image, &BalatroModelConfig::default(), true).map(|mut state| {
+      enrich_ui_numeric_readings_from_image(&mut state, &image);
+      state
+    }) {
+      Ok(state) => return Ok((image, Ok(state))),
+      Err(error) if Instant::now() >= deadline => return Ok((image, Err(error))),
+      Err(_) => {
+        delay = Duration::from_millis(250);
+      }
+    }
+  }
+}
+
+fn capture_from_image(image: &Path) -> Result<Capture, CliError> {
+  let rgba = image::open(image)?.to_rgba8();
+  let width = rgba.width();
+  let height = rgba.height();
+  Ok(Capture {
+    image: rgba,
+    bounds: Rect::new(0.0, 0.0, f64::from(width), f64::from(height)),
+    scale_factor: 1.0,
+    backend: "image-file".to_string(),
+    fallback_reason: None,
+  })
+}
+
+#[cfg(not(target_os = "macos"))]
+fn observe_live_target(
+  _target: &str,
+  _config: &BalatroModelConfig,
+  _no_cache: bool,
+) -> Result<BalatroState, CliError> {
+  Err(CliError::MissingImage)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn read_cards_live(
+  _target: &str,
+  _config: &BalatroModelConfig,
+  _no_cache: bool,
+  _requested: &Option<Vec<u32>>,
+  _frame_out: Option<&Path>,
+) -> Result<Vec<CardReadResult>, CliError> {
+  Err(CliError::MissingImage)
+}
+
+#[cfg(target_os = "macos")]
+fn capture_window(
+  session: &auv_driver_macos::MacosDriverSession,
+  window: &auv_driver::window::Window,
+) -> Result<Capture, CliError> {
+  match session.window().capture_with(
+    window,
+    CaptureOptions {
+      activation: Activation::ActivateFirst {
+        settle: Duration::from_millis(250),
+      },
+      ..CaptureOptions::default()
+    },
+  ) {
+    Ok(capture) => Ok(capture),
+    Err(error) => capture_window_via_display_region(session, window, error.to_string()),
+  }
+}
+
+#[cfg(target_os = "macos")]
+fn capture_window_via_display_region(
+  session: &auv_driver_macos::MacosDriverSession,
+  window: &auv_driver::window::Window,
+  primary_error: String,
+) -> Result<Capture, CliError> {
+  // NOTICE: Balatro/love can make ScreenCaptureKit window capture time out
+  // while display-region capture still works. Keep this fallback local to the
+  // game surface until the shared capture contract can expose backend choices
+  // explicitly.
+  let mut region = window.frame;
+  region.origin.x = region.origin.x.round();
+  region.origin.y = region.origin.y.round();
+  region.size.width = region.size.width.round();
+  region.size.height = region.size.height.round();
+  let mut capture = session
+    .display()
+    .capture_region(CaptureOptions {
+      activation: Activation::KeepCurrent,
+      region: Some(region),
+      ..CaptureOptions::default()
+    })
+    .map_err(|fallback_error| {
+      CliError::Message(format!(
+        "window capture failed ({primary_error}); display-region fallback also failed ({fallback_error})"
+      ))
+    })?
+    .capture;
+  capture.backend = format!("{}:window-frame-fallback", capture.backend);
+  capture.fallback_reason = Some(primary_error);
+  Ok(capture)
+}
+
+#[cfg(target_os = "macos")]
+fn save_capture_to_path(capture: &Capture, path: &Path) -> Result<PathBuf, CliError> {
+  if let Some(parent) = path.parent()
+    && !parent.as_os_str().is_empty()
+  {
+    fs::create_dir_all(parent)?;
+  }
+  capture.image.save(path)?;
+  Ok(path.to_path_buf())
+}
+
+#[cfg(target_os = "macos")]
+fn save_capture_to_temp(capture: &Capture, prefix: &str) -> Result<PathBuf, CliError> {
+  let path = std::env::temp_dir().join(format!(
+    "auv-game-balatro-{prefix}-{}-{}.png",
+    std::process::id(),
+    unique_nanos()
+  ));
+  capture.image.save(&path)?;
+  Ok(path)
+}
+
+#[cfg(target_os = "macos")]
+fn capture_window_to_temp(
+  session: &auv_driver_macos::MacosDriverSession,
+  window: &auv_driver::window::Window,
+  prefix: &str,
+) -> Result<PathBuf, CliError> {
+  let capture = capture_window(session, window)?;
+  save_capture_to_temp(&capture, prefix)
+}
+
+fn unique_nanos() -> u128 {
+  SystemTime::now()
+    .duration_since(UNIX_EPOCH)
+    .map(|duration| duration.as_nanos())
+    .unwrap_or_default()
+}
+
+fn find_button<'a>(state: &'a BalatroState, id: &str) -> Result<&'a ButtonTarget, CliError> {
+  select_button_for_slot(&state.buttons, id, None)
+}
+
+fn select_store_buy_confirm_button(state: &BalatroState) -> Result<&ButtonTarget, CliError> {
+  best_button(&state.buttons, "button_purchase")
+    .or_else(|| best_button(&state.buttons, "button_use"))
+    .ok_or_else(|| {
+      CliError::Message(
+        "could not find button_purchase or button_use in selected store item frame".to_string(),
+      )
+    })
+}
+
+fn best_button<'a>(buttons: &'a [ButtonTarget], id: &str) -> Option<&'a ButtonTarget> {
+  buttons
+    .iter()
+    .filter(|button| button.id == id)
+    .max_by(|left, right| {
+      left
+        .confidence
+        .partial_cmp(&right.confidence)
+        .unwrap_or(std::cmp::Ordering::Equal)
+    })
+}
+
+fn resolve_store_next_round_target(state: &BalatroState) -> Result<ResolvedActionTarget, CliError> {
+  if let Some(button) = best_button(&state.buttons, "button_store_next_round") {
+    return Ok(ResolvedActionTarget {
+      source: ActionTargetSource::YoloButton,
+      label: button.id.clone(),
+      frame_point: bbox_center_point(button.bbox),
+      fallback_reason: None,
+    });
+  }
+
+  let has_store_evidence = has_store_layout_evidence(state);
+  let purchase_visible = best_button(&state.buttons, "button_purchase").is_some();
+  let pack_choices_visible = best_button(&state.buttons, "button_card_pack_skip").is_some()
+    || !active_pack_choices(state).is_empty();
+  if has_store_evidence && !purchase_visible && !pack_choices_visible {
+    // Store phase classification or the derived store flag is the evidence
+    // that keeps this fallback scoped to the live store screen; a visible
+    // purchase button means a store item is selected, so this point is unsafe.
+    // NOTICE: Fallback ratios come from a live 1646x963 store capture point
+    // around (594,429), normalized to (0.361,0.446). Remove this once stable
+    // YOLO/button target detection covers `button_store_next_round`.
+    return Ok(ResolvedActionTarget {
+      source: ActionTargetSource::LayoutFallback,
+      label: "button_store_next_round".to_string(),
+      frame_point: Point::new(
+        f64::from(state.frame.image_size.width) * 0.361,
+        f64::from(state.frame.image_size.height) * 0.446,
+      ),
+      fallback_reason: Some("yolo_button_missing_visible_layout_match".to_string()),
+    });
+  }
+
+  Err(CliError::Message(
+    "could not find button_store_next_round in observed Balatro frame".to_string(),
+  ))
+}
+
+fn resolve_consumable_use_target(
+  state: &BalatroState,
+  slot_index: u32,
+) -> Result<ResolvedActionTarget, CliError> {
+  if let Some(button) = best_button(&state.buttons, "button_use") {
+    return Ok(ResolvedActionTarget {
+      source: ActionTargetSource::YoloButton,
+      label: button.id.clone(),
+      frame_point: bbox_center_point(button.bbox),
+      fallback_reason: None,
+    });
+  }
+
+  let consumable = select_consumable(state, slot_index)?;
+  let width = consumable.bbox.width().max(1.0);
+  let height = consumable.bbox.height().max(1.0);
+  let x = (consumable.bbox.x2 + width * 0.32).min(state.frame.image_size.width as f32 - 1.0);
+  let y = (consumable.bbox.y1 + height * 0.60).min(state.frame.image_size.height as f32 - 1.0);
+  Ok(ResolvedActionTarget {
+    source: ActionTargetSource::LayoutFallback,
+    label: "button_use".to_string(),
+    frame_point: Point::new(f64::from(x), f64::from(y)),
+    fallback_reason: Some("consumable_use_button_missing_selected_card_layout_match".to_string()),
+  })
+}
+
+fn has_store_layout_evidence(state: &BalatroState) -> bool {
+  if state.phase == BalatroPhase::Store || state.store.is_store || !state.store.items.is_empty() {
+    return true;
+  }
+  if has_empty_store_shell_evidence(state) {
+    return true;
+  }
+
+  let width = state.frame.image_size.width.max(1) as f32;
+  let height = state.frame.image_size.height.max(1) as f32;
+  state.raw_entities.iter().any(|evidence| {
+    let detection = &evidence.detection;
+    let center_x = (detection.bbox.x1 + detection.bbox.x2) / 2.0;
+    let center_y = (detection.bbox.y1 + detection.bbox.y2) / 2.0;
+    matches!(
+      detection.label.as_str(),
+      "joker_card" | "tarot_card" | "planet_card" | "card_pack"
+    ) && center_x > width * 0.42
+      && center_x < width * 0.82
+      && center_y > height * 0.35
+      && center_y < height * 0.96
+  })
+}
+
+fn has_empty_store_shell_evidence(state: &BalatroState) -> bool {
+  state.phase == BalatroPhase::Unknown
+    && state.hand.is_empty()
+    && best_button(&state.buttons, "button_run_info").is_some()
+    && best_button(&state.buttons, "button_options").is_some()
+    && best_button(&state.buttons, "button_purchase").is_none()
+    && best_button(&state.buttons, "button_card_pack_skip").is_none()
+    && best_button(&state.buttons, "button_cash_out").is_none()
+    && best_button(&state.buttons, "button_level_select").is_none()
+    && best_button(&state.buttons, "button_level_skip").is_none()
+}
+
+fn resolve_pack_confirm_target(
+  state: &BalatroState,
+  choice: &PackChoice,
+) -> Result<ResolvedActionTarget, CliError> {
+  if let Some(button) = best_button(&state.buttons, "button_use") {
+    return Ok(ResolvedActionTarget {
+      source: ActionTargetSource::YoloButton,
+      label: button.id.clone(),
+      frame_point: bbox_center_point(button.bbox),
+      fallback_reason: None,
+    });
+  }
+
+  if best_button(&state.buttons, "button_card_pack_skip").is_none()
+    && active_pack_choices(state).is_empty()
+  {
+    return Err(CliError::Message(
+      "could not resolve pack confirm target without active pack evidence".to_string(),
+    ));
+  }
+
+  // NOTICE: The 0.82 height fallback comes from live active-pack captures where
+  // Balatro places the confirm button below the selected choice. Remove this
+  // fallback once `button_use` detection is stable for active pack selections.
+  Ok(ResolvedActionTarget {
+    source: ActionTargetSource::LayoutFallback,
+    label: "pack_confirm".to_string(),
+    frame_point: Point::new(
+      f64::from((choice.bbox.x1 + choice.bbox.x2) / 2.0),
+      f64::from(state.frame.image_size.height) * 0.82,
+    ),
+    fallback_reason: Some("pack_confirm_button_missing_visible_layout_match".to_string()),
+  })
+}
+
+fn blind_buttons(state: &BalatroState) -> Vec<&ButtonTarget> {
+  let mut buttons = state
+    .buttons
+    .iter()
+    .filter(|button| {
+      matches!(
+        button.id.as_str(),
+        "button_level_select" | "button_level_skip"
+      )
+    })
+    .collect::<Vec<_>>();
+  buttons.sort_by(|left, right| {
+    left
+      .bbox
+      .x1
+      .partial_cmp(&right.bbox.x1)
+      .unwrap_or(std::cmp::Ordering::Equal)
+  });
+  buttons
+}
+
+fn select_button_for_slot<'a>(
+  buttons: &'a [ButtonTarget],
+  id: &str,
+  slot_index: Option<u32>,
+) -> Result<&'a ButtonTarget, CliError> {
+  let mut matches = buttons
+    .iter()
+    .filter(|button| button.id == id)
+    .collect::<Vec<_>>();
+
+  if let Some(index) = slot_index {
+    matches.sort_by(|left, right| {
+      left
+        .bbox
+        .x1
+        .partial_cmp(&right.bbox.x1)
+        .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    matches
+      .get(index as usize)
+      .copied()
+      .ok_or_else(|| CliError::Message(format!("could not find {id} at blind:{index}")))
+  } else {
+    matches
+      .into_iter()
+      .max_by(|left, right| {
+        left
+          .confidence
+          .partial_cmp(&right.confidence)
+          .unwrap_or(std::cmp::Ordering::Equal)
+      })
+      .ok_or_else(|| CliError::Message(format!("could not find {id} in observed Balatro frame")))
+  }
+}
+
+fn parse_blind_slot_index(slot: &str) -> Result<u32, CliError> {
+  let Some(index) = slot.strip_prefix("blind:") else {
+    return Err(CliError::Message(format!(
+      "blind select requires --slot blind:N, got {slot}"
+    )));
+  };
+  index
+    .parse::<u32>()
+    .map_err(|_| CliError::Message(format!("blind slot index must be an integer, got {slot}")))
+}
+
+fn parse_prefixed_slot_index(slot: &str, prefix: &str) -> Result<u32, CliError> {
+  let slot = slot.trim();
+  let expected = format!("{prefix}:");
+  let Some(index) = slot.strip_prefix(&expected) else {
+    return Err(CliError::Message(format!(
+      "object operation requires --slot {prefix}:N, got {slot}"
+    )));
+  };
+  index.parse::<u32>().map_err(|_| {
+    CliError::Message(format!(
+      "{prefix} slot index must be an integer, got {slot}"
+    ))
+  })
+}
+
+fn parse_store_slot_index(slot: &str) -> Result<u32, CliError> {
+  parse_prefixed_slot_index(slot, "store")
+}
+
+fn parse_joker_slot_index(slot: &str) -> Result<u32, CliError> {
+  parse_prefixed_slot_index(slot, "joker")
+}
+
+fn parse_consumable_slot_index(slot: &str) -> Result<u32, CliError> {
+  parse_prefixed_slot_index(slot, "consumable")
+}
+
+fn parse_pack_slot_index(slot: &str) -> Result<u32, CliError> {
+  parse_prefixed_slot_index(slot, "pack")
+}
+
+fn parse_hand_slot_indices(slots: &str) -> Result<Vec<u32>, CliError> {
+  slots
+    .split(',')
+    .map(|slot| {
+      let slot = slot.trim();
+      let Some(index) = slot.strip_prefix("hand:") else {
+        return Err(CliError::Message(format!(
+          "card operation requires --slots hand:N[,hand:N...], got {slot}"
+        )));
+      };
+      index
+        .parse::<u32>()
+        .map_err(|_| CliError::Message(format!("hand slot index must be an integer, got {slot}")))
+    })
+    .collect()
+}
+
+fn parse_hand_target_indices(targets: &[String]) -> Result<Vec<u32>, CliError> {
+  targets
+    .iter()
+    .map(|target| {
+      parse_prefixed_slot_index(target, "hand").map_err(|_| {
+        CliError::Message(format!(
+          "targeted consumable operation requires --targets hand:N[,hand:N...], got {target}"
+        ))
+      })
+    })
+    .collect()
+}
+
+fn parse_card_read_slots(slot: &str) -> Result<Option<Vec<u32>>, CliError> {
+  let slot = slot.trim();
+  if matches!(slot, "all" | "hand:all") {
+    return Ok(None);
+  }
+  parse_hand_slot_indices(slot).map(Some)
+}
+
+fn enrich_ui_numeric_readings_from_image(state: &mut BalatroState, image: &Path) {
+  let Ok(image) = image::open(image).map(|image| image.to_rgba8()) else {
+    return;
+  };
+  let crops = state
+    .raw_ui
+    .iter()
+    .filter_map(|evidence| {
+      let label = evidence.detection.label.as_str();
+      if state.phase != BalatroPhase::Playing && is_score_ui_label(label) {
+        return None;
+      }
+      is_numeric_ui_label(label).then(|| {
+        crop_detection_to_temp(&image, evidence.detection.bbox, label)
+          .map(|crop| (label.to_string(), crop))
+      })?
+    })
+    .collect::<Vec<_>>();
+
+  for (label, crop) in crops {
+    if is_single_ui_digit_label(&label)
+      && let Some(digit) = infer_single_ui_digit_from_crop(&crop)
+      && is_allowed_single_ui_digit(&label, digit)
+    {
+      apply_ui_numeric_reading(
+        &label,
+        &digit.to_string(),
+        &mut state.scores,
+        &mut state.rounds,
+      );
+      continue;
+    }
+    if use_score_digit_reader(&label)
+      && let Some(text) =
+        infer_ui_digit_text_from_crop_with_foreground(&crop, score_ui_digit_foreground(&label))
+      && let Some(text) = ui_digit_text_for_label(&label, &text)
+    {
+      apply_ui_numeric_reading(&label, &text, &mut state.scores, &mut state.rounds);
+      continue;
+    }
+    // TODO(balatro-first-party-ocr): cash and other non-glyph numeric fields
+    // need a real OCR boundary. Deferred until AUV owns or selects a
+    // first-party OCR tool instead of invoking owner-local Python sidecars.
+  }
+}
+
+fn is_score_ui_label(label: &str) -> bool {
+  matches!(
+    label,
+    "ui_score_chips"
+      | "ui_score_current"
+      | "ui_score_mult"
+      | "ui_score_round_score"
+      | "ui_score_target_score"
+  )
+}
+
+fn is_numeric_ui_label(label: &str) -> bool {
+  matches!(
+    label,
+    "ui_score_chips"
+      | "ui_score_current"
+      | "ui_score_mult"
+      | "ui_score_round_score"
+      | "ui_score_target_score"
+      | "ui_data_cash"
+      | "ui_data_discards_left"
+      | "ui_data_hands_left"
+      | "ui_round_ante_current"
+      | "ui_round_ante_left"
+      | "ui_round_round_current"
+      | "ui_round_round_left"
+  )
+}
+
+fn is_single_ui_digit_label(label: &str) -> bool {
+  matches!(
+    label,
+    "ui_data_discards_left"
+      | "ui_data_hands_left"
+      | "ui_round_ante_current"
+      | "ui_round_ante_left"
+      | "ui_round_round_current"
+      | "ui_round_round_left"
+  )
+}
+
+fn is_allowed_single_ui_digit(label: &str, digit: u8) -> bool {
+  match label {
+    "ui_data_discards_left" | "ui_data_hands_left" => digit <= 5,
+    "ui_round_ante_current" | "ui_round_ante_left" => (1..=8).contains(&digit),
+    "ui_round_round_current" | "ui_round_round_left" => digit <= 8,
+    _ => true,
+  }
+}
+
+fn ui_digit_text_for_label(label: &str, digits: &str) -> Option<String> {
+  if digits.is_empty() || !digits.chars().all(|character| character.is_ascii_digit()) {
+    return None;
+  }
+  match label {
+    "ui_score_mult" => Some(format!("x{digits}")),
+    "ui_score_round_score" => {
+      let score_digits = digits.strip_prefix('0').unwrap_or(digits);
+      Some(
+        if score_digits.is_empty() {
+          "0"
+        } else {
+          score_digits
+        }
+        .to_string(),
+      )
+    }
+    "ui_score_chips" | "ui_score_current" | "ui_score_target_score" => Some(digits.to_string()),
+    _ => None,
+  }
+}
+
+fn score_ui_digit_foreground(label: &str) -> UiDigitForeground {
+  match label {
+    "ui_score_target_score" => UiDigitForeground::Colored,
+    _ => UiDigitForeground::White,
+  }
+}
+
+fn use_score_digit_reader(label: &str) -> bool {
+  matches!(
+    label,
+    "ui_score_chips" | "ui_score_current" | "ui_score_mult" | "ui_score_round_score"
+  )
+}
+
+fn apply_ui_numeric_reading(
+  label: &str,
+  text: &str,
+  scores: &mut ScoreState,
+  rounds: &mut RoundState,
+) {
+  let Some(value) = normalize_ui_numeric_text_for_label(label, text) else {
+    return;
+  };
+  match label {
+    "ui_score_chips" => scores.chips = Some(value),
+    "ui_score_current" => scores.current_score = Some(value),
+    "ui_score_mult" => scores.mult = Some(value),
+    "ui_score_round_score" => scores.round_score = Some(value),
+    "ui_score_target_score" => scores.target_score = Some(value),
+    "ui_data_cash" => rounds.cash = Some(value),
+    "ui_data_discards_left" => rounds.discards_left = Some(value),
+    "ui_data_hands_left" => rounds.hands_left = Some(value),
+    "ui_round_ante_current" => rounds.ante_current = Some(value),
+    "ui_round_ante_left" => rounds.ante_left = Some(value),
+    "ui_round_round_current" => rounds.round_current = Some(value),
+    "ui_round_round_left" => rounds.round_left = Some(value),
+    _ => {}
+  }
+}
+
+fn infer_single_ui_digit_from_crop(crop: &Path) -> Option<u8> {
+  let image = image::open(crop).ok()?.to_rgba8();
+  let reading = infer_ui_digit_text_from_image_with_foreground(&image, UiDigitForeground::Colored)?;
+  let mut chars = reading.chars();
+  let digit = chars.next()?.to_digit(10)? as u8;
+  chars.next().is_none().then_some(digit)
+}
+
+fn infer_ui_digit_text_from_crop_with_foreground(
+  crop: &Path,
+  foreground: UiDigitForeground,
+) -> Option<String> {
+  let image = image::open(crop).ok()?.to_rgba8();
+  infer_ui_digit_text_from_image_with_foreground(&image, foreground)
+}
+
+fn infer_ui_digit_text_from_image_with_foreground(
+  image: &RgbaImage,
+  foreground: UiDigitForeground,
+) -> Option<String> {
+  let mut digits = String::new();
+  for points in ui_digit_glyph_segments(image, foreground)? {
+    let mask = normalized_ui_digit_mask_from_points(points)?;
+    if let Some(digit) = infer_ui_digit_from_mask(&mask) {
+      digits.push(char::from(b'0' + digit));
+    }
+  }
+  (!digits.is_empty()).then_some(digits)
+}
+
+fn infer_ui_digit_from_mask(mask: &[bool; UI_DIGIT_MASK_CELLS]) -> Option<u8> {
+  UI_DIGIT_TEMPLATES
+    .iter()
+    .map(|template| (template.digit, ui_digit_mask_distance(&mask, template.rows)))
+    .min_by(|left, right| {
+      left
+        .1
+        .partial_cmp(&right.1)
+        .unwrap_or(std::cmp::Ordering::Equal)
+    })
+    .and_then(|(digit, distance)| (distance <= 0.32).then_some(digit))
+}
+
+fn normalized_ui_digit_mask_from_points(
+  foreground: Vec<(u32, u32)>,
+) -> Option<[bool; UI_DIGIT_MASK_CELLS]> {
+  let min_x = foreground.iter().map(|(x, _)| *x).min()?;
+  let min_y = foreground.iter().map(|(_, y)| *y).min()?;
+  let max_x = foreground.iter().map(|(x, _)| *x).max()?;
+  let max_y = foreground.iter().map(|(_, y)| *y).max()?;
+  let width = (max_x - min_x + 1).max(1);
+  let height = (max_y - min_y + 1).max(1);
+  let foreground = foreground
+    .into_iter()
+    .collect::<std::collections::HashSet<_>>();
+  let mut mask = [false; UI_DIGIT_MASK_CELLS];
+  for ty in 0..UI_DIGIT_MASK_H {
+    for tx in 0..UI_DIGIT_MASK_W {
+      let x_start = min_x + (tx as u32 * width / UI_DIGIT_MASK_W as u32);
+      let x_end = min_x + ((tx as u32 + 1) * width / UI_DIGIT_MASK_W as u32).max(1);
+      let y_start = min_y + (ty as u32 * height / UI_DIGIT_MASK_H as u32);
+      let y_end = min_y + ((ty as u32 + 1) * height / UI_DIGIT_MASK_H as u32).max(1);
+      let mut hits = 0_u32;
+      let mut total = 0_u32;
+      for y in y_start..=y_end.min(max_y) {
+        for x in x_start..=x_end.min(max_x) {
+          total += 1;
+          if foreground.contains(&(x, y)) {
+            hits += 1;
+          }
+        }
+      }
+      mask[ty * UI_DIGIT_MASK_W + tx] = total > 0 && hits as f32 / total as f32 >= 0.18;
+    }
+  }
+  Some(mask)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum UiDigitForeground {
+  Colored,
+  White,
+}
+
+fn ui_digit_glyph_segments(
+  image: &RgbaImage,
+  foreground: UiDigitForeground,
+) -> Option<Vec<Vec<(u32, u32)>>> {
+  let width = image.width();
+  let height = image.height();
+  let mut columns = vec![Vec::<(u32, u32)>::new(); width as usize];
+  for y in 0..height {
+    for x in 0..width {
+      if is_ui_digit_pixel(image.get_pixel(x, y).0, foreground) {
+        columns[x as usize].push((x, y));
+      }
+    }
+  }
+
+  let mut segments = Vec::new();
+  let mut current = Vec::new();
+  let mut empty_columns = 0_u32;
+  for column in columns {
+    if column.is_empty() {
+      if !current.is_empty() {
+        empty_columns += 1;
+      }
+      if empty_columns >= 3 && !current.is_empty() {
+        segments.push(std::mem::take(&mut current));
+        empty_columns = 0;
+      }
+      continue;
+    }
+    if empty_columns > 0 && empty_columns < 3 {
+      empty_columns = 0;
+    }
+    current.extend(column);
+  }
+  if !current.is_empty() {
+    segments.push(current);
+  }
+
+  let mut segments = segments
+    .into_iter()
+    .filter(|segment| segment.len() >= 20)
+    .collect::<Vec<_>>();
+  if let Some(max_height) = segments.iter().map(|segment| segment_height(segment)).max() {
+    // Score crops can include commas, chip icons, or small UI fragments. The
+    // digit templates are scale-invariant, so size filtering has to happen
+    // before mask matching or those fragments may become plausible digits.
+    let min_digit_height = (max_height as f32 * 0.72).ceil() as u32;
+    segments.retain(|segment| segment_height(segment) >= min_digit_height);
+  }
+  (!segments.is_empty()).then_some(segments)
+}
+
+fn segment_height(segment: &[(u32, u32)]) -> u32 {
+  let min_y = segment.iter().map(|(_, y)| *y).min().unwrap_or(0);
+  let max_y = segment.iter().map(|(_, y)| *y).max().unwrap_or(min_y);
+  max_y - min_y + 1
+}
+
+fn is_ui_digit_pixel([r, g, b, a]: [u8; 4], foreground: UiDigitForeground) -> bool {
+  if a < 80 {
+    return false;
+  }
+  let max = r.max(g).max(b);
+  let min = r.min(g).min(b);
+  if foreground == UiDigitForeground::White {
+    return min > 145 && max > 180;
+  }
+  let green_label = g > r.saturating_add(18) && g > b.saturating_add(18);
+  max > 75 && max - min > 35 && !green_label
+}
+
+fn ui_digit_mask_distance(mask: &[bool; UI_DIGIT_MASK_CELLS], rows: [&str; 7]) -> f32 {
+  let mut different = 0;
+  for (row_index, row) in rows.iter().enumerate() {
+    for (column_index, character) in row.chars().enumerate() {
+      let expected = character == '#';
+      if mask[row_index * UI_DIGIT_MASK_W + column_index] != expected {
+        different += 1;
+      }
+    }
+  }
+  different as f32 / UI_DIGIT_MASK_CELLS as f32
+}
+
+const UI_DIGIT_MASK_W: usize = 5;
+const UI_DIGIT_MASK_H: usize = 7;
+const UI_DIGIT_MASK_CELLS: usize = UI_DIGIT_MASK_W * UI_DIGIT_MASK_H;
+
+struct UiDigitTemplate {
+  digit: u8,
+  rows: [&'static str; 7],
+}
+
+const UI_DIGIT_TEMPLATES: &[UiDigitTemplate] = &[
+  UiDigitTemplate {
+    digit: 0,
+    rows: [
+      ".###.", "#####", "##.##", "##.##", "##.##", "#####", ".###.",
+    ],
+  },
+  UiDigitTemplate {
+    digit: 1,
+    rows: [
+      "####.", "####.", ".###.", ".###.", ".###.", "#####", "#####",
+    ],
+  },
+  UiDigitTemplate {
+    digit: 2,
+    rows: [
+      "#####", "....#", "....#", "#####", "#....", "#....", "#####",
+    ],
+  },
+  UiDigitTemplate {
+    digit: 3,
+    rows: [
+      "#####", "#####", ".####", ".####", "...##", "#####", "#####",
+    ],
+  },
+  UiDigitTemplate {
+    digit: 4,
+    rows: [
+      "##.##", "##.##", "##.##", "#####", ".####", "...##", "...##",
+    ],
+  },
+  UiDigitTemplate {
+    digit: 5,
+    rows: [
+      "#####", "#....", "#....", "#####", "....#", "....#", "#####",
+    ],
+  },
+  UiDigitTemplate {
+    digit: 6,
+    rows: [
+      "#####", "#....", "#....", "#####", "#...#", "#...#", "#####",
+    ],
+  },
+  UiDigitTemplate {
+    digit: 7,
+    rows: [
+      "#####", "....#", "....#", "...#.", "..#..", ".#...", ".#...",
+    ],
+  },
+  UiDigitTemplate {
+    digit: 8,
+    rows: [
+      "#####", "#...#", "#...#", "#####", "#...#", "#...#", "#####",
+    ],
+  },
+  UiDigitTemplate {
+    digit: 9,
+    rows: [
+      "#####", "#...#", "#...#", "#####", "....#", "....#", "#####",
+    ],
+  },
+];
+
+fn normalize_ui_numeric_text_for_label(label: &str, text: &str) -> Option<String> {
+  let value = normalize_ui_numeric_text(text)?;
+  if is_single_ui_digit_label(label) {
+    return value
+      .chars()
+      .find(|character| character.is_ascii_digit())
+      .map(|character| character.to_string());
+  }
+  Some(value)
+}
+
+fn normalize_ui_numeric_text(text: &str) -> Option<String> {
+  let normalized = text
+    .chars()
+    .filter_map(|character| match character {
+      '0'..='9' | '$' | '/' | '+' | '-' | '.' => Some(character),
+      'x' | 'X' | '×' => Some('x'),
+      'O' | 'o' | '〇' | '○' => Some('0'),
+      ',' | ' ' | '\n' | '\r' | '\t' => None,
+      _ => None,
+    })
+    .collect::<String>();
+  (!normalized.is_empty()).then_some(normalized)
+}
+
+fn crop_detection_to_temp(image: &RgbaImage, bbox: BoundingBox, label: &str) -> Option<PathBuf> {
+  let image_w = image.width().max(1);
+  let image_h = image.height().max(1);
+  let pad_x = (bbox.width().max(1.0) * 0.08).ceil();
+  let pad_y = (bbox.height().max(1.0) * 0.12).ceil();
+  let x1 = (bbox.x1 - pad_x).floor().max(0.0) as u32;
+  let y1 = (bbox.y1 - pad_y).floor().max(0.0) as u32;
+  let x2 = (bbox.x2 + pad_x).ceil().min(image_w as f32) as u32;
+  let y2 = (bbox.y2 + pad_y).ceil().min(image_h as f32) as u32;
+  if x2 <= x1 || y2 <= y1 {
+    return None;
+  }
+  let crop = image::imageops::crop_imm(image, x1, y1, x2 - x1, y2 - y1).to_image();
+  let resized = image::imageops::resize(
+    &crop,
+    (x2 - x1).saturating_mul(4).max(1),
+    (y2 - y1).saturating_mul(4).max(1),
+    image::imageops::FilterType::Nearest,
+  );
+  let path = std::env::temp_dir().join(format!(
+    "auv-game-balatro-ui-{}-{}-{}.png",
+    label,
+    std::process::id(),
+    unique_nanos()
+  ));
+  resized.save(&path).ok()?;
+  Some(path)
+}
+
+fn select_hand_cards<'a>(
+  state: &'a BalatroState,
+  slot_indices: &[u32],
+) -> Result<Vec<&'a CardSlot>, CliError> {
+  slot_indices
+    .iter()
+    .map(|index| select_hand_card(state, *index))
+    .collect()
+}
+
+fn select_hand_card(state: &BalatroState, slot_index: u32) -> Result<&CardSlot, CliError> {
+  state
+    .hand
+    .get(slot_index as usize)
+    .ok_or_else(|| CliError::Message(format!("could not find hand:{slot_index}")))
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+struct HandCardInteraction {
+  slot: SlotId,
+  bbox: BoundingBox,
+  confidence: f32,
+  selected: bool,
+  click_frame_point: Point,
+  visual_fingerprint: Option<String>,
+}
+
+fn hand_card_interactions(state: &BalatroState) -> Vec<HandCardInteraction> {
+  state
+    .hand
+    .iter()
+    .map(|card| HandCardInteraction {
+      slot: card.slot,
+      bbox: card.bbox.clone(),
+      confidence: card.confidence,
+      selected: hand_slot_is_selected(state, card.slot.index),
+      click_frame_point: hand_card_click_frame_point(state, card),
+      visual_fingerprint: card.cache.visual_fingerprint.clone(),
+    })
+    .collect()
+}
+
+fn selected_hand_slot_indices(state: &BalatroState, requested: &[u32]) -> Vec<u32> {
+  hand_card_interactions(state)
+    .into_iter()
+    .filter(|interaction| requested.contains(&interaction.slot.index) && interaction.selected)
+    .map(|interaction| interaction.slot.index)
+    .collect()
+}
+
+fn hand_selection_matches_requested(state: &BalatroState, requested: &[u32]) -> bool {
+  let mut selected = selected_hand_slot_indices(state, &hand_slot_indices(state));
+  let mut requested = requested.to_vec();
+  selected.sort_unstable();
+  requested.sort_unstable();
+  selected == requested
+}
+
+fn selected_slots_to_clear(state: &BalatroState, requested: &[u32]) -> Vec<u32> {
+  selected_hand_slot_indices(state, &hand_slot_indices(state))
+    .into_iter()
+    .filter(|slot_index| !requested.contains(slot_index))
+    .collect()
+}
+
+fn requested_slots_to_select(state: &BalatroState, requested: &[u32]) -> Vec<u32> {
+  requested
+    .iter()
+    .copied()
+    .filter(|slot_index| !hand_slot_is_selected(state, *slot_index))
+    .collect()
+}
+
+fn hand_slot_is_selected(state: &BalatroState, slot_index: u32) -> bool {
+  if best_button(&state.buttons, "button_play").is_none()
+    && best_button(&state.buttons, "button_discard").is_none()
+    && best_button(&state.buttons, "button_use").is_none()
+  {
+    return false;
+  }
+  let Some(baseline_y) = hand_selection_baseline_y(state) else {
+    return false;
+  };
+  let Some(card) = state.hand.get(slot_index as usize) else {
+    return false;
+  };
+  // Balatro indicates selected hand cards by raising them before the play or
+  // discard button is pressed. Use the current hand's lower row as the baseline
+  // so stale selections from an earlier failed command are visible and can be
+  // cleared before a new play/discard operation.
+  card.bbox.y1 <= baseline_y - 18.0
+}
+
+fn hand_selection_baseline_y(state: &BalatroState) -> Option<f32> {
+  state
+    .hand
+    .iter()
+    .map(|card| card.bbox.y1)
+    .max_by(|left, right| left.total_cmp(right))
+}
+
+fn hand_slot_indices(state: &BalatroState) -> Vec<u32> {
+  (0..state.hand.len() as u32).collect()
+}
+
+fn select_cards_for_read<'a>(
+  state: &'a BalatroState,
+  requested: &Option<Vec<u32>>,
+) -> Result<Vec<&'a CardSlot>, CliError> {
+  match requested {
+    Some(indices) => select_hand_cards(state, indices),
+    None => Ok(state.hand.iter().collect()),
+  }
+}
+
+fn select_store_item(state: &BalatroState, index: u32) -> Result<&StoreItem, CliError> {
+  state
+    .store
+    .items
+    .get(index as usize)
+    .ok_or_else(|| CliError::Message(format!("could not find store:{index}")))
+}
+
+fn select_joker(state: &BalatroState, index: u32) -> Result<&JokerSlot, CliError> {
+  state
+    .jokers
+    .get(index as usize)
+    .ok_or_else(|| CliError::Message(format!("could not find joker:{index}")))
+}
+
+fn select_consumable(state: &BalatroState, index: u32) -> Result<&ConsumableSlot, CliError> {
+  state
+    .consumables
+    .get(index as usize)
+    .ok_or_else(|| CliError::Message(format!("could not find consumable:{index}")))
+}
+
+fn object_read_from_state(
+  state: &BalatroState,
+  slot: &str,
+  zone: ObjectReadZone,
+) -> Result<ObjectReadResult, CliError> {
+  let (slot, kind, bbox, confidence) = match zone {
+    ObjectReadZone::Store => {
+      let index = parse_store_slot_index(slot)?;
+      let item = select_store_item(state, index)?;
+      (
+        item.slot,
+        object_kind_label(&item.kind)?,
+        item.bbox,
+        item.confidence,
+      )
+    }
+    ObjectReadZone::Joker => {
+      let index = parse_joker_slot_index(slot)?;
+      let joker = select_joker(state, index)?;
+      (
+        joker.slot,
+        "joker".to_string(),
+        joker.bbox,
+        joker.confidence,
+      )
+    }
+    ObjectReadZone::Consumable => {
+      let index = parse_consumable_slot_index(slot)?;
+      let consumable = select_consumable(state, index)?;
+      (
+        consumable.slot,
+        object_kind_label(&consumable.kind)?,
+        consumable.bbox,
+        consumable.confidence,
+      )
+    }
+  };
+
+  Ok(ObjectReadResult {
+    slot,
+    kind,
+    bbox,
+    confidence,
+    reading: ObjectReadValue::unread(),
+    evidence: ObjectReadEvidence {
+      frame: state.frame.source.clone(),
+      source: "observation_without_hover_ocr".to_string(),
+      hover_required: true,
+      hover_frame: None,
+      hover_ocr_region: None,
+      hover_error: None,
+    },
+  })
+}
+
+fn object_kind_label<T>(kind: &T) -> Result<String, CliError>
+where
+  T: Serialize,
+{
+  serde_json::to_value(kind)?
+    .as_str()
+    .map(str::to_string)
+    .ok_or_else(|| CliError::Message("object kind must serialize as a string".to_string()))
+}
+
+fn active_pack_choices(state: &BalatroState) -> Vec<PackChoice> {
+  if best_button(&state.buttons, "button_card_pack_skip").is_none() {
+    return Vec::new();
+  }
+
+  let height = state.frame.image_size.height.max(1) as f32;
+  let width = state.frame.image_size.width.max(1) as f32;
+  let mut choices = state
+    .raw_entities
+    .iter()
+    .filter_map(|evidence| {
+      let detection = &evidence.detection;
+      let center_x = (detection.bbox.x1 + detection.bbox.x2) / 2.0;
+      let center_y = (detection.bbox.y1 + detection.bbox.y2) / 2.0;
+      let in_choice_area = center_x > width * 0.28
+        && center_x < width * 0.78
+        && center_y > height * 0.55
+        && center_y < height * 0.86;
+      let is_choice = matches!(
+        detection.label.as_str(),
+        "joker_card" | "tarot_card" | "planet_card" | "spectral_card" | "poker_card_front"
+      ) && in_choice_area;
+      is_choice.then(|| PackChoice {
+        slot_index: 0,
+        kind: detection.label.clone(),
+        detector_label: detection.label.clone(),
+        hint: pack_choice_hint(&detection.label).to_string(),
+        hover_required: true,
+        hover_text: None,
+        hover_frame: None,
+        hover_ocr_region: None,
+        hover_error: None,
+        bbox: detection.bbox,
+        confidence: detection.confidence,
+      })
+    })
+    .collect::<Vec<_>>();
+  choices.sort_by(|left, right| {
+    left
+      .bbox
+      .x1
+      .partial_cmp(&right.bbox.x1)
+      .unwrap_or(std::cmp::Ordering::Equal)
+  });
+  for (index, choice) in choices.iter_mut().enumerate() {
+    choice.slot_index = index as u32;
+  }
+  choices
+}
+
+fn pack_choice_hint(label: &str) -> &'static str {
+  match label {
+    "poker_card_front" => {
+      "active pack choice; detector label may be ambiguous in Standard/Buffoon packs, use hover OCR before strategic choice"
+    }
+    "joker_card" => "active joker pack choice; use hover OCR to read joker name/effect",
+    "tarot_card" => "active tarot pack choice; use hover OCR to read tarot name/effect",
+    "planet_card" => "active planet pack choice; use hover OCR to read planet name/hand upgrade",
+    "spectral_card" => "active spectral pack choice; use hover OCR to read spectral name/effect",
+    _ => "active pack choice; use hover OCR before strategic choice",
+  }
+}
+
+fn pack_choice_hover_ocr_region() -> RatioRect {
+  RatioRect::new(0.20, 0.02, 0.70, 0.72)
+}
+
+fn object_hover_ocr_region() -> RatioRect {
+  RatioRect::new(0.16, 0.02, 0.72, 0.78)
+}
+
+fn pack_ocr_words() -> Vec<&'static str> {
+  vec![
+    "Joker",
+    "Tarot",
+    "Planet",
+    "Spectral",
+    "The Fool",
+    "The Magician",
+    "The High Priestess",
+    "The Empress",
+    "The Emperor",
+    "The Hierophant",
+    "The Lovers",
+    "The Chariot",
+    "Justice",
+    "The Hermit",
+    "The Wheel of Fortune",
+    "Strength",
+    "The Hanged Man",
+    "Death",
+    "Temperance",
+    "The Devil",
+    "The Tower",
+    "The Star",
+    "The Moon",
+    "The Sun",
+    "Judgement",
+    "The World",
+  ]
+}
+
+fn object_ocr_words() -> Vec<&'static str> {
+  let mut words = pack_ocr_words();
+  words.extend([
+    "Joker",
+    "Common",
+    "Uncommon",
+    "Rare",
+    "Negative",
+    "Foil",
+    "Holographic",
+    "Polychrome",
+    "Mult",
+    "Chips",
+    "倍率",
+    "筹码",
+    "小丑牌",
+    "塔罗牌",
+    "星球牌",
+    "优惠券",
+    "普通",
+    "罕见",
+    "稀有",
+  ]);
+  words
+}
+
+fn non_empty_trimmed_text(text: &str) -> Option<String> {
+  let text = text.trim();
+  (!text.is_empty()).then(|| text.to_string())
+}
+
+fn select_pack_choice(choices: &[PackChoice], index: u32) -> Result<&PackChoice, CliError> {
+  choices
+    .get(index as usize)
+    .ok_or_else(|| CliError::Message(format!("could not find pack:{index}")))
+}
+
+fn ocr_region_for_card(state: &BalatroState, card: &CardSlot) -> RatioRect {
+  let width = f64::from(state.frame.image_size.width).max(1.0);
+  let height = f64::from(state.frame.image_size.height).max(1.0);
+  let card_w = f64::from(card.bbox.width().max(1.0));
+  let card_h = f64::from(card.bbox.height().max(1.0));
+  RatioRect::new(
+    f64::from(card.bbox.x1) / width,
+    f64::from(card.bbox.y1) / height,
+    (card_w * 0.38) / width,
+    (card_h * 0.46) / height,
+  )
+}
+
+#[cfg(target_os = "macos")]
+fn card_corner_capture(capture: &Capture, state: &BalatroState, card: &CardSlot) -> Capture {
+  let (x, y, width, height) = card_corner_pixels(capture, state, card);
+  let crop = image::imageops::crop_imm(&capture.image, x, y, width, height).to_image();
+  let scale = 6;
+  let resized = image::imageops::resize(
+    &crop,
+    width * scale,
+    height * scale,
+    image::imageops::FilterType::Nearest,
+  );
+  Capture {
+    image: resized,
+    bounds: Rect::new(
+      0.0,
+      0.0,
+      f64::from(width * scale),
+      f64::from(height * scale),
+    ),
+    scale_factor: capture.scale_factor,
+    backend: format!("{}:card-corner", capture.backend),
+    fallback_reason: capture.fallback_reason.clone(),
+  }
+}
+
+#[cfg(target_os = "macos")]
+fn infer_suit_from_card_corner(
+  capture: &Capture,
+  state: &BalatroState,
+  card: &CardSlot,
+) -> Option<&'static str> {
+  let (x, y, width, height) = card_corner_pixels(capture, state, card);
+  let mut hearts = 0u32;
+  let mut diamonds = 0u32;
+  let mut clubs = 0u32;
+  let mut spades = 0u32;
+  for py in y..(y + height) {
+    for px in x..(x + width) {
+      let [r, g, b, a] = capture.image.get_pixel(px, py).0;
+      let r16 = i16::from(r);
+      let g16 = i16::from(g);
+      let b16 = i16::from(b);
+      if a < 120 {
+        continue;
+      }
+      if r > 170 && g < 95 && b < 95 {
+        hearts += 1;
+      } else if r > 170 && g > 110 && b < 100 {
+        diamonds += 1;
+      } else if b > 135 && g > 90 && r < 130 {
+        clubs += 1;
+      } else if g > 55 && g16 > r16 + 18 && g16 > b16 + 8 && r < 110 && b < 115 {
+        spades += 1;
+      }
+    }
+  }
+  [
+    ("hearts", hearts),
+    ("diamonds", diamonds),
+    ("clubs", clubs),
+    ("spades", spades),
+  ]
+  .into_iter()
+  .max_by_key(|(_, count)| *count)
+  .and_then(|(suit, count)| if count >= 8 { Some(suit) } else { None })
+}
+
+#[cfg(target_os = "macos")]
+fn card_corner_pixels(
+  capture: &Capture,
+  state: &BalatroState,
+  card: &CardSlot,
+) -> (u32, u32, u32, u32) {
+  let image_w = capture.image.width().max(1);
+  let image_h = capture.image.height().max(1);
+  let scale_x = image_w as f32 / state.frame.image_size.width.max(1) as f32;
+  let scale_y = image_h as f32 / state.frame.image_size.height.max(1) as f32;
+  let x = (card.bbox.x1.max(0.0) * scale_x).floor() as u32;
+  let y = (card.bbox.y1.max(0.0) * scale_y).floor() as u32;
+  let width = (card.bbox.width().max(1.0) * 0.38 * scale_x).ceil() as u32;
+  let height = (card.bbox.height().max(1.0) * 0.46 * scale_y).ceil() as u32;
+  let x = x.min(image_w.saturating_sub(1));
+  let y = y.min(image_h.saturating_sub(1));
+  let width = width.min(image_w - x).max(1);
+  let height = height.min(image_h - y).max(1);
+  (x, y, width, height)
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Clone, Debug)]
+struct RankTemplate {
+  rank: &'static str,
+  suit: &'static str,
+  mask: NormalizedMask,
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Clone, Debug)]
+struct NormalizedMask {
+  pixels: Vec<bool>,
+}
+
+#[cfg(target_os = "macos")]
+fn load_deck_rank_templates() -> Option<Vec<RankTemplate>> {
+  let atlas = load_deck_atlas()?;
+  let ranks = [
+    "A", "2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K",
+  ];
+  let suits = ["hearts", "clubs", "diamonds", "spades"];
+  let cell_w = atlas.width() / ranks.len() as u32;
+  let cell_h = atlas.height() / suits.len() as u32;
+  let mut templates = Vec::new();
+  for (suit_index, suit) in suits.into_iter().enumerate() {
+    for (rank_index, rank) in ranks.into_iter().enumerate() {
+      let x = rank_index as u32 * cell_w;
+      let y = suit_index as u32 * cell_h;
+      let width = (cell_w as f32 * 0.26).ceil() as u32;
+      let height = (cell_h as f32 * 0.35).ceil() as u32;
+      let crop = image::imageops::crop_imm(&atlas, x, y, width, height).to_image();
+      if let Some(mask) = normalized_foreground_mask(&crop) {
+        templates.push(RankTemplate { rank, suit, mask });
+      }
+    }
+  }
+  (!templates.is_empty()).then_some(templates)
+}
+
+#[cfg(target_os = "macos")]
+fn load_deck_atlas() -> Option<RgbaImage> {
+  if let Ok(cache_dir) = setup_cache_dir(None) {
+    if let Some(image) = load_deck_atlas_from_setup_cache(&cache_dir) {
+      return Some(image);
+    }
+  }
+
+  None
+}
+
+#[cfg(target_os = "macos")]
+fn load_deck_atlas_from_setup_cache(cache_dir: &Path) -> Option<RgbaImage> {
+  let deck_atlas_path = cache_dir.join(DECK_ATLAS_CACHE_FILE);
+  if !deck_atlas_path.exists() {
+    return None;
+  }
+  image::open(deck_atlas_path)
+    .ok()
+    .map(|image| image.to_rgba8())
+}
+
+#[cfg(target_os = "macos")]
+fn infer_rank_from_deck_template(
+  corner: &RgbaImage,
+  templates: Option<&[RankTemplate]>,
+  suit: Option<&str>,
+) -> Option<(String, f32)> {
+  let width = (corner.width() as f32 * 0.45).ceil() as u32;
+  let height = (corner.height() as f32 * 0.56).ceil() as u32;
+  let observed_region =
+    image::imageops::crop_imm(corner, 0, 0, width.max(1), height.max(1)).to_image();
+  let observed = normalized_observed_rank_mask(&observed_region)?;
+  templates?
+    .iter()
+    .filter(|template| suit.is_none_or(|suit| template.suit == suit))
+    .map(|template| {
+      let distance = mask_distance(&observed, &template.mask);
+      (template.rank, 1.0 - distance)
+    })
+    .max_by(|left, right| {
+      left
+        .1
+        .partial_cmp(&right.1)
+        .unwrap_or(std::cmp::Ordering::Equal)
+    })
+    .and_then(|(rank, confidence)| {
+      (confidence >= 0.75).then(|| (rank.to_string(), confidence.clamp(0.0, 1.0)))
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn normalized_observed_rank_mask(image: &RgbaImage) -> Option<NormalizedMask> {
+  let mut min_x = image.width();
+  let mut min_y = image.height();
+  let mut max_x = 0;
+  let mut max_y = 0;
+  for y in 0..image.height() {
+    for x in 0..image.width() {
+      if is_card_glyph_pixel(image.get_pixel(x, y).0) {
+        min_x = min_x.min(x);
+        min_y = min_y.min(y);
+        max_x = max_x.max(x);
+        max_y = max_y.max(y);
+      }
+    }
+  }
+  if min_x > max_x || min_y > max_y {
+    return None;
+  }
+
+  // The card-corner crop contains rank above suit. OCR benefits from seeing
+  // both, but template matching must isolate the rank glyph or a `9♥` can look
+  // closer to another rank plus suit blob than to the rank alone.
+  let bbox_h = max_y - min_y + 1;
+  let rank_h = ((bbox_h as f32 * 0.45).ceil() as u32).max(1);
+  let crop = image::imageops::crop_imm(image, min_x, min_y, max_x - min_x + 1, rank_h).to_image();
+  normalized_foreground_mask(&crop)
+}
+
+#[cfg(target_os = "macos")]
+fn normalized_foreground_mask(image: &RgbaImage) -> Option<NormalizedMask> {
+  const MASK_W: usize = 24;
+  const MASK_H: usize = 32;
+
+  let mut min_x = image.width();
+  let mut min_y = image.height();
+  let mut max_x = 0;
+  let mut max_y = 0;
+  for y in 0..image.height() {
+    for x in 0..image.width() {
+      if is_card_glyph_pixel(image.get_pixel(x, y).0) {
+        min_x = min_x.min(x);
+        min_y = min_y.min(y);
+        max_x = max_x.max(x);
+        max_y = max_y.max(y);
+      }
+    }
+  }
+  if min_x > max_x || min_y > max_y {
+    return None;
+  }
+
+  let width = (max_x - min_x + 1).max(1);
+  let height = (max_y - min_y + 1).max(1);
+  let mut pixels = vec![false; MASK_W * MASK_H];
+  for ty in 0..MASK_H {
+    for tx in 0..MASK_W {
+      let sx = min_x + ((tx as f32 + 0.5) / MASK_W as f32 * width as f32) as u32;
+      let sy = min_y + ((ty as f32 + 0.5) / MASK_H as f32 * height as f32) as u32;
+      pixels[ty * MASK_W + tx] = is_card_glyph_pixel(
+        image
+          .get_pixel(sx.min(image.width() - 1), sy.min(image.height() - 1))
+          .0,
+      );
+    }
+  }
+  Some(NormalizedMask { pixels })
+}
+
+#[cfg(target_os = "macos")]
+fn is_card_glyph_pixel([r, g, b, a]: [u8; 4]) -> bool {
+  if a < 80 {
+    return false;
+  }
+  let max = r.max(g).max(b);
+  let min = r.min(g).min(b);
+  max > 35 && max - min > 18 && !(r > 210 && g > 210 && b > 210)
+}
+
+#[cfg(target_os = "macos")]
+fn mask_distance(left: &NormalizedMask, right: &NormalizedMask) -> f32 {
+  let different = left
+    .pixels
+    .iter()
+    .zip(&right.pixels)
+    .filter(|(left, right)| left != right)
+    .count();
+  different as f32 / left.pixels.len().max(1) as f32
+}
+
+fn parse_card_reading(
+  raw_text: &str,
+  suit: Option<&str>,
+  confidence: Option<f32>,
+) -> CardReadValue {
+  let normalized = normalize_card_text(raw_text);
+  let rank = extract_rank(&normalized);
+  let suit = suit
+    .map(str::to_string)
+    .or_else(|| detect_suit(&normalized));
+  let suit_symbol = suit.as_deref().and_then(suit_symbol).map(str::to_string);
+  let short_code = rank.as_ref().zip(suit.as_deref()).map(|(rank, suit)| {
+    format!(
+      "{rank}{}",
+      match suit {
+        "hearts" => "H",
+        "diamonds" => "D",
+        "clubs" => "C",
+        "spades" => "S",
+        _ => "?",
+      }
+    )
+  });
+  let valid = rank.is_some() && suit.is_some();
+  CardReadValue {
+    status: if valid { "read" } else { "partial" },
+    raw_text: (!raw_text.trim().is_empty()).then(|| raw_text.to_string()),
+    normalized_text: (!normalized.is_empty()).then_some(normalized),
+    rank,
+    suit,
+    suit_symbol,
+    short_code,
+    confidence,
+    valid,
+  }
+}
+
+fn apply_inferred_rank(reading: &mut CardReadValue, rank: String, confidence: f32) {
+  reading.rank = Some(rank);
+  reading.confidence = Some(reading.confidence.unwrap_or(confidence).max(confidence));
+  reading.short_code = reading
+    .rank
+    .as_ref()
+    .zip(reading.suit.as_deref())
+    .map(|(rank, suit)| {
+      format!(
+        "{rank}{}",
+        match suit {
+          "hearts" => "H",
+          "diamonds" => "D",
+          "clubs" => "C",
+          "spades" => "S",
+          _ => "?",
+        }
+      )
+    });
+  reading.valid = reading.rank.is_some() && reading.suit.is_some();
+  reading.status = if reading.valid { "read" } else { "partial" };
+}
+
+fn should_hover_reread_card(reading: &CardReadValue) -> bool {
+  !reading.valid
+    || reading
+      .confidence
+      .is_some_and(|confidence| confidence < 0.85)
+}
+
+fn normalize_card_text(text: &str) -> String {
+  let mut normalized = text
+    .trim()
+    .replace('：', ":")
+    .replace('，', ",")
+    .replace("红挑", "红桃")
+    .replace("黑挑", "黑桃")
+    .replace("方申", "方片")
+    .replace("梅华", "梅花");
+  normalized.retain(|ch| !ch.is_whitespace());
+  normalized.to_uppercase()
+}
+
+fn extract_rank(text: &str) -> Option<String> {
+  for rank in [
+    "10", "A", "K", "Q", "J", "T", "9", "8", "7", "6", "5", "4", "3", "2",
+  ] {
+    if text.contains(rank) {
+      return Some(if rank == "T" { "10" } else { rank }.to_string());
+    }
+  }
+  None
+}
+
+fn detect_suit(text: &str) -> Option<String> {
+  [
+    ("diamonds", ["方片", "方块", "DIAMOND", "♦"].as_slice()),
+    ("hearts", ["红桃", "红心", "HEART", "♥"].as_slice()),
+    ("spades", ["黑桃", "SPADE", "♠"].as_slice()),
+    ("clubs", ["梅花", "CLUB", "♣"].as_slice()),
+  ]
+  .into_iter()
+  .find_map(|(suit, patterns)| {
+    patterns
+      .iter()
+      .any(|pattern| text.contains(pattern))
+      .then(|| suit.to_string())
+  })
+}
+
+fn suit_symbol(suit: &str) -> Option<&'static str> {
+  match suit {
+    "hearts" => Some("♥"),
+    "diamonds" => Some("♦"),
+    "clubs" => Some("♣"),
+    "spades" => Some("♠"),
+    _ => None,
+  }
+}
+
+fn card_ocr_words() -> [&'static str; 21] {
+  [
+    "A", "K", "Q", "J", "10", "9", "8", "7", "6", "5", "4", "3", "2", "红桃", "方片", "方块",
+    "黑桃", "梅花", "Hearts", "Diamonds", "Spades",
+  ]
+}
+
+fn window_point_from_button(
+  state: &BalatroState,
+  window: &auv_driver::window::Window,
+  button: &ButtonTarget,
+) -> Point {
+  window_point_from_frame_point(state, window, bbox_center_point(button.bbox))
+}
+
+fn window_point_from_store_item(
+  state: &BalatroState,
+  window: &auv_driver::window::Window,
+  item: &StoreItem,
+) -> Point {
+  window_point_from_frame_point(state, window, bbox_center_point(item.bbox))
+}
+
+fn window_point_from_joker(
+  state: &BalatroState,
+  window: &auv_driver::window::Window,
+  joker: &JokerSlot,
+) -> Point {
+  window_point_from_frame_point(state, window, bbox_center_point(joker.bbox))
+}
+
+fn window_point_from_consumable(
+  state: &BalatroState,
+  window: &auv_driver::window::Window,
+  consumable: &ConsumableSlot,
+) -> Point {
+  window_point_from_frame_point(state, window, bbox_center_point(consumable.bbox))
+}
+
+fn bbox_center_point(bbox: auv_inference_common::BoundingBox) -> Point {
+  Point::new(
+    f64::from((bbox.x1 + bbox.x2) / 2.0),
+    f64::from((bbox.y1 + bbox.y2) / 2.0),
+  )
+}
+
+fn window_point_from_frame_point(
+  state: &BalatroState,
+  window: &auv_driver::window::Window,
+  point: Point,
+) -> Point {
+  let width = f64::from(state.frame.image_size.width).max(1.0);
+  let height = f64::from(state.frame.image_size.height).max(1.0);
+  Point::new(
+    point.x / width * window.frame.size.width,
+    point.y / height * window.frame.size.height,
+  )
+}
+
+fn normalized_window_point(window: &auv_driver::window::Window, x: f64, y: f64) -> Point {
+  Point::new(x * window.frame.size.width, y * window.frame.size.height)
+}
+
+fn window_point_from_hand_card(
+  state: &BalatroState,
+  window: &auv_driver::window::Window,
+  card: &CardSlot,
+) -> Point {
+  window_point_from_frame_point(state, window, hand_card_click_frame_point(state, card))
+}
+
+fn hand_card_click_frame_point(state: &BalatroState, card: &CardSlot) -> Point {
+  let width = (card.bbox.x2 - card.bbox.x1).max(1.0);
+  let height = (card.bbox.y2 - card.bbox.y1).max(1.0);
+  // Balatro hand cards overlap heavily. A raw bbox center or fixed ratio can
+  // land inside a neighboring card's hit area. Estimate the visible horizontal
+  // strip from adjacent hand-card boxes and click the middle of that strip.
+  let index = card.slot.index as usize;
+  let mut visible_left = card.bbox.x1;
+  let mut visible_right = card.bbox.x2;
+  if index > 0
+    && let Some(previous) = state.hand.get(index - 1)
+  {
+    visible_left = visible_left.max(previous.bbox.x2.min(card.bbox.x2));
+  }
+  if let Some(next) = state.hand.get(index + 1) {
+    visible_right = visible_right.min(next.bbox.x1.max(card.bbox.x1));
+  }
+  let x = if visible_right > visible_left + 8.0 {
+    (visible_left + visible_right) / 2.0
+  } else {
+    card.bbox.x1 + width * 0.5
+  };
+  Point::new(f64::from(x), f64::from(card.bbox.y1 + height * 0.52))
+}
+
+fn verify_card_operation(operation: &str, before: &BalatroState, after: &BalatroState) -> bool {
+  match operation {
+    "cards.select" => before.phase == BalatroPhase::Playing && after.phase == BalatroPhase::Playing,
+    "cards.play" | "cards.discard" => {
+      before.phase == BalatroPhase::Playing
+        && (after.phase != BalatroPhase::Playing
+          || after.hand.len() != before.hand.len()
+          || hand_fingerprints_changed(before, after))
+    }
+    _ => false,
+  }
+}
+
+fn card_operation_evidence(
+  operation: &str,
+  before: &BalatroState,
+  after: &BalatroState,
+) -> Vec<&'static str> {
+  let mut evidence = Vec::new();
+  if before.phase == BalatroPhase::Playing {
+    evidence.push("before_phase_playing");
+  }
+  if after.phase != before.phase {
+    evidence.push("phase_changed");
+  }
+  if after.hand.len() != before.hand.len() {
+    evidence.push("hand_count_changed");
+  }
+  if matches!(operation, "cards.play" | "cards.discard") && hand_fingerprints_changed(before, after)
+  {
+    evidence.push("hand_fingerprints_changed");
+  }
+  evidence
+}
+
+fn hand_fingerprints_changed(before: &BalatroState, after: &BalatroState) -> bool {
+  let before_fingerprints = hand_fingerprints(before);
+  let after_fingerprints = hand_fingerprints(after);
+  !before_fingerprints.is_empty()
+    && !after_fingerprints.is_empty()
+    && before_fingerprints != after_fingerprints
+}
+
+fn hand_fingerprints(state: &BalatroState) -> Vec<&str> {
+  state
+    .hand
+    .iter()
+    .filter_map(|card| card.cache.visual_fingerprint.as_deref())
+    .collect()
+}
+
+fn verify_store_buy(before: &BalatroState, after: &BalatroState) -> bool {
+  after.store.items.len() < before.store.items.len()
+    || after.jokers.len() > before.jokers.len()
+    || after.consumables.len() > before.consumables.len()
+    || after.phase != before.phase
+}
+
+fn store_buy_evidence(before: &BalatroState, after: &BalatroState) -> Vec<&'static str> {
+  let mut evidence = Vec::new();
+  if after.store.items.len() < before.store.items.len() {
+    evidence.push("store_item_count_decreased");
+  }
+  if after.jokers.len() > before.jokers.len() {
+    evidence.push("joker_count_increased");
+  }
+  if after.consumables.len() > before.consumables.len() {
+    evidence.push("consumable_count_increased");
+  }
+  if after.phase != before.phase {
+    evidence.push("phase_changed");
+  }
+  evidence
+}
+
+fn verify_sell_operation(
+  zone: ObjectReadZone,
+  before: &BalatroState,
+  after: &BalatroState,
+) -> bool {
+  match zone {
+    ObjectReadZone::Joker => {
+      after.jokers.len() < before.jokers.len() || cash_changed(before, after)
+    }
+    ObjectReadZone::Consumable => {
+      after.consumables.len() < before.consumables.len() || cash_changed(before, after)
+    }
+    ObjectReadZone::Store => false,
+  }
+}
+
+fn sell_operation_evidence(
+  zone: ObjectReadZone,
+  before: &BalatroState,
+  after: &BalatroState,
+) -> Vec<&'static str> {
+  let mut evidence = Vec::new();
+  if zone == ObjectReadZone::Joker && after.jokers.len() < before.jokers.len() {
+    evidence.push("joker_count_decreased");
+  }
+  if zone == ObjectReadZone::Consumable && after.consumables.len() < before.consumables.len() {
+    evidence.push("consumable_count_decreased");
+  }
+  if cash_changed(before, after) {
+    evidence.push("cash_changed");
+  }
+  evidence
+}
+
+fn cash_changed(before: &BalatroState, after: &BalatroState) -> bool {
+  matches!(
+    (&before.rounds.cash, &after.rounds.cash),
+    (Some(before_cash), Some(after_cash)) if before_cash != after_cash
+  )
+}
+
+fn verify_single_button_activation(
+  button_id: &str,
+  before: &BalatroState,
+  after: &BalatroState,
+) -> bool {
+  match button_id {
+    "button_cash_out" => {
+      best_button(&before.buttons, "button_cash_out").is_some()
+        && (best_button(&after.buttons, "button_cash_out").is_none()
+          || after.phase == BalatroPhase::Store
+          || after.store.is_store)
+    }
+    _ => {
+      best_button(&before.buttons, button_id).is_some()
+        && best_button(&after.buttons, button_id).is_none()
+    }
+  }
+}
+
+fn verify_consumable_use(before: &BalatroState, after: &BalatroState) -> bool {
+  after.consumables.len() < before.consumables.len()
+    || after.phase != before.phase
+    || after.scores != before.scores
+}
+
+fn consumable_use_evidence(before: &BalatroState, after: &BalatroState) -> Vec<&'static str> {
+  let mut evidence = Vec::new();
+  if after.consumables.len() < before.consumables.len() {
+    evidence.push("consumable_count_decreased");
+  }
+  if after.phase != before.phase {
+    evidence.push("phase_changed");
+  }
+  if after.scores != before.scores {
+    evidence.push("scores_changed");
+  }
+  evidence
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::model::{
+    BALATRO_STATE_SCHEMA_VERSION, CacheHint, ConsumableKind, ConsumableSlot, FrameRef, JokerSlot,
+    ObjectZone, Reading, RoundState, ScoreState, SlotId, StoreItem, StoreItemKind, StoreState,
+  };
+  use auv_inference_common::ImageSize;
+  use auv_inference_common::{BoundingBox, Detection};
+
+  fn button(id: &str, x1: f32, confidence: f32) -> ButtonTarget {
+    ButtonTarget {
+      id: id.to_string(),
+      label: id.trim_start_matches("button_").to_string(),
+      bbox: BoundingBox {
+        x1,
+        y1: 10.0,
+        x2: x1 + 20.0,
+        y2: 30.0,
+      },
+      confidence,
+    }
+  }
+
+  #[test]
+  fn setup_extracts_deck_atlas_to_cache_and_reuses_it() {
+    let root = unique_temp_dir("balatro-setup-extract");
+    let love_path = create_fake_love(&root);
+    let cache_dir = root.join("cache");
+    let args = SetupArgs {
+      love: Some(love_path.clone()),
+      app: None,
+      cache_dir: Some(cache_dir.clone()),
+      check: false,
+      force: false,
+      json: true,
+    };
+
+    let report = setup_balatro_assets(&args).unwrap();
+
+    assert_eq!(report.status, SetupStatus::Extracted);
+    assert_eq!(
+      report.source_love_path.as_deref(),
+      Some(love_path.as_path())
+    );
+    assert!(report.deck_atlas_path.exists());
+    assert!(report.manifest_path.exists());
+    image::open(&report.deck_atlas_path).expect("extracted deck atlas should be an image");
+    let manifest = fs::read_to_string(&report.manifest_path).unwrap();
+    assert!(manifest.contains(SETUP_MANIFEST_SCHEMA_VERSION));
+    assert!(manifest.contains("deck_atlas_sha256"));
+
+    let reused = setup_balatro_assets(&args).unwrap();
+
+    assert_eq!(reused.status, SetupStatus::Reused);
+    assert_eq!(reused.source_love_path, None);
+
+    let checked = setup_balatro_assets(&SetupArgs {
+      check: true,
+      ..args
+    })
+    .unwrap();
+
+    assert_eq!(checked.status, SetupStatus::Ready);
+    let _ = fs::remove_dir_all(root);
+  }
+
+  #[test]
+  fn deck_atlas_can_load_from_setup_cache() {
+    let root = unique_temp_dir("balatro-setup-cache-load");
+    let cache_dir = root.join("cache");
+    fs::create_dir_all(&cache_dir).unwrap();
+    let deck_atlas_path = cache_dir.join(DECK_ATLAS_CACHE_FILE);
+    RgbaImage::from_pixel(4, 3, image::Rgba([1, 2, 3, 255]))
+      .save(&deck_atlas_path)
+      .unwrap();
+
+    let atlas = load_deck_atlas_from_setup_cache(&cache_dir).unwrap();
+
+    assert_eq!(atlas.width(), 4);
+    assert_eq!(atlas.height(), 3);
+    let _ = fs::remove_dir_all(root);
+  }
+
+  #[test]
+  fn blind_select_resolves_slot_by_left_to_right_button_order() {
+    let buttons = vec![
+      button("button_level_select", 300.0, 0.96),
+      button("button_level_select", 100.0, 0.94),
+      button("button_level_select", 500.0, 0.98),
+    ];
+
+    let selected = select_button_for_slot(&buttons, "button_level_select", Some(1)).unwrap();
+
+    assert_eq!(selected.bbox.x1, 300.0);
+  }
+
+  #[test]
+  fn blind_skip_uses_highest_confidence_skip_button_without_slot() {
+    let buttons = vec![
+      button("button_level_skip", 200.0, 0.91),
+      button("button_level_skip", 100.0, 0.97),
+    ];
+
+    let selected = select_button_for_slot(&buttons, "button_level_skip", None).unwrap();
+
+    assert_eq!(selected.confidence, 0.97);
+  }
+
+  #[test]
+  fn hand_slot_parser_accepts_comma_separated_hand_indices_only() {
+    assert_eq!(
+      parse_hand_slot_indices("hand:0,hand:2,hand:4").unwrap(),
+      vec![0, 2, 4]
+    );
+
+    assert!(parse_hand_slot_indices("store:0").is_err());
+    assert!(parse_hand_slot_indices("hand:x").is_err());
+  }
+
+  #[test]
+  fn object_slot_parsers_accept_expected_zone_prefixes() {
+    assert_eq!(parse_store_slot_index("store:0").unwrap(), 0);
+    assert_eq!(parse_joker_slot_index("joker:1").unwrap(), 1);
+    assert_eq!(parse_consumable_slot_index("consumable:2").unwrap(), 2);
+    assert_eq!(parse_pack_slot_index("pack:3").unwrap(), 3);
+
+    assert!(parse_store_slot_index("joker:0").is_err());
+    assert!(parse_joker_slot_index("store:1").is_err());
+    assert!(parse_consumable_slot_index("pack:2").is_err());
+    assert!(parse_pack_slot_index("pack:x").is_err());
+  }
+
+  #[test]
+  fn store_slot_selection_uses_observed_store_items() {
+    let state = synthetic_store_state(vec![
+      store_item(0, StoreItemKind::Joker, 500.0),
+      store_item(1, StoreItemKind::Planet, 700.0),
+    ]);
+
+    let selected = select_store_item(&state, 1).unwrap();
+
+    assert_eq!(selected.slot, SlotId::new(ObjectZone::Store, 1));
+    assert_eq!(selected.kind, StoreItemKind::Planet);
+    assert!(select_store_item(&state, 2).is_err());
+  }
+
+  #[test]
+  fn consumable_slot_selection_uses_observed_consumables() {
+    let mut state = synthetic_store_state(Vec::new());
+    state.consumables = vec![consumable_item(0, 1000.0), consumable_item(1, 1200.0)];
+
+    assert_eq!(select_consumable(&state, 1).unwrap().bbox.x1, 1200.0);
+    assert!(select_consumable(&state, 2).is_err());
+  }
+
+  #[test]
+  fn object_read_from_state_returns_static_evidence() {
+    let mut state = synthetic_store_state(vec![store_item(0, StoreItemKind::Joker, 500.0)]);
+    state.jokers = vec![joker_item(0, 700.0)];
+    state.consumables = vec![consumable_item(0, 1000.0)];
+
+    let store = object_read_from_state(&state, "store:0", ObjectReadZone::Store).unwrap();
+    assert_eq!(store.slot.to_string(), "store:0");
+    assert_eq!(store.kind, "joker");
+    assert_eq!(store.reading.status, "unread");
+    assert_eq!(store.reading.raw_text, None);
+    assert_eq!(store.reading.confidence, None);
+    assert_eq!(store.evidence.source, "observation_without_hover_ocr");
+    assert!(store.evidence.hover_required);
+
+    let joker = object_read_from_state(&state, "joker:0", ObjectReadZone::Joker).unwrap();
+    assert_eq!(joker.slot.to_string(), "joker:0");
+    assert_eq!(joker.kind, "joker");
+    assert_eq!(joker.reading.status, "unread");
+    assert_eq!(joker.reading.raw_text, None);
+    assert_eq!(joker.reading.confidence, None);
+    assert_eq!(joker.evidence.source, "observation_without_hover_ocr");
+    assert!(joker.evidence.hover_required);
+
+    let consumable =
+      object_read_from_state(&state, "consumable:0", ObjectReadZone::Consumable).unwrap();
+    assert_eq!(consumable.slot.to_string(), "consumable:0");
+    assert_eq!(consumable.kind, "planet");
+    assert_eq!(consumable.reading.status, "unread");
+    assert_eq!(consumable.reading.raw_text, None);
+    assert_eq!(consumable.reading.confidence, None);
+    assert_eq!(consumable.evidence.source, "observation_without_hover_ocr");
+    assert!(consumable.evidence.hover_required);
+  }
+
+  #[test]
+  fn active_pack_choices_are_lower_row_cards() {
+    let mut state = synthetic_store_state(Vec::new());
+    state.phase = BalatroPhase::Unknown;
+    state.raw_entities = vec![
+      crate::model::ObjectEvidence {
+        model: "entities-test".to_string(),
+        detection: raw_detection("joker_card", 500.0, 70.0, 650.0, 260.0),
+      },
+      crate::model::ObjectEvidence {
+        model: "entities-test".to_string(),
+        detection: raw_detection("spectral_card", 860.0, 610.0, 1000.0, 800.0),
+      },
+      crate::model::ObjectEvidence {
+        model: "entities-test".to_string(),
+        detection: raw_detection("tarot_card", 540.0, 610.0, 680.0, 800.0),
+      },
+      crate::model::ObjectEvidence {
+        model: "entities-test".to_string(),
+        detection: raw_detection("joker_card", 1020.0, 610.0, 1160.0, 800.0),
+      },
+      crate::model::ObjectEvidence {
+        model: "entities-test".to_string(),
+        detection: raw_detection("planet_card", 700.0, 610.0, 840.0, 800.0),
+      },
+      crate::model::ObjectEvidence {
+        model: "entities-test".to_string(),
+        detection: raw_detection("poker_card_front", 380.0, 610.0, 520.0, 800.0),
+      },
+      crate::model::ObjectEvidence {
+        model: "entities-test".to_string(),
+        detection: raw_detection("poker_card_front", 460.0, 790.0, 600.0, 940.0),
+      },
+      crate::model::ObjectEvidence {
+        model: "entities-test".to_string(),
+        detection: raw_detection("poker_card_front", 1320.0, 610.0, 1480.0, 800.0),
+      },
+      crate::model::ObjectEvidence {
+        model: "entities-test".to_string(),
+        detection: raw_detection("poker_card_stack", 1380.0, 610.0, 1540.0, 800.0),
+      },
+    ];
+    state
+      .buttons
+      .push(button("button_card_pack_skip", 1080.0, 0.95));
+
+    let choices = active_pack_choices(&state);
+
+    assert_eq!(choices.len(), 5);
+    assert_eq!(
+      choices
+        .iter()
+        .map(|choice| choice.kind.as_str())
+        .collect::<Vec<_>>(),
+      vec![
+        "poker_card_front",
+        "tarot_card",
+        "planet_card",
+        "spectral_card",
+        "joker_card"
+      ]
+    );
+    assert_eq!(
+      choices
+        .iter()
+        .map(|choice| choice.slot_index)
+        .collect::<Vec<_>>(),
+      vec![0, 1, 2, 3, 4]
+    );
+  }
+
+  #[test]
+  fn pack_choice_hover_region_covers_center_tooltip_area() {
+    assert_eq!(
+      pack_choice_hover_ocr_region(),
+      RatioRect::new(0.20, 0.02, 0.70, 0.72)
+    );
+  }
+
+  #[test]
+  fn pack_confirm_fallback_requires_active_pack_evidence() {
+    let mut state = synthetic_store_state(Vec::new());
+    state.phase = BalatroPhase::Unknown;
+    let choice = PackChoice {
+      slot_index: 0,
+      kind: "tarot_card".to_string(),
+      detector_label: "tarot_card".to_string(),
+      hint: pack_choice_hint("tarot_card").to_string(),
+      hover_required: true,
+      hover_text: None,
+      hover_frame: None,
+      hover_ocr_region: None,
+      hover_error: None,
+      bbox: BoundingBox {
+        x1: 540.0,
+        y1: 610.0,
+        x2: 680.0,
+        y2: 800.0,
+      },
+      confidence: 0.9,
+    };
+
+    assert!(resolve_pack_confirm_target(&state, &choice).is_err());
+
+    state.buttons.push(button("button_use", 760.0, 0.96));
+    let use_button = resolve_pack_confirm_target(&state, &choice).unwrap();
+    assert_eq!(use_button.source, ActionTargetSource::YoloButton);
+
+    state.buttons.clear();
+    state
+      .buttons
+      .push(button("button_card_pack_skip", 1080.0, 0.95));
+    let fallback = resolve_pack_confirm_target(&state, &choice).unwrap();
+    assert_eq!(fallback.source, ActionTargetSource::LayoutFallback);
+    assert_eq!(
+      fallback.fallback_reason.as_deref(),
+      Some("pack_confirm_button_missing_visible_layout_match")
+    );
+  }
+
+  #[test]
+  fn consumable_use_target_prefers_yolo_button_then_layout_fallback() {
+    let mut state = synthetic_store_state(Vec::new());
+    state.consumables = vec![consumable_item(0, 1250.0)];
+    state.buttons.push(button("button_use", 1420.0, 0.96));
+    let use_button = resolve_consumable_use_target(&state, 0).unwrap();
+    assert_eq!(use_button.source, ActionTargetSource::YoloButton);
+
+    state.buttons.clear();
+    let fallback = resolve_consumable_use_target(&state, 0).unwrap();
+    assert_eq!(fallback.source, ActionTargetSource::LayoutFallback);
+    assert_eq!(
+      fallback.fallback_reason.as_deref(),
+      Some("consumable_use_button_missing_selected_card_layout_match")
+    );
+    assert!(fallback.frame_point.x > 1250.0);
+  }
+
+  #[test]
+  fn store_next_round_target_prefers_yolo_button_then_layout_fallback() {
+    let mut state = synthetic_store_state(Vec::new());
+    state
+      .buttons
+      .push(button("button_store_next_round", 490.0, 0.98));
+    let target = resolve_store_next_round_target(&state).unwrap();
+    assert_eq!(target.source, ActionTargetSource::YoloButton);
+
+    state.buttons.clear();
+    state.store.is_store = true;
+    state.store.can_next_round = false;
+    let fallback = resolve_store_next_round_target(&state).unwrap();
+    assert_eq!(fallback.source, ActionTargetSource::LayoutFallback);
+    assert_eq!(
+      fallback.fallback_reason.as_deref(),
+      Some("yolo_button_missing_visible_layout_match")
+    );
+
+    state.buttons.push(button("button_purchase", 580.0, 0.96));
+    assert!(resolve_store_next_round_target(&state).is_err());
+  }
+
+  #[test]
+  fn store_next_round_target_falls_back_from_visible_store_pack_evidence() {
+    let mut state = synthetic_store_state(Vec::new());
+    state.phase = BalatroPhase::Unknown;
+    state.store.is_store = false;
+    state.raw_entities = vec![crate::model::ObjectEvidence {
+      model: "entities-test".to_string(),
+      detection: raw_detection("card_pack", 1010.0, 680.0, 1160.0, 915.0),
+    }];
+
+    let fallback = resolve_store_next_round_target(&state).unwrap();
+
+    assert_eq!(fallback.source, ActionTargetSource::LayoutFallback);
+    assert_eq!(
+      fallback.fallback_reason.as_deref(),
+      Some("yolo_button_missing_visible_layout_match")
+    );
+  }
+
+  #[test]
+  fn store_next_round_target_does_not_fallback_during_pack_choice() {
+    let mut state = synthetic_store_state(Vec::new());
+    state.phase = BalatroPhase::Unknown;
+    state.store.is_store = false;
+    state.raw_entities = vec![crate::model::ObjectEvidence {
+      model: "entities-test".to_string(),
+      detection: raw_detection("tarot_card", 540.0, 610.0, 680.0, 800.0),
+    }];
+    state
+      .buttons
+      .push(button("button_card_pack_skip", 1080.0, 0.95));
+
+    assert!(resolve_store_next_round_target(&state).is_err());
+  }
+
+  #[test]
+  fn store_next_round_target_falls_back_from_empty_store_shell() {
+    let mut state = synthetic_store_state(Vec::new());
+    state.phase = BalatroPhase::Unknown;
+    state.store.is_store = false;
+    state.buttons.push(button("button_run_info", 180.0, 0.95));
+    state.buttons.push(button("button_options", 190.0, 0.95));
+
+    let fallback = resolve_store_next_round_target(&state).unwrap();
+
+    assert_eq!(fallback.source, ActionTargetSource::LayoutFallback);
+    assert_eq!(
+      fallback.fallback_reason.as_deref(),
+      Some("yolo_button_missing_visible_layout_match")
+    );
+  }
+
+  #[test]
+  fn store_buy_confirm_accepts_purchase_or_use_button() {
+    let mut selected = synthetic_store_state(Vec::new());
+    selected.buttons.push(button("button_use", 700.0, 0.94));
+
+    let use_button = select_store_buy_confirm_button(&selected).unwrap();
+    assert_eq!(use_button.id, "button_use");
+
+    selected
+      .buttons
+      .push(button("button_purchase", 500.0, 0.96));
+    let purchase_button = select_store_buy_confirm_button(&selected).unwrap();
+    assert_eq!(purchase_button.id, "button_purchase");
+  }
+
+  #[test]
+  fn card_read_parser_combines_rank_text_with_inferred_suit() {
+    let reading = parse_card_reading("10", Some("spades"), Some(0.99));
+
+    assert_eq!(reading.rank.as_deref(), Some("10"));
+    assert_eq!(reading.suit.as_deref(), Some("spades"));
+    assert_eq!(reading.short_code.as_deref(), Some("10S"));
+    assert_eq!(reading.confidence, Some(0.99));
+    assert!(reading.valid);
+  }
+
+  #[test]
+  fn card_hover_reread_policy_targets_partial_or_low_confidence_reads() {
+    let high_confidence = parse_card_reading("Q", Some("spades"), Some(0.90));
+    let low_confidence = parse_card_reading("Q", Some("spades"), Some(0.84));
+    let partial = parse_card_reading("F", Some("spades"), Some(0.79));
+
+    assert!(!should_hover_reread_card(&high_confidence));
+    assert!(should_hover_reread_card(&low_confidence));
+    assert!(should_hover_reread_card(&partial));
+  }
+
+  #[test]
+  fn card_operation_verification_accepts_changed_hand_fingerprints() {
+    let mut before = synthetic_store_state(Vec::new());
+    before.phase = BalatroPhase::Playing;
+    before.hand = vec![
+      hand_card(0, "before-a"),
+      hand_card(1, "before-b"),
+      hand_card(2, "before-c"),
+    ];
+
+    let mut after = before.clone();
+    after.hand = vec![
+      hand_card(0, "after-a"),
+      hand_card(1, "after-b"),
+      hand_card(2, "after-c"),
+    ];
+
+    assert!(verify_card_operation("cards.play", &before, &after));
+    assert!(verify_card_operation("cards.discard", &before, &after));
+  }
+
+  #[test]
+  fn sell_operation_verification_accepts_joker_count_decrease() {
+    let mut before = synthetic_store_state(Vec::new());
+    before.jokers = vec![joker_item(0, 100.0), joker_item(1, 140.0)];
+    let mut after = before.clone();
+    after.jokers.pop();
+
+    assert!(verify_sell_operation(
+      ObjectReadZone::Joker,
+      &before,
+      &after
+    ));
+    assert_eq!(
+      sell_operation_evidence(ObjectReadZone::Joker, &before, &after),
+      vec!["joker_count_decreased"]
+    );
+  }
+
+  #[test]
+  fn sell_operation_verification_accepts_consumable_count_decrease() {
+    let mut before = synthetic_store_state(Vec::new());
+    before.consumables = vec![consumable_item(0, 100.0), consumable_item(1, 140.0)];
+    let mut after = before.clone();
+    after.consumables.pop();
+
+    assert!(verify_sell_operation(
+      ObjectReadZone::Consumable,
+      &before,
+      &after
+    ));
+    assert_eq!(
+      sell_operation_evidence(ObjectReadZone::Consumable, &before, &after),
+      vec!["consumable_count_decreased"]
+    );
+  }
+
+  #[test]
+  fn sell_operation_verification_accepts_cash_change_when_detection_is_noisy() {
+    let mut before = synthetic_store_state(Vec::new());
+    before.jokers = vec![joker_item(0, 100.0)];
+    before.rounds.cash = Some("$7".to_string());
+    let mut after = before.clone();
+    after.rounds.cash = Some("$9".to_string());
+
+    assert!(verify_sell_operation(
+      ObjectReadZone::Joker,
+      &before,
+      &after
+    ));
+    assert_eq!(
+      sell_operation_evidence(ObjectReadZone::Joker, &before, &after),
+      vec!["cash_changed"]
+    );
+  }
+
+  #[test]
+  fn selected_hand_slot_indices_require_requested_cards_to_be_raised() {
+    let mut selected = synthetic_store_state(Vec::new());
+    selected.phase = BalatroPhase::Playing;
+    selected.hand = vec![
+      hand_card(0, "card-a"),
+      hand_card(1, "card-b"),
+      hand_card(2, "card-c"),
+    ];
+    selected.hand[0].bbox.y1 -= 24.0;
+    selected.hand[0].bbox.y2 -= 24.0;
+    selected.hand[2].bbox.y1 -= 24.0;
+    selected.hand[2].bbox.y2 -= 24.0;
+    selected.buttons.push(button("button_play", 600.0, 0.96));
+
+    assert_eq!(
+      selected_hand_slot_indices(&selected, &[0, 1, 2]),
+      vec![0, 2]
+    );
+  }
+
+  #[test]
+  fn selected_hand_slot_indices_ignore_normal_hand_fan_variation() {
+    let mut state = synthetic_store_state(Vec::new());
+    state.phase = BalatroPhase::Playing;
+    state.hand = vec![
+      hand_card(0, "card-a"),
+      hand_card(1, "card-b"),
+      hand_card(2, "card-c"),
+    ];
+    state.hand[1].bbox.y1 -= 8.0;
+    state.hand[1].bbox.y2 -= 8.0;
+
+    assert!(selected_hand_slot_indices(&state, &[0, 1, 2]).is_empty());
+  }
+
+  #[test]
+  fn selected_hand_slot_indices_require_play_or_discard_button_evidence() {
+    let mut state = synthetic_store_state(Vec::new());
+    state.phase = BalatroPhase::Playing;
+    state.hand = vec![
+      hand_card(0, "card-a"),
+      hand_card(1, "card-b"),
+      hand_card(2, "card-c"),
+    ];
+    state.hand[1].bbox.y1 -= 24.0;
+    state.hand[1].bbox.y2 -= 24.0;
+
+    assert!(selected_hand_slot_indices(&state, &[0, 1, 2]).is_empty());
+  }
+
+  #[test]
+  fn selected_hand_slot_indices_accept_use_button_evidence_for_consumable_targets() {
+    let mut state = synthetic_store_state(Vec::new());
+    state.hand = vec![
+      hand_card(0, "card-a"),
+      hand_card(1, "card-b"),
+      hand_card(2, "card-c"),
+    ];
+    state.hand[1].bbox.y1 -= 24.0;
+    state.hand[1].bbox.y2 -= 24.0;
+    state.buttons.push(button("button_use", 600.0, 0.96));
+
+    assert_eq!(selected_hand_slot_indices(&state, &[0, 1, 2]), vec![1]);
+  }
+
+  #[test]
+  fn parse_hand_target_indices_accepts_comma_split_hand_slots() {
+    let targets = vec!["hand:1".to_string(), "hand:2".to_string()];
+
+    assert_eq!(parse_hand_target_indices(&targets).unwrap(), vec![1, 2]);
+  }
+
+  #[test]
+  fn parse_hand_target_indices_rejects_non_hand_targets() {
+    let targets = vec!["joker:1".to_string()];
+    let error = parse_hand_target_indices(&targets).unwrap_err();
+
+    assert!(error.to_string().contains("hand:N"), "{error}");
+  }
+
+  #[test]
+  fn hand_selection_matches_requested_rejects_extra_selected_slots() {
+    let mut state = synthetic_store_state(Vec::new());
+    state.phase = BalatroPhase::Playing;
+    state.hand = vec![
+      hand_card(0, "card-a"),
+      hand_card(1, "card-b"),
+      hand_card(2, "card-c"),
+    ];
+    state.hand[0].bbox.y1 -= 24.0;
+    state.hand[0].bbox.y2 -= 24.0;
+    state.hand[2].bbox.y1 -= 24.0;
+    state.hand[2].bbox.y2 -= 24.0;
+    state.buttons.push(button("button_play", 600.0, 0.96));
+
+    assert!(!hand_selection_matches_requested(&state, &[0]));
+    assert!(hand_selection_matches_requested(&state, &[0, 2]));
+  }
+
+  #[test]
+  fn hand_selection_plan_keeps_requested_selected_cards() {
+    let mut state = synthetic_store_state(Vec::new());
+    state.phase = BalatroPhase::Playing;
+    state.hand = vec![
+      hand_card(0, "card-a"),
+      hand_card(1, "card-b"),
+      hand_card(2, "card-c"),
+    ];
+    state.hand[1].bbox.y1 -= 24.0;
+    state.hand[1].bbox.y2 -= 24.0;
+    state.hand[2].bbox.y1 -= 24.0;
+    state.hand[2].bbox.y2 -= 24.0;
+    state.buttons.push(button("button_play", 600.0, 0.96));
+
+    assert_eq!(selected_slots_to_clear(&state, &[1]), vec![2]);
+    assert_eq!(requested_slots_to_select(&state, &[0, 1]), vec![0]);
+  }
+
+  #[test]
+  fn hand_card_click_frame_point_uses_visible_strip_between_neighbors() {
+    let mut state = synthetic_store_state(Vec::new());
+    state.phase = BalatroPhase::Playing;
+    state.hand = vec![
+      hand_card(0, "card-a"),
+      hand_card(1, "card-b"),
+      hand_card(2, "card-c"),
+    ];
+    let point = hand_card_click_frame_point(&state, &state.hand[1]);
+
+    assert!(point.x > state.hand[0].bbox.x2 as f64);
+    assert!(point.x < state.hand[2].bbox.x1 as f64);
+    assert!((point.y - 120.8).abs() < 0.001);
+  }
+
+  #[test]
+  fn hand_card_interactions_report_click_points_and_selection_state() {
+    let mut state = synthetic_store_state(Vec::new());
+    state.phase = BalatroPhase::Playing;
+    state.hand = vec![
+      hand_card(0, "card-a"),
+      hand_card(1, "card-b"),
+      hand_card(2, "card-c"),
+    ];
+    state.hand[1].bbox.y1 -= 24.0;
+    state.hand[1].bbox.y2 -= 24.0;
+    state.buttons.push(button("button_play", 600.0, 0.96));
+
+    let interactions = hand_card_interactions(&state);
+
+    assert_eq!(interactions.len(), 3);
+    assert_eq!(interactions[1].slot.index, 1);
+    assert!(interactions[1].selected);
+    assert!(!interactions[0].selected);
+    assert_eq!(
+      interactions[1].visual_fingerprint.as_deref(),
+      Some("card-b")
+    );
+    assert!(interactions[1].click_frame_point.x > state.hand[0].bbox.x2 as f64);
+    assert!(interactions[1].click_frame_point.x < state.hand[2].bbox.x1 as f64);
+  }
+
+  #[test]
+  fn operation_summary_strips_bbox_and_trace_details() {
+    let mut payload = serde_json::json!({
+      "operation": "cards.select",
+      "target": "Balatro",
+      "selected_cards": [
+        {
+          "slot": { "zone": "hand", "index": 0 },
+          "bbox": { "x1": 1.0, "y1": 2.0, "x2": 3.0, "y2": 4.0 },
+        }
+      ],
+      "click_targets": [
+        {
+          "slot": { "zone": "hand", "index": 0 },
+          "bbox": { "x1": 1.0, "y1": 2.0, "x2": 3.0, "y2": 4.0 },
+          "point": { "x": 12.0, "y": 34.0 },
+        }
+      ],
+      "selection_evidence": {
+        "requested_slots": [0],
+        "selected_slots": [0],
+        "passed": true
+      },
+      "verification": {
+        "mode": "targeted",
+        "passed": true,
+        "after_image": "/tmp/after.png",
+        "retry_click_point": { "x": 1.0, "y": 2.0 },
+      }
+    });
+
+    strip_operation_details(&mut payload);
+
+    assert_eq!(payload["operation"], "cards.select");
+    assert_eq!(payload["verification"]["passed"], true);
+    assert!(payload.get("selected_cards").is_none());
+    assert!(payload.get("click_targets").is_none());
+    assert!(payload.get("selection_evidence").is_none());
+    assert!(payload["verification"].get("after_image").is_none());
+    assert!(payload["verification"].get("retry_click_point").is_none());
+  }
+
+  #[test]
+  fn operation_details_are_left_intact_when_not_stripped() {
+    let payload = serde_json::json!({
+      "operation": "cards.select",
+      "selected_cards": [
+        {
+          "bbox": { "x1": 1.0, "y1": 2.0, "x2": 3.0, "y2": 4.0 },
+        }
+      ],
+    });
+
+    assert!(payload["selected_cards"][0].get("bbox").is_some());
+  }
+
+  #[test]
+  fn ui_numeric_readings_populate_scores_and_rounds_by_label() {
+    let mut scores = ScoreState::default();
+    let mut rounds = RoundState::default();
+
+    apply_ui_numeric_reading("ui_score_chips", " 1O ", &mut scores, &mut rounds);
+    apply_ui_numeric_reading("ui_score_mult", " x 4 ", &mut scores, &mut rounds);
+    apply_ui_numeric_reading("ui_score_round_score", " 280/ ", &mut scores, &mut rounds);
+    apply_ui_numeric_reading("ui_score_target_score", " 300 ", &mut scores, &mut rounds);
+    apply_ui_numeric_reading("ui_data_hands_left", " 31 ", &mut scores, &mut rounds);
+    apply_ui_numeric_reading("ui_data_discards_left", " 2 ", &mut scores, &mut rounds);
+    apply_ui_numeric_reading("ui_data_cash", " $7 ", &mut scores, &mut rounds);
+    apply_ui_numeric_reading("ui_round_ante_current", " 1 ", &mut scores, &mut rounds);
+
+    assert_eq!(scores.chips.as_deref(), Some("10"));
+    assert_eq!(scores.mult.as_deref(), Some("x4"));
+    assert_eq!(scores.round_score.as_deref(), Some("280/"));
+    assert_eq!(scores.target_score.as_deref(), Some("300"));
+    assert_eq!(rounds.hands_left.as_deref(), Some("3"));
+    assert_eq!(rounds.discards_left.as_deref(), Some("2"));
+    assert_eq!(rounds.cash.as_deref(), Some("$7"));
+    assert_eq!(rounds.ante_current.as_deref(), Some("1"));
+  }
+
+  #[test]
+  fn ui_numeric_readings_ignore_empty_normalized_text() {
+    let mut scores = ScoreState::default();
+    let mut rounds = RoundState::default();
+
+    apply_ui_numeric_reading("ui_data_hands_left", "abc", &mut scores, &mut rounds);
+
+    assert!(rounds.hands_left.is_none());
+  }
+
+  #[test]
+  fn ui_digit_reader_segments_multiple_glyphs() {
+    let image = synthetic_ui_digit_image("300");
+
+    let reading =
+      infer_ui_digit_text_from_image_with_foreground(&image, UiDigitForeground::Colored);
+
+    assert_eq!(reading.as_deref(), Some("300"));
+  }
+
+  #[test]
+  fn ui_digit_score_reading_formats_mult_label() {
+    assert_eq!(
+      ui_digit_text_for_label("ui_score_mult", "3").as_deref(),
+      Some("x3")
+    );
+    assert_eq!(
+      ui_digit_text_for_label("ui_score_target_score", "300").as_deref(),
+      Some("300")
+    );
+  }
+
+  #[test]
+  fn ui_digit_score_reading_drops_round_score_chip_icon() {
+    assert_eq!(
+      ui_digit_text_for_label("ui_score_round_score", "00").as_deref(),
+      Some("0")
+    );
+    assert_eq!(
+      ui_digit_text_for_label("ui_score_round_score", "0300").as_deref(),
+      Some("300")
+    );
+  }
+
+  #[test]
+  fn ui_digit_reader_matches_balatro_thick_one() {
+    let mask = mask_from_rows([
+      "####.", "####.", ".###.", ".###.", ".###.", "#####", "#####",
+    ]);
+
+    assert_eq!(infer_ui_digit_from_mask(&mask), Some(1));
+  }
+
+  #[test]
+  fn white_ui_digit_reader_ignores_colored_score_background() {
+    let mut image = RgbaImage::from_pixel(80, 56, image::Rgba([220, 70, 60, 255]));
+    draw_synthetic_ui_digit(&mut image, '0', 20, image::Rgba([245, 245, 245, 255]));
+
+    let reading = infer_ui_digit_text_from_image_with_foreground(&image, UiDigitForeground::White);
+
+    assert_eq!(reading.as_deref(), Some("0"));
+  }
+
+  #[test]
+  fn ui_digit_reader_ignores_score_punctuation_sized_glyphs() {
+    let mut image = RgbaImage::from_pixel(240, 56, image::Rgba([20, 25, 24, 255]));
+    let color = image::Rgba([240, 80, 60, 255]);
+    draw_synthetic_ui_digit_scaled(&mut image, '1', 0, 8, color);
+    draw_synthetic_ui_digit_scaled(&mut image, '4', 44, 8, color);
+    draw_synthetic_ui_digit_scaled(&mut image, '4', 90, 5, color);
+    draw_synthetic_ui_digit_scaled(&mut image, '0', 132, 8, color);
+    draw_synthetic_ui_digit_scaled(&mut image, '4', 176, 8, color);
+
+    let reading =
+      infer_ui_digit_text_from_image_with_foreground(&image, UiDigitForeground::Colored);
+
+    assert_eq!(reading.as_deref(), Some("1404"));
+  }
+
+  fn synthetic_ui_digit_image(text: &str) -> RgbaImage {
+    let scale = 8;
+    let gap = 4;
+    let width = text.len() as u32 * UI_DIGIT_MASK_W as u32 * scale
+      + text.len().saturating_sub(1) as u32 * gap;
+    let height = UI_DIGIT_MASK_H as u32 * scale;
+    let mut image = RgbaImage::from_pixel(width, height, image::Rgba([20, 25, 24, 255]));
+    let mut cursor_x = 0;
+    for character in text.chars() {
+      draw_synthetic_ui_digit(
+        &mut image,
+        character,
+        cursor_x,
+        image::Rgba([240, 80, 60, 255]),
+      );
+      cursor_x += UI_DIGIT_MASK_W as u32 * scale + gap;
+    }
+    image
+  }
+
+  fn draw_synthetic_ui_digit(
+    image: &mut RgbaImage,
+    character: char,
+    cursor_x: u32,
+    color: image::Rgba<u8>,
+  ) {
+    draw_synthetic_ui_digit_scaled(image, character, cursor_x, 8, color);
+  }
+
+  fn draw_synthetic_ui_digit_scaled(
+    image: &mut RgbaImage,
+    character: char,
+    cursor_x: u32,
+    scale: u32,
+    color: image::Rgba<u8>,
+  ) {
+    let digit = character.to_digit(10).unwrap() as u8;
+    let template = UI_DIGIT_TEMPLATES
+      .iter()
+      .find(|template| template.digit == digit)
+      .unwrap();
+    for (row_index, row) in template.rows.iter().enumerate() {
+      for (column_index, pixel) in row.chars().enumerate() {
+        if pixel != '#' {
+          continue;
+        }
+        for y in 0..scale {
+          for x in 0..scale {
+            image.put_pixel(
+              cursor_x + column_index as u32 * scale + x,
+              row_index as u32 * scale + y,
+              color,
+            );
+          }
+        }
+      }
+    }
+  }
+
+  fn mask_from_rows(rows: [&str; 7]) -> [bool; UI_DIGIT_MASK_CELLS] {
+    let mut mask = [false; UI_DIGIT_MASK_CELLS];
+    for (row_index, row) in rows.iter().enumerate() {
+      for (column_index, character) in row.chars().enumerate() {
+        mask[row_index * UI_DIGIT_MASK_W + column_index] = character == '#';
+      }
+    }
+    mask
+  }
+
+  fn synthetic_store_state(items: Vec<StoreItem>) -> BalatroState {
+    BalatroState {
+      schema_version: BALATRO_STATE_SCHEMA_VERSION.to_owned(),
+      frame: FrameRef {
+        source: "synthetic-store.png".to_owned(),
+        image_size: ImageSize {
+          width: 1600,
+          height: 960,
+        },
+      },
+      phase: BalatroPhase::Store,
+      scores: ScoreState::default(),
+      rounds: RoundState::default(),
+      hand: Vec::new(),
+      jokers: Vec::new(),
+      consumables: Vec::new(),
+      store: StoreState {
+        is_store: true,
+        item_count: items.len() as u32,
+        can_reroll: false,
+        can_next_round: true,
+        items,
+      },
+      buttons: Vec::new(),
+      diagnostics: Vec::new(),
+      raw_entities: Vec::new(),
+      raw_ui: Vec::new(),
+    }
+  }
+
+  fn store_item(index: u32, kind: StoreItemKind, x1: f32) -> StoreItem {
+    StoreItem {
+      slot: SlotId::new(ObjectZone::Store, index),
+      kind,
+      bbox: BoundingBox {
+        x1,
+        y1: 390.0,
+        x2: x1 + 140.0,
+        y2: 610.0,
+      },
+      confidence: 0.9,
+      reading: Reading::unread(),
+      cache: CacheHint::default(),
+    }
+  }
+
+  fn consumable_item(index: u32, x1: f32) -> ConsumableSlot {
+    ConsumableSlot {
+      slot: SlotId::new(ObjectZone::Consumable, index),
+      kind: ConsumableKind::Planet,
+      bbox: BoundingBox {
+        x1,
+        y1: 10.0,
+        x2: x1 + 20.0,
+        y2: 40.0,
+      },
+      confidence: 0.9,
+      reading: Reading::unread(),
+      cache: CacheHint::default(),
+    }
+  }
+
+  fn joker_item(index: u32, x1: f32) -> JokerSlot {
+    JokerSlot {
+      slot: SlotId::new(ObjectZone::Joker, index),
+      bbox: BoundingBox {
+        x1,
+        y1: 10.0,
+        x2: x1 + 20.0,
+        y2: 40.0,
+      },
+      confidence: 0.9,
+      reading: Reading::unread(),
+      cache: CacheHint::default(),
+    }
+  }
+
+  fn hand_card(index: u32, fingerprint: &str) -> CardSlot {
+    CardSlot {
+      slot: SlotId::new(ObjectZone::Hand, index),
+      kind: "poker_card_front".to_string(),
+      bbox: BoundingBox {
+        x1: 100.0 + index as f32 * 20.0,
+        y1: 100.0,
+        x2: 120.0 + index as f32 * 20.0,
+        y2: 140.0,
+      },
+      confidence: 0.9,
+      reading: Reading::unread(),
+      cache: CacheHint {
+        needs_reading: true,
+        visual_fingerprint: Some(fingerprint.to_string()),
+        changed_since_last_read: true,
+      },
+    }
+  }
+
+  fn raw_detection(label: &str, x1: f32, y1: f32, x2: f32, y2: f32) -> Detection {
+    Detection {
+      class_id: 0,
+      label: label.to_string(),
+      confidence: 0.9,
+      bbox: BoundingBox { x1, y1, x2, y2 },
+    }
+  }
+
+  fn unique_temp_dir(label: &str) -> PathBuf {
+    let path = std::env::temp_dir().join(format!(
+      "auv-game-balatro-{label}-{}-{}",
+      std::process::id(),
+      now_millis()
+    ));
+    fs::create_dir_all(&path).unwrap();
+    path
+  }
+
+  fn create_fake_love(root: &Path) -> PathBuf {
+    let source_root = root.join("love-src");
+    let atlas_dir = source_root.join("resources").join("textures").join("2x");
+    fs::create_dir_all(&atlas_dir).unwrap();
+    RgbaImage::from_pixel(4, 3, image::Rgba([64, 32, 16, 255]))
+      .save(atlas_dir.join("8BitDeck.png"))
+      .unwrap();
+    let love_path = root.join("Balatro.love");
+    let output = ProcessCommand::new("zip")
+      .arg("-q")
+      .arg("-r")
+      .arg(&love_path)
+      .arg("resources")
+      .current_dir(&source_root)
+      .output()
+      .expect("zip should be available for setup extraction tests");
+    assert!(
+      output.status.success(),
+      "failed to create fake love archive: {}",
+      String::from_utf8_lossy(&output.stderr)
+    );
+    love_path
+  }
+}

--- a/crates/auv-game-balatro/src/config.rs
+++ b/crates/auv-game-balatro/src/config.rs
@@ -1,0 +1,346 @@
+use std::path::{Path, PathBuf};
+
+use auv_inference_ultralytics::InferenceDevice;
+use hf_hub::{HFClientSync, HFError};
+use thiserror::Error;
+
+const HF_OWNER: &str = "proj-airi";
+const ENTITIES_MODEL_REPO: &str = "games-balatro-2024-yolo-entities-detection";
+const ENTITIES_DATASET_REPO: &str = "games-balatro-2024-entities-detection";
+const UI_MODEL_REPO: &str = "games-balatro-2024-yolo-ui-detection";
+const UI_DATASET_REPO: &str = "games-balatro-2024-ui-detection";
+const CARD_CORNER_MODEL_REPO: &str = "games-balatro-2024-card-corner-classifier";
+const ONNX_MODEL_FILE: &str = "onnx/model.onnx";
+const CLASSES_FILE: &str = "data/train/yolo/classes.txt";
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum BalatroModelAsset {
+  Local(PathBuf),
+  HuggingFace {
+    repo_kind: HuggingFaceRepoKind,
+    owner: &'static str,
+    repo: &'static str,
+    filename: &'static str,
+  },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HuggingFaceRepoKind {
+  Model,
+  Dataset,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BalatroModelConfig {
+  pub entities_model: BalatroModelAsset,
+  pub entities_classes: BalatroModelAsset,
+  pub ui_model: BalatroModelAsset,
+  pub ui_classes: BalatroModelAsset,
+  pub card_corner_model: BalatroModelAsset,
+  pub device: InferenceDevice,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ResolvedBalatroModelConfig {
+  pub entities_model: PathBuf,
+  pub entities_classes: PathBuf,
+  pub ui_model: PathBuf,
+  pub ui_classes: PathBuf,
+  pub device: InferenceDevice,
+}
+
+#[derive(Debug, Error)]
+pub enum BalatroModelConfigError {
+  #[error("failed to initialize Hugging Face client: {0}")]
+  HuggingFaceClient(#[source] HFError),
+  #[error("failed to resolve Hugging Face {repo_kind:?} asset {owner}/{repo}:{filename}: {source}")]
+  HuggingFaceAsset {
+    repo_kind: HuggingFaceRepoKind,
+    owner: &'static str,
+    repo: &'static str,
+    filename: &'static str,
+    #[source]
+    source: HFError,
+  },
+}
+
+impl BalatroModelConfig {
+  pub fn from_observe_args(args: &crate::cli::ObserveArgs) -> Self {
+    let defaults = Self::default();
+    Self {
+      entities_model: args
+        .entities_model
+        .clone()
+        .map(BalatroModelAsset::Local)
+        .unwrap_or(defaults.entities_model),
+      entities_classes: args
+        .entities_classes
+        .clone()
+        .map(BalatroModelAsset::Local)
+        .unwrap_or(defaults.entities_classes),
+      ui_model: args
+        .ui_model
+        .clone()
+        .map(BalatroModelAsset::Local)
+        .unwrap_or(defaults.ui_model),
+      ui_classes: args
+        .ui_classes
+        .clone()
+        .map(BalatroModelAsset::Local)
+        .unwrap_or(defaults.ui_classes),
+      card_corner_model: args
+        .card_corner_model
+        .clone()
+        .map(BalatroModelAsset::Local)
+        .unwrap_or(defaults.card_corner_model),
+      device: args.device.clone(),
+    }
+  }
+
+  pub fn resolve(&self) -> Result<ResolvedBalatroModelConfig, BalatroModelConfigError> {
+    let mut client = None;
+    Ok(ResolvedBalatroModelConfig {
+      entities_model: self.entities_model.resolve_with_client(&mut client)?,
+      entities_classes: self.entities_classes.resolve_with_client(&mut client)?,
+      ui_model: self.ui_model.resolve_with_client(&mut client)?,
+      ui_classes: self.ui_classes.resolve_with_client(&mut client)?,
+      device: self.device.clone(),
+    })
+  }
+}
+
+impl BalatroModelAsset {
+  pub fn local(path: impl Into<PathBuf>) -> Self {
+    Self::Local(path.into())
+  }
+
+  pub const fn hugging_face_model(
+    owner: &'static str,
+    repo: &'static str,
+    filename: &'static str,
+  ) -> Self {
+    Self::HuggingFace {
+      repo_kind: HuggingFaceRepoKind::Model,
+      owner,
+      repo,
+      filename,
+    }
+  }
+
+  pub const fn hugging_face_dataset(
+    owner: &'static str,
+    repo: &'static str,
+    filename: &'static str,
+  ) -> Self {
+    Self::HuggingFace {
+      repo_kind: HuggingFaceRepoKind::Dataset,
+      owner,
+      repo,
+      filename,
+    }
+  }
+
+  pub fn resolve_path(&self) -> Result<PathBuf, BalatroModelConfigError> {
+    self.resolve_with_client(&mut None)
+  }
+
+  fn resolve_with_client(
+    &self,
+    client: &mut Option<HFClientSync>,
+  ) -> Result<PathBuf, BalatroModelConfigError> {
+    match self {
+      BalatroModelAsset::Local(path) => Ok(path.clone()),
+      BalatroModelAsset::HuggingFace {
+        repo_kind,
+        owner,
+        repo,
+        filename,
+      } => {
+        let client = match client {
+          Some(client) => client,
+          None => {
+            client.insert(HFClientSync::new().map_err(BalatroModelConfigError::HuggingFaceClient)?)
+          }
+        };
+        match repo_kind {
+          HuggingFaceRepoKind::Model => client
+            .model(*owner, *repo)
+            .download_file()
+            .filename(*filename)
+            .send(),
+          HuggingFaceRepoKind::Dataset => client
+            .dataset(*owner, *repo)
+            .download_file()
+            .filename(*filename)
+            .send(),
+        }
+        .map_err(|source| BalatroModelConfigError::HuggingFaceAsset {
+          repo_kind: *repo_kind,
+          owner,
+          repo,
+          filename,
+          source,
+        })
+      }
+    }
+  }
+}
+
+impl Default for BalatroModelConfig {
+  fn default() -> Self {
+    Self {
+      entities_model: BalatroModelAsset::hugging_face_model(
+        HF_OWNER,
+        ENTITIES_MODEL_REPO,
+        ONNX_MODEL_FILE,
+      ),
+      entities_classes: BalatroModelAsset::hugging_face_dataset(
+        HF_OWNER,
+        ENTITIES_DATASET_REPO,
+        CLASSES_FILE,
+      ),
+      ui_model: BalatroModelAsset::hugging_face_model(HF_OWNER, UI_MODEL_REPO, ONNX_MODEL_FILE),
+      ui_classes: BalatroModelAsset::hugging_face_dataset(HF_OWNER, UI_DATASET_REPO, CLASSES_FILE),
+      card_corner_model: BalatroModelAsset::hugging_face_model(
+        HF_OWNER,
+        CARD_CORNER_MODEL_REPO,
+        ONNX_MODEL_FILE,
+      ),
+      device: InferenceDevice::Cpu,
+    }
+  }
+}
+
+pub fn load_class_names(path: &Path) -> Result<Vec<String>, std::io::Error> {
+  let contents = std::fs::read_to_string(path)?;
+  Ok(
+    contents
+      .lines()
+      .map(str::trim)
+      .filter(|line| !line.is_empty())
+      .map(str::to_owned)
+      .collect(),
+  )
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::cli::{Format, ObserveArgs};
+  use auv_inference_ultralytics::InferenceDevice;
+  use std::time::{SystemTime, UNIX_EPOCH};
+
+  #[test]
+  fn default_assets_use_hugging_face_sources() {
+    let config = BalatroModelConfig::default();
+
+    assert_eq!(
+      &config.entities_model,
+      &BalatroModelAsset::hugging_face_model(
+        "proj-airi",
+        "games-balatro-2024-yolo-entities-detection",
+        "onnx/model.onnx"
+      ),
+    );
+    assert_eq!(
+      &config.entities_classes,
+      &BalatroModelAsset::hugging_face_dataset(
+        "proj-airi",
+        "games-balatro-2024-entities-detection",
+        "data/train/yolo/classes.txt"
+      ),
+    );
+    assert_eq!(
+      &config.ui_model,
+      &BalatroModelAsset::hugging_face_model(
+        "proj-airi",
+        "games-balatro-2024-yolo-ui-detection",
+        "onnx/model.onnx"
+      ),
+    );
+    assert_eq!(
+      &config.ui_classes,
+      &BalatroModelAsset::hugging_face_dataset(
+        "proj-airi",
+        "games-balatro-2024-ui-detection",
+        "data/train/yolo/classes.txt"
+      ),
+    );
+    assert_eq!(
+      &config.card_corner_model,
+      &BalatroModelAsset::hugging_face_model(
+        "proj-airi",
+        "games-balatro-2024-card-corner-classifier",
+        "onnx/model.onnx"
+      ),
+    );
+    assert_eq!(config.device, InferenceDevice::Cpu);
+  }
+
+  #[test]
+  fn default_assets_do_not_reference_owner_local_paths() {
+    let config = BalatroModelConfig::default();
+
+    let rendered = format!("{config:?}");
+
+    assert!(
+      !rendered.contains("/Users/") && !rendered.contains("/home/"),
+      "default Balatro model config should be portable, got {rendered}"
+    );
+  }
+
+  #[test]
+  fn observe_args_override_paths_and_device() {
+    let args = ObserveArgs {
+      image: None,
+      target: "Balatro".to_string(),
+      json: false,
+      format: Format::Text,
+      json_out: None,
+      no_cache: false,
+      entities_model: Some(PathBuf::from("/tmp/entities.onnx")),
+      entities_classes: Some(PathBuf::from("/tmp/entities.txt")),
+      ui_model: Some(PathBuf::from("/tmp/ui.onnx")),
+      ui_classes: Some(PathBuf::from("/tmp/ui.txt")),
+      card_corner_model: Some(PathBuf::from("/tmp/card-corner.onnx")),
+      device: InferenceDevice::Cuda(2),
+    };
+
+    let config = BalatroModelConfig::from_observe_args(&args);
+
+    assert_eq!(
+      config.entities_model,
+      BalatroModelAsset::local("/tmp/entities.onnx")
+    );
+    assert_eq!(
+      config.entities_classes,
+      BalatroModelAsset::local("/tmp/entities.txt")
+    );
+    assert_eq!(config.ui_model, BalatroModelAsset::local("/tmp/ui.onnx"));
+    assert_eq!(config.ui_classes, BalatroModelAsset::local("/tmp/ui.txt"));
+    assert_eq!(
+      config.card_corner_model,
+      BalatroModelAsset::local("/tmp/card-corner.onnx")
+    );
+    assert_eq!(config.device, InferenceDevice::Cuda(2));
+  }
+
+  #[test]
+  fn load_class_names_trims_and_skips_blank_lines() {
+    let path = unique_temp_path("balatro-classes");
+    std::fs::write(&path, "  card\n\nbutton  \n   \nblind\n").unwrap();
+
+    let class_names = load_class_names(&path).unwrap();
+
+    assert_eq!(class_names, vec!["card", "button", "blind"]);
+    let _ = std::fs::remove_file(path);
+  }
+
+  fn unique_temp_path(prefix: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+      .duration_since(UNIX_EPOCH)
+      .unwrap()
+      .as_nanos();
+    std::env::temp_dir().join(format!("{prefix}-{}-{nanos}.txt", std::process::id()))
+  }
+}

--- a/crates/auv-game-balatro/src/detector.rs
+++ b/crates/auv-game-balatro/src/detector.rs
@@ -1,0 +1,62 @@
+use std::path::Path;
+
+use auv_inference_common::{DetectionOptions, DetectionSet, InferenceResult, ModelId};
+use auv_inference_ultralytics::{UltralyticsDetector, UltralyticsModelConfig};
+
+use crate::config::{BalatroModelConfig, load_class_names};
+
+#[derive(Debug)]
+pub struct BalatroDetectors {
+  entities: UltralyticsDetector,
+  ui: UltralyticsDetector,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct BalatroDetectionSets {
+  pub entities: DetectionSet,
+  pub ui: DetectionSet,
+}
+
+impl BalatroDetectors {
+  pub fn load(config: BalatroModelConfig) -> InferenceResult<Self> {
+    let config =
+      config
+        .resolve()
+        .map_err(|error| auv_inference_common::InferenceError::Backend {
+          message: error.to_string(),
+        })?;
+    let entities = UltralyticsDetector::load(UltralyticsModelConfig {
+      model_id: ModelId("balatro-entities".to_owned()),
+      model_path: config.entities_model,
+      input_size: Some(640),
+      options: balatro_detection_options(),
+      device: config.device.clone(),
+      class_names_override: Some(load_class_names(&config.entities_classes)?),
+    })?;
+    let ui = UltralyticsDetector::load(UltralyticsModelConfig {
+      model_id: ModelId("balatro-ui".to_owned()),
+      model_path: config.ui_model,
+      input_size: Some(640),
+      options: balatro_detection_options(),
+      device: config.device,
+      class_names_override: Some(load_class_names(&config.ui_classes)?),
+    })?;
+
+    Ok(Self { entities, ui })
+  }
+
+  pub fn detect_path(&self, image: impl AsRef<Path>) -> InferenceResult<BalatroDetectionSets> {
+    let image = image.as_ref();
+    let entities = self.entities.detect_path(image)?;
+    let ui = self.ui.detect_path(image)?;
+    Ok(BalatroDetectionSets { entities, ui })
+  }
+}
+
+fn balatro_detection_options() -> DetectionOptions {
+  DetectionOptions {
+    confidence_threshold: 0.25,
+    iou_threshold: 0.45,
+    max_detections: 300,
+  }
+}

--- a/crates/auv-game-balatro/src/lib.rs
+++ b/crates/auv-game-balatro/src/lib.rs
@@ -1,0 +1,19 @@
+pub mod cache;
+#[cfg(feature = "card-corner-onnx")]
+pub mod card_corner;
+pub mod cli;
+pub mod config;
+pub mod detector;
+pub mod model;
+pub mod observation;
+pub mod operation;
+pub mod output;
+
+pub use cli::{CliArgs, Command, OutputMode};
+pub use config::BalatroModelConfig;
+pub use model::{
+  BalatroPhase, BalatroState, ButtonTarget, CardSlot, ConsumableSlot, JokerSlot, RoundState,
+  ScoreState, StoreItem, StoreState,
+};
+pub use observation::{ObservationError, observe_image};
+pub use operation::{OperationRequest, OperationResult, VerificationMode, VerificationProfile};

--- a/crates/auv-game-balatro/src/model.rs
+++ b/crates/auv-game-balatro/src/model.rs
@@ -1,0 +1,254 @@
+use std::fmt;
+
+use auv_inference_common::{BoundingBox, Detection, ImageSize};
+use serde::{Deserialize, Serialize};
+
+pub const BALATRO_STATE_SCHEMA_VERSION: &str = "auv.game.balatro.state.v0";
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BalatroPhase {
+  Playing,
+  Store,
+  BlindSelect,
+  GameOver,
+  MainMenu,
+  Unknown,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ObjectZone {
+  Hand,
+  Joker,
+  Consumable,
+  Store,
+  Button,
+  Score,
+  Round,
+  Blind,
+  Unknown,
+}
+
+impl ObjectZone {
+  pub fn as_str(self) -> &'static str {
+    match self {
+      Self::Hand => "hand",
+      Self::Joker => "joker",
+      Self::Consumable => "consumable",
+      Self::Store => "store",
+      Self::Button => "button",
+      Self::Score => "score",
+      Self::Round => "round",
+      Self::Blind => "blind",
+      Self::Unknown => "unknown",
+    }
+  }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct SlotId {
+  pub zone: ObjectZone,
+  pub index: u32,
+}
+
+impl SlotId {
+  pub fn new(zone: ObjectZone, index: u32) -> Self {
+    Self { zone, index }
+  }
+}
+
+impl fmt::Display for SlotId {
+  fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(formatter, "{}:{}", self.zone.as_str(), self.index)
+  }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct FrameRef {
+  pub source: String,
+  pub image_size: ImageSize,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct ObjectEvidence {
+  pub model: String,
+  pub detection: Detection,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReadingStatus {
+  Unread,
+  Cached,
+  Read,
+  NeedsRefresh,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct Reading {
+  pub status: ReadingStatus,
+  pub text: Option<String>,
+  pub confidence: Option<f32>,
+}
+
+impl Reading {
+  pub fn unread() -> Self {
+    Self {
+      status: ReadingStatus::Unread,
+      text: None,
+      confidence: None,
+    }
+  }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct CacheHint {
+  pub needs_reading: bool,
+  pub visual_fingerprint: Option<String>,
+  pub changed_since_last_read: bool,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct CardSlot {
+  pub slot: SlotId,
+  pub kind: String,
+  pub bbox: BoundingBox,
+  pub confidence: f32,
+  pub reading: Reading,
+  pub cache: CacheHint,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct JokerSlot {
+  pub slot: SlotId,
+  pub bbox: BoundingBox,
+  pub confidence: f32,
+  pub reading: Reading,
+  pub cache: CacheHint,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConsumableKind {
+  Tarot,
+  Planet,
+  Spectral,
+  Unknown,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct ConsumableSlot {
+  pub slot: SlotId,
+  pub kind: ConsumableKind,
+  pub bbox: BoundingBox,
+  pub confidence: f32,
+  pub reading: Reading,
+  pub cache: CacheHint,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StoreItemKind {
+  Joker,
+  Tarot,
+  Planet,
+  Spectral,
+  CardPack,
+  PlayingCard,
+  Voucher,
+  Unknown,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct StoreItem {
+  pub slot: SlotId,
+  pub kind: StoreItemKind,
+  pub bbox: BoundingBox,
+  pub confidence: f32,
+  pub reading: Reading,
+  pub cache: CacheHint,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct ScoreState {
+  pub chips: Option<String>,
+  pub mult: Option<String>,
+  pub current_score: Option<String>,
+  pub round_score: Option<String>,
+  pub target_score: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct RoundState {
+  pub cash: Option<String>,
+  pub hands_left: Option<String>,
+  pub discards_left: Option<String>,
+  pub ante_current: Option<String>,
+  pub ante_left: Option<String>,
+  pub round_current: Option<String>,
+  pub round_left: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct ButtonTarget {
+  pub id: String,
+  pub label: String,
+  pub bbox: BoundingBox,
+  pub confidence: f32,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+pub struct StoreState {
+  pub is_store: bool,
+  pub item_count: u32,
+  pub can_reroll: bool,
+  pub can_next_round: bool,
+  pub items: Vec<StoreItem>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct BalatroDiagnostic {
+  pub code: String,
+  pub message: String,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct BalatroState {
+  pub schema_version: String,
+  pub frame: FrameRef,
+  pub phase: BalatroPhase,
+  pub scores: ScoreState,
+  pub rounds: RoundState,
+  pub hand: Vec<CardSlot>,
+  pub jokers: Vec<JokerSlot>,
+  pub consumables: Vec<ConsumableSlot>,
+  pub store: StoreState,
+  pub buttons: Vec<ButtonTarget>,
+  pub diagnostics: Vec<BalatroDiagnostic>,
+  pub raw_entities: Vec<ObjectEvidence>,
+  pub raw_ui: Vec<ObjectEvidence>,
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn slot_id_formats_zone_and_index() {
+    assert_eq!(SlotId::new(ObjectZone::Hand, 3).to_string(), "hand:3");
+    assert_eq!(SlotId::new(ObjectZone::Store, 1).to_string(), "store:1");
+  }
+
+  #[test]
+  fn phase_serializes_as_snake_case() {
+    assert_eq!(
+      serde_json::to_string(&BalatroPhase::Store).unwrap(),
+      "\"store\""
+    );
+    assert_eq!(
+      serde_json::to_string(&BalatroPhase::GameOver).unwrap(),
+      "\"game_over\""
+    );
+  }
+}

--- a/crates/auv-game-balatro/src/observation.rs
+++ b/crates/auv-game-balatro/src/observation.rs
@@ -1,0 +1,873 @@
+use std::path::Path;
+
+use auv_inference_common::{Detection, DetectionSet, ImageSize, InferenceError};
+use image::RgbImage;
+use thiserror::Error;
+
+use crate::cache::cache_hint_for_detection;
+use crate::config::BalatroModelConfig;
+use crate::detector::{BalatroDetectionSets, BalatroDetectors};
+use crate::model::{
+  BALATRO_STATE_SCHEMA_VERSION, BalatroDiagnostic, BalatroPhase, BalatroState, ButtonTarget,
+  CacheHint, CardSlot, ConsumableKind, ConsumableSlot, FrameRef, JokerSlot, ObjectEvidence,
+  ObjectZone, Reading, RoundState, ScoreState, SlotId, StoreItem, StoreItemKind, StoreState,
+};
+
+#[derive(Debug, Error)]
+pub enum ObservationError {
+  #[error("inference error: {0}")]
+  Inference(#[from] InferenceError),
+  #[error("I/O error: {0}")]
+  Io(#[from] std::io::Error),
+  #[error("image error: {0}")]
+  Image(#[from] image::ImageError),
+}
+
+pub fn observe_image(
+  image_path: impl AsRef<Path>,
+  config: &BalatroModelConfig,
+  no_cache: bool,
+) -> Result<BalatroState, ObservationError> {
+  let image_path = image_path.as_ref();
+  let image = image::open(image_path)?.to_rgb8();
+  let image_size = ImageSize {
+    width: image.width(),
+    height: image.height(),
+  };
+  let detectors = BalatroDetectors::load(config.clone())?;
+  let detections = detectors.detect_path(image_path)?;
+
+  Ok(build_state_from_detections(
+    image_path.display().to_string(),
+    image_size,
+    &image,
+    detections,
+    no_cache,
+  ))
+}
+
+pub fn build_state_from_detections(
+  source: impl Into<String>,
+  image_size: ImageSize,
+  image: &RgbImage,
+  detections: BalatroDetectionSets,
+  no_cache: bool,
+) -> BalatroState {
+  let raw_entities = evidence_from_set(&detections.entities);
+  let raw_ui = evidence_from_set(&detections.ui);
+  let mut entity_detections = detections.entities.detections;
+  let mut ui_detections = detections.ui.detections;
+
+  entity_detections.sort_by(compare_left_to_right);
+  ui_detections.sort_by(compare_left_to_right);
+
+  let hand = card_slots(
+    entity_detections
+      .iter()
+      .filter(|detection| matches_label(detection, &["poker_card_front", "poker_card_back"])),
+    ObjectZone::Hand,
+    image,
+    no_cache,
+  );
+  let jokers = entity_detections
+    .iter()
+    .filter(|detection| detection.label == "joker_card")
+    .enumerate()
+    .map(|(index, detection)| JokerSlot {
+      slot: SlotId::new(ObjectZone::Joker, index as u32),
+      bbox: detection.bbox,
+      confidence: detection.confidence,
+      reading: Reading::unread(),
+      cache: cache_hint_for_detection(detection, image, no_cache),
+    })
+    .collect();
+  let consumables = entity_detections
+    .iter()
+    .filter_map(|detection| consumable_kind(&detection.label).map(|kind| (detection, kind)))
+    .enumerate()
+    .map(|(index, (detection, kind))| ConsumableSlot {
+      slot: SlotId::new(ObjectZone::Consumable, index as u32),
+      kind,
+      bbox: detection.bbox,
+      confidence: detection.confidence,
+      reading: Reading::unread(),
+      cache: cache_hint_for_detection(detection, image, no_cache),
+    })
+    .collect();
+  let buttons: Vec<ButtonTarget> = ui_detections
+    .iter()
+    .filter(|detection| detection.label.starts_with("button_"))
+    .map(|detection| ButtonTarget {
+      id: detection.label.clone(),
+      label: detection
+        .label
+        .strip_prefix("button_")
+        .unwrap_or(&detection.label)
+        .to_owned(),
+      bbox: detection.bbox,
+      confidence: detection.confidence,
+    })
+    .collect();
+  let store = store_state(&entity_detections, &ui_detections, image, no_cache);
+  let phase = infer_phase(&entity_detections, &ui_detections);
+  let diagnostics = diagnostics_for_detections(&entity_detections, &ui_detections);
+
+  BalatroState {
+    schema_version: BALATRO_STATE_SCHEMA_VERSION.to_owned(),
+    frame: FrameRef {
+      source: source.into(),
+      image_size,
+    },
+    phase,
+    scores: ScoreState::default(),
+    rounds: RoundState::default(),
+    hand,
+    jokers,
+    consumables,
+    store,
+    buttons,
+    diagnostics,
+    raw_entities,
+    raw_ui,
+  }
+}
+
+fn diagnostics_for_detections(entities: &[Detection], ui: &[Detection]) -> Vec<BalatroDiagnostic> {
+  if entities.is_empty() && ui.is_empty() {
+    return vec![BalatroDiagnostic {
+      code: "empty_detection_sets".to_string(),
+      message: "Balatro detectors returned no entity or UI boxes for this frame".to_string(),
+    }];
+  }
+  Vec::new()
+}
+
+fn evidence_from_set(set: &DetectionSet) -> Vec<ObjectEvidence> {
+  set
+    .detections
+    .iter()
+    .cloned()
+    .map(|detection| ObjectEvidence {
+      model: set.model_id.0.clone(),
+      detection,
+    })
+    .collect()
+}
+
+fn card_slots<'a>(
+  detections: impl Iterator<Item = &'a Detection>,
+  zone: ObjectZone,
+  image: &RgbImage,
+  no_cache: bool,
+) -> Vec<CardSlot> {
+  detections
+    .enumerate()
+    .map(|(index, detection)| CardSlot {
+      slot: SlotId::new(zone, index as u32),
+      kind: detection.label.clone(),
+      bbox: detection.bbox,
+      confidence: detection.confidence,
+      reading: Reading::unread(),
+      cache: cache_hint_for_detection(detection, image, no_cache),
+    })
+    .collect()
+}
+
+fn store_state(
+  entities: &[Detection],
+  ui: &[Detection],
+  image: &RgbImage,
+  no_cache: bool,
+) -> StoreState {
+  let can_reroll = ui
+    .iter()
+    .any(|detection| detection.label == "button_store_reroll");
+  let can_next_round = ui
+    .iter()
+    .any(|detection| detection.label == "button_store_next_round");
+  let is_store = can_reroll || can_next_round || ui.iter().any(is_store_control);
+  let items = if is_store {
+    store_items_for_store_context(entities, image, no_cache)
+  } else {
+    Vec::new()
+  };
+  let item_count = items.len() as u32;
+
+  StoreState {
+    is_store,
+    item_count,
+    can_reroll,
+    can_next_round,
+    items,
+  }
+}
+
+fn store_items_for_store_context(
+  entities: &[Detection],
+  image: &RgbImage,
+  no_cache: bool,
+) -> Vec<StoreItem> {
+  let mut items = entities
+    .iter()
+    .filter_map(|detection| store_item_kind(&detection.label).map(|kind| (detection, kind)))
+    .filter(|(detection, kind)| {
+      is_store_item_candidate(detection, kind, image.width(), image.height())
+    })
+    .enumerate()
+    .map(|(index, (detection, kind))| StoreItem {
+      slot: SlotId::new(ObjectZone::Store, index as u32),
+      kind,
+      bbox: detection.bbox,
+      confidence: detection.confidence,
+      reading: Reading::unread(),
+      cache: cache_hint_for_detection(detection, image, no_cache),
+    })
+    .collect::<Vec<_>>();
+
+  append_voucher_layout_candidate(&mut items, image.width(), image.height());
+  items
+}
+
+fn is_store_item_candidate(
+  detection: &Detection,
+  kind: &StoreItemKind,
+  image_width: u32,
+  image_height: u32,
+) -> bool {
+  let width = image_width.max(1) as f32;
+  let height = image_height.max(1) as f32;
+  let center_x = center_x(detection) / width;
+  let center_y = (detection.bbox.y1 + detection.bbox.y2) / 2.0 / height;
+
+  let (max_x, min_y, max_y) = match kind {
+    StoreItemKind::CardPack => (0.90, 0.22, 0.96),
+    _ => (0.82, 0.32, 0.75),
+  };
+
+  // Thresholds are normalized from live Balatro store captures: keep store
+  // products while excluding top owned joker/consumable rows and the visually
+  // anchored right deck stack. Card packs can sit in the lower shop row at
+  // smaller window scales, so their vertical band is intentionally taller than
+  // ordinary card products.
+  (0.20..=max_x).contains(&center_x) && (min_y..=max_y).contains(&center_y)
+}
+
+fn infer_phase(entities: &[Detection], ui: &[Detection]) -> BalatroPhase {
+  if ui.iter().any(is_store_control) {
+    BalatroPhase::Store
+  } else if ui
+    .iter()
+    .any(|detection| matches_label(detection, &["button_play", "button_discard"]))
+    || (entities.iter().any(is_hand_card) && ui.iter().any(is_hand_sort_control))
+  {
+    BalatroPhase::Playing
+  } else if ui.iter().any(|detection| {
+    matches_label(
+      detection,
+      &[
+        "button_select_blind",
+        "button_skip_blind",
+        "button_level_select",
+      ],
+    )
+  }) {
+    BalatroPhase::BlindSelect
+  } else if ui
+    .iter()
+    .any(|detection| detection.label == "button_new_run")
+    && ui
+      .iter()
+      .any(|detection| detection.label == "button_main_menu")
+  {
+    BalatroPhase::GameOver
+  } else if ui.iter().any(|detection| {
+    matches_label(
+      detection,
+      &[
+        "button_main_menu_play",
+        "button_new_run",
+        "button_new_run_play",
+      ],
+    )
+  }) {
+    BalatroPhase::MainMenu
+  } else {
+    BalatroPhase::Unknown
+  }
+}
+
+fn is_hand_card(detection: &Detection) -> bool {
+  matches_label(detection, &["poker_card_front", "poker_card_back"])
+}
+
+fn is_hand_sort_control(detection: &Detection) -> bool {
+  matches_label(
+    detection,
+    &["button_sort_hand_rank", "button_sort_hand_suits"],
+  )
+}
+
+fn is_store_control(detection: &Detection) -> bool {
+  matches_label(
+    detection,
+    &[
+      "button_store_reroll",
+      "button_store_next_round",
+      "button_purchase",
+    ],
+  )
+}
+
+fn consumable_kind(label: &str) -> Option<ConsumableKind> {
+  match label {
+    "tarot_card" => Some(ConsumableKind::Tarot),
+    "planet_card" => Some(ConsumableKind::Planet),
+    "spectral_card" => Some(ConsumableKind::Spectral),
+    _ => None,
+  }
+}
+
+fn store_item_kind(label: &str) -> Option<StoreItemKind> {
+  match label {
+    "joker_card" => Some(StoreItemKind::Joker),
+    "tarot_card" => Some(StoreItemKind::Tarot),
+    "planet_card" => Some(StoreItemKind::Planet),
+    "spectral_card" => Some(StoreItemKind::Spectral),
+    "card_pack" => Some(StoreItemKind::CardPack),
+    "poker_card_front" => Some(StoreItemKind::PlayingCard),
+    // TODO(voucher-detection): detector-backed voucher labels are deferred
+    // until the entities dataset grows that class. Store observation currently
+    // adds a low-confidence layout fallback candidate instead.
+    _ => None,
+  }
+}
+
+fn append_voucher_layout_candidate(
+  items: &mut Vec<StoreItem>,
+  image_width: u32,
+  image_height: u32,
+) {
+  if image_width < 600 || image_height < 400 {
+    return;
+  }
+  if !items
+    .iter()
+    .any(|item| item.kind != StoreItemKind::CardPack)
+  {
+    return;
+  }
+  let bbox = voucher_layout_bbox(image_width, image_height);
+  if items
+    .iter()
+    .any(|item| bbox_overlap_ratio(item.bbox, bbox) > 0.25)
+  {
+    return;
+  }
+  let slot = SlotId::new(ObjectZone::Store, items.len() as u32);
+  items.push(StoreItem {
+    slot,
+    kind: StoreItemKind::Voucher,
+    bbox,
+    confidence: 0.35,
+    reading: Reading::unread(),
+    cache: CacheHint {
+      needs_reading: true,
+      visual_fingerprint: None,
+      changed_since_last_read: false,
+    },
+  });
+}
+
+fn voucher_layout_bbox(image_width: u32, image_height: u32) -> auv_inference_common::BoundingBox {
+  let width = image_width.max(1) as f32;
+  let height = image_height.max(1) as f32;
+  auv_inference_common::BoundingBox {
+    x1: width * 0.22,
+    y1: height * 0.58,
+    x2: width * 0.39,
+    y2: height * 0.86,
+  }
+}
+
+fn bbox_overlap_ratio(
+  left: auv_inference_common::BoundingBox,
+  right: auv_inference_common::BoundingBox,
+) -> f32 {
+  let x1 = left.x1.max(right.x1);
+  let y1 = left.y1.max(right.y1);
+  let x2 = left.x2.min(right.x2);
+  let y2 = left.y2.min(right.y2);
+  let overlap_width = (x2 - x1).max(0.0);
+  let overlap_height = (y2 - y1).max(0.0);
+  let overlap_area = overlap_width * overlap_height;
+  let right_area = ((right.x2 - right.x1).max(0.0) * (right.y2 - right.y1).max(0.0)).max(1.0);
+  overlap_area / right_area
+}
+
+fn matches_label(detection: &Detection, labels: &[&str]) -> bool {
+  labels.iter().any(|label| detection.label == *label)
+}
+
+fn compare_left_to_right(left: &Detection, right: &Detection) -> std::cmp::Ordering {
+  center_x(left)
+    .partial_cmp(&center_x(right))
+    .unwrap_or(std::cmp::Ordering::Equal)
+}
+
+fn center_x(detection: &Detection) -> f32 {
+  (detection.bbox.x1 + detection.bbox.x2) / 2.0
+}
+
+#[cfg(test)]
+mod tests {
+  use auv_inference_common::{BoundingBox, Detection, DetectionSet, ImageSize, ModelId};
+  use image::{Rgb, RgbImage};
+
+  use super::*;
+  use crate::cache::cache_hint_for_detection;
+  use crate::detector::BalatroDetectionSets;
+  use crate::model::{
+    BALATRO_STATE_SCHEMA_VERSION, BalatroPhase, ConsumableKind, ObjectZone, SlotId, StoreItemKind,
+  };
+
+  #[test]
+  fn synthetic_hand_cards_sort_left_to_right_with_slot_ids() {
+    let image = test_image();
+    let detections = detection_sets(
+      vec![
+        detection("poker_card_front", 90.0, 20.0, 120.0, 70.0),
+        detection("poker_card_back", 10.0, 20.0, 40.0, 70.0),
+      ],
+      vec![],
+    );
+
+    let state = build_state_from_detections(
+      "synthetic.png",
+      image_size(&image),
+      &image,
+      detections,
+      false,
+    );
+
+    assert_eq!(state.hand.len(), 2);
+    assert_eq!(state.hand[0].slot, SlotId::new(ObjectZone::Hand, 0));
+    assert_eq!(state.hand[0].kind, "poker_card_back");
+    assert_eq!(state.hand[1].slot, SlotId::new(ObjectZone::Hand, 1));
+    assert_eq!(state.hand[1].kind, "poker_card_front");
+  }
+
+  #[test]
+  fn store_phase_detects_store_controls() {
+    let image = test_image();
+    let detections = detection_sets(
+      vec![detection("joker_card", 30.0, 40.0, 60.0, 90.0)],
+      vec![detection("button_store_reroll", 10.0, 120.0, 50.0, 145.0)],
+    );
+
+    let state = build_state_from_detections(
+      "synthetic.png",
+      image_size(&image),
+      &image,
+      detections,
+      false,
+    );
+
+    assert_eq!(state.phase, BalatroPhase::Store);
+    assert!(state.store.is_store);
+    assert!(state.store.can_reroll);
+    assert_eq!(state.store.item_count, 1);
+    assert_eq!(state.store.items[0].slot, SlotId::new(ObjectZone::Store, 0));
+    assert_eq!(state.store.items[0].kind, StoreItemKind::Joker);
+  }
+
+  #[test]
+  fn new_run_play_button_detects_main_menu_phase() {
+    let image = test_image();
+    let detections = detection_sets(
+      vec![],
+      vec![detection("button_new_run_play", 40.0, 120.0, 80.0, 145.0)],
+    );
+
+    let state = build_state_from_detections(
+      "synthetic.png",
+      image_size(&image),
+      &image,
+      detections,
+      false,
+    );
+
+    assert_eq!(state.phase, BalatroPhase::MainMenu);
+  }
+
+  #[test]
+  fn game_over_buttons_detect_game_over_phase() {
+    let image = test_image();
+    let detections = detection_sets(
+      vec![],
+      vec![
+        detection("button_new_run", 40.0, 120.0, 80.0, 145.0),
+        detection("button_main_menu", 90.0, 120.0, 130.0, 145.0),
+      ],
+    );
+
+    let state = build_state_from_detections(
+      "synthetic-game-over.png",
+      image_size(&image),
+      &image,
+      detections,
+      false,
+    );
+
+    assert_eq!(state.phase, BalatroPhase::GameOver);
+  }
+
+  #[test]
+  fn empty_detection_sets_build_unknown_state_with_diagnostic() {
+    let image = test_image();
+    let detections = detection_sets(vec![], vec![]);
+
+    let state = build_state_from_detections(
+      "synthetic-empty.png",
+      image_size(&image),
+      &image,
+      detections,
+      false,
+    );
+
+    assert_eq!(state.phase, BalatroPhase::Unknown);
+    assert_eq!(state.diagnostics.len(), 1);
+    assert_eq!(state.diagnostics[0].code, "empty_detection_sets");
+  }
+
+  #[test]
+  fn build_state_preserves_frame_schema_raw_evidence_and_static_surfaces() {
+    let image = test_image();
+    let detections = detection_sets(
+      vec![
+        detection("tarot_card", 5.0, 10.0, 25.0, 40.0),
+        detection("planet_card", 30.0, 10.0, 50.0, 40.0),
+        detection("spectral_card", 55.0, 10.0, 75.0, 40.0),
+        detection("card_pack", 80.0, 10.0, 110.0, 45.0),
+      ],
+      vec![
+        detection("button_play", 10.0, 120.0, 40.0, 145.0),
+        detection("button_discard", 45.0, 120.0, 90.0, 145.0),
+      ],
+    );
+
+    let state = build_state_from_detections(
+      "synthetic.png",
+      image_size(&image),
+      &image,
+      detections,
+      false,
+    );
+
+    assert_eq!(state.schema_version, BALATRO_STATE_SCHEMA_VERSION);
+    assert_eq!(state.frame.source, "synthetic.png");
+    assert_eq!(state.frame.image_size, image_size(&image));
+    assert_eq!(state.phase, BalatroPhase::Playing);
+    assert_eq!(state.raw_entities.len(), 4);
+    assert_eq!(state.raw_entities[0].model, "entities-test");
+    assert_eq!(state.raw_ui.len(), 2);
+    assert_eq!(state.raw_ui[0].model, "ui-test");
+    assert!(state.scores.chips.is_none());
+    assert!(state.rounds.cash.is_none());
+    assert!(state.diagnostics.is_empty());
+
+    assert_eq!(state.consumables.len(), 3);
+    assert_eq!(
+      state.consumables[0].slot,
+      SlotId::new(ObjectZone::Consumable, 0)
+    );
+    assert_eq!(state.consumables[0].kind, ConsumableKind::Tarot);
+    assert_eq!(state.consumables[1].kind, ConsumableKind::Planet);
+    assert_eq!(state.consumables[2].kind, ConsumableKind::Spectral);
+
+    assert!(!state.store.is_store);
+    assert_eq!(state.store.items.len(), 0);
+    assert_eq!(state.store.item_count, 0);
+
+    assert_eq!(state.buttons.len(), 2);
+    assert_eq!(state.buttons[0].id, "button_play");
+    assert_eq!(state.buttons[0].label, "play");
+    assert_eq!(state.buttons[1].id, "button_discard");
+    assert_eq!(state.buttons[1].label, "discard");
+  }
+
+  #[test]
+  fn playing_consumables_do_not_create_store_slots() {
+    let image = test_image();
+    let detections = detection_sets(
+      vec![
+        detection("tarot_card", 5.0, 10.0, 25.0, 40.0),
+        detection("planet_card", 30.0, 10.0, 50.0, 40.0),
+      ],
+      vec![
+        detection("button_play", 10.0, 120.0, 40.0, 145.0),
+        detection("button_discard", 45.0, 120.0, 90.0, 145.0),
+      ],
+    );
+
+    let state = build_state_from_detections(
+      "synthetic.png",
+      image_size(&image),
+      &image,
+      detections,
+      false,
+    );
+
+    assert_eq!(state.phase, BalatroPhase::Playing);
+    assert_eq!(state.consumables.len(), 2);
+    assert!(!state.store.is_store);
+    assert_eq!(state.store.item_count, 0);
+    assert!(state.store.items.is_empty());
+  }
+
+  #[test]
+  fn store_items_exclude_owned_jokers_and_deck_stack_by_layout() {
+    let image = test_image_with_size(1600, 960);
+    let detections = detection_sets_for_image(
+      &image,
+      vec![
+        detection("joker_card", 280.0, 80.0, 420.0, 260.0),
+        detection("joker_card", 460.0, 80.0, 600.0, 260.0),
+        detection("joker_card", 560.0, 390.0, 700.0, 610.0),
+        detection("planet_card", 760.0, 390.0, 900.0, 610.0),
+        detection("poker_card_front", 1340.0, 430.0, 1440.0, 570.0),
+        detection("poker_card_back", 1360.0, 450.0, 1460.0, 590.0),
+      ],
+      vec![detection(
+        "button_store_next_round",
+        1320.0,
+        760.0,
+        1530.0,
+        850.0,
+      )],
+    );
+
+    let state = build_state_from_detections(
+      "synthetic-store.png",
+      image_size(&image),
+      &image,
+      detections,
+      false,
+    );
+
+    assert_eq!(state.phase, BalatroPhase::Store);
+    assert!(state.store.is_store);
+    assert_eq!(state.store.item_count, 3);
+    assert_eq!(state.store.items[0].slot, SlotId::new(ObjectZone::Store, 0));
+    assert_eq!(state.store.items[0].kind, StoreItemKind::Joker);
+    assert_eq!(state.store.items[0].bbox.x1, 560.0);
+    assert_eq!(state.store.items[1].slot, SlotId::new(ObjectZone::Store, 1));
+    assert_eq!(state.store.items[1].kind, StoreItemKind::Planet);
+    assert_eq!(state.store.items[1].bbox.x1, 760.0);
+    assert_eq!(state.store.items[2].slot, SlotId::new(ObjectZone::Store, 2));
+    assert_eq!(state.store.items[2].kind, StoreItemKind::Voucher);
+  }
+
+  #[test]
+  fn store_items_include_card_pack_in_right_area() {
+    let image = test_image_with_size(1600, 960);
+    let detections = detection_sets_for_image(
+      &image,
+      vec![detection("card_pack", 1220.0, 390.0, 1560.0, 610.0)],
+      vec![detection(
+        "button_store_next_round",
+        1320.0,
+        760.0,
+        1530.0,
+        850.0,
+      )],
+    );
+
+    let state = build_state_from_detections(
+      "synthetic-store-pack.png",
+      image_size(&image),
+      &image,
+      detections,
+      false,
+    );
+
+    assert_eq!(state.store.item_count, 1);
+    assert_eq!(state.store.items[0].slot, SlotId::new(ObjectZone::Store, 0));
+    assert_eq!(state.store.items[0].kind, StoreItemKind::CardPack);
+    assert_eq!(state.store.items[0].bbox.x1, 1220.0);
+    assert_eq!(state.store.items[0].bbox.y1, 390.0);
+  }
+
+  #[test]
+  fn voucher_store_candidate_uses_layout_fallback_without_detector_class() {
+    let image = test_image_with_size(1600, 960);
+    let detections = detection_sets_for_image(
+      &image,
+      vec![detection("joker_card", 560.0, 390.0, 700.0, 610.0)],
+      vec![detection(
+        "button_store_next_round",
+        1320.0,
+        760.0,
+        1530.0,
+        850.0,
+      )],
+    );
+
+    let state = build_state_from_detections(
+      "synthetic-store-voucher.png",
+      image_size(&image),
+      &image,
+      detections,
+      false,
+    );
+
+    assert_eq!(state.phase, BalatroPhase::Store);
+    assert_eq!(state.store.item_count, 2);
+    assert_eq!(state.store.items[0].kind, StoreItemKind::Joker);
+    assert_eq!(state.store.items[1].slot, SlotId::new(ObjectZone::Store, 1));
+    assert_eq!(state.store.items[1].kind, StoreItemKind::Voucher);
+    assert!(state.store.items[1].confidence < 0.5);
+  }
+
+  #[test]
+  fn store_items_include_lower_row_card_pack_at_small_window_scale() {
+    let image = test_image_with_size(950, 583);
+    let detections = detection_sets_for_image(
+      &image,
+      vec![detection("card_pack", 542.0, 415.0, 628.0, 553.0)],
+      vec![detection(
+        "button_store_next_round",
+        273.0,
+        236.0,
+        397.0,
+        300.0,
+      )],
+    );
+
+    let state = build_state_from_detections(
+      "synthetic-small-store-pack.png",
+      image_size(&image),
+      &image,
+      detections,
+      false,
+    );
+
+    assert_eq!(state.store.item_count, 1);
+    assert_eq!(state.store.items[0].slot, SlotId::new(ObjectZone::Store, 0));
+    assert_eq!(state.store.items[0].kind, StoreItemKind::CardPack);
+  }
+
+  #[test]
+  fn hand_cards_can_infer_playing_phase_before_play_buttons_are_visible() {
+    let image = test_image();
+    let detections = detection_sets(
+      vec![detection("poker_card_front", 40.0, 40.0, 70.0, 100.0)],
+      vec![
+        detection("button_sort_hand_rank", 10.0, 120.0, 40.0, 145.0),
+        detection("button_sort_hand_suits", 45.0, 120.0, 90.0, 145.0),
+      ],
+    );
+
+    let state = build_state_from_detections(
+      "synthetic.png",
+      image_size(&image),
+      &image,
+      detections,
+      false,
+    );
+
+    assert_eq!(state.phase, BalatroPhase::Playing);
+  }
+
+  #[test]
+  fn cache_hint_does_not_panic_for_partially_out_of_bounds_bbox() {
+    let image = test_image();
+    let detection = Detection {
+      class_id: 0,
+      label: "joker_card".to_owned(),
+      confidence: 0.9,
+      bbox: BoundingBox {
+        x1: -5.0,
+        y1: 2.0,
+        x2: 8.0,
+        y2: 20.0,
+      },
+    };
+
+    let hint = cache_hint_for_detection(&detection, &image, false);
+
+    assert!(hint.needs_reading);
+    assert!(hint.visual_fingerprint.is_some());
+  }
+
+  #[test]
+  fn no_cache_keeps_visual_fingerprint_for_verification_evidence() {
+    let image = test_image();
+    let detection = Detection {
+      class_id: 0,
+      label: "poker_card_front".to_owned(),
+      confidence: 0.9,
+      bbox: BoundingBox {
+        x1: 2.0,
+        y1: 2.0,
+        x2: 16.0,
+        y2: 20.0,
+      },
+    };
+
+    let hint = cache_hint_for_detection(&detection, &image, true);
+
+    assert!(hint.needs_reading);
+    assert!(hint.visual_fingerprint.is_some());
+    assert!(hint.changed_since_last_read);
+  }
+
+  fn detection_sets(entities: Vec<Detection>, ui: Vec<Detection>) -> BalatroDetectionSets {
+    let image = test_image();
+    detection_sets_for_image(&image, entities, ui)
+  }
+
+  fn detection_sets_for_image(
+    image: &RgbImage,
+    entities: Vec<Detection>,
+    ui: Vec<Detection>,
+  ) -> BalatroDetectionSets {
+    BalatroDetectionSets {
+      entities: DetectionSet {
+        model_id: ModelId("entities-test".to_owned()),
+        image_size: image_size(image),
+        detections: entities,
+      },
+      ui: DetectionSet {
+        model_id: ModelId("ui-test".to_owned()),
+        image_size: image_size(image),
+        detections: ui,
+      },
+    }
+  }
+
+  fn detection(label: &str, x1: f32, y1: f32, x2: f32, y2: f32) -> Detection {
+    Detection {
+      class_id: 0,
+      label: label.to_owned(),
+      confidence: 0.9,
+      bbox: BoundingBox { x1, y1, x2, y2 },
+    }
+  }
+
+  fn test_image() -> RgbImage {
+    test_image_with_size(160, 160)
+  }
+
+  fn test_image_with_size(width: u32, height: u32) -> RgbImage {
+    RgbImage::from_fn(width, height, |x, y| {
+      Rgb([(x % 251) as u8, (y % 251) as u8, ((x + y) % 251) as u8])
+    })
+  }
+
+  fn image_size(image: &RgbImage) -> ImageSize {
+    ImageSize {
+      width: image.width(),
+      height: image.height(),
+    }
+  }
+}

--- a/crates/auv-game-balatro/src/operation.rs
+++ b/crates/auv-game-balatro/src/operation.rs
@@ -1,0 +1,23 @@
+// TODO(balatro-operations-v1): Target resolution, driver delivery, operation
+// request/result fields, and semantic verification are deferred until the
+// owner-approved operation slice. These opaque placeholders keep Task 2 focused
+// on model/output contracts without stabilizing an operation wire shape.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OperationRequest {
+  _private: (),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OperationResult {
+  _private: (),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VerificationMode {
+  _private: (),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VerificationProfile {
+  _private: (),
+}

--- a/crates/auv-game-balatro/src/output.rs
+++ b/crates/auv-game-balatro/src/output.rs
@@ -1,0 +1,73 @@
+use std::fmt;
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::process;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::Serialize;
+use thiserror::Error;
+
+use crate::model::BalatroState;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum OutputMode {
+  Human,
+  Json,
+  JsonFile(PathBuf),
+}
+
+#[derive(Debug, Error)]
+pub enum OutputError {
+  #[error("failed to write JSON output: {0}")]
+  Io(#[from] io::Error),
+  #[error("failed to serialize JSON output: {0}")]
+  Json(#[from] serde_json::Error),
+}
+
+pub fn write_json_file(path: &Path, value: &impl Serialize) -> Result<(), OutputError> {
+  let mut bytes = serde_json::to_vec_pretty(value)?;
+  bytes.push(b'\n');
+
+  let temp_path = temporary_path(path);
+  let mut file = OpenOptions::new()
+    .create_new(true)
+    .write(true)
+    .open(&temp_path)?;
+  file.write_all(&bytes)?;
+  file.sync_all()?;
+  drop(file);
+
+  fs::rename(&temp_path, path)?;
+  Ok(())
+}
+
+fn temporary_path(path: &Path) -> PathBuf {
+  let nonce = SystemTime::now()
+    .duration_since(UNIX_EPOCH)
+    .map(|duration| duration.as_nanos())
+    .unwrap_or_default();
+  let file_name = path
+    .file_name()
+    .and_then(|name| name.to_str())
+    .unwrap_or("auv-game-balatro-output");
+  path.with_file_name(format!(".{file_name}.{}.{}.tmp", process::id(), nonce))
+}
+
+pub struct HumanStateSummary<'a>(pub &'a BalatroState);
+
+impl fmt::Display for HumanStateSummary<'_> {
+  fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    let state = self.0;
+    write!(
+      formatter,
+      "Balatro state: phase={:?}, hand={}, jokers={}, consumables={}, store_items={}, buttons={}",
+      state.phase,
+      state.hand.len(),
+      state.jokers.len(),
+      state.consumables.len(),
+      state.store.item_count,
+      state.buttons.len()
+    )
+  }
+}

--- a/crates/auv-game-balatro/tests/cli.rs
+++ b/crates/auv-game-balatro/tests/cli.rs
@@ -1,0 +1,814 @@
+use std::path::PathBuf;
+
+use auv_game_balatro::cli::{
+  BlindsArgs, BlindsCommand, CardsArgs, CardsCommand, CliArgs, CliError, Command, ConsumablesArgs,
+  ConsumablesCommand, Format, GameArgs, GameCommand, JokersArgs, JokersCommand, ObjectiveArgs,
+  PackArgs, PackCommand, RoundsArgs, RoundsCommand, ScoresArgs, ScoresCommand, SetupArgs,
+  StoreArgs, StoreCommand, VerifyModeArg, run,
+};
+use auv_game_balatro::output::OutputMode;
+use auv_inference_ultralytics::InferenceDevice;
+use clap::Parser;
+
+#[test]
+fn rejects_dry_run_for_balatro_operations() {
+  let error = CliArgs::try_parse_from(["auv-game-balatro", "store", "next-round", "--dry-run"])
+    .expect_err("Balatro mutating commands should not expose dry-run");
+
+  assert!(
+    error
+      .to_string()
+      .contains("unexpected argument '--dry-run'"),
+    "{error}"
+  );
+}
+
+#[test]
+fn parses_setup_asset_command_flags() {
+  let args = CliArgs::parse_from([
+    "auv-game-balatro",
+    "setup",
+    "--love",
+    "Balatro.love",
+    "--cache-dir",
+    "cache",
+    "--force",
+    "--json",
+  ]);
+
+  let Command::Setup(SetupArgs {
+    love,
+    app,
+    cache_dir,
+    check,
+    force,
+    json,
+  }) = args.command
+  else {
+    panic!("expected setup command");
+  };
+
+  assert_eq!(love, Some(PathBuf::from("Balatro.love")));
+  assert_eq!(app, None);
+  assert_eq!(cache_dir, Some(PathBuf::from("cache")));
+  assert!(!check);
+  assert!(force);
+  assert!(json);
+}
+
+#[test]
+fn parses_details_aliases_for_balatro_operations() {
+  let details = CliArgs::parse_from(["auv-game-balatro", "cards", "clear", "--details"]);
+  let Command::Cards(CardsArgs {
+    command: CardsCommand::Clear(details_args),
+  }) = details.command
+  else {
+    panic!("expected cards clear command");
+  };
+  assert!(details_args.details);
+
+  let detailed = CliArgs::parse_from(["auv-game-balatro", "pack", "skip", "--detailed"]);
+  let Command::Pack(PackArgs {
+    command: PackCommand::Skip(detailed_args),
+  }) = detailed.command
+  else {
+    panic!("expected pack skip command");
+  };
+  assert!(detailed_args.details);
+}
+
+#[test]
+fn parses_cards_hand_observation_flags() {
+  let args = CliArgs::parse_from([
+    "auv-game-balatro",
+    "cards",
+    "hand",
+    "--image",
+    "balatro.jpg",
+    "--json",
+    "--no-cache",
+    "--target",
+    "Balatro",
+  ]);
+
+  let Command::Cards(CardsArgs {
+    command: CardsCommand::Hand(hand),
+  }) = args.command
+  else {
+    panic!("expected cards hand command");
+  };
+
+  assert_eq!(hand.image, Some(PathBuf::from("balatro.jpg")));
+  assert!(hand.json);
+  assert!(hand.no_cache);
+  assert_eq!(hand.target, "Balatro");
+  assert_eq!(hand.output_mode(), OutputMode::Json);
+}
+
+#[test]
+fn parses_store_buy_operation_flags() {
+  let args = CliArgs::parse_from([
+    "auv-game-balatro",
+    "store",
+    "buy",
+    "--slot",
+    "store:0",
+    "--details",
+    "--verify",
+    "--verify-mode",
+    "weak",
+  ]);
+
+  let Command::Store(StoreArgs {
+    command: StoreCommand::Buy(buy),
+  }) = args.command
+  else {
+    panic!("expected store buy command");
+  };
+
+  assert_eq!(buy.slot, "store:0");
+  assert!(buy.control.details);
+  assert!(buy.control.verify);
+  assert_eq!(buy.control.verify_mode, VerifyModeArg::Weak);
+}
+
+#[test]
+fn parses_store_read_buy_and_reroll_commands() {
+  let read = CliArgs::parse_from([
+    "auv-game-balatro",
+    "store",
+    "read",
+    "--slot",
+    "store:1",
+    "--json",
+  ]);
+  let Command::Store(StoreArgs {
+    command: StoreCommand::Read(read_args),
+  }) = read.command
+  else {
+    panic!("expected store read command");
+  };
+  assert_eq!(read_args.slot, "store:1");
+  assert!(read_args.observe.json);
+
+  let buy = CliArgs::parse_from([
+    "auv-game-balatro",
+    "store",
+    "buy",
+    "--slot",
+    "store:0",
+    "--verify",
+  ]);
+  let Command::Store(StoreArgs {
+    command: StoreCommand::Buy(buy_args),
+  }) = buy.command
+  else {
+    panic!("expected store buy command");
+  };
+  assert_eq!(buy_args.slot, "store:0");
+  assert!(buy_args.control.verify);
+
+  let reroll = CliArgs::parse_from([
+    "auv-game-balatro",
+    "store",
+    "reroll",
+    "--verify-mode",
+    "weak",
+  ]);
+  let Command::Store(StoreArgs {
+    command: StoreCommand::Reroll(reroll_args),
+  }) = reroll.command
+  else {
+    panic!("expected store reroll command");
+  };
+  assert_eq!(reroll_args.verify_mode, VerifyModeArg::Weak);
+}
+
+#[test]
+fn parses_pack_read_choose_and_skip_commands() {
+  let read = CliArgs::parse_from(["auv-game-balatro", "pack", "read", "--json"]);
+  let Command::Pack(PackArgs {
+    command: PackCommand::Read(read_args),
+  }) = read.command
+  else {
+    panic!("expected pack read command");
+  };
+  assert!(read_args.json);
+
+  let choose = CliArgs::parse_from([
+    "auv-game-balatro",
+    "pack",
+    "choose",
+    "--slot",
+    "pack:2",
+    "--verify",
+  ]);
+  let Command::Pack(PackArgs {
+    command: PackCommand::Choose(choose_args),
+  }) = choose.command
+  else {
+    panic!("expected pack choose command");
+  };
+  assert_eq!(choose_args.slot, "pack:2");
+  assert!(choose_args.control.verify);
+
+  let skip = CliArgs::parse_from(["auv-game-balatro", "pack", "skip", "--verify"]);
+  let Command::Pack(PackArgs {
+    command: PackCommand::Skip(skip_args),
+  }) = skip.command
+  else {
+    panic!("expected pack skip command");
+  };
+  assert!(skip_args.verify);
+}
+
+#[test]
+fn parses_consumable_and_joker_read_use_commands() {
+  let read_joker = CliArgs::parse_from([
+    "auv-game-balatro",
+    "jokers",
+    "read",
+    "--slot",
+    "joker:0",
+    "--json",
+  ]);
+  let Command::Jokers(JokersArgs {
+    command: JokersCommand::Read(joker_args),
+  }) = read_joker.command
+  else {
+    panic!("expected jokers read command");
+  };
+  assert_eq!(joker_args.slot, "joker:0");
+  assert!(joker_args.observe.json);
+
+  let read_consumable = CliArgs::parse_from([
+    "auv-game-balatro",
+    "consumables",
+    "read",
+    "--slot",
+    "consumable:1",
+  ]);
+  let Command::Consumables(ConsumablesArgs {
+    command: ConsumablesCommand::Read(read_args),
+  }) = read_consumable.command
+  else {
+    panic!("expected consumables read command");
+  };
+  assert_eq!(read_args.slot, "consumable:1");
+
+  let use_consumable = CliArgs::parse_from([
+    "auv-game-balatro",
+    "consumables",
+    "use",
+    "--slot",
+    "consumable:0",
+    "--verify",
+  ]);
+  let Command::Consumables(ConsumablesArgs {
+    command: ConsumablesCommand::Use(use_args),
+  }) = use_consumable.command
+  else {
+    panic!("expected consumables use command");
+  };
+  assert_eq!(use_args.slot, "consumable:0");
+  assert!(use_args.control.verify);
+}
+
+#[test]
+fn parses_consumable_sell_and_target_operations() {
+  let sell_consumable = CliArgs::parse_from([
+    "auv-game-balatro",
+    "consumables",
+    "sell",
+    "--slot",
+    "consumable:0",
+    "--verify",
+  ]);
+  let Command::Consumables(ConsumablesArgs {
+    command: ConsumablesCommand::Sell(sell_args),
+  }) = sell_consumable.command
+  else {
+    panic!("expected consumables sell command");
+  };
+  assert_eq!(sell_args.slot, "consumable:0");
+  assert!(sell_args.control.verify);
+
+  let use_consumable = CliArgs::parse_from([
+    "auv-game-balatro",
+    "consumables",
+    "use",
+    "--slot",
+    "consumable:0",
+    "--targets",
+    "hand:1,hand:2",
+    "--verify",
+  ]);
+  let Command::Consumables(ConsumablesArgs {
+    command: ConsumablesCommand::Use(use_args),
+  }) = use_consumable.command
+  else {
+    panic!("expected consumables use command");
+  };
+  assert_eq!(use_args.slot, "consumable:0");
+  assert_eq!(use_args.targets, vec!["hand:1", "hand:2"]);
+  assert!(use_args.control.verify);
+
+  let pack_choose = CliArgs::parse_from([
+    "auv-game-balatro",
+    "pack",
+    "choose",
+    "--slot",
+    "pack:0",
+    "--targets",
+    "hand:1",
+    "--verify",
+  ]);
+  let Command::Pack(PackArgs {
+    command: PackCommand::Choose(choose_args),
+  }) = pack_choose.command
+  else {
+    panic!("expected pack choose command");
+  };
+  assert_eq!(choose_args.slot, "pack:0");
+  assert_eq!(choose_args.targets, vec!["hand:1"]);
+  assert!(choose_args.control.verify);
+}
+
+#[test]
+fn deferred_mutating_object_commands_validate_slot_prefixes_first() {
+  let cases = [
+    (
+      CliArgs::parse_from(["auv-game-balatro", "store", "buy", "--slot", "bad"]),
+      "store:N",
+    ),
+    (
+      CliArgs::parse_from(["auv-game-balatro", "consumables", "use", "--slot", "bad"]),
+      "consumable:N",
+    ),
+    (
+      CliArgs::parse_from(["auv-game-balatro", "jokers", "sell", "--slot", "bad"]),
+      "joker:N",
+    ),
+  ];
+
+  for (args, expected) in cases {
+    let error = run(args).expect_err("invalid slot should fail before deferred execution");
+    let CliError::Message(message) = error else {
+      panic!("expected slot validation error, got {error:?}");
+    };
+    assert!(message.contains(expected), "{message}");
+  }
+
+  let reroll = CliArgs::parse_from(["auv-game-balatro", "store", "reroll"]);
+  assert!(matches!(
+    run(reroll),
+    Err(CliError::Deferred {
+      command: "store.reroll",
+      ..
+    })
+  ));
+}
+
+#[test]
+fn parses_game_state_format_json() {
+  let args = CliArgs::parse_from([
+    "auv-game-balatro",
+    "game",
+    "state",
+    "--image",
+    "balatro.jpg",
+    "--format",
+    "json",
+  ]);
+
+  let Command::Game(GameArgs {
+    command: GameCommand::State(state),
+  }) = args.command
+  else {
+    panic!("expected game state command");
+  };
+
+  assert_eq!(state.image, Some(PathBuf::from("balatro.jpg")));
+  assert_eq!(state.format, Format::Json);
+  assert_eq!(state.output_mode(), OutputMode::Json);
+}
+
+#[test]
+fn parses_game_cash_out_operation_flags() {
+  let args = CliArgs::parse_from([
+    "auv-game-balatro",
+    "game",
+    "cash-out",
+    "--verify",
+    "--timeout-ms",
+    "1800",
+  ]);
+
+  let Command::Game(GameArgs {
+    command: GameCommand::CashOut(cash_out),
+  }) = args.command
+  else {
+    panic!("expected game cash-out command");
+  };
+
+  assert!(cash_out.verify);
+  assert_eq!(cash_out.timeout_ms, Some(1800));
+}
+
+#[test]
+fn parses_game_restart_operation_flags() {
+  let args = CliArgs::parse_from([
+    "auv-game-balatro",
+    "game",
+    "restart",
+    "--details",
+    "--verify",
+  ]);
+
+  let Command::Game(GameArgs {
+    command: GameCommand::Restart(restart),
+  }) = args.command
+  else {
+    panic!("expected game restart command");
+  };
+
+  assert!(restart.details);
+  assert!(restart.verify);
+}
+
+#[test]
+fn parses_objective_observation_includes() {
+  let args = CliArgs::parse_from([
+    "auv-game-balatro",
+    "objective",
+    "--include-scores",
+    "--include-rounds",
+    "--image",
+    "balatro.jpg",
+  ]);
+
+  let Command::Objective(ObjectiveArgs {
+    observe,
+    include_scores,
+    include_rounds,
+  }) = args.command
+  else {
+    panic!("expected objective command");
+  };
+
+  assert!(include_scores);
+  assert!(include_rounds);
+  assert_eq!(observe.image, Some(PathBuf::from("balatro.jpg")));
+  assert_eq!(observe.output_mode(), OutputMode::Human);
+}
+
+#[test]
+fn parses_store_status_observation_defaults() {
+  let args = CliArgs::parse_from([
+    "auv-game-balatro",
+    "store",
+    "status",
+    "--image",
+    "balatro.jpg",
+  ]);
+
+  let Command::Store(StoreArgs {
+    command: StoreCommand::Status(status),
+  }) = args.command
+  else {
+    panic!("expected store status command");
+  };
+
+  assert_eq!(status.image, Some(PathBuf::from("balatro.jpg")));
+  assert_eq!(status.device, InferenceDevice::Cpu);
+  assert_eq!(status.output_mode(), OutputMode::Human);
+}
+
+#[test]
+fn parses_observation_model_overrides() {
+  let args = CliArgs::parse_from([
+    "auv-game-balatro",
+    "store",
+    "status",
+    "--entities-model",
+    "entities.onnx",
+    "--entities-classes",
+    "entities.txt",
+    "--ui-model",
+    "ui.onnx",
+    "--ui-classes",
+    "ui.txt",
+    "--card-corner-model",
+    "card-corner.onnx",
+  ]);
+
+  let Command::Store(StoreArgs {
+    command: StoreCommand::Status(status),
+  }) = args.command
+  else {
+    panic!("expected store status command");
+  };
+
+  assert_eq!(status.entities_model, Some(PathBuf::from("entities.onnx")));
+  assert_eq!(status.entities_classes, Some(PathBuf::from("entities.txt")));
+  assert_eq!(status.ui_model, Some(PathBuf::from("ui.onnx")));
+  assert_eq!(status.ui_classes, Some(PathBuf::from("ui.txt")));
+  assert_eq!(
+    status.card_corner_model,
+    Some(PathBuf::from("card-corner.onnx"))
+  );
+}
+
+#[test]
+fn maps_json_out_to_file_output_mode() {
+  let args = CliArgs::parse_from([
+    "auv-game-balatro",
+    "game",
+    "state",
+    "--json-out",
+    "state.json",
+    "--json",
+  ]);
+
+  let Command::Game(GameArgs {
+    command: GameCommand::State(state),
+  }) = args.command
+  else {
+    panic!("expected game state command");
+  };
+
+  assert_eq!(
+    state.output_mode(),
+    OutputMode::JsonFile(PathBuf::from("state.json"))
+  );
+}
+
+#[test]
+fn parses_operation_slots_and_timeout() {
+  let args = CliArgs::parse_from([
+    "auv-game-balatro",
+    "cards",
+    "play",
+    "--slots",
+    "hand:0,hand:1",
+    "--timeout-ms",
+    "750",
+  ]);
+
+  let Command::Cards(CardsArgs {
+    command: CardsCommand::Play(play),
+  }) = args.command
+  else {
+    panic!("expected cards play command");
+  };
+
+  assert_eq!(play.slots, "hand:0,hand:1");
+  assert_eq!(play.control.timeout_ms, Some(750));
+  assert_eq!(play.control.verify_mode, VerifyModeArg::Targeted);
+}
+
+#[test]
+fn parses_scores_and_rounds_get_commands() {
+  let scores = CliArgs::parse_from(["auv-game-balatro", "scores", "get", "--image", "a.png"]);
+  let Command::Scores(ScoresArgs {
+    command: ScoresCommand::Get(score_args),
+  }) = scores.command
+  else {
+    panic!("expected scores get command");
+  };
+  assert_eq!(score_args.image, Some(PathBuf::from("a.png")));
+
+  let rounds = CliArgs::parse_from(["auv-game-balatro", "rounds", "get", "--image", "b.png"]);
+  let Command::Rounds(RoundsArgs {
+    command: RoundsCommand::Get(round_args),
+  }) = rounds.command
+  else {
+    panic!("expected rounds get command");
+  };
+  assert_eq!(round_args.image, Some(PathBuf::from("b.png")));
+}
+
+#[test]
+fn parses_card_list_read_and_select_commands() {
+  let list = CliArgs::parse_from(["auv-game-balatro", "cards", "ls", "--image", "hand.png"]);
+  let Command::Cards(CardsArgs {
+    command: CardsCommand::Ls(list_args),
+  }) = list.command
+  else {
+    panic!("expected cards ls command");
+  };
+  assert_eq!(list_args.image, Some(PathBuf::from("hand.png")));
+
+  let read = CliArgs::parse_from([
+    "auv-game-balatro",
+    "cards",
+    "read",
+    "--slot",
+    "hand:3",
+    "--no-cache",
+    "--target",
+    "Balatro",
+  ]);
+  let Command::Cards(CardsArgs {
+    command: CardsCommand::Read(read_args),
+  }) = read.command
+  else {
+    panic!("expected cards read command");
+  };
+  assert_eq!(read_args.slot, "hand:3");
+  assert!(read_args.observe.no_cache);
+  assert_eq!(read_args.observe.target, "Balatro");
+
+  let select = CliArgs::parse_from([
+    "auv-game-balatro",
+    "cards",
+    "select",
+    "--slots",
+    "hand:0,hand:2",
+  ]);
+  let Command::Cards(CardsArgs {
+    command: CardsCommand::Select(select_args),
+  }) = select.command
+  else {
+    panic!("expected cards select command");
+  };
+  assert_eq!(select_args.slots, "hand:0,hand:2");
+
+  let clear = CliArgs::parse_from(["auv-game-balatro", "cards", "clear", "--verify"]);
+  let Command::Cards(CardsArgs {
+    command: CardsCommand::Clear(clear_args),
+  }) = clear.command
+  else {
+    panic!("expected cards clear command");
+  };
+  assert!(clear_args.verify);
+}
+
+#[test]
+fn parses_cards_discard_command() {
+  let discard = CliArgs::parse_from([
+    "auv-game-balatro",
+    "cards",
+    "discard",
+    "--slots",
+    "hand:1,hand:3",
+    "--verify",
+  ]);
+  let Command::Cards(CardsArgs {
+    command: CardsCommand::Discard(discard_args),
+  }) = discard.command
+  else {
+    panic!("expected cards discard command");
+  };
+  assert_eq!(discard_args.slots, "hand:1,hand:3");
+  assert!(discard_args.control.verify);
+}
+
+#[test]
+fn parses_joker_consumable_store_and_blind_object_commands() {
+  let jokers = CliArgs::parse_from(["auv-game-balatro", "jokers", "ls", "--image", "j.png"]);
+  let Command::Jokers(JokersArgs {
+    command: JokersCommand::Ls(joker_args),
+  }) = jokers.command
+  else {
+    panic!("expected jokers ls command");
+  };
+  assert_eq!(joker_args.image, Some(PathBuf::from("j.png")));
+
+  let joker_read = CliArgs::parse_from(["auv-game-balatro", "jokers", "read", "--slot", "joker:1"]);
+  let Command::Jokers(JokersArgs {
+    command: JokersCommand::Read(joker_read_args),
+  }) = joker_read.command
+  else {
+    panic!("expected jokers read command");
+  };
+  assert_eq!(joker_read_args.slot, "joker:1");
+
+  let joker_sell = CliArgs::parse_from(["auv-game-balatro", "jokers", "sell", "--slot", "joker:2"]);
+  let Command::Jokers(JokersArgs {
+    command: JokersCommand::Sell(joker_sell_args),
+  }) = joker_sell.command
+  else {
+    panic!("expected jokers sell command");
+  };
+  assert_eq!(joker_sell_args.slot, "joker:2");
+
+  let consumables =
+    CliArgs::parse_from(["auv-game-balatro", "consumables", "ls", "--image", "c.png"]);
+  let Command::Consumables(ConsumablesArgs {
+    command: ConsumablesCommand::Ls(consumable_args),
+  }) = consumables.command
+  else {
+    panic!("expected consumables ls command");
+  };
+  assert_eq!(consumable_args.image, Some(PathBuf::from("c.png")));
+
+  let consumable_use = CliArgs::parse_from([
+    "auv-game-balatro",
+    "consumables",
+    "use",
+    "--slot",
+    "consumable:0",
+  ]);
+  let Command::Consumables(ConsumablesArgs {
+    command: ConsumablesCommand::Use(use_args),
+  }) = consumable_use.command
+  else {
+    panic!("expected consumables use command");
+  };
+  assert_eq!(use_args.slot, "consumable:0");
+
+  let store_ls = CliArgs::parse_from(["auv-game-balatro", "store", "ls", "--image", "s.png"]);
+  let Command::Store(StoreArgs {
+    command: StoreCommand::Ls(store_args),
+  }) = store_ls.command
+  else {
+    panic!("expected store ls command");
+  };
+  assert_eq!(store_args.image, Some(PathBuf::from("s.png")));
+
+  let next_round = CliArgs::parse_from([
+    "auv-game-balatro",
+    "store",
+    "next-round",
+    "--target",
+    "Balatro",
+    "--details",
+  ]);
+  let Command::Store(StoreArgs {
+    command: StoreCommand::NextRound(next_round_args),
+  }) = next_round.command
+  else {
+    panic!("expected store next-round command");
+  };
+  assert!(next_round_args.details);
+  assert_eq!(next_round_args.target, "Balatro");
+
+  let reroll = CliArgs::parse_from(["auv-game-balatro", "store", "reroll", "--verify"]);
+  let Command::Store(StoreArgs {
+    command: StoreCommand::Reroll(reroll_args),
+  }) = reroll.command
+  else {
+    panic!("expected store reroll command");
+  };
+  assert!(reroll_args.verify);
+
+  let blinds = CliArgs::parse_from(["auv-game-balatro", "blinds", "ls", "--image", "b.png"]);
+  let Command::Blinds(BlindsArgs {
+    command: BlindsCommand::Ls(blind_args),
+  }) = blinds.command
+  else {
+    panic!("expected blinds ls command");
+  };
+  assert_eq!(blind_args.image, Some(PathBuf::from("b.png")));
+
+  let blind_select = CliArgs::parse_from([
+    "auv-game-balatro",
+    "blinds",
+    "select",
+    "--slot",
+    "blind:small",
+  ]);
+  let Command::Blinds(BlindsArgs {
+    command: BlindsCommand::Select(select_args),
+  }) = blind_select.command
+  else {
+    panic!("expected blinds select command");
+  };
+  assert_eq!(select_args.slot, "blind:small");
+
+  let blind_skip = CliArgs::parse_from(["auv-game-balatro", "blinds", "skip", "--details"]);
+  let Command::Blinds(BlindsArgs {
+    command: BlindsCommand::Skip(skip_args),
+  }) = blind_skip.command
+  else {
+    panic!("expected blinds skip command");
+  };
+  assert!(skip_args.details);
+}
+
+#[test]
+fn rejects_missing_targets_for_targeted_commands() {
+  assert!(
+    CliArgs::try_parse_from(["auv-game-balatro", "cards", "read"]).is_err(),
+    "cards read should require --slot"
+  );
+  assert!(
+    CliArgs::try_parse_from(["auv-game-balatro", "store", "buy"]).is_err(),
+    "store buy should require --slot"
+  );
+  assert!(
+    CliArgs::try_parse_from(["auv-game-balatro", "cards", "play"]).is_err(),
+    "cards play should require --slots"
+  );
+}
+
+#[test]
+fn displays_cli_value_enums() {
+  assert_eq!(Format::default(), Format::Text);
+  assert_eq!(Format::Text.to_string(), "text");
+  assert_eq!(Format::Json.to_string(), "json");
+  assert_eq!(VerifyModeArg::Targeted.to_string(), "targeted");
+  assert_eq!(VerifyModeArg::Weak.to_string(), "weak");
+  assert_eq!(VerifyModeArg::ActivationOnly.to_string(), "activation-only");
+}

--- a/crates/auv-game-balatro/tests/real_balatro.rs
+++ b/crates/auv-game-balatro/tests/real_balatro.rs
@@ -1,0 +1,86 @@
+use std::path::{Path, PathBuf};
+
+use auv_game_balatro::config::BalatroModelConfig;
+use auv_game_balatro::observation::observe_image;
+use auv_game_balatro::output::write_json_file;
+use auv_inference_common::{Detection, render_annotated_image};
+use image::ImageReader;
+
+#[test]
+#[ignore = "loads or downloads Balatro ONNX models and writes smoke artifacts"]
+fn real_balatro_fixture_observes_state_and_writes_artifacts()
+-> Result<(), Box<dyn std::error::Error>> {
+  let config = BalatroModelConfig::default();
+  let resolved = config.resolve()?;
+  assert_exists(&resolved.entities_model);
+  assert_exists(&resolved.entities_classes);
+  assert_exists(&resolved.ui_model);
+  assert_exists(&resolved.ui_classes);
+
+  let image_path = repo_root()
+    .join("crates")
+    .join("auv-inference-ultralytics")
+    .join("tests")
+    .join("fixtures")
+    .join("balatro")
+    .join("balatro.jpg");
+  assert_exists(&image_path);
+
+  let state = observe_image(&image_path, &config, false)?;
+
+  assert!(
+    !state.raw_entities.is_empty(),
+    "real Balatro entities model returned no detections"
+  );
+  assert!(
+    !state.raw_ui.is_empty(),
+    "real Balatro UI model returned no detections"
+  );
+  assert!(!state.hand.is_empty(), "expected hand cards in fixture");
+  assert!(!state.jokers.is_empty(), "expected joker cards in fixture");
+  assert!(!state.buttons.is_empty(), "expected buttons in fixture");
+  assert_eq!(state.phase, auv_game_balatro::model::BalatroPhase::Playing);
+
+  let json_path = std::env::temp_dir().join("auv-game-balatro-real-state.json");
+  write_json_file(&json_path, &state)?;
+
+  let source_image = ImageReader::open(&image_path)?.decode()?.to_rgb8();
+  let detections = state
+    .raw_entities
+    .iter()
+    .chain(state.raw_ui.iter())
+    .map(|evidence| evidence.detection.clone())
+    .collect::<Vec<Detection>>();
+  let annotated = render_annotated_image(&source_image, &detections);
+  let annotated_path = std::env::temp_dir().join("auv-game-balatro-real-annotated.png");
+  annotated.save(&annotated_path)?;
+
+  eprintln!(
+    "real Balatro smoke: entities={} ui={} hand={} jokers={} buttons={} state={} annotated={}",
+    state.raw_entities.len(),
+    state.raw_ui.len(),
+    state.hand.len(),
+    state.jokers.len(),
+    state.buttons.len(),
+    json_path.display(),
+    annotated_path.display()
+  );
+
+  Ok(())
+}
+
+fn assert_exists(path: &Path) {
+  assert!(
+    path.exists(),
+    "missing required Balatro smoke path: {}",
+    path.display()
+  );
+}
+
+fn repo_root() -> PathBuf {
+  Path::new(env!("CARGO_MANIFEST_DIR"))
+    .parent()
+    .and_then(Path::parent)
+    .expect("auv-game-balatro should live under crates/")
+    .to_path_buf()
+}


### PR DESCRIPTION
## Summary

- Add the `auv-game-balatro` crate with Balatro observation, CLI operations, setup extraction, and card/object read helpers.
- Resolve Balatro ONNX assets from Hugging Face by default, including the card-corner CNN model at `proj-airi/games-balatro-2024-card-corner-classifier`.
- Keep user overrides explicit through CLI flags (`--entities-model`, `--entities-classes`, `--ui-model`, `--ui-classes`, `--card-corner-model`) and remove owner-local/env-path fallbacks.
- Add `setup` for extracting the local Steam `Balatro.love` deck atlas into AUV's setup cache, without redistributing game assets.
- Add the small `auv-inference-ort` wrapper used by the optional card-corner ONNX feature.
- Expose macOS native `pointer::move_point` for live hover/read flows.

## Notes

- Runtime deck atlas lookup now reads the setup cache only. There is no `/Users/neko` hardcoded path and no `BALATRO_*` or custom AUV env override.
- `.runs/` is ignored so local Balatro run artifacts do not get committed.

## Verification

- `cargo check -p auv-game-balatro`
- `cargo test -p auv-game-balatro`
- `cargo test -p auv-game-balatro --features card-corner-onnx`
- `cargo check -p auv-game-balatro --features card-corner-onnx --examples`
- `cargo fmt --check`
- `git diff --check`
- `hack/generate-swift-bridge`
- `cd crates/auv-driver-macos/native/swift && swift build`
- `cd crates/auv-overlay-macos/native/swift && swift build`
- `rg -n "/Users/neko|/private/tmp|BALATRO_DECK_ATLAS_PATH|BALATRO_LOVE_PATH|AUV_GAME_BALATRO|BALATRO_ASSET_ROOT|CACHE_DIR_ENV" crates/auv-game-balatro || true`
