### PR TITLE
feat(auv-apple-notes): implemented

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "auv-apple-notes"
+version = "0.0.1"
+dependencies = [
+ "auv-driver",
+ "auv-driver-macos",
+ "clap",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "auv-apple-textedit"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
   ".",
+  "crates/auv-apple-notes",
   "crates/auv-apple-textedit",
   "crates/auv-driver",
   "crates/auv-driver-macos",

--- a/crates/auv-apple-notes/Cargo.toml
+++ b/crates/auv-apple-notes/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "auv-apple-notes"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+readme.workspace = true
+license.workspace = true
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+auv-driver = { path = "../auv-driver" }
+auv-driver-macos = { path = "../auv-driver-macos" }
+clap = { version = "4", features = ["derive"] }
+serde.workspace = true
+serde_json.workspace = true

--- a/crates/auv-apple-notes/src/bin/auv-apple-notes.rs
+++ b/crates/auv-apple-notes/src/bin/auv-apple-notes.rs
@@ -1,0 +1,3 @@
+fn main() -> std::process::ExitCode {
+  auv_apple_notes::cli::run()
+}

--- a/crates/auv-apple-notes/src/cli.rs
+++ b/crates/auv-apple-notes/src/cli.rs
@@ -1,0 +1,250 @@
+use std::process::ExitCode;
+
+use clap::{Args, Parser, Subcommand};
+
+use crate::commands::note::{
+  DEFAULT_APP_ID, DEFAULT_BODY_ROLE, DEFAULT_FOCUS_QUERY, DEFAULT_SETTLE_MS, NoteCommand,
+  NoteCompare, NoteFocus, NoteNew, NoteWrite, run_note_command,
+};
+use crate::driver::MacosNotesDriver;
+
+#[derive(Clone, Debug, Parser)]
+#[command(
+  name = "auv-apple-notes",
+  disable_help_subcommand = true,
+  about = "Notes app commands"
+)]
+struct CliArgs {
+  #[command(subcommand)]
+  command: CliCommand,
+}
+
+#[derive(Clone, Debug, Subcommand)]
+enum CliCommand {
+  /// Operate on Notes notes.
+  Note(NoteArgs),
+}
+
+#[derive(Clone, Debug, Args)]
+struct NoteArgs {
+  #[command(subcommand)]
+  command: NoteSubcommand,
+}
+
+#[derive(Clone, Debug, Subcommand)]
+enum NoteSubcommand {
+  /// Create a new note.
+  New(NoteNewArgs),
+  /// Write content into the current note body.
+  Write(NoteWriteArgs),
+  /// Compare note body text against expected content.
+  Compare(NoteCompareArgs),
+  /// Focus the note body.
+  Focus(NoteFocusArgs),
+}
+
+#[derive(Clone, Debug, Args)]
+struct NoteNewArgs {
+  #[arg(long = "app-id", default_value = DEFAULT_APP_ID)]
+  app_id: String,
+  #[arg(long = "settle-ms", default_value_t = DEFAULT_SETTLE_MS)]
+  settle_ms: u64,
+}
+
+#[derive(Clone, Debug, Args)]
+struct NoteWriteArgs {
+  #[arg(value_name = "content")]
+  content: String,
+  #[arg(long = "new")]
+  new_note: bool,
+  #[arg(long = "replace")]
+  replace: bool,
+  #[arg(long = "verify")]
+  verify: bool,
+  #[arg(long = "app-id", default_value = DEFAULT_APP_ID)]
+  app_id: String,
+  #[arg(long = "focus-query", default_value = DEFAULT_FOCUS_QUERY)]
+  focus_query: String,
+  #[arg(long = "focus-candidate", default_value = "")]
+  focus_candidate: String,
+  #[arg(long = "role", default_value = DEFAULT_BODY_ROLE)]
+  role: String,
+  #[arg(long = "activate-settle-ms", default_value_t = DEFAULT_SETTLE_MS)]
+  activate_settle_ms: u64,
+  #[arg(long = "create-settle-ms", default_value_t = DEFAULT_SETTLE_MS)]
+  create_settle_ms: u64,
+  #[arg(long = "input-settle-ms", default_value_t = DEFAULT_SETTLE_MS)]
+  input_settle_ms: u64,
+}
+
+#[derive(Clone, Debug, Args)]
+struct NoteCompareArgs {
+  #[arg(value_name = "content")]
+  content: String,
+  #[arg(long = "role", default_value = DEFAULT_BODY_ROLE)]
+  role: String,
+  #[arg(long = "app-id", default_value = DEFAULT_APP_ID)]
+  app_id: String,
+}
+
+#[derive(Clone, Debug, Args)]
+struct NoteFocusArgs {
+  #[arg(long = "query", default_value = DEFAULT_FOCUS_QUERY)]
+  query: String,
+  #[arg(long = "candidate", default_value = "")]
+  candidate: String,
+  #[arg(long = "app-id", default_value = DEFAULT_APP_ID)]
+  app_id: String,
+}
+
+pub fn parse_from<I, T>(args: I) -> Result<NoteCommand, clap::Error>
+where
+  I: IntoIterator<Item = T>,
+  T: Into<std::ffi::OsString> + Clone,
+{
+  let args = CliArgs::try_parse_from(args)?;
+  Ok(match args.command {
+    CliCommand::Note(note) => match note.command {
+      NoteSubcommand::New(args) => NoteCommand::New(NoteNew {
+        app_id: args.app_id,
+        settle_ms: args.settle_ms,
+      }),
+      NoteSubcommand::Write(args) => NoteCommand::Write(NoteWrite {
+        app_id: args.app_id,
+        content: args.content,
+        new_note: args.new_note,
+        replace: args.replace,
+        verify: args.verify,
+        focus_query: args.focus_query,
+        focus_candidate: args.focus_candidate,
+        compare_role: args.role,
+        activate_settle_ms: args.activate_settle_ms,
+        create_settle_ms: args.create_settle_ms,
+        input_settle_ms: args.input_settle_ms,
+      }),
+      NoteSubcommand::Compare(args) => NoteCommand::Compare(NoteCompare {
+        app_id: args.app_id,
+        content: args.content,
+        role: args.role,
+      }),
+      NoteSubcommand::Focus(args) => NoteCommand::Focus(NoteFocus {
+        app_id: args.app_id,
+        query: args.query,
+        candidate: args.candidate,
+      }),
+    },
+  })
+}
+
+pub fn run() -> ExitCode {
+  let command = match parse_from(std::env::args_os()) {
+    Ok(command) => command,
+    Err(error) => {
+      let _ = error.print();
+      return ExitCode::from(2);
+    }
+  };
+  let mut driver = match MacosNotesDriver::open_local() {
+    Ok(driver) => driver,
+    Err(error) => {
+      eprintln!("{error}");
+      return ExitCode::from(1);
+    }
+  };
+  match run_note_command(&command, &mut driver) {
+    Ok(report) => {
+      println!("{}", report.command);
+      ExitCode::SUCCESS
+    }
+    Err(error) => {
+      eprintln!("{error}");
+      ExitCode::from(1)
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn parse_note_new_maps_defaults() {
+    let command = parse_from(["auv-apple-notes", "note", "new"]).expect("command should parse");
+
+    assert_eq!(command, NoteCommand::New(NoteNew::defaults()));
+  }
+
+  #[test]
+  fn parse_note_write_maps_content_and_flags() {
+    let command = parse_from([
+      "auv-apple-notes",
+      "note",
+      "write",
+      "hello",
+      "--new",
+      "--replace",
+      "--verify",
+    ])
+    .expect("command should parse");
+
+    assert_eq!(
+      command,
+      NoteCommand::Write(NoteWrite {
+        app_id: DEFAULT_APP_ID.to_string(),
+        content: "hello".to_string(),
+        new_note: true,
+        replace: true,
+        verify: true,
+        focus_query: DEFAULT_FOCUS_QUERY.to_string(),
+        focus_candidate: String::new(),
+        compare_role: DEFAULT_BODY_ROLE.to_string(),
+        activate_settle_ms: DEFAULT_SETTLE_MS,
+        create_settle_ms: DEFAULT_SETTLE_MS,
+        input_settle_ms: DEFAULT_SETTLE_MS,
+      })
+    );
+  }
+
+  #[test]
+  fn parse_note_compare_maps_role() {
+    let command = parse_from([
+      "auv-apple-notes",
+      "note",
+      "compare",
+      "hello",
+      "--role",
+      "AXStaticText",
+    ])
+    .expect("command should parse");
+
+    assert_eq!(
+      command,
+      NoteCommand::Compare(NoteCompare {
+        app_id: DEFAULT_APP_ID.to_string(),
+        content: "hello".to_string(),
+        role: "AXStaticText".to_string(),
+      })
+    );
+  }
+
+  #[test]
+  fn parse_note_focus_maps_query() {
+    let command = parse_from([
+      "auv-apple-notes",
+      "note",
+      "focus",
+      "--query",
+      "First Text View",
+    ])
+    .expect("command should parse");
+
+    assert_eq!(
+      command,
+      NoteCommand::Focus(NoteFocus {
+        app_id: DEFAULT_APP_ID.to_string(),
+        query: "First Text View".to_string(),
+        candidate: String::new(),
+      })
+    );
+  }
+}

--- a/crates/auv-apple-notes/src/commands/mod.rs
+++ b/crates/auv-apple-notes/src/commands/mod.rs
@@ -1,0 +1,1 @@
+pub mod note;

--- a/crates/auv-apple-notes/src/commands/note.rs
+++ b/crates/auv-apple-notes/src/commands/note.rs
@@ -1,0 +1,394 @@
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use crate::driver::{NotesDriver, OperationResult, StepOutcome, VerificationOutcome};
+
+pub const DEFAULT_APP_ID: &str = "com.apple.Notes";
+pub const DEFAULT_NOTE_TEXT: &str = "AUV_NOTE_MARKER_2026_05_21_V2";
+pub const DEFAULT_FOCUS_QUERY: &str = "Note Body Text View";
+pub const DEFAULT_BODY_ROLE: &str = "AXTextArea";
+pub const DEFAULT_SETTLE_MS: u64 = 250;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum NoteCommand {
+  New(NoteNew),
+  Write(NoteWrite),
+  Compare(NoteCompare),
+  Focus(NoteFocus),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NoteNew {
+  pub app_id: String,
+  pub settle_ms: u64,
+}
+
+impl NoteNew {
+  pub fn defaults() -> Self {
+    Self {
+      app_id: DEFAULT_APP_ID.to_string(),
+      settle_ms: DEFAULT_SETTLE_MS,
+    }
+  }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NoteWrite {
+  pub app_id: String,
+  pub content: String,
+  pub new_note: bool,
+  pub replace: bool,
+  pub verify: bool,
+  pub focus_query: String,
+  pub focus_candidate: String,
+  pub compare_role: String,
+  pub activate_settle_ms: u64,
+  pub create_settle_ms: u64,
+  pub input_settle_ms: u64,
+}
+
+impl NoteWrite {
+  pub fn defaults_with_content(content: impl Into<String>) -> Self {
+    Self {
+      app_id: DEFAULT_APP_ID.to_string(),
+      content: content.into(),
+      new_note: false,
+      replace: false,
+      verify: false,
+      focus_query: DEFAULT_FOCUS_QUERY.to_string(),
+      focus_candidate: String::new(),
+      compare_role: DEFAULT_BODY_ROLE.to_string(),
+      activate_settle_ms: DEFAULT_SETTLE_MS,
+      create_settle_ms: DEFAULT_SETTLE_MS,
+      input_settle_ms: DEFAULT_SETTLE_MS,
+    }
+  }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NoteCompare {
+  pub app_id: String,
+  pub content: String,
+  pub role: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NoteFocus {
+  pub app_id: String,
+  pub query: String,
+  pub candidate: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NoteCommandReport {
+  pub command: &'static str,
+  pub outcomes: Vec<StepOutcome>,
+  pub verification: Option<VerificationOutcome>,
+}
+
+pub fn run_note_command(
+  command: &NoteCommand,
+  driver: &mut impl NotesDriver,
+) -> OperationResult<NoteCommandReport> {
+  match command {
+    NoteCommand::New(command) => run_new(command, driver),
+    NoteCommand::Write(command) => run_write(command, driver),
+    NoteCommand::Compare(command) => run_compare(command, driver),
+    NoteCommand::Focus(command) => run_focus(command, driver),
+  }
+}
+
+fn run_new(command: &NoteNew, driver: &mut impl NotesDriver) -> OperationResult<NoteCommandReport> {
+  let outcomes = vec![
+    driver.activate_app(&command.app_id, Duration::from_millis(command.settle_ms))?,
+    driver.create_note(&command.app_id, Duration::from_millis(command.settle_ms))?,
+  ];
+  Ok(NoteCommandReport {
+    command: "note.new",
+    outcomes,
+    verification: None,
+  })
+}
+
+fn run_write(
+  command: &NoteWrite,
+  driver: &mut impl NotesDriver,
+) -> OperationResult<NoteCommandReport> {
+  let mut outcomes = vec![driver.activate_app(
+    &command.app_id,
+    Duration::from_millis(command.activate_settle_ms),
+  )?];
+  if command.new_note {
+    outcomes.push(driver.create_note(
+      &command.app_id,
+      Duration::from_millis(command.create_settle_ms),
+    )?);
+  }
+  outcomes.push(driver.focus_note_body(
+    &command.app_id,
+    &command.focus_query,
+    &command.focus_candidate,
+  )?);
+  outcomes.push(driver.paste_text_preserve_clipboard(
+    &command.app_id,
+    &command.content,
+    command.replace,
+    Duration::from_millis(command.input_settle_ms),
+  )?);
+  let verification = if command.verify {
+    Some(driver.verify_ax_text(&command.app_id, &command.content, &command.compare_role)?)
+  } else {
+    None
+  };
+  normalize_write_step_ids(&mut outcomes);
+  Ok(NoteCommandReport {
+    command: "note.write",
+    outcomes,
+    verification,
+  })
+}
+
+fn run_compare(
+  command: &NoteCompare,
+  driver: &mut impl NotesDriver,
+) -> OperationResult<NoteCommandReport> {
+  let verification = driver.verify_ax_text(&command.app_id, &command.content, &command.role)?;
+  Ok(NoteCommandReport {
+    command: "note.compare",
+    outcomes: Vec::new(),
+    verification: Some(verification),
+  })
+}
+
+fn run_focus(
+  command: &NoteFocus,
+  driver: &mut impl NotesDriver,
+) -> OperationResult<NoteCommandReport> {
+  let outcome = driver.focus_note_body(&command.app_id, &command.query, &command.candidate)?;
+  Ok(NoteCommandReport {
+    command: "note.focus",
+    outcomes: vec![outcome],
+    verification: None,
+  })
+}
+
+fn normalize_write_step_ids(outcomes: &mut [StepOutcome]) {
+  for outcome in outcomes.iter_mut() {
+    outcome.step_id = match outcome.step_id {
+      "activate" => "note-write.activate",
+      "note.create" => "note-write.new",
+      "focus" => "note-write.focus",
+      "paste" => "note-write.paste",
+      _ => outcome.step_id,
+    };
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use auv_driver::{InputActionResult, InputDeliveryPath};
+
+  #[derive(Default)]
+  struct RecordingNotesDriver {
+    calls: Vec<String>,
+  }
+
+  impl NotesDriver for RecordingNotesDriver {
+    fn activate_app(&mut self, app_id: &str, settle: Duration) -> OperationResult<StepOutcome> {
+      self
+        .calls
+        .push(format!("activate:{app_id}:{}", settle.as_millis()));
+      Ok(StepOutcome {
+        step_id: "activate",
+        summary: "activated".to_string(),
+        input_action_result: None,
+      })
+    }
+
+    fn create_note(&mut self, app_id: &str, settle: Duration) -> OperationResult<StepOutcome> {
+      self
+        .calls
+        .push(format!("new:{app_id}:{}", settle.as_millis()));
+      Ok(StepOutcome {
+        step_id: "note.create",
+        summary: "created".to_string(),
+        input_action_result: Some(InputActionResult::single_success(
+          InputDeliveryPath::AxPress,
+        )),
+      })
+    }
+
+    fn focus_note_body(
+      &mut self,
+      app_id: &str,
+      query: &str,
+      candidate: &str,
+    ) -> OperationResult<StepOutcome> {
+      self
+        .calls
+        .push(format!("focus:{app_id}:{query}:{candidate}"));
+      Ok(StepOutcome {
+        step_id: "focus",
+        summary: "focused".to_string(),
+        input_action_result: Some(InputActionResult::single_success(
+          InputDeliveryPath::AxFocus,
+        )),
+      })
+    }
+
+    fn paste_text_preserve_clipboard(
+      &mut self,
+      app_id: &str,
+      text: &str,
+      replace_existing: bool,
+      settle: Duration,
+    ) -> OperationResult<StepOutcome> {
+      self.calls.push(format!(
+        "paste:{app_id}:{text}:{replace_existing}:{}",
+        settle.as_millis()
+      ));
+      Ok(StepOutcome {
+        step_id: "paste",
+        summary: "pasted".to_string(),
+        input_action_result: Some(InputActionResult::single_success(
+          InputDeliveryPath::ClipboardPaste,
+        )),
+      })
+    }
+
+    fn verify_ax_text(
+      &mut self,
+      app_id: &str,
+      target_text: &str,
+      target_role: &str,
+    ) -> OperationResult<VerificationOutcome> {
+      self
+        .calls
+        .push(format!("compare:{app_id}:{target_text}:{target_role}"));
+      Ok(VerificationOutcome {
+        matched_role: target_role.to_string(),
+        matched_text: format!("prefix {target_text} suffix"),
+        artifact_count: 1,
+      })
+    }
+  }
+
+  #[test]
+  fn note_new_activates_and_creates_note() {
+    let command = NoteCommand::New(NoteNew::defaults());
+    let mut driver = RecordingNotesDriver::default();
+
+    let report = run_note_command(&command, &mut driver).expect("command should run");
+
+    assert_eq!(report.command, "note.new");
+    assert_eq!(
+      driver.calls,
+      vec!["activate:com.apple.Notes:250", "new:com.apple.Notes:250"]
+    );
+  }
+
+  #[test]
+  fn note_write_can_create_focus_paste_and_verify() {
+    let mut command = NoteWrite::defaults_with_content(DEFAULT_NOTE_TEXT);
+    command.new_note = true;
+    command.verify = true;
+    let command = NoteCommand::Write(command);
+    let mut driver = RecordingNotesDriver::default();
+
+    let report = run_note_command(&command, &mut driver).expect("command should run");
+
+    assert_eq!(report.command, "note.write");
+    assert_eq!(
+      driver.calls,
+      vec![
+        "activate:com.apple.Notes:250",
+        "new:com.apple.Notes:250",
+        "focus:com.apple.Notes:Note Body Text View:",
+        "paste:com.apple.Notes:AUV_NOTE_MARKER_2026_05_21_V2:false:250",
+        "compare:com.apple.Notes:AUV_NOTE_MARKER_2026_05_21_V2:AXTextArea",
+      ]
+    );
+    assert_eq!(
+      report
+        .outcomes
+        .iter()
+        .map(|outcome| outcome.step_id)
+        .collect::<Vec<_>>(),
+      vec![
+        "note-write.activate",
+        "note-write.new",
+        "note-write.focus",
+        "note-write.paste"
+      ]
+    );
+    assert!(report.verification.is_some());
+  }
+
+  #[test]
+  fn note_write_without_new_or_verify_focuses_and_pastes_existing_note() {
+    let command = NoteCommand::Write(NoteWrite::defaults_with_content("hello"));
+    let mut driver = RecordingNotesDriver::default();
+
+    let report = run_note_command(&command, &mut driver).expect("command should run");
+
+    assert_eq!(
+      driver.calls,
+      vec![
+        "activate:com.apple.Notes:250",
+        "focus:com.apple.Notes:Note Body Text View:",
+        "paste:com.apple.Notes:hello:false:250",
+      ]
+    );
+    assert_eq!(
+      report
+        .outcomes
+        .iter()
+        .map(|outcome| outcome.step_id)
+        .collect::<Vec<_>>(),
+      vec![
+        "note-write.activate",
+        "note-write.focus",
+        "note-write.paste"
+      ]
+    );
+    assert!(report.verification.is_none());
+  }
+
+  #[test]
+  fn note_compare_only_verifies_body_text() {
+    let command = NoteCommand::Compare(NoteCompare {
+      app_id: DEFAULT_APP_ID.to_string(),
+      content: "hello".to_string(),
+      role: DEFAULT_BODY_ROLE.to_string(),
+    });
+    let mut driver = RecordingNotesDriver::default();
+
+    let report = run_note_command(&command, &mut driver).expect("command should run");
+
+    assert_eq!(report.command, "note.compare");
+    assert_eq!(
+      driver.calls,
+      vec!["compare:com.apple.Notes:hello:AXTextArea"]
+    );
+  }
+
+  #[test]
+  fn note_focus_is_a_debuggable_note_subcommand() {
+    let command = NoteCommand::Focus(NoteFocus {
+      app_id: DEFAULT_APP_ID.to_string(),
+      query: DEFAULT_FOCUS_QUERY.to_string(),
+      candidate: String::new(),
+    });
+    let mut driver = RecordingNotesDriver::default();
+
+    let report = run_note_command(&command, &mut driver).expect("command should run");
+
+    assert_eq!(report.command, "note.focus");
+    assert_eq!(
+      driver.calls,
+      vec!["focus:com.apple.Notes:Note Body Text View:"]
+    );
+  }
+}

--- a/crates/auv-apple-notes/src/driver.rs
+++ b/crates/auv-apple-notes/src/driver.rs
@@ -1,0 +1,166 @@
+use std::time::Duration;
+
+use auv_driver::{
+  ActivationPolicy, App, Driver, InputActionResult, InputDeliveryPath, PasteTextOptions,
+  PrepareForInputOptions, TextSubmit, Window, WindowSelector,
+};
+use auv_driver_macos::MacosDriverSession;
+use serde::{Deserialize, Serialize};
+
+pub type OperationResult<T> = Result<T, String>;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StepOutcome {
+  pub step_id: &'static str,
+  pub summary: String,
+  pub input_action_result: Option<InputActionResult>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VerificationOutcome {
+  pub matched_role: String,
+  pub matched_text: String,
+  pub artifact_count: usize,
+}
+
+pub trait NotesDriver {
+  fn activate_app(&mut self, app_id: &str, settle: Duration) -> OperationResult<StepOutcome>;
+
+  fn create_note(&mut self, app_id: &str, settle: Duration) -> OperationResult<StepOutcome>;
+
+  fn focus_note_body(
+    &mut self,
+    app_id: &str,
+    query: &str,
+    candidate: &str,
+  ) -> OperationResult<StepOutcome>;
+
+  fn paste_text_preserve_clipboard(
+    &mut self,
+    app_id: &str,
+    text: &str,
+    replace_existing: bool,
+    settle: Duration,
+  ) -> OperationResult<StepOutcome>;
+
+  fn verify_ax_text(
+    &mut self,
+    app_id: &str,
+    target_text: &str,
+    target_role: &str,
+  ) -> OperationResult<VerificationOutcome>;
+}
+
+pub struct MacosNotesDriver {
+  session: MacosDriverSession,
+}
+
+impl MacosNotesDriver {
+  pub fn open_local() -> OperationResult<Self> {
+    let session = auv_driver_macos::MacosDriver::new()
+      .open_local()
+      .map_err(|error| error.to_string())?;
+    Ok(Self { session })
+  }
+
+  pub fn from_session(session: MacosDriverSession) -> Self {
+    Self { session }
+  }
+
+  fn main_window(&self, app_id: &str) -> OperationResult<Window> {
+    self
+      .session
+      .window()
+      .resolve(main_window_selector(app_id))
+      .map_err(|error| error.to_string())
+  }
+}
+
+impl NotesDriver for MacosNotesDriver {
+  fn activate_app(&mut self, app_id: &str, settle: Duration) -> OperationResult<StepOutcome> {
+    let window = self.main_window(app_id)?;
+    self
+      .session
+      .window()
+      .prepare_for_input(
+        &window,
+        PrepareForInputOptions {
+          activation: ActivationPolicy::Foreground { settle },
+          preserve_frontmost: false,
+          install_focus_guard: false,
+          settle: Duration::ZERO,
+        },
+      )
+      .map_err(|error| error.to_string())?;
+    Ok(StepOutcome {
+      step_id: "note.activate",
+      summary: format!("activated foreground Notes window for {app_id}"),
+      input_action_result: None,
+    })
+  }
+
+  fn create_note(&mut self, _app_id: &str, _settle: Duration) -> OperationResult<StepOutcome> {
+    // TODO(auv-driver-macos-ax-press): `note new` needs a typed AX button
+    // press API before this crate can create a note without root legacy
+    // debug.axPressButton behavior.
+    Err("typed Notes AX note creation is not available yet".to_string())
+  }
+
+  fn focus_note_body(
+    &mut self,
+    _app_id: &str,
+    _query: &str,
+    _candidate: &str,
+  ) -> OperationResult<StepOutcome> {
+    // TODO(auv-driver-macos-ax-focus): `note focus` needs typed AX text-input
+    // focus before app-local Notes commands can safely paste into the note
+    // body.
+    Err("typed Notes AX body focus is not available yet".to_string())
+  }
+
+  fn paste_text_preserve_clipboard(
+    &mut self,
+    _app_id: &str,
+    text: &str,
+    replace_existing: bool,
+    settle: Duration,
+  ) -> OperationResult<StepOutcome> {
+    self
+      .session
+      .input()
+      .paste_text(PasteTextOptions {
+        text: text.to_string(),
+        replace_existing,
+        submit: TextSubmit::No,
+        settle,
+      })
+      .map_err(|error| error.to_string())?;
+    Ok(StepOutcome {
+      step_id: "note-write.paste",
+      summary: "pasted Notes body through auv-driver-macos clipboard input".to_string(),
+      input_action_result: Some(InputActionResult::single_success(
+        InputDeliveryPath::ClipboardPaste,
+      )),
+    })
+  }
+
+  fn verify_ax_text(
+    &mut self,
+    _app_id: &str,
+    _target_text: &str,
+    _target_role: &str,
+  ) -> OperationResult<VerificationOutcome> {
+    // TODO(auv-driver-macos-ax-verify): `note compare` needs typed AX text
+    // observation in `auv-driver-macos` before Notes can verify note body text
+    // without root legacy verify.axText behavior.
+    Err("typed Notes AX text verification is not available yet".to_string())
+  }
+}
+
+fn main_window_selector(app_id: &str) -> WindowSelector {
+  WindowSelector {
+    app: Some(App::bundle_id(app_id)),
+    title: None,
+    main_visible: true,
+  }
+}

--- a/crates/auv-apple-notes/src/lib.rs
+++ b/crates/auv-apple-notes/src/lib.rs
@@ -1,0 +1,11 @@
+pub mod cli;
+pub mod commands;
+pub mod driver;
+
+pub use commands::note::{
+  DEFAULT_APP_ID, DEFAULT_BODY_ROLE, DEFAULT_FOCUS_QUERY, DEFAULT_NOTE_TEXT, DEFAULT_SETTLE_MS,
+  NoteCommand, NoteCommandReport, NoteCompare, NoteFocus, NoteNew, NoteWrite, run_note_command,
+};
+pub use driver::{
+  MacosNotesDriver, NotesDriver, OperationResult, StepOutcome, VerificationOutcome,
+};


### PR DESCRIPTION
## Summary
- Add an app-local `auv-apple-notes` crate with `note new`, `note write`, `note compare`, and `note focus` commands.
- Use public driver APIs for app activation and clipboard paste.
- Keep note creation, focus, and AX verification as explicit typed-driver deferrals.

## Verification
- `cargo test -p auv-apple-notes`
- `cargo fmt --package auv-apple-notes --check`
- `cargo check -p auv-apple-notes`
- `git diff --check`