### PR TITLE
feat(auv-apple-textedit): implemented

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "auv-apple-textedit"
+version = "0.0.1"
+dependencies = [
+ "auv-driver",
+ "auv-driver-macos",
+ "clap",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "auv-cli"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
   ".",
+  "crates/auv-apple-textedit",
   "crates/auv-driver",
   "crates/auv-driver-macos",
   "crates/auv-game-balatro",

--- a/crates/auv-apple-textedit/Cargo.toml
+++ b/crates/auv-apple-textedit/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "auv-apple-textedit"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+readme.workspace = true
+license.workspace = true
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+auv-driver = { path = "../auv-driver" }
+auv-driver-macos = { path = "../auv-driver-macos" }
+clap = { version = "4", features = ["derive"] }
+serde.workspace = true
+serde_json.workspace = true

--- a/crates/auv-apple-textedit/src/bin/auv-apple-textedit.rs
+++ b/crates/auv-apple-textedit/src/bin/auv-apple-textedit.rs
@@ -1,0 +1,3 @@
+fn main() -> std::process::ExitCode {
+  auv_apple_textedit::cli::run()
+}

--- a/crates/auv-apple-textedit/src/cli.rs
+++ b/crates/auv-apple-textedit/src/cli.rs
@@ -1,0 +1,220 @@
+use std::process::ExitCode;
+
+use clap::{Args, Parser, Subcommand};
+
+use crate::commands::document::{
+  DEFAULT_APP_ID, DEFAULT_BODY_ROLE, DEFAULT_FOCUS_QUERY, DEFAULT_SETTLE_MS, DocumentCommand,
+  DocumentCompare, DocumentFocus, DocumentWrite, run_document_command,
+};
+use crate::driver::MacosTextEditDriver;
+
+#[derive(Clone, Debug, Parser)]
+#[command(
+  name = "auv-apple-textedit",
+  disable_help_subcommand = true,
+  about = "TextEdit app commands"
+)]
+struct CliArgs {
+  #[command(subcommand)]
+  command: CliCommand,
+}
+
+#[derive(Clone, Debug, Subcommand)]
+enum CliCommand {
+  /// Operate on the current TextEdit document.
+  Document(DocumentArgs),
+}
+
+#[derive(Clone, Debug, Args)]
+struct DocumentArgs {
+  #[command(subcommand)]
+  command: DocumentSubcommand,
+}
+
+#[derive(Clone, Debug, Subcommand)]
+enum DocumentSubcommand {
+  /// Write content into the document body.
+  Write(DocumentWriteArgs),
+  /// Compare document body text against expected content.
+  Compare(DocumentCompareArgs),
+  /// Focus the document body.
+  Focus(DocumentFocusArgs),
+}
+
+#[derive(Clone, Debug, Args)]
+struct DocumentWriteArgs {
+  #[arg(value_name = "content")]
+  content: String,
+  #[arg(long = "replace")]
+  replace: bool,
+  #[arg(long = "verify")]
+  verify: bool,
+  #[arg(long = "app-id", default_value = DEFAULT_APP_ID)]
+  app_id: String,
+  #[arg(long = "focus-query", default_value = DEFAULT_FOCUS_QUERY)]
+  focus_query: String,
+  #[arg(long = "focus-candidate", default_value = "")]
+  focus_candidate: String,
+  #[arg(long = "role", default_value = DEFAULT_BODY_ROLE)]
+  role: String,
+  #[arg(long = "activate-settle-ms", default_value_t = DEFAULT_SETTLE_MS)]
+  activate_settle_ms: u64,
+  #[arg(long = "input-settle-ms", default_value_t = DEFAULT_SETTLE_MS)]
+  input_settle_ms: u64,
+}
+
+#[derive(Clone, Debug, Args)]
+struct DocumentCompareArgs {
+  #[arg(value_name = "content")]
+  content: String,
+  #[arg(long = "role", default_value = DEFAULT_BODY_ROLE)]
+  role: String,
+  #[arg(long = "app-id", default_value = DEFAULT_APP_ID)]
+  app_id: String,
+}
+
+#[derive(Clone, Debug, Args)]
+struct DocumentFocusArgs {
+  #[arg(long = "query", default_value = DEFAULT_FOCUS_QUERY)]
+  query: String,
+  #[arg(long = "candidate", default_value = "")]
+  candidate: String,
+  #[arg(long = "app-id", default_value = DEFAULT_APP_ID)]
+  app_id: String,
+}
+
+pub fn parse_from<I, T>(args: I) -> Result<DocumentCommand, clap::Error>
+where
+  I: IntoIterator<Item = T>,
+  T: Into<std::ffi::OsString> + Clone,
+{
+  let args = CliArgs::try_parse_from(args)?;
+  Ok(match args.command {
+    CliCommand::Document(document) => match document.command {
+      DocumentSubcommand::Write(args) => DocumentCommand::Write(DocumentWrite {
+        app_id: args.app_id,
+        content: args.content,
+        replace: args.replace,
+        verify: args.verify,
+        focus_query: args.focus_query,
+        focus_candidate: args.focus_candidate,
+        compare_role: args.role,
+        activate_settle_ms: args.activate_settle_ms,
+        input_settle_ms: args.input_settle_ms,
+      }),
+      DocumentSubcommand::Compare(args) => DocumentCommand::Compare(DocumentCompare {
+        app_id: args.app_id,
+        content: args.content,
+        role: args.role,
+      }),
+      DocumentSubcommand::Focus(args) => DocumentCommand::Focus(DocumentFocus {
+        app_id: args.app_id,
+        query: args.query,
+        candidate: args.candidate,
+      }),
+    },
+  })
+}
+
+pub fn run() -> ExitCode {
+  let command = match parse_from(std::env::args_os()) {
+    Ok(command) => command,
+    Err(error) => {
+      let _ = error.print();
+      return ExitCode::from(2);
+    }
+  };
+  let mut driver = match MacosTextEditDriver::open_local() {
+    Ok(driver) => driver,
+    Err(error) => {
+      eprintln!("{error}");
+      return ExitCode::from(1);
+    }
+  };
+  match run_document_command(&command, &mut driver) {
+    Ok(report) => {
+      println!("{}", report.command);
+      ExitCode::SUCCESS
+    }
+    Err(error) => {
+      eprintln!("{error}");
+      ExitCode::from(1)
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn parse_document_write_maps_content_and_flags() {
+    let command = parse_from([
+      "auv-apple-textedit",
+      "document",
+      "write",
+      "hello",
+      "--replace",
+      "--verify",
+    ])
+    .expect("command should parse");
+
+    assert_eq!(
+      command,
+      DocumentCommand::Write(DocumentWrite {
+        app_id: DEFAULT_APP_ID.to_string(),
+        content: "hello".to_string(),
+        replace: true,
+        verify: true,
+        focus_query: DEFAULT_FOCUS_QUERY.to_string(),
+        focus_candidate: String::new(),
+        compare_role: DEFAULT_BODY_ROLE.to_string(),
+        activate_settle_ms: DEFAULT_SETTLE_MS,
+        input_settle_ms: DEFAULT_SETTLE_MS,
+      })
+    );
+  }
+
+  #[test]
+  fn parse_document_compare_maps_role() {
+    let command = parse_from([
+      "auv-apple-textedit",
+      "document",
+      "compare",
+      "hello",
+      "--role",
+      "AXTextArea",
+    ])
+    .expect("command should parse");
+
+    assert_eq!(
+      command,
+      DocumentCommand::Compare(DocumentCompare {
+        app_id: DEFAULT_APP_ID.to_string(),
+        content: "hello".to_string(),
+        role: DEFAULT_BODY_ROLE.to_string(),
+      })
+    );
+  }
+
+  #[test]
+  fn parse_document_focus_maps_query() {
+    let command = parse_from([
+      "auv-apple-textedit",
+      "document",
+      "focus",
+      "--query",
+      "First Text View",
+    ])
+    .expect("command should parse");
+
+    assert_eq!(
+      command,
+      DocumentCommand::Focus(DocumentFocus {
+        app_id: DEFAULT_APP_ID.to_string(),
+        query: DEFAULT_FOCUS_QUERY.to_string(),
+        candidate: String::new(),
+      })
+    );
+  }
+}

--- a/crates/auv-apple-textedit/src/commands/document.rs
+++ b/crates/auv-apple-textedit/src/commands/document.rs
@@ -1,0 +1,301 @@
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use crate::driver::{OperationResult, StepOutcome, TextEditDriver, VerificationOutcome};
+
+pub const DEFAULT_APP_ID: &str = "com.apple.TextEdit";
+pub const DEFAULT_MARKER_TEXT: &str = "AUV_TEXTEDIT_MARKER_2026_05_17";
+pub const DEFAULT_FOCUS_QUERY: &str = "First Text View";
+pub const DEFAULT_BODY_ROLE: &str = "AXTextArea";
+pub const DEFAULT_SETTLE_MS: u64 = 250;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DocumentCommand {
+  Write(DocumentWrite),
+  Compare(DocumentCompare),
+  Focus(DocumentFocus),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DocumentWrite {
+  pub app_id: String,
+  pub content: String,
+  pub replace: bool,
+  pub verify: bool,
+  pub focus_query: String,
+  pub focus_candidate: String,
+  pub compare_role: String,
+  pub activate_settle_ms: u64,
+  pub input_settle_ms: u64,
+}
+
+impl DocumentWrite {
+  pub fn defaults_with_content(content: impl Into<String>) -> Self {
+    Self {
+      app_id: DEFAULT_APP_ID.to_string(),
+      content: content.into(),
+      replace: true,
+      verify: true,
+      focus_query: DEFAULT_FOCUS_QUERY.to_string(),
+      focus_candidate: String::new(),
+      compare_role: DEFAULT_BODY_ROLE.to_string(),
+      activate_settle_ms: DEFAULT_SETTLE_MS,
+      input_settle_ms: DEFAULT_SETTLE_MS,
+    }
+  }
+
+  pub fn marker_defaults() -> Self {
+    Self::defaults_with_content(DEFAULT_MARKER_TEXT)
+  }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DocumentCompare {
+  pub app_id: String,
+  pub content: String,
+  pub role: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DocumentFocus {
+  pub app_id: String,
+  pub query: String,
+  pub candidate: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DocumentCommandReport {
+  pub command: &'static str,
+  pub outcomes: Vec<StepOutcome>,
+  pub verification: Option<VerificationOutcome>,
+}
+
+pub fn run_document_command(
+  command: &DocumentCommand,
+  driver: &mut impl TextEditDriver,
+) -> OperationResult<DocumentCommandReport> {
+  match command {
+    DocumentCommand::Write(command) => run_write(command, driver),
+    DocumentCommand::Compare(command) => run_compare(command, driver),
+    DocumentCommand::Focus(command) => run_focus(command, driver),
+  }
+}
+
+fn run_write(
+  command: &DocumentWrite,
+  driver: &mut impl TextEditDriver,
+) -> OperationResult<DocumentCommandReport> {
+  let mut outcomes = vec![
+    driver.activate_app(
+      &command.app_id,
+      Duration::from_millis(command.activate_settle_ms),
+    )?,
+    driver.focus_text_input(
+      &command.app_id,
+      &command.focus_query,
+      &command.focus_candidate,
+    )?,
+    driver.paste_text_preserve_clipboard(
+      &command.app_id,
+      &command.content,
+      command.replace,
+      Duration::from_millis(command.input_settle_ms),
+    )?,
+  ];
+  let verification = if command.verify {
+    Some(driver.verify_ax_text(&command.app_id, &command.content, &command.compare_role)?)
+  } else {
+    None
+  };
+  normalize_write_step_ids(&mut outcomes);
+  Ok(DocumentCommandReport {
+    command: "document.write",
+    outcomes,
+    verification,
+  })
+}
+
+fn run_compare(
+  command: &DocumentCompare,
+  driver: &mut impl TextEditDriver,
+) -> OperationResult<DocumentCommandReport> {
+  let verification = driver.verify_ax_text(&command.app_id, &command.content, &command.role)?;
+  Ok(DocumentCommandReport {
+    command: "document.compare",
+    outcomes: Vec::new(),
+    verification: Some(verification),
+  })
+}
+
+fn run_focus(
+  command: &DocumentFocus,
+  driver: &mut impl TextEditDriver,
+) -> OperationResult<DocumentCommandReport> {
+  let outcome = driver.focus_text_input(&command.app_id, &command.query, &command.candidate)?;
+  Ok(DocumentCommandReport {
+    command: "document.focus",
+    outcomes: vec![outcome],
+    verification: None,
+  })
+}
+
+fn normalize_write_step_ids(outcomes: &mut [StepOutcome]) {
+  for (index, outcome) in outcomes.iter_mut().enumerate() {
+    outcome.step_id = match index {
+      0 => "document-write.activate",
+      1 => "document-write.focus",
+      2 => "document-write.paste",
+      _ => outcome.step_id,
+    };
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use auv_driver::{InputActionResult, InputDeliveryPath};
+
+  #[derive(Default)]
+  struct RecordingTextEditDriver {
+    calls: Vec<String>,
+  }
+
+  impl TextEditDriver for RecordingTextEditDriver {
+    fn activate_app(&mut self, app_id: &str, settle: Duration) -> OperationResult<StepOutcome> {
+      self
+        .calls
+        .push(format!("activate:{app_id}:{}", settle.as_millis()));
+      Ok(StepOutcome {
+        step_id: "activate",
+        summary: "activated".to_string(),
+        input_action_result: None,
+      })
+    }
+
+    fn focus_text_input(
+      &mut self,
+      app_id: &str,
+      query: &str,
+      candidate: &str,
+    ) -> OperationResult<StepOutcome> {
+      self
+        .calls
+        .push(format!("focus:{app_id}:{query}:{candidate}"));
+      Ok(StepOutcome {
+        step_id: "focus",
+        summary: "focused".to_string(),
+        input_action_result: Some(InputActionResult::single_success(
+          InputDeliveryPath::WindowTargetedMouse,
+        )),
+      })
+    }
+
+    fn paste_text_preserve_clipboard(
+      &mut self,
+      app_id: &str,
+      text: &str,
+      replace_existing: bool,
+      settle: Duration,
+    ) -> OperationResult<StepOutcome> {
+      self.calls.push(format!(
+        "paste:{app_id}:{text}:{replace_existing}:{}",
+        settle.as_millis()
+      ));
+      Ok(StepOutcome {
+        step_id: "paste",
+        summary: "pasted".to_string(),
+        input_action_result: Some(InputActionResult::single_success(
+          InputDeliveryPath::ClipboardPaste,
+        )),
+      })
+    }
+
+    fn verify_ax_text(
+      &mut self,
+      app_id: &str,
+      target_text: &str,
+      target_role: &str,
+    ) -> OperationResult<VerificationOutcome> {
+      self
+        .calls
+        .push(format!("compare:{app_id}:{target_text}:{target_role}"));
+      Ok(VerificationOutcome {
+        matched_role: target_role.to_string(),
+        matched_text: format!("prefix {target_text} suffix"),
+        artifact_count: 1,
+      })
+    }
+  }
+
+  #[test]
+  fn document_write_runs_focus_paste_and_optional_compare() {
+    let command = DocumentCommand::Write(DocumentWrite::marker_defaults());
+    let mut driver = RecordingTextEditDriver::default();
+
+    let report = run_document_command(&command, &mut driver).expect("command should run");
+
+    assert_eq!(report.command, "document.write");
+    assert_eq!(
+      driver.calls,
+      vec![
+        "activate:com.apple.TextEdit:250",
+        "focus:com.apple.TextEdit:First Text View:",
+        "paste:com.apple.TextEdit:AUV_TEXTEDIT_MARKER_2026_05_17:true:250",
+        "compare:com.apple.TextEdit:AUV_TEXTEDIT_MARKER_2026_05_17:AXTextArea",
+      ]
+    );
+    assert_eq!(
+      report
+        .outcomes
+        .iter()
+        .map(|outcome| outcome.step_id)
+        .collect::<Vec<_>>(),
+      vec![
+        "document-write.activate",
+        "document-write.focus",
+        "document-write.paste"
+      ]
+    );
+    assert!(report.verification.is_some());
+  }
+
+  #[test]
+  fn document_compare_only_verifies_body_text() {
+    let command = DocumentCommand::Compare(DocumentCompare {
+      app_id: DEFAULT_APP_ID.to_string(),
+      content: "hello".to_string(),
+      role: DEFAULT_BODY_ROLE.to_string(),
+    });
+    let mut driver = RecordingTextEditDriver::default();
+
+    let report = run_document_command(&command, &mut driver).expect("command should run");
+
+    assert_eq!(report.command, "document.compare");
+    assert_eq!(
+      driver.calls,
+      vec!["compare:com.apple.TextEdit:hello:AXTextArea"]
+    );
+    assert!(report.outcomes.is_empty());
+    assert!(report.verification.is_some());
+  }
+
+  #[test]
+  fn document_focus_is_a_debuggable_document_subcommand() {
+    let command = DocumentCommand::Focus(DocumentFocus {
+      app_id: DEFAULT_APP_ID.to_string(),
+      query: DEFAULT_FOCUS_QUERY.to_string(),
+      candidate: String::new(),
+    });
+    let mut driver = RecordingTextEditDriver::default();
+
+    let report = run_document_command(&command, &mut driver).expect("command should run");
+
+    assert_eq!(report.command, "document.focus");
+    assert_eq!(
+      driver.calls,
+      vec!["focus:com.apple.TextEdit:First Text View:"]
+    );
+    assert_eq!(report.outcomes.len(), 1);
+  }
+}

--- a/crates/auv-apple-textedit/src/commands/mod.rs
+++ b/crates/auv-apple-textedit/src/commands/mod.rs
@@ -1,0 +1,1 @@
+pub mod document;

--- a/crates/auv-apple-textedit/src/driver.rs
+++ b/crates/auv-apple-textedit/src/driver.rs
@@ -1,0 +1,157 @@
+use std::time::Duration;
+
+use auv_driver::{
+  ActivationPolicy, App, Driver, InputActionResult, InputDeliveryPath, PasteTextOptions,
+  PrepareForInputOptions, TextSubmit, Window, WindowSelector,
+};
+use auv_driver_macos::MacosDriverSession;
+use serde::{Deserialize, Serialize};
+
+pub type OperationResult<T> = Result<T, String>;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StepOutcome {
+  pub step_id: &'static str,
+  pub summary: String,
+  pub input_action_result: Option<InputActionResult>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VerificationOutcome {
+  pub matched_role: String,
+  pub matched_text: String,
+  pub artifact_count: usize,
+}
+
+pub trait TextEditDriver {
+  fn activate_app(&mut self, app_id: &str, settle: Duration) -> OperationResult<StepOutcome>;
+
+  fn focus_text_input(
+    &mut self,
+    app_id: &str,
+    query: &str,
+    candidate: &str,
+  ) -> OperationResult<StepOutcome>;
+
+  fn paste_text_preserve_clipboard(
+    &mut self,
+    app_id: &str,
+    text: &str,
+    replace_existing: bool,
+    settle: Duration,
+  ) -> OperationResult<StepOutcome>;
+
+  fn verify_ax_text(
+    &mut self,
+    app_id: &str,
+    target_text: &str,
+    target_role: &str,
+  ) -> OperationResult<VerificationOutcome>;
+}
+
+pub struct MacosTextEditDriver {
+  session: MacosDriverSession,
+}
+
+impl MacosTextEditDriver {
+  pub fn open_local() -> OperationResult<Self> {
+    let session = auv_driver_macos::MacosDriver::new()
+      .open_local()
+      .map_err(|error| error.to_string())?;
+    Ok(Self { session })
+  }
+
+  pub fn from_session(session: MacosDriverSession) -> Self {
+    Self { session }
+  }
+
+  fn main_window(&self, app_id: &str) -> OperationResult<Window> {
+    self
+      .session
+      .window()
+      .resolve(main_window_selector(app_id))
+      .map_err(|error| error.to_string())
+  }
+}
+
+impl TextEditDriver for MacosTextEditDriver {
+  fn activate_app(&mut self, app_id: &str, settle: Duration) -> OperationResult<StepOutcome> {
+    let window = self.main_window(app_id)?;
+    self
+      .session
+      .window()
+      .prepare_for_input(
+        &window,
+        PrepareForInputOptions {
+          activation: ActivationPolicy::Foreground { settle },
+          preserve_frontmost: false,
+          install_focus_guard: false,
+          settle: Duration::ZERO,
+        },
+      )
+      .map_err(|error| error.to_string())?;
+    Ok(StepOutcome {
+      step_id: "activate-target-app",
+      summary: format!("activated foreground TextEdit window for {app_id}"),
+      input_action_result: None,
+    })
+  }
+
+  fn focus_text_input(
+    &mut self,
+    _app_id: &str,
+    _query: &str,
+    _candidate: &str,
+  ) -> OperationResult<StepOutcome> {
+    // TODO(auv-driver-macos-ax-focus): `document focus` needs a typed
+    // AX-query focus API in `auv-driver-macos`; implement this adapter method
+    // once it is available without routing through root runtime.rs.
+    Err("typed TextEdit AX text-input focus is not available yet".to_string())
+  }
+
+  fn paste_text_preserve_clipboard(
+    &mut self,
+    _app_id: &str,
+    text: &str,
+    replace_existing: bool,
+    settle: Duration,
+  ) -> OperationResult<StepOutcome> {
+    self
+      .session
+      .input()
+      .paste_text(PasteTextOptions {
+        text: text.to_string(),
+        replace_existing,
+        submit: TextSubmit::No,
+        settle,
+      })
+      .map_err(|error| error.to_string())?;
+    Ok(StepOutcome {
+      step_id: "document-write",
+      summary: "pasted TextEdit document body through auv-driver-macos clipboard input".to_string(),
+      input_action_result: Some(InputActionResult::single_success(
+        InputDeliveryPath::ClipboardPaste,
+      )),
+    })
+  }
+
+  fn verify_ax_text(
+    &mut self,
+    _app_id: &str,
+    _target_text: &str,
+    _target_role: &str,
+  ) -> OperationResult<VerificationOutcome> {
+    // TODO(auv-driver-macos-ax-verify): `document compare` needs typed AX text
+    // observation in `auv-driver-macos` before this app-local command can
+    // replace legacy verify.axText end-to-end.
+    Err("typed TextEdit AX text verification is not available yet".to_string())
+  }
+}
+
+fn main_window_selector(app_id: &str) -> WindowSelector {
+  WindowSelector {
+    app: Some(App::bundle_id(app_id)),
+    title: None,
+    main_visible: true,
+  }
+}

--- a/crates/auv-apple-textedit/src/lib.rs
+++ b/crates/auv-apple-textedit/src/lib.rs
@@ -1,0 +1,12 @@
+pub mod cli;
+pub mod commands;
+pub mod driver;
+
+pub use commands::document::{
+  DEFAULT_APP_ID, DEFAULT_BODY_ROLE, DEFAULT_FOCUS_QUERY, DEFAULT_MARKER_TEXT, DEFAULT_SETTLE_MS,
+  DocumentCommand, DocumentCommandReport, DocumentCompare, DocumentFocus, DocumentWrite,
+  run_document_command,
+};
+pub use driver::{
+  MacosTextEditDriver, OperationResult, StepOutcome, TextEditDriver, VerificationOutcome,
+};


### PR DESCRIPTION
## Summary
- Add an app-local `auv-apple-textedit` crate with `document write`, `document compare`, and `document focus` commands.
- Use public `auv-driver` / `auv-driver-macos` APIs for activation and clipboard paste.
- Keep typed AX focus/verification gaps explicit as unsupported boundaries.

## Verification
- `cargo test -p auv-apple-textedit`
- `cargo fmt --package auv-apple-textedit --check`
- `cargo check -p auv-apple-textedit`
- `git diff --check`