### PR TITLE
chore(gitignore): ignore local notes and run artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,8 @@ dist-ssr
 .eslintcache
 
 .auv/
+.runs/
+docs/notes/
 
 # Temporary fixture artifact emitted by scroll-scan tests.
 scan-page-*-observe.json


### PR DESCRIPTION
## Summary
- ignore local `.runs/` artifact directories
- ignore `docs/notes/` scratch material so personal notes do not clutter status

## Verification
- `git diff --check`