### PR TITLE
feat(auv-qqmusic): implemented

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,6 +469,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "auv-qqmusic"
+version = "0.0.1"
+dependencies = [
+ "auv-driver",
+ "auv-driver-macos",
+ "clap",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "auv-steam"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
   ".",
   "crates/auv-apple-textedit",
+  "crates/auv-qqmusic",
   "crates/auv-driver",
   "crates/auv-driver-macos",
   "crates/auv-game-balatro",

--- a/crates/auv-qqmusic/Cargo.toml
+++ b/crates/auv-qqmusic/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "auv-qqmusic"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+readme.workspace = true
+license.workspace = true
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+auv-driver = { path = "../auv-driver" }
+auv-driver-macos = { path = "../auv-driver-macos" }
+clap = { version = "4", features = ["derive"] }
+serde.workspace = true
+serde_json.workspace = true

--- a/crates/auv-qqmusic/src/bin/auv-qqmusic.rs
+++ b/crates/auv-qqmusic/src/bin/auv-qqmusic.rs
@@ -1,0 +1,3 @@
+fn main() -> std::process::ExitCode {
+  auv_qqmusic::cli::run()
+}

--- a/crates/auv-qqmusic/src/cli.rs
+++ b/crates/auv-qqmusic/src/cli.rs
@@ -1,0 +1,358 @@
+use std::process::ExitCode;
+
+use clap::{Args, Parser, Subcommand, error::ErrorKind};
+
+use crate::driver::MacosQqMusicDriver;
+use crate::search::{
+  DEFAULT_ANCHOR_TIMEOUT_MS, DEFAULT_APP_ID, DEFAULT_SETTLE_MS, SearchCommand, SearchResultsAction,
+  SearchResultsClick, SearchResultsSelect, SearchSubmit, run_search_command,
+};
+
+#[derive(Clone, Debug, Parser)]
+#[command(
+  name = "auv-qqmusic",
+  disable_help_subcommand = true,
+  about = "QQMusic app commands"
+)]
+struct CliArgs {
+  #[command(subcommand)]
+  command: CliCommand,
+}
+
+#[derive(Clone, Debug, Subcommand)]
+enum CliCommand {
+  /// Search QQMusic and operate on search results.
+  Search(SearchArgs),
+}
+
+#[derive(Clone, Debug, Args)]
+#[command(args_conflicts_with_subcommands = true, subcommand_negates_reqs = true)]
+struct SearchArgs {
+  #[arg(value_name = "query")]
+  query: Option<String>,
+  #[command(subcommand)]
+  results: Option<SearchSubcommand>,
+}
+
+#[derive(Clone, Debug, Subcommand)]
+enum SearchSubcommand {
+  /// Operate on search results.
+  Results(SearchResultsArgs),
+}
+
+#[derive(Clone, Debug, Args)]
+struct SearchResultsArgs {
+  #[command(subcommand)]
+  command: SearchResultsSubcommand,
+}
+
+#[derive(Clone, Debug, Subcommand)]
+enum SearchResultsSubcommand {
+  /// Select a result by visible text anchor.
+  Select(SearchResultsSelectArgs),
+  /// Click a result by anchor, row, or candidate ref.
+  Click(SearchResultsClickArgs),
+}
+
+#[derive(Clone, Debug, Args)]
+struct SearchResultsSelectArgs {
+  #[arg(value_name = "query")]
+  query: String,
+  #[arg(long = "anchor")]
+  anchor: String,
+  #[arg(long = "app-id", default_value = DEFAULT_APP_ID)]
+  app_id: String,
+  #[arg(long = "settle-ms", default_value_t = DEFAULT_SETTLE_MS)]
+  settle_ms: u64,
+  #[arg(long = "anchor-timeout-ms", default_value_t = DEFAULT_ANCHOR_TIMEOUT_MS)]
+  anchor_timeout_ms: u64,
+}
+
+#[derive(Clone, Debug, Args)]
+struct SearchResultsClickArgs {
+  #[arg(value_name = "query", required_unless_present_any = ["row", "candidate_ref"])]
+  query: Option<String>,
+  #[arg(long = "anchor", conflicts_with_all = ["row", "candidate_ref"])]
+  anchor: Option<String>,
+  #[arg(long = "row", conflicts_with_all = ["anchor", "candidate_ref"])]
+  row: Option<usize>,
+  #[arg(long = "candidate-ref", conflicts_with_all = ["anchor", "row"])]
+  candidate_ref: Option<String>,
+  #[arg(long = "app-id", default_value = DEFAULT_APP_ID)]
+  app_id: String,
+  #[arg(long = "settle-ms", default_value_t = DEFAULT_SETTLE_MS)]
+  settle_ms: u64,
+  #[arg(long = "anchor-timeout-ms", default_value_t = DEFAULT_ANCHOR_TIMEOUT_MS)]
+  anchor_timeout_ms: u64,
+}
+
+pub fn parse_from<I, T>(args: I) -> Result<SearchCommand, clap::Error>
+where
+  I: IntoIterator<Item = T>,
+  T: Into<std::ffi::OsString> + Clone,
+{
+  let args = CliArgs::try_parse_from(args)?;
+  Ok(match args.command {
+    CliCommand::Search(search) => match search.results {
+      None => SearchCommand::Search(SearchSubmit::defaults_with_query(search.query.ok_or_else(
+        || {
+          clap::Error::raw(
+            ErrorKind::MissingRequiredArgument,
+            "auv-qqmusic search requires <query>",
+          )
+        },
+      )?)),
+      Some(SearchSubcommand::Results(results)) => match results.command {
+        SearchResultsSubcommand::Select(args) => {
+          SearchCommand::Results(SearchResultsAction::Select(SearchResultsSelect {
+            app_id: args.app_id,
+            query: args.query,
+            anchor: args.anchor,
+            settle_ms: args.settle_ms,
+            anchor_timeout_ms: args.anchor_timeout_ms,
+          }))
+        }
+        SearchResultsSubcommand::Click(args) => {
+          validate_click_args(&args)?;
+          SearchCommand::Results(SearchResultsAction::Click(SearchResultsClick {
+            app_id: args.app_id,
+            query: args.query,
+            anchor: args.anchor,
+            row: args.row,
+            candidate_ref_json: args.candidate_ref,
+            settle_ms: args.settle_ms,
+            anchor_timeout_ms: args.anchor_timeout_ms,
+          }))
+        }
+      },
+    },
+  })
+}
+
+fn validate_click_args(args: &SearchResultsClickArgs) -> Result<(), clap::Error> {
+  let selector_count = args.anchor.is_some() as usize
+    + args.row.is_some() as usize
+    + args.candidate_ref.is_some() as usize;
+  if selector_count == 0 {
+    return Err(clap::Error::raw(
+      ErrorKind::MissingRequiredArgument,
+      "search results click requires --anchor, --row, or --candidate-ref",
+    ));
+  }
+  if args.candidate_ref.is_some() {
+    if args.query.is_some() {
+      return Err(clap::Error::raw(
+        ErrorKind::ArgumentConflict,
+        "search results click --candidate-ref does not take <query>",
+      ));
+    }
+    return Ok(());
+  }
+  if args.query.is_none() {
+    return Err(clap::Error::raw(
+      ErrorKind::MissingRequiredArgument,
+      "search results click --anchor and --row require <query>",
+    ));
+  }
+  Ok(())
+}
+
+pub fn run() -> ExitCode {
+  let command = match parse_from(std::env::args_os()) {
+    Ok(command) => command,
+    Err(error) => {
+      let _ = error.print();
+      return ExitCode::from(2);
+    }
+  };
+  let mut driver = match MacosQqMusicDriver::open_local() {
+    Ok(driver) => driver,
+    Err(error) => {
+      eprintln!("{error}");
+      return ExitCode::from(1);
+    }
+  };
+  match run_search_command(&command, &mut driver) {
+    Ok(report) => {
+      if let Some(unsupported) = report.unsupported {
+        eprintln!("{unsupported}");
+        ExitCode::from(2)
+      } else {
+        println!("{}", report.command);
+        ExitCode::SUCCESS
+      }
+    }
+    Err(error) => {
+      eprintln!("{error}");
+      ExitCode::from(1)
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn parse_search_maps_query() {
+    let command = parse_from(["auv-qqmusic", "search", "周杰伦"]).expect("command should parse");
+
+    assert_eq!(
+      command,
+      SearchCommand::Search(SearchSubmit::defaults_with_query("周杰伦"))
+    );
+  }
+
+  #[test]
+  fn parse_search_requires_query_without_results_subcommand() {
+    let error = parse_from(["auv-qqmusic", "search"]).expect_err("query should be required");
+
+    assert_eq!(error.kind(), ErrorKind::MissingRequiredArgument);
+  }
+
+  #[test]
+  fn parse_search_results_select_maps_query_and_anchor() {
+    let command = parse_from([
+      "auv-qqmusic",
+      "search",
+      "results",
+      "select",
+      "周杰伦",
+      "--anchor",
+      "晴天",
+    ])
+    .expect("command should parse");
+
+    assert_eq!(
+      command,
+      SearchCommand::Results(SearchResultsAction::Select(SearchResultsSelect {
+        app_id: DEFAULT_APP_ID.to_string(),
+        query: "周杰伦".to_string(),
+        anchor: "晴天".to_string(),
+        settle_ms: DEFAULT_SETTLE_MS,
+        anchor_timeout_ms: DEFAULT_ANCHOR_TIMEOUT_MS,
+      }))
+    );
+  }
+
+  #[test]
+  fn parse_search_results_click_maps_anchor() {
+    let command = parse_from([
+      "auv-qqmusic",
+      "search",
+      "results",
+      "click",
+      "周杰伦",
+      "--anchor",
+      "晴天",
+    ])
+    .expect("command should parse");
+
+    assert_eq!(
+      command,
+      SearchCommand::Results(SearchResultsAction::Click(SearchResultsClick {
+        app_id: DEFAULT_APP_ID.to_string(),
+        query: Some("周杰伦".to_string()),
+        anchor: Some("晴天".to_string()),
+        row: None,
+        candidate_ref_json: None,
+        settle_ms: DEFAULT_SETTLE_MS,
+        anchor_timeout_ms: DEFAULT_ANCHOR_TIMEOUT_MS,
+      }))
+    );
+  }
+
+  #[test]
+  fn parse_search_results_click_maps_row_unsupported_shape() {
+    let command = parse_from([
+      "auv-qqmusic",
+      "search",
+      "results",
+      "click",
+      "周杰伦",
+      "--row",
+      "2",
+    ])
+    .expect("command should parse");
+
+    assert!(matches!(
+      command,
+      SearchCommand::Results(SearchResultsAction::Click(SearchResultsClick {
+        row: Some(2),
+        ..
+      }))
+    ));
+  }
+
+  #[test]
+  fn parse_search_results_click_maps_candidate_ref_unsupported_shape() {
+    let command = parse_from([
+      "auv-qqmusic",
+      "search",
+      "results",
+      "click",
+      "--candidate-ref",
+      "{\"candidate\":\"ref\"}",
+    ])
+    .expect("command should parse");
+
+    assert!(matches!(
+      command,
+      SearchCommand::Results(SearchResultsAction::Click(SearchResultsClick {
+        candidate_ref_json: Some(_),
+        query: None,
+        ..
+      }))
+    ));
+  }
+
+  #[test]
+  fn parse_search_results_click_row_requires_query() {
+    let error = parse_from(["auv-qqmusic", "search", "results", "click", "--row", "2"])
+      .expect_err("row selector should require query");
+
+    assert_eq!(error.kind(), ErrorKind::MissingRequiredArgument);
+  }
+
+  #[test]
+  fn parse_search_results_click_requires_selector() {
+    let error = parse_from(["auv-qqmusic", "search", "results", "click", "周杰伦"])
+      .expect_err("click should require a result selector");
+
+    assert_eq!(error.kind(), ErrorKind::MissingRequiredArgument);
+  }
+
+  #[test]
+  fn parse_search_results_click_rejects_conflicting_selectors() {
+    let error = parse_from([
+      "auv-qqmusic",
+      "search",
+      "results",
+      "click",
+      "周杰伦",
+      "--anchor",
+      "晴天",
+      "--row",
+      "2",
+    ])
+    .expect_err("selectors should be mutually exclusive");
+
+    assert_eq!(error.kind(), ErrorKind::ArgumentConflict);
+  }
+
+  #[test]
+  fn parse_search_results_click_candidate_ref_rejects_query() {
+    let error = parse_from([
+      "auv-qqmusic",
+      "search",
+      "results",
+      "click",
+      "周杰伦",
+      "--candidate-ref",
+      "{\"candidate\":\"ref\"}",
+    ])
+    .expect_err("candidate ref should carry the target without query");
+
+    assert_eq!(error.kind(), ErrorKind::ArgumentConflict);
+  }
+}

--- a/crates/auv-qqmusic/src/driver.rs
+++ b/crates/auv-qqmusic/src/driver.rs
@@ -1,0 +1,190 @@
+use std::time::Duration;
+
+use auv_driver::{
+  ActivationPolicy, App, Click, ClickOptions, Driver, InputPolicy, KeyPressOptions,
+  PasteTextOptions, PrepareForInputOptions, TextSubmit, WaitOptions, Window, WindowPoint,
+  WindowSelector,
+};
+use auv_driver_macos::MacosDriverSession;
+
+use crate::search::{DEFAULT_SEARCH_REGION, SearchAnchorMatch, SearchStep};
+
+pub type OperationResult<T> = Result<T, String>;
+
+pub trait QqMusicDriver {
+  fn activate_app(&mut self, app_id: &str, settle: Duration) -> OperationResult<SearchStep>;
+
+  fn press_search_shortcut(
+    &mut self,
+    shortcut: &str,
+    settle: Duration,
+  ) -> OperationResult<SearchStep>;
+
+  fn paste_query(&mut self, query: &str, settle: Duration) -> OperationResult<SearchStep>;
+
+  fn wait_anchor(
+    &mut self,
+    app_id: &str,
+    anchor: &str,
+    timeout: Duration,
+  ) -> OperationResult<SearchAnchorMatch>;
+
+  fn click_anchor(
+    &mut self,
+    app_id: &str,
+    anchor: &SearchAnchorMatch,
+    click: Click,
+    settle: Duration,
+  ) -> OperationResult<SearchStep>;
+}
+
+pub struct MacosQqMusicDriver {
+  session: MacosDriverSession,
+}
+
+impl MacosQqMusicDriver {
+  pub fn open_local() -> OperationResult<Self> {
+    let session = auv_driver_macos::MacosDriver::new()
+      .open_local()
+      .map_err(|error| error.to_string())?;
+    Ok(Self { session })
+  }
+
+  pub fn from_session(session: MacosDriverSession) -> Self {
+    Self { session }
+  }
+
+  fn main_window(&self, app_id: &str) -> OperationResult<Window> {
+    self
+      .session
+      .window()
+      .resolve(main_window_selector(app_id))
+      .map_err(|error| error.to_string())
+  }
+}
+
+impl QqMusicDriver for MacosQqMusicDriver {
+  fn activate_app(&mut self, app_id: &str, settle: Duration) -> OperationResult<SearchStep> {
+    let window = self.main_window(app_id)?;
+    self
+      .session
+      .window()
+      .prepare_for_input(
+        &window,
+        PrepareForInputOptions {
+          activation: ActivationPolicy::Foreground { settle },
+          preserve_frontmost: false,
+          install_focus_guard: false,
+          settle: Duration::ZERO,
+        },
+      )
+      .map_err(|error| error.to_string())?;
+    Ok(SearchStep::new("search.activate", "activated QQMusic"))
+  }
+
+  fn press_search_shortcut(
+    &mut self,
+    shortcut: &str,
+    settle: Duration,
+  ) -> OperationResult<SearchStep> {
+    let result = self
+      .session
+      .input()
+      .press_key(KeyPressOptions {
+        key: shortcut.to_string(),
+        settle,
+      })
+      .map_err(|error| error.to_string())?;
+    Ok(SearchStep::with_input(
+      "search.shortcut",
+      format!("pressed {shortcut}"),
+      result,
+    ))
+  }
+
+  fn paste_query(&mut self, query: &str, settle: Duration) -> OperationResult<SearchStep> {
+    self
+      .session
+      .input()
+      .paste_text(PasteTextOptions {
+        text: query.to_string(),
+        replace_existing: true,
+        submit: TextSubmit::Return,
+        settle,
+      })
+      .map_err(|error| error.to_string())?;
+    Ok(SearchStep::new(
+      "search.query",
+      "pasted and submitted search query",
+    ))
+  }
+
+  fn wait_anchor(
+    &mut self,
+    app_id: &str,
+    anchor: &str,
+    timeout: Duration,
+  ) -> OperationResult<SearchAnchorMatch> {
+    let window = self.main_window(app_id)?;
+    let matches = self
+      .session
+      .window()
+      .wait_text(
+        &window,
+        anchor,
+        DEFAULT_SEARCH_REGION,
+        WaitOptions {
+          timeout,
+          poll_interval: Duration::from_millis(100),
+        },
+      )
+      .map_err(|error| error.to_string())?;
+    let Some(best) = matches.best_match() else {
+      return Err(format!("search result anchor {anchor:?} was not found"));
+    };
+    Ok(SearchAnchorMatch {
+      text: best.text.clone(),
+      confidence: best.confidence,
+      point: best.action_point(),
+    })
+  }
+
+  fn click_anchor(
+    &mut self,
+    app_id: &str,
+    anchor: &SearchAnchorMatch,
+    click: Click,
+    settle: Duration,
+  ) -> OperationResult<SearchStep> {
+    let window = self.main_window(app_id)?;
+    let result = self
+      .session
+      .window()
+      .click(
+        &window,
+        WindowPoint::new(anchor.point.x, anchor.point.y),
+        ClickOptions {
+          policy: InputPolicy::ForegroundPreferred,
+          click,
+          ..ClickOptions::default()
+        },
+      )
+      .map_err(|error| error.to_string())?;
+    if !settle.is_zero() {
+      std::thread::sleep(settle);
+    }
+    Ok(SearchStep::with_input(
+      "search.results.click",
+      "clicked search result anchor",
+      result,
+    ))
+  }
+}
+
+fn main_window_selector(app_id: &str) -> WindowSelector {
+  WindowSelector {
+    app: Some(App::bundle_id(app_id)),
+    title: None,
+    main_visible: true,
+  }
+}

--- a/crates/auv-qqmusic/src/lib.rs
+++ b/crates/auv-qqmusic/src/lib.rs
@@ -1,0 +1,9 @@
+pub mod cli;
+pub mod driver;
+pub mod search;
+
+pub use driver::{MacosQqMusicDriver, OperationResult, QqMusicDriver};
+pub use search::{
+  DEFAULT_APP_ID, DEFAULT_SEARCH_SHORTCUT, DEFAULT_SETTLE_MS, SearchCommand, SearchCommandReport,
+  SearchResultsAction, SearchResultsClick, SearchResultsSelect, SearchSubmit, run_search_command,
+};

--- a/crates/auv-qqmusic/src/search.rs
+++ b/crates/auv-qqmusic/src/search.rs
@@ -1,0 +1,436 @@
+use std::time::Duration;
+
+use auv_driver::{Click, InputActionResult, Point, RatioRect};
+use serde::{Deserialize, Serialize};
+
+use crate::driver::{OperationResult, QqMusicDriver};
+
+pub const DEFAULT_APP_ID: &str = "com.tencent.QQMusicMac";
+pub const DEFAULT_SEARCH_SHORTCUT: &str = "cmd+f";
+pub const DEFAULT_SETTLE_MS: u64 = 250;
+pub const DEFAULT_ANCHOR_TIMEOUT_MS: u64 = 5_000;
+pub const DEFAULT_SEARCH_REGION: RatioRect = RatioRect {
+  x: 0.0,
+  y: 0.0,
+  width: 1.0,
+  height: 1.0,
+};
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum SearchCommand {
+  Search(SearchSubmit),
+  Results(SearchResultsAction),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SearchSubmit {
+  pub app_id: String,
+  pub query: String,
+  pub shortcut: String,
+  pub settle_ms: u64,
+}
+
+impl SearchSubmit {
+  pub fn defaults_with_query(query: impl Into<String>) -> Self {
+    Self {
+      app_id: DEFAULT_APP_ID.to_string(),
+      query: query.into(),
+      shortcut: DEFAULT_SEARCH_SHORTCUT.to_string(),
+      settle_ms: DEFAULT_SETTLE_MS,
+    }
+  }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum SearchResultsAction {
+  Select(SearchResultsSelect),
+  Click(SearchResultsClick),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SearchResultsSelect {
+  pub app_id: String,
+  pub query: String,
+  pub anchor: String,
+  pub settle_ms: u64,
+  pub anchor_timeout_ms: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SearchResultsClick {
+  pub app_id: String,
+  pub query: Option<String>,
+  pub anchor: Option<String>,
+  pub row: Option<usize>,
+  pub candidate_ref_json: Option<String>,
+  pub settle_ms: u64,
+  pub anchor_timeout_ms: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SearchAnchorMatch {
+  pub text: String,
+  pub confidence: f64,
+  pub point: Point,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SearchStep {
+  pub step_id: &'static str,
+  pub summary: String,
+  pub input_action_result: Option<InputActionResult>,
+}
+
+impl SearchStep {
+  pub fn new(step_id: &'static str, summary: impl Into<String>) -> Self {
+    Self {
+      step_id,
+      summary: summary.into(),
+      input_action_result: None,
+    }
+  }
+
+  pub fn with_input(
+    step_id: &'static str,
+    summary: impl Into<String>,
+    input_action_result: InputActionResult,
+  ) -> Self {
+    Self {
+      step_id,
+      summary: summary.into(),
+      input_action_result: Some(input_action_result),
+    }
+  }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SearchCommandReport {
+  pub command: &'static str,
+  pub steps: Vec<SearchStep>,
+  pub anchor: Option<SearchAnchorMatch>,
+  pub unsupported: Option<String>,
+}
+
+pub fn run_search_command(
+  command: &SearchCommand,
+  driver: &mut impl QqMusicDriver,
+) -> OperationResult<SearchCommandReport> {
+  match command {
+    SearchCommand::Search(command) => run_search(command, driver),
+    SearchCommand::Results(SearchResultsAction::Select(command)) => run_select(command, driver),
+    SearchCommand::Results(SearchResultsAction::Click(command)) => run_click(command, driver),
+  }
+}
+
+fn run_search(
+  command: &SearchSubmit,
+  driver: &mut impl QqMusicDriver,
+) -> OperationResult<SearchCommandReport> {
+  let steps = execute_search_phase(
+    driver,
+    &command.app_id,
+    &command.query,
+    &command.shortcut,
+    command.settle_ms,
+  )?;
+  Ok(SearchCommandReport {
+    command: "search",
+    steps,
+    anchor: None,
+    unsupported: None,
+  })
+}
+
+fn run_select(
+  command: &SearchResultsSelect,
+  driver: &mut impl QqMusicDriver,
+) -> OperationResult<SearchCommandReport> {
+  let mut steps = execute_search_phase(
+    driver,
+    &command.app_id,
+    &command.query,
+    DEFAULT_SEARCH_SHORTCUT,
+    command.settle_ms,
+  )?;
+  let anchor = driver.wait_anchor(
+    &command.app_id,
+    &command.anchor,
+    Duration::from_millis(command.anchor_timeout_ms),
+  )?;
+  steps.push(driver.click_anchor(
+    &command.app_id,
+    &anchor,
+    Click::Single,
+    Duration::from_millis(command.settle_ms),
+  )?);
+  Ok(SearchCommandReport {
+    command: "search.results.select",
+    steps,
+    anchor: Some(anchor),
+    unsupported: None,
+  })
+}
+
+fn run_click(
+  command: &SearchResultsClick,
+  driver: &mut impl QqMusicDriver,
+) -> OperationResult<SearchCommandReport> {
+  if command.row.is_some() {
+    // TODO(qqmusic-row-click): row selection is parsed for the agreed CLI shape,
+    // but execution is deferred until a typed result-row detection API exists.
+    return Ok(unsupported(
+      "search.results.click --row needs a typed row detection API",
+    ));
+  }
+  if command.candidate_ref_json.is_some() {
+    // TODO(qqmusic-candidate-ref-click): CandidateRef execution is deferred until
+    // QQMusic has a typed CandidateRef consumer instead of ad-hoc JSON parsing.
+    return Ok(unsupported(
+      "search.results.click --candidate-ref needs a typed CandidateRef consumer API",
+    ));
+  }
+  let query = command.query.as_deref().ok_or_else(|| {
+    "search.results.click requires <query> unless --candidate-ref is used".to_string()
+  })?;
+  let anchor_text = command.anchor.as_deref().ok_or_else(|| {
+    "search.results.click requires --anchor, --row, or --candidate-ref".to_string()
+  })?;
+  let mut steps = execute_search_phase(
+    driver,
+    &command.app_id,
+    query,
+    DEFAULT_SEARCH_SHORTCUT,
+    command.settle_ms,
+  )?;
+  let anchor = driver.wait_anchor(
+    &command.app_id,
+    anchor_text,
+    Duration::from_millis(command.anchor_timeout_ms),
+  )?;
+  steps.push(driver.click_anchor(
+    &command.app_id,
+    &anchor,
+    Click::Double {
+      interval: Duration::from_millis(80),
+    },
+    Duration::from_millis(command.settle_ms),
+  )?);
+  Ok(SearchCommandReport {
+    command: "search.results.click",
+    steps,
+    anchor: Some(anchor),
+    unsupported: None,
+  })
+}
+
+fn execute_search_phase(
+  driver: &mut impl QqMusicDriver,
+  app_id: &str,
+  query: &str,
+  shortcut: &str,
+  settle_ms: u64,
+) -> OperationResult<Vec<SearchStep>> {
+  Ok(vec![
+    driver.activate_app(app_id, Duration::from_millis(settle_ms))?,
+    driver.press_search_shortcut(shortcut, Duration::from_millis(settle_ms))?,
+    driver.paste_query(query, Duration::from_millis(settle_ms))?,
+  ])
+}
+
+fn unsupported(message: impl Into<String>) -> SearchCommandReport {
+  SearchCommandReport {
+    command: "search.results.click",
+    steps: Vec::new(),
+    anchor: None,
+    unsupported: Some(message.into()),
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use auv_driver::{InputActionResult, InputDeliveryPath};
+
+  #[derive(Default)]
+  struct RecordingQqMusicDriver {
+    calls: Vec<String>,
+  }
+
+  impl QqMusicDriver for RecordingQqMusicDriver {
+    fn activate_app(&mut self, app_id: &str, settle: Duration) -> OperationResult<SearchStep> {
+      self
+        .calls
+        .push(format!("activate:{app_id}:{}", settle.as_millis()));
+      Ok(SearchStep::new("activate", "activated"))
+    }
+
+    fn press_search_shortcut(
+      &mut self,
+      shortcut: &str,
+      settle: Duration,
+    ) -> OperationResult<SearchStep> {
+      self
+        .calls
+        .push(format!("shortcut:{shortcut}:{}", settle.as_millis()));
+      Ok(SearchStep::with_input(
+        "shortcut",
+        "pressed shortcut",
+        InputActionResult::single_success(InputDeliveryPath::ForegroundSystemEvents),
+      ))
+    }
+
+    fn paste_query(&mut self, query: &str, settle: Duration) -> OperationResult<SearchStep> {
+      self
+        .calls
+        .push(format!("paste:{query}:{}", settle.as_millis()));
+      Ok(SearchStep::new("paste", "pasted query"))
+    }
+
+    fn wait_anchor(
+      &mut self,
+      app_id: &str,
+      anchor: &str,
+      timeout: Duration,
+    ) -> OperationResult<SearchAnchorMatch> {
+      self
+        .calls
+        .push(format!("anchor:{app_id}:{anchor}:{}", timeout.as_millis()));
+      Ok(SearchAnchorMatch {
+        text: anchor.to_string(),
+        confidence: 0.95,
+        point: Point::new(100.0, 200.0),
+      })
+    }
+
+    fn click_anchor(
+      &mut self,
+      app_id: &str,
+      anchor: &SearchAnchorMatch,
+      click: Click,
+      settle: Duration,
+    ) -> OperationResult<SearchStep> {
+      self.calls.push(format!(
+        "click:{app_id}:{}:{click:?}:{}",
+        anchor.text,
+        settle.as_millis()
+      ));
+      Ok(SearchStep::with_input(
+        "click",
+        "clicked",
+        InputActionResult::single_success(InputDeliveryPath::WindowTargetedMouse),
+      ))
+    }
+  }
+
+  #[test]
+  fn search_command_runs_search_phase() {
+    let command = SearchCommand::Search(SearchSubmit::defaults_with_query("周杰伦"));
+    let mut driver = RecordingQqMusicDriver::default();
+
+    let report = run_search_command(&command, &mut driver).expect("command should run");
+
+    assert_eq!(report.command, "search");
+    assert_eq!(
+      driver.calls,
+      vec![
+        "activate:com.tencent.QQMusicMac:250",
+        "shortcut:cmd+f:250",
+        "paste:周杰伦:250",
+      ]
+    );
+  }
+
+  #[test]
+  fn search_results_select_searches_and_single_clicks_anchor() {
+    let command = SearchCommand::Results(SearchResultsAction::Select(SearchResultsSelect {
+      app_id: DEFAULT_APP_ID.to_string(),
+      query: "周杰伦".to_string(),
+      anchor: "晴天".to_string(),
+      settle_ms: DEFAULT_SETTLE_MS,
+      anchor_timeout_ms: DEFAULT_ANCHOR_TIMEOUT_MS,
+    }));
+    let mut driver = RecordingQqMusicDriver::default();
+
+    let report = run_search_command(&command, &mut driver).expect("command should run");
+
+    assert_eq!(report.command, "search.results.select");
+    assert_eq!(
+      report.anchor.as_ref().map(|anchor| anchor.text.as_str()),
+      Some("晴天")
+    );
+    assert!(
+      driver
+        .calls
+        .iter()
+        .any(|call| call.contains("click:com.tencent.QQMusicMac:晴天:Single"))
+    );
+  }
+
+  #[test]
+  fn search_results_click_anchor_double_clicks_anchor() {
+    let command = SearchCommand::Results(SearchResultsAction::Click(SearchResultsClick {
+      app_id: DEFAULT_APP_ID.to_string(),
+      query: Some("周杰伦".to_string()),
+      anchor: Some("晴天".to_string()),
+      row: None,
+      candidate_ref_json: None,
+      settle_ms: DEFAULT_SETTLE_MS,
+      anchor_timeout_ms: DEFAULT_ANCHOR_TIMEOUT_MS,
+    }));
+    let mut driver = RecordingQqMusicDriver::default();
+
+    let report = run_search_command(&command, &mut driver).expect("command should run");
+
+    assert_eq!(report.command, "search.results.click");
+    assert!(
+      driver
+        .calls
+        .iter()
+        .any(|call| call.contains("click:com.tencent.QQMusicMac:晴天:Double"))
+    );
+  }
+
+  #[test]
+  fn search_results_click_row_is_explicitly_unsupported() {
+    let command = SearchCommand::Results(SearchResultsAction::Click(SearchResultsClick {
+      app_id: DEFAULT_APP_ID.to_string(),
+      query: Some("周杰伦".to_string()),
+      anchor: None,
+      row: Some(2),
+      candidate_ref_json: None,
+      settle_ms: DEFAULT_SETTLE_MS,
+      anchor_timeout_ms: DEFAULT_ANCHOR_TIMEOUT_MS,
+    }));
+    let mut driver = RecordingQqMusicDriver::default();
+
+    let report = run_search_command(&command, &mut driver).expect("unsupported is reported");
+
+    assert_eq!(
+      report.unsupported.as_deref(),
+      Some("search.results.click --row needs a typed row detection API")
+    );
+    assert!(driver.calls.is_empty());
+  }
+
+  #[test]
+  fn search_results_click_candidate_ref_is_explicitly_unsupported() {
+    let command = SearchCommand::Results(SearchResultsAction::Click(SearchResultsClick {
+      app_id: DEFAULT_APP_ID.to_string(),
+      query: None,
+      anchor: None,
+      row: None,
+      candidate_ref_json: Some("{\"candidate\":\"ref\"}".to_string()),
+      settle_ms: DEFAULT_SETTLE_MS,
+      anchor_timeout_ms: DEFAULT_ANCHOR_TIMEOUT_MS,
+    }));
+    let mut driver = RecordingQqMusicDriver::default();
+
+    let report = run_search_command(&command, &mut driver).expect("unsupported is reported");
+
+    assert_eq!(
+      report.unsupported.as_deref(),
+      Some("search.results.click --candidate-ref needs a typed CandidateRef consumer API")
+    );
+    assert!(driver.calls.is_empty());
+  }
+}


### PR DESCRIPTION
## Summary
- Add an app-local `auv-qqmusic` crate with `search` and `search results` commands.
- Implement anchor-based search result select/click through public typed driver APIs.
- Parse row and candidate-ref command shapes while keeping execution explicitly unsupported until typed APIs exist.

## Verification
- `cargo test -p auv-qqmusic`
- `cargo fmt --package auv-qqmusic --check`
- `cargo check -p auv-qqmusic`
- `git diff --check`