### PR TITLE
refactor(auv-cli-invoke): better structure and registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,7 +381,6 @@ name = "auv-cli-invoke"
 version = "0.0.1"
 dependencies = [
  "auv-cli-invoke-macros",
- "auv-driver",
 ]
 
 [[package]]

--- a/crates/auv-cli-invoke-macros/src/lib.rs
+++ b/crates/auv-cli-invoke-macros/src/lib.rs
@@ -2,9 +2,11 @@ use std::collections::BTreeMap;
 
 use proc_macro::{TokenStream, TokenTree};
 
+const ALLOWED_ATTR_KEYS: &[&str] = &["id", "group", "summary", "args"];
+
 #[proc_macro_attribute]
 pub fn invoke_command(attr: TokenStream, item: TokenStream) -> TokenStream {
-  let handler_name = match find_function_name(item.clone()) {
+  let function_name = match find_function_name(item.clone()) {
     Some(name) => name,
     None => return compile_error("invoke_command must annotate a function"),
   };
@@ -12,20 +14,8 @@ pub fn invoke_command(attr: TokenStream, item: TokenStream) -> TokenStream {
     Ok(values) => values,
     Err(error) => return compile_error(&error),
   };
-  for key in [
-    "id",
-    "group",
-    "summary",
-    "driver",
-    "operation",
-    "args",
-    "disturbance",
-    "max_disturbance",
-    "artifacts",
-    "signals",
-    "verification",
-  ] {
-    if !values.contains_key(key) {
+  for key in ALLOWED_ATTR_KEYS {
+    if !values.contains_key(*key) {
       return compile_error(&format!(
         "invoke_command missing required `{key}` attribute"
       ));
@@ -39,54 +29,17 @@ pub fn invoke_command(attr: TokenStream, item: TokenStream) -> TokenStream {
     Err(error) => return compile_error(&error),
   };
   let summary = &values["summary"];
-  let driver = &values["driver"];
-  let operation = &values["operation"];
   let args = &values["args"];
-  let disturbance = &values["disturbance"];
-  let max_disturbance = &values["max_disturbance"];
-  let artifacts = &values["artifacts"];
-  let signals = &values["signals"];
-  let verification = &values["verification"];
-  let export_name = format!("{handler_name}_invoke_command");
-
-  let spec_call = if let Some(operation_namespace) = values.get("operation_namespace") {
-    format!(
-      "::auv_cli_invoke::command::spec_with_operation_namespace(
-        {id},
-        ::auv_cli_invoke::InvokeNamespace::{namespace},
-        {operation_namespace},
-        {summary},
-        {driver},
-        {operation},
-        {disturbance},
-        {max_disturbance},
-        {args},
-        &{artifacts},
-        &{signals},
-        {verification},
-      )"
-    )
-  } else {
-    format!(
-      "::auv_cli_invoke::command::spec(
-        {id},
-        ::auv_cli_invoke::InvokeNamespace::{namespace},
-        {summary},
-        {driver},
-        {operation},
-        {disturbance},
-        {max_disturbance},
-        {args},
-        &{artifacts},
-        &{signals},
-        {verification},
-      )"
-    )
-  };
+  let export_name = format!("{function_name}_invoke_command");
 
   let generated = format!(
     "pub fn {export_name}() -> ::auv_cli_invoke::InvokeCommand {{
-      {spec_call}.with_handler({handler_name}, stringify!({handler_name}))
+      ::auv_cli_invoke::command::spec(
+        {id},
+        ::auv_cli_invoke::InvokeNamespace::{namespace},
+        {summary},
+        {args},
+      )
     }}"
   );
 
@@ -118,6 +71,7 @@ fn parse_attrs(attr: TokenStream) -> Result<BTreeMap<String, String>, String> {
       continue;
     }
     let (key, value) = parse_key_value(entry)?;
+    validate_attr_key(&key)?;
     if values.insert(key.clone(), value).is_some() {
       return Err(format!("invoke_command duplicate `{key}` attribute"));
     }
@@ -160,6 +114,16 @@ fn parse_key_value(tokens: Vec<TokenTree>) -> Result<(String, String), String> {
   Ok((key, tokens_to_string(value_tokens)))
 }
 
+fn validate_attr_key(key: &str) -> Result<(), String> {
+  if ALLOWED_ATTR_KEYS.contains(&key) {
+    Ok(())
+  } else {
+    Err(format!(
+      "invoke_command unknown attribute `{key}`; expected only: id, group, summary, args"
+    ))
+  }
+}
+
 fn tokens_to_string(tokens: Vec<TokenTree>) -> String {
   tokens.into_iter().collect::<TokenStream>().to_string()
 }
@@ -189,7 +153,7 @@ fn compile_error(message: &str) -> TokenStream {
 
 #[cfg(test)]
 mod tests {
-  use super::namespace_for_group_literal;
+  use super::{namespace_for_group_literal, validate_attr_key};
 
   #[test]
   fn namespace_for_group_literal_accepts_supported_groups() {
@@ -208,5 +172,25 @@ mod tests {
 
     assert!(error.contains("invoke_command unknown group"));
     assert!(error.contains("mediaControl"));
+  }
+
+  #[test]
+  fn validate_attr_key_rejects_execution_metadata_keys() {
+    for key in [
+      "driver",
+      "operation",
+      "disturbance",
+      "max_disturbance",
+      "artifacts",
+      "signals",
+      "verification",
+      "operation_namespace",
+    ] {
+      let error = validate_attr_key(key).expect_err("old execution metadata should be rejected");
+
+      assert!(error.contains("invoke_command unknown attribute"));
+      assert!(error.contains(key));
+      assert!(error.contains("id, group, summary, args"));
+    }
   }
 }

--- a/crates/auv-cli-invoke/Cargo.toml
+++ b/crates/auv-cli-invoke/Cargo.toml
@@ -13,5 +13,4 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-auv-driver = { path = "../auv-driver" }
 auv-cli-invoke-macros = { path = "../auv-cli-invoke-macros" }

--- a/crates/auv-cli-invoke/src/arg.rs
+++ b/crates/auv-cli-invoke/src/arg.rs
@@ -28,13 +28,13 @@ pub const QUERY: ArgSpec = ArgSpec {
   flag: "--query",
   value_name: "TEXT",
   required: true,
-  help: "Text query required by the driver operation.",
+  help: "Text query used by the invoke command.",
 };
 pub const OPTIONAL_QUERY: ArgSpec = ArgSpec {
   flag: "--query",
   value_name: "TEXT",
   required: false,
-  help: "Text query used by the driver operation; required unless --candidate is supplied.",
+  help: "Text query used by the invoke command; required unless --candidate is supplied.",
 };
 pub const CANDIDATE: ArgSpec = ArgSpec {
   flag: "--candidate",
@@ -46,13 +46,13 @@ pub const TEXT: ArgSpec = ArgSpec {
   flag: "--text",
   value_name: "TEXT",
   required: true,
-  help: "Text content required by the driver operation.",
+  help: "Text content used by the invoke command.",
 };
 pub const TARGET_TEXT: ArgSpec = ArgSpec {
   flag: "--target_text",
   value_name: "TEXT",
   required: true,
-  help: "Expected AX text required by the verification operation.",
+  help: "Expected AX text used by the invoke command.",
 };
 pub const IMAGE_PATH: ArgSpec = ArgSpec {
   flag: "--image_path",

--- a/crates/auv-cli-invoke/src/command.rs
+++ b/crates/auv-cli-invoke/src/command.rs
@@ -1,44 +1,4 @@
-use std::collections::BTreeMap;
-
-use auv_driver::{OperationDisturbance, OperationNamespace, OperationSpec};
-
 use crate::arg::ArgSpec;
-
-pub const NONE: &[OperationDisturbance] = &[OperationDisturbance::None];
-pub const NONE_OR_FOREGROUND: &[OperationDisturbance] = &[
-  OperationDisturbance::None,
-  OperationDisturbance::ForegroundApp,
-];
-pub(crate) const FOREGROUND_KEYBOARD: &[OperationDisturbance] = &[
-  OperationDisturbance::ForegroundApp,
-  OperationDisturbance::Keyboard,
-];
-pub(crate) const FOREGROUND_KEYBOARD_CLIPBOARD: &[OperationDisturbance] = &[
-  OperationDisturbance::ForegroundApp,
-  OperationDisturbance::Keyboard,
-  OperationDisturbance::Clipboard,
-];
-pub(crate) const MEDIA_TRANSPORT: &[OperationDisturbance] = &[OperationDisturbance::Keyboard];
-pub(crate) const FOREGROUND_ONLY: &[OperationDisturbance] = &[OperationDisturbance::ForegroundApp];
-pub(crate) const FOCUS_POINTER_ENTRY: &[OperationDisturbance] = &[
-  OperationDisturbance::Focus,
-  OperationDisturbance::ForegroundApp,
-  OperationDisturbance::Keyboard,
-  OperationDisturbance::Pointer,
-];
-pub(crate) const POINTER_WITH_FOREGROUND: &[OperationDisturbance] = &[
-  OperationDisturbance::ForegroundApp,
-  OperationDisturbance::Pointer,
-];
-pub(crate) const PRESS_BUTTON_DISTURBANCE: &[OperationDisturbance] = &[
-  OperationDisturbance::ForegroundApp,
-  OperationDisturbance::Keyboard,
-  OperationDisturbance::Pointer,
-];
-pub(crate) const CAPTURE_AX_TREE_DISTURBANCE: &[OperationDisturbance] = &[
-  OperationDisturbance::ForegroundApp,
-  OperationDisturbance::Keyboard,
-];
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum InvokeNamespace {
@@ -69,61 +29,12 @@ impl InvokeNamespace {
   }
 }
 
-#[derive(Clone, Copy, Debug)]
-pub struct InvokeContext<'a> {
-  pub target_application_id: Option<&'a str>,
-  pub target_label: Option<&'a str>,
-  pub inputs: &'a BTreeMap<String, String>,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct InvokeDriverDispatch {
-  pub command_id: &'static str,
-  pub driver_id: &'static str,
-  pub operation: &'static str,
-  pub target_application_id: Option<String>,
-  pub target_label: Option<String>,
-  pub inputs: BTreeMap<String, String>,
-}
-
-pub type InvokeCommandHandler = fn(InvokeContext<'_>, &InvokeCommand) -> InvokeDriverDispatch;
-
 #[derive(Clone, Debug)]
 pub struct InvokeCommand {
-  pub operation: OperationSpec,
+  pub id: &'static str,
   pub namespace: InvokeNamespace,
+  pub summary: &'static str,
   pub args: &'static [ArgSpec],
-  pub artifacts: &'static [&'static str],
-  pub signals: &'static [&'static str],
-  pub verification: &'static str,
-  pub handler: InvokeCommandHandler,
-  pub handler_name: &'static str,
-}
-
-impl InvokeCommand {
-  pub fn dispatch(&self, context: InvokeContext<'_>) -> InvokeDriverDispatch {
-    (self.handler)(context, self)
-  }
-
-  pub fn with_handler(mut self, handler: InvokeCommandHandler, handler_name: &'static str) -> Self {
-    self.handler = handler;
-    self.handler_name = handler_name;
-    self
-  }
-}
-
-pub fn default_driver_dispatch(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  InvokeDriverDispatch {
-    command_id: command.operation.id,
-    driver_id: command.operation.driver_id,
-    operation: command.operation.operation,
-    target_application_id: context.target_application_id.map(str::to_string),
-    target_label: context.target_label.map(str::to_string),
-    inputs: context.inputs.clone(),
-  }
 }
 
 #[derive(Clone, Debug)]
@@ -160,85 +71,18 @@ pub enum CommandNode {
 }
 
 // The registry files use this as a compact declaration DSL: every field maps
-// directly to one part of the public help/operation contract.
-#[allow(clippy::too_many_arguments)]
+// directly to one part of the public invoke command metadata.
 #[doc(hidden)]
 pub fn spec(
   id: &'static str,
   namespace: InvokeNamespace,
   summary: &'static str,
-  driver_id: &'static str,
-  operation: &'static str,
-  disturbance_classes: &'static [OperationDisturbance],
-  max_disturbance: OperationDisturbance,
   args: &'static [ArgSpec],
-  artifacts: &'static [&'static str],
-  signals: &'static [&'static str],
-  verification: &'static str,
-) -> InvokeCommand {
-  spec_with_operation_namespace(
-    id,
-    namespace,
-    operation_namespace_for_invoke(namespace),
-    summary,
-    driver_id,
-    operation,
-    disturbance_classes,
-    max_disturbance,
-    args,
-    artifacts,
-    signals,
-    verification,
-  )
-}
-
-// Same declaration DSL as `spec`, with an explicit driver operation namespace
-// for commands whose invoke group does not imply the operation family.
-#[allow(clippy::too_many_arguments)]
-#[doc(hidden)]
-pub fn spec_with_operation_namespace(
-  id: &'static str,
-  namespace: InvokeNamespace,
-  operation_namespace: OperationNamespace,
-  summary: &'static str,
-  driver_id: &'static str,
-  operation: &'static str,
-  disturbance_classes: &'static [OperationDisturbance],
-  max_disturbance: OperationDisturbance,
-  args: &'static [ArgSpec],
-  artifacts: &'static [&'static str],
-  signals: &'static [&'static str],
-  verification: &'static str,
 ) -> InvokeCommand {
   InvokeCommand {
-    operation: OperationSpec {
-      id,
-      summary,
-      driver_id,
-      operation,
-      disturbance_classes,
-      max_disturbance,
-      namespace: operation_namespace,
-    },
+    id,
     namespace,
+    summary,
     args,
-    artifacts,
-    signals,
-    verification,
-    handler: default_driver_dispatch,
-    handler_name: "default_driver_dispatch",
-  }
-}
-
-fn operation_namespace_for_invoke(namespace: InvokeNamespace) -> OperationNamespace {
-  match namespace {
-    InvokeNamespace::Display
-    | InvokeNamespace::Screen
-    | InvokeNamespace::Window
-    | InvokeNamespace::MediaControl
-    | InvokeNamespace::Steam
-    | InvokeNamespace::Fixture => OperationNamespace::Observe,
-    InvokeNamespace::Input | InvokeNamespace::App => OperationNamespace::Action,
-    InvokeNamespace::Overlay => OperationNamespace::Overlay,
   }
 }

--- a/crates/auv-cli-invoke/src/commands/app.rs
+++ b/crates/auv-cli-invoke/src/commands/app.rs
@@ -1,10 +1,7 @@
-use auv_driver::OperationDisturbance;
-
 use crate::{
-  CommandGroup, InvokeCommand, InvokeContext, InvokeDriverDispatch,
+  CommandGroup,
   arg::{NO_ARGS, TARGET_ARGS},
-  command::{FOREGROUND_ONLY, NONE},
-  default_driver_dispatch, invoke_command,
+  invoke_command,
 };
 
 pub fn group() -> CommandGroup {
@@ -17,35 +14,14 @@ pub fn group() -> CommandGroup {
   id = "app.probePermissions",
   group = "app",
   summary = "Probe macOS screen recording, accessibility, and automation permissions.",
-  driver = "macos.desktop",
-  operation = "probe_permissions",
   args = NO_ARGS,
-  disturbance = NONE,
-  max_disturbance = OperationDisturbance::None,
-  artifacts = [],
-  signals = ["permission.screenRecording", "permission.accessibility"],
-  verification = "read-only; no semantic success claim",
 )]
-pub fn probe_permissions(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn probe_permissions() {}
 
 #[invoke_command(
   id = "app.activate",
   group = "app",
   summary = "Bring a target macOS app to the foreground before a foreground-dependent step.",
-  driver = "macos.desktop",
-  operation = "activate_app",
   args = TARGET_ARGS,
-  disturbance = FOREGROUND_ONLY,
-  max_disturbance = OperationDisturbance::ForegroundApp,
-  artifacts = ["input-action-result"],
-  signals = ["app.activated"],
-  verification = "activation-only; semantic success requires a separate verification result",
 )]
-pub fn activate_app(context: InvokeContext<'_>, command: &InvokeCommand) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn activate_app() {}

--- a/crates/auv-cli-invoke/src/commands/display.rs
+++ b/crates/auv-cli-invoke/src/commands/display.rs
@@ -1,10 +1,7 @@
-use auv_driver::OperationDisturbance;
-
 use crate::{
-  CommandGroup, InvokeCommand, InvokeContext, InvokeDriverDispatch,
+  CommandGroup,
   arg::{NO_ARGS, TARGET_ARGS},
-  command::{NONE, NONE_OR_FOREGROUND},
-  default_driver_dispatch, invoke_command,
+  invoke_command,
 };
 
 pub fn group() -> CommandGroup {
@@ -20,92 +17,38 @@ pub fn group() -> CommandGroup {
   id = "display.capture",
   group = "display",
   summary = "Capture one display screenshot with a coordinate contract through xcap. If activate_target_before_capture is true, the target app is foregrounded first.",
-  driver = "macos.desktop",
-  operation = "capture_display",
   args = TARGET_ARGS,
-  disturbance = NONE_OR_FOREGROUND,
-  max_disturbance = OperationDisturbance::ForegroundApp,
-  artifacts = ["display-capture", "capture-contract"],
-  signals = [],
-  verification = "capture-only; no semantic success claim",
 )]
-pub fn capture_display(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn capture_display() {}
 
 #[invoke_command(
   id = "display.list",
   group = "display",
   summary = "List connected displays using the normalized AUV coordinate contract.",
-  driver = "macos.desktop",
-  operation = "list_displays",
   args = NO_ARGS,
-  disturbance = NONE,
-  max_disturbance = OperationDisturbance::None,
-  artifacts = [],
-  signals = ["display.count"],
-  verification = "read-only; no semantic success claim",
 )]
-pub fn list_displays(context: InvokeContext<'_>, command: &InvokeCommand) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn list_displays() {}
 
 #[invoke_command(
   id = "display.projectScreenshotPoint",
   group = "display",
   summary = "Project main-display screenshot pixels back into AUV global logical coordinates.",
-  driver = "macos.desktop",
-  operation = "project_screenshot_point",
   args = NO_ARGS,
-  disturbance = NONE,
-  max_disturbance = OperationDisturbance::None,
-  artifacts = [],
-  signals = [],
-  verification = "projection-only; no semantic success claim",
 )]
-pub fn project_screenshot_point(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn project_screenshot_point() {}
 
 #[invoke_command(
   id = "display.identifyPoint",
   group = "display",
   summary = "Resolve a logical desktop point against the current macOS display layout.",
-  driver = "macos.desktop",
-  operation = "identify_point",
   args = NO_ARGS,
-  disturbance = NONE,
-  max_disturbance = OperationDisturbance::None,
-  artifacts = [],
-  signals = [],
-  verification = "read-only; no semantic success claim",
 )]
-pub fn identify_point(context: InvokeContext<'_>, command: &InvokeCommand) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn identify_point() {}
 
 #[invoke_command(
   id = "display.probeCoordinateReadiness",
   group = "display",
   summary = "Capture a screenshot and compare its pixels against the observed macOS coordinate space.",
-  driver = "macos.desktop",
-  operation = "probe_coordinate_readiness",
   args = NO_ARGS,
-  disturbance = NONE,
-  max_disturbance = OperationDisturbance::None,
-  artifacts = [],
-  signals = [],
-  verification = "read-only readiness probe; no semantic success claim",
 )]
-pub fn probe_coordinate_readiness(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn probe_coordinate_readiness() {}

--- a/crates/auv-cli-invoke/src/commands/fixture.rs
+++ b/crates/auv-cli-invoke/src/commands/fixture.rs
@@ -1,9 +1,4 @@
-use auv_driver::OperationDisturbance;
-
-use crate::{
-  CommandGroup, InvokeCommand, InvokeContext, InvokeDriverDispatch, arg::NO_ARGS, command::NONE,
-  default_driver_dispatch, invoke_command,
-};
+use crate::{CommandGroup, arg::NO_ARGS, invoke_command};
 
 pub fn group() -> CommandGroup {
   CommandGroup::new("fixture", "FIXTURE").command(observe_invoke_command())
@@ -13,15 +8,6 @@ pub fn group() -> CommandGroup {
   id = "fixture.observe",
   group = "fixture",
   summary = "Emit a deterministic observation result without touching the real UI.",
-  driver = "fixture.observe",
-  operation = "observe_fixture_scene",
   args = NO_ARGS,
-  disturbance = NONE,
-  max_disturbance = OperationDisturbance::None,
-  artifacts = ["operation-result"],
-  signals = ["fixture.scene"],
-  verification = "read-only; no semantic success claim",
 )]
-pub fn observe(context: InvokeContext<'_>, command: &InvokeCommand) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn observe() {}

--- a/crates/auv-cli-invoke/src/commands/input.rs
+++ b/crates/auv-cli-invoke/src/commands/input.rs
@@ -1,16 +1,10 @@
-use auv_driver::OperationDisturbance;
-
 use crate::{
-  CommandGroup, InvokeCommand, InvokeContext, InvokeDriverDispatch,
+  CommandGroup,
   arg::{
     KEY_ARGS, QUERY_ARGS, QUERY_OR_CANDIDATE_ARGS, QUERY_OR_CANDIDATE_OVERLAY_ARGS,
     QUERY_OVERLAY_ARGS, TARGET_ARGS, TEXT_ARGS, WINDOW_ARGS, WINDOW_QUERY_OVERLAY_ARGS,
   },
-  command::{
-    CAPTURE_AX_TREE_DISTURBANCE, FOCUS_POINTER_ENTRY, FOREGROUND_KEYBOARD,
-    FOREGROUND_KEYBOARD_CLIPBOARD, POINTER_WITH_FOREGROUND, PRESS_BUTTON_DISTURBANCE,
-  },
-  default_driver_dispatch, invoke_command,
+  invoke_command,
 };
 
 pub fn group() -> CommandGroup {
@@ -33,238 +27,103 @@ pub fn group() -> CommandGroup {
 #[invoke_command(
   id = "input.focusText",
   group = "input",
-  summary = "Focus a target macOS text input through AX, either by --query text or by a promoted --candidate JSON payload carrying the typed search-entry contract candidate.",
-  driver = "macos.desktop",
-  operation = "focus_text_input",
+  summary = "Focus a target macOS text input through AX, either by --query text or by a promoted --candidate JSON payload.",
   args = QUERY_OR_CANDIDATE_ARGS,
-  disturbance = FOCUS_POINTER_ENTRY,
-  max_disturbance = OperationDisturbance::Pointer,
-  artifacts = ["input-action-result"],
-  signals = ["input.method"],
-  verification = "activation-only; semantic success requires a separate verification result",
 )]
-pub fn focus_text_input(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn focus_text_input() {}
 
 #[invoke_command(
   id = "input.pressButton",
   group = "input",
   summary = "Press a known macOS button-like control by query through AX.",
-  driver = "macos.desktop",
-  operation = "press_button",
   args = QUERY_ARGS,
-  disturbance = PRESS_BUTTON_DISTURBANCE,
-  max_disturbance = OperationDisturbance::Pointer,
-  artifacts = ["input-action-result"],
-  signals = ["input.method"],
-  verification = "activation-only; semantic success requires a separate verification result",
 )]
-pub fn press_button(context: InvokeContext<'_>, command: &InvokeCommand) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn press_button() {}
 
 #[invoke_command(
   id = "input.axPressButton",
   group = "input",
-  summary = "Press a control by query via AXUIElementPerformAction; does not warp the real cursor (cursorDisturbance=none). Pass --overlay true to draw a visual AUV cursor over the target during the press for the dual-cursor effect. Falls back with an error when the AX target has no matching action; use input.pressButton for non-AX-pressable targets.",
-  driver = "macos.desktop",
-  operation = "ax_press_button",
+  summary = "Press a control by query via AXUIElementPerformAction without moving the real cursor. Pass --overlay true to draw a visual AUV cursor over the target. Falls back with an error when the AX target has no matching action; use input.pressButton for non-AX-pressable targets.",
   args = QUERY_OVERLAY_ARGS,
-  disturbance = CAPTURE_AX_TREE_DISTURBANCE,
-  max_disturbance = OperationDisturbance::Keyboard,
-  artifacts = ["input-action-result"],
-  signals = ["input.method"],
-  verification = "activation-only; semantic success requires a separate verification result",
 )]
-pub fn ax_press_button(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn ax_press_button() {}
 
 #[invoke_command(
   id = "input.axFocusText",
   group = "input",
-  summary = "Focus a text input by query or promoted --candidate JSON via AXUIElementSetAttributeValue(kAXFocusedAttribute); does not warp the real cursor (cursorDisturbance=none, focusMechanism=ax-attribute). Pass --overlay true for the dual-cursor visual (auv replay cursor animates to the target while the real cursor stays put). Errors when the target does not accept programmatic focus; use input.focusText if pointer warp is acceptable.",
-  driver = "macos.desktop",
-  operation = "ax_focus_text_input",
+  summary = "Focus a text input by query or promoted --candidate JSON via AXUIElementSetAttributeValue(kAXFocusedAttribute) without moving the real cursor. Pass --overlay true for the dual-cursor visual. Errors when the target does not accept programmatic focus; use input.focusText if pointer movement is acceptable.",
   args = QUERY_OR_CANDIDATE_OVERLAY_ARGS,
-  disturbance = CAPTURE_AX_TREE_DISTURBANCE,
-  max_disturbance = OperationDisturbance::Keyboard,
-  artifacts = ["input-action-result"],
-  signals = ["input.method"],
-  verification = "activation-only; semantic success requires a separate verification result",
 )]
-pub fn ax_focus_text_input(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn ax_focus_text_input() {}
 
 #[invoke_command(
   id = "input.axClickWindowText",
   group = "input",
-  summary = "Find visible text in a window via Vision OCR, resolve the AX node at that point, then press it via AXUIElementPerformAction (cursorDisturbance=none). Pass --overlay true for the dual-cursor visual. Errors with a hint to window.clickText when the OCR anchor maps to a canvas-rendered or non-AX-pressable region.",
-  driver = "macos.desktop",
-  operation = "ax_click_window_text",
+  summary = "Find visible text in a window via Vision OCR, resolve the AX node at that point, then press it via AXUIElementPerformAction without moving the real cursor. Pass --overlay true for the dual-cursor visual. Errors with a hint to window.clickText when the OCR anchor maps to a canvas-rendered or non-AX-pressable region.",
   args = WINDOW_QUERY_OVERLAY_ARGS,
-  disturbance = CAPTURE_AX_TREE_DISTURBANCE,
-  max_disturbance = OperationDisturbance::Keyboard,
-  artifacts = ["input-action-result"],
-  signals = ["input.method"],
-  verification = "activation-only; semantic success requires a separate verification result",
 )]
-pub fn ax_click_window_text(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn ax_click_window_text() {}
 
 #[invoke_command(
   id = "input.smartPress",
   group = "input",
-  summary = "ActionResolver v0 diagnostic press: try OCR-to-AX press first; if it fails and --allow_pointer_fallback is not false, fall back to pointer click. Records actionResolver.* signals plus the selected method, fallback reason, and disturbance metadata.",
-  driver = "macos.desktop",
-  operation = "smart_press",
+  summary = "ActionResolver v0 diagnostic press: try OCR-to-AX press first; if it fails and pointer fallback is allowed, fall back to pointer click.",
   args = WINDOW_QUERY_OVERLAY_ARGS,
-  disturbance = POINTER_WITH_FOREGROUND,
-  max_disturbance = OperationDisturbance::Pointer,
-  artifacts = ["input-action-result"],
-  signals = ["actionResolver.method", "actionResolver.fallbackReason"],
-  verification = "activation-only; semantic success requires a separate verification result",
 )]
-pub fn smart_press(context: InvokeContext<'_>, command: &InvokeCommand) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn smart_press() {}
 
 #[invoke_command(
   id = "input.typeText",
   group = "input",
   summary = "Type text into the active macOS control through System Events.",
-  driver = "macos.desktop",
-  operation = "type_text",
   args = TEXT_ARGS,
-  disturbance = FOREGROUND_KEYBOARD,
-  max_disturbance = OperationDisturbance::Keyboard,
-  artifacts = ["input-action-result"],
-  signals = ["input.method"],
-  verification = "activation-only; semantic success requires a separate verification result",
 )]
-pub fn type_text(context: InvokeContext<'_>, command: &InvokeCommand) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn type_text() {}
 
 #[invoke_command(
   id = "input.pasteText",
   group = "input",
   summary = "Paste text into the active macOS control through the clipboard, then restore the prior clipboard snapshot.",
-  driver = "macos.desktop",
-  operation = "paste_text_preserve_clipboard",
   args = TEXT_ARGS,
-  disturbance = FOREGROUND_KEYBOARD_CLIPBOARD,
-  max_disturbance = OperationDisturbance::Clipboard,
-  artifacts = ["input-action-result"],
-  signals = ["input.method"],
-  verification = "activation-only; semantic success requires a separate verification result",
 )]
-pub fn paste_text_preserve_clipboard(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn paste_text_preserve_clipboard() {}
 
 #[invoke_command(
   id = "input.key",
   group = "input",
   summary = "Press a keyboard key or shortcut in the active macOS app through System Events.",
-  driver = "macos.desktop",
-  operation = "press_key",
   args = KEY_ARGS,
-  disturbance = FOREGROUND_KEYBOARD,
-  max_disturbance = OperationDisturbance::Keyboard,
-  artifacts = ["input-action-result"],
-  signals = ["input.method"],
-  verification = "activation-only; semantic success requires a separate verification result",
 )]
-pub fn press_key(context: InvokeContext<'_>, command: &InvokeCommand) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn press_key() {}
 
 #[invoke_command(
   id = "input.clickPoint",
   group = "input",
-  summary = "Click a macOS global logical point through Quartz and record its display contract.",
-  driver = "macos.desktop",
-  operation = "click_point",
+  summary = "Click a macOS global logical point through Quartz.",
   args = TARGET_ARGS,
-  disturbance = POINTER_WITH_FOREGROUND,
-  max_disturbance = OperationDisturbance::Pointer,
-  artifacts = ["input-action-result"],
-  signals = ["input.method"],
-  verification = "activation-only; semantic success requires a separate verification result",
 )]
-pub fn click_point(context: InvokeContext<'_>, command: &InvokeCommand) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn click_point() {}
 
 #[invoke_command(
   id = "input.clickWindowPoint",
   group = "input",
-  summary = "Click a point relative to a target macOS window and record the resolved global point, either from --relative_x/--relative_y inputs or from a promoted --candidate JSON payload carrying the typed window-action contract candidate.",
-  driver = "macos.desktop",
-  operation = "click_window_point",
+  summary = "Click a point relative to a target macOS window, either from --relative_x/--relative_y inputs or from a promoted --candidate JSON payload.",
   args = WINDOW_ARGS,
-  disturbance = POINTER_WITH_FOREGROUND,
-  max_disturbance = OperationDisturbance::Pointer,
-  artifacts = ["input-action-result"],
-  signals = ["input.method"],
-  verification = "activation-only; semantic success requires a separate verification result",
 )]
-pub fn click_window_point(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn click_window_point() {}
 
 #[invoke_command(
   id = "input.teachClick",
   group = "input",
   summary = "Capture a target window before and after a human-taught click, recording global and window-local click coordinates for automation debugging.",
-  driver = "macos.desktop",
-  operation = "teach_click",
   args = WINDOW_ARGS,
-  disturbance = POINTER_WITH_FOREGROUND,
-  max_disturbance = OperationDisturbance::Pointer,
-  artifacts = ["input-action-result"],
-  signals = ["input.method"],
-  verification = "activation-only; semantic success requires a separate verification result",
 )]
-pub fn teach_click(context: InvokeContext<'_>, command: &InvokeCommand) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn teach_click() {}
 
 #[invoke_command(
   id = "input.scrollPoint",
   group = "input",
-  summary = "Scroll at a macOS global logical point through Quartz and record its display contract.",
-  driver = "macos.desktop",
-  operation = "scroll_point",
+  summary = "Scroll at a macOS global logical point through Quartz.",
   args = TARGET_ARGS,
-  disturbance = POINTER_WITH_FOREGROUND,
-  max_disturbance = OperationDisturbance::Pointer,
-  artifacts = ["input-action-result"],
-  signals = ["input.method"],
-  verification = "activation-only; semantic success requires a separate verification result",
 )]
-pub fn scroll_point(context: InvokeContext<'_>, command: &InvokeCommand) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn scroll_point() {}

--- a/crates/auv-cli-invoke/src/commands/media_control.rs
+++ b/crates/auv-cli-invoke/src/commands/media_control.rs
@@ -1,11 +1,4 @@
-use auv_driver::{OperationDisturbance, OperationNamespace};
-
-use crate::{
-  CommandGroup, InvokeCommand, InvokeContext, InvokeDriverDispatch,
-  arg::NO_ARGS,
-  command::{MEDIA_TRANSPORT, NONE},
-  default_driver_dispatch, invoke_command,
-};
+use crate::{CommandGroup, arg::NO_ARGS, invoke_command};
 
 pub fn group() -> CommandGroup {
   CommandGroup::new("mediaControl", "MEDIA CONTROL")
@@ -21,123 +14,46 @@ pub fn group() -> CommandGroup {
   id = "mediaControl.nowPlaying",
   group = "mediaControl",
   summary = "Read structured now-playing media state from the desktop backend.",
-  driver = "macos.desktop",
-  operation = "media_control_now_playing",
   args = NO_ARGS,
-  disturbance = NONE,
-  max_disturbance = OperationDisturbance::None,
-  artifacts = ["now-playing-v0"],
-  signals = ["mediaControl.present", "mediaControl.title", "mediaControl.isPlaying", "mediaControl.sourceBundleId", "mediaControl.verification"],
-  verification = "read-only; verified means the backend returned a structured state",
 )]
-pub fn media_control_now_playing(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn media_control_now_playing() {}
 
 #[invoke_command(
   id = "mediaControl.play",
   group = "mediaControl",
-  operation_namespace = OperationNamespace::Action,
   summary = "Send a generic system media play command and read now-playing state for verification.",
-  driver = "macos.desktop",
-  operation = "media_control_play",
   args = NO_ARGS,
-  disturbance = MEDIA_TRANSPORT,
-  max_disturbance = OperationDisturbance::Keyboard,
-  artifacts = ["now-playing-v0"],
-  signals = ["mediaControl.present", "mediaControl.title", "mediaControl.isPlaying", "mediaControl.sourceBundleId", "mediaControl.verification"],
-  verification = "verified when playback is present and playing after the command; otherwise inconclusive",
 )]
-pub fn media_control_play(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn media_control_play() {}
 
 #[invoke_command(
   id = "mediaControl.pause",
   group = "mediaControl",
-  operation_namespace = OperationNamespace::Action,
   summary = "Send a generic system media pause command and read now-playing state for verification.",
-  driver = "macos.desktop",
-  operation = "media_control_pause",
   args = NO_ARGS,
-  disturbance = MEDIA_TRANSPORT,
-  max_disturbance = OperationDisturbance::Keyboard,
-  artifacts = ["now-playing-v0"],
-  signals = ["mediaControl.present", "mediaControl.title", "mediaControl.isPlaying", "mediaControl.sourceBundleId", "mediaControl.verification"],
-  verification = "verified when playback is present and paused after the command; otherwise inconclusive",
 )]
-pub fn media_control_pause(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn media_control_pause() {}
 
 #[invoke_command(
   id = "mediaControl.togglePlayPause",
   group = "mediaControl",
-  operation_namespace = OperationNamespace::Action,
   summary = "Send a generic system media play/pause toggle command and compare now-playing state before and after.",
-  driver = "macos.desktop",
-  operation = "media_control_toggle_play_pause",
   args = NO_ARGS,
-  disturbance = MEDIA_TRANSPORT,
-  max_disturbance = OperationDisturbance::Keyboard,
-  artifacts = ["now-playing-v0"],
-  signals = ["mediaControl.present", "mediaControl.title", "mediaControl.isPlaying", "mediaControl.sourceBundleId", "mediaControl.verification"],
-  verification = "verified when observed playback state changes after the command; otherwise inconclusive",
 )]
-pub fn media_control_toggle_play_pause(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn media_control_toggle_play_pause() {}
 
 #[invoke_command(
   id = "mediaControl.next",
   group = "mediaControl",
-  operation_namespace = OperationNamespace::Action,
   summary = "Send a generic system media next-track command and compare now-playing identity before and after.",
-  driver = "macos.desktop",
-  operation = "media_control_next",
   args = NO_ARGS,
-  disturbance = MEDIA_TRANSPORT,
-  max_disturbance = OperationDisturbance::Keyboard,
-  artifacts = ["now-playing-v0"],
-  signals = ["mediaControl.present", "mediaControl.title", "mediaControl.isPlaying", "mediaControl.sourceBundleId", "mediaControl.verification"],
-  verification = "verified when content identity or title changes after the command; otherwise inconclusive",
 )]
-pub fn media_control_next(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn media_control_next() {}
 
 #[invoke_command(
   id = "mediaControl.previous",
   group = "mediaControl",
-  operation_namespace = OperationNamespace::Action,
   summary = "Send a generic system media previous-track command and compare now-playing identity before and after.",
-  driver = "macos.desktop",
-  operation = "media_control_previous",
   args = NO_ARGS,
-  disturbance = MEDIA_TRANSPORT,
-  max_disturbance = OperationDisturbance::Keyboard,
-  artifacts = ["now-playing-v0"],
-  signals = ["mediaControl.present", "mediaControl.title", "mediaControl.isPlaying", "mediaControl.sourceBundleId", "mediaControl.verification"],
-  verification = "verified when content identity or title changes after the command; otherwise inconclusive",
 )]
-pub fn media_control_previous(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn media_control_previous() {}

--- a/crates/auv-cli-invoke/src/commands/overlay.rs
+++ b/crates/auv-cli-invoke/src/commands/overlay.rs
@@ -1,10 +1,7 @@
-use auv_driver::OperationDisturbance;
-
 use crate::{
-  CommandGroup, InvokeCommand, InvokeContext, InvokeDriverDispatch,
+  CommandGroup,
   arg::{NO_ARGS, TARGET_ARGS},
-  command::{NONE, POINTER_WITH_FOREGROUND},
-  default_driver_dispatch, invoke_command,
+  invoke_command,
 };
 
 pub fn group() -> CommandGroup {
@@ -27,238 +24,94 @@ pub fn group() -> CommandGroup {
   id = "overlay.clickPoint",
   group = "overlay",
   summary = "Move the visual AUV cursor to a target point, click, flash the click-state cursor, then hide overlay. The real cursor visibly warps to the click target and back (cursorDisturbance=warp-visible).",
-  driver = "macos.desktop",
-  operation = "overlay_click_point",
   args = TARGET_ARGS,
-  disturbance = POINTER_WITH_FOREGROUND,
-  max_disturbance = OperationDisturbance::Pointer,
-  artifacts = ["input-action-result"],
-  signals = ["overlay.cursor"],
-  verification = "visualization-only; semantic success requires a separate verification result",
 )]
-pub fn overlay_click_point(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn overlay_click_point() {}
 
 #[invoke_command(
   id = "overlay.showCursor",
   group = "overlay",
   summary = "Show a visual-only AUV cursor label overlay inside the current process.",
-  driver = "macos.desktop",
-  operation = "overlay_show_cursor",
   args = NO_ARGS,
-  disturbance = NONE,
-  max_disturbance = OperationDisturbance::None,
-  artifacts = [],
-  signals = ["overlay.cursor"],
-  verification = "visualization-only; no semantic success claim",
 )]
-pub fn overlay_show_cursor(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn overlay_show_cursor() {}
 
 #[invoke_command(
   id = "overlay.showDualCursor",
   group = "overlay",
   summary = "Show visual-only dual cursor overlays: AUV at a target point and You at the current hardware cursor.",
-  driver = "macos.desktop",
-  operation = "overlay_show_dual_cursor",
   args = NO_ARGS,
-  disturbance = NONE,
-  max_disturbance = OperationDisturbance::None,
-  artifacts = [],
-  signals = ["overlay.cursor"],
-  verification = "visualization-only; no semantic success claim",
 )]
-pub fn overlay_show_dual_cursor(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn overlay_show_dual_cursor() {}
 
 #[invoke_command(
   id = "overlay.applyCursorBatch",
   group = "overlay",
   summary = "Apply a JSON batch of visual-only overlay cursor operations in one process.",
-  driver = "macos.desktop",
-  operation = "overlay_apply_cursor_batch",
   args = NO_ARGS,
-  disturbance = NONE,
-  max_disturbance = OperationDisturbance::None,
-  artifacts = [],
-  signals = ["overlay.cursor"],
-  verification = "visualization-only; no semantic success claim",
 )]
-pub fn overlay_apply_cursor_batch(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn overlay_apply_cursor_batch() {}
 
 #[invoke_command(
   id = "overlay.setCursor",
   group = "overlay",
   summary = "Show or update one visual-only overlay cursor by cursor_id.",
-  driver = "macos.desktop",
-  operation = "overlay_set_cursor",
   args = NO_ARGS,
-  disturbance = NONE,
-  max_disturbance = OperationDisturbance::None,
-  artifacts = [],
-  signals = ["overlay.cursor"],
-  verification = "visualization-only; no semantic success claim",
 )]
-pub fn overlay_set_cursor(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn overlay_set_cursor() {}
 
 #[invoke_command(
   id = "overlay.moveCursor",
   group = "overlay",
   summary = "Animate the visual-only AUV cursor from the current hardware cursor toward a target point.",
-  driver = "macos.desktop",
-  operation = "overlay_move_cursor",
   args = NO_ARGS,
-  disturbance = NONE,
-  max_disturbance = OperationDisturbance::None,
-  artifacts = [],
-  signals = ["overlay.cursor"],
-  verification = "visualization-only; no semantic success claim",
 )]
-pub fn overlay_move_cursor(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn overlay_move_cursor() {}
 
 #[invoke_command(
   id = "overlay.moveCursorById",
   group = "overlay",
   summary = "Animate one visual-only overlay cursor by cursor_id, reusing its previous position when available.",
-  driver = "macos.desktop",
-  operation = "overlay_move_cursor_by_id",
   args = NO_ARGS,
-  disturbance = NONE,
-  max_disturbance = OperationDisturbance::None,
-  artifacts = [],
-  signals = ["overlay.cursor"],
-  verification = "visualization-only; no semantic success claim",
 )]
-pub fn overlay_move_cursor_by_id(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn overlay_move_cursor_by_id() {}
 
 #[invoke_command(
   id = "overlay.flashCursor",
   group = "overlay",
   summary = "Flash the AUV click-state cursor sprite at a target point.",
-  driver = "macos.desktop",
-  operation = "overlay_flash_cursor",
   args = NO_ARGS,
-  disturbance = NONE,
-  max_disturbance = OperationDisturbance::None,
-  artifacts = [],
-  signals = ["overlay.cursor"],
-  verification = "visualization-only; no semantic success claim",
 )]
-pub fn overlay_flash_cursor(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn overlay_flash_cursor() {}
 
 #[invoke_command(
   id = "overlay.flashCursorById",
   group = "overlay",
   summary = "Flash the AUV click-state cursor sprite for one overlay cursor_id.",
-  driver = "macos.desktop",
-  operation = "overlay_flash_cursor_by_id",
   args = NO_ARGS,
-  disturbance = NONE,
-  max_disturbance = OperationDisturbance::None,
-  artifacts = [],
-  signals = ["overlay.cursor"],
-  verification = "visualization-only; no semantic success claim",
 )]
-pub fn overlay_flash_cursor_by_id(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn overlay_flash_cursor_by_id() {}
 
 #[invoke_command(
   id = "overlay.hideCursorId",
   group = "overlay",
   summary = "Hide one visual-only overlay cursor by cursor_id.",
-  driver = "macos.desktop",
-  operation = "overlay_hide_cursor_id",
   args = NO_ARGS,
-  disturbance = NONE,
-  max_disturbance = OperationDisturbance::None,
-  artifacts = [],
-  signals = ["overlay.cursor"],
-  verification = "visualization-only; no semantic success claim",
 )]
-pub fn overlay_hide_cursor_id(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn overlay_hide_cursor_id() {}
 
 #[invoke_command(
   id = "overlay.hideCursor",
   group = "overlay",
   summary = "Hide the visual-only AUV cursor label overlay inside the current process.",
-  driver = "macos.desktop",
-  operation = "overlay_hide_cursor",
   args = NO_ARGS,
-  disturbance = NONE,
-  max_disturbance = OperationDisturbance::None,
-  artifacts = [],
-  signals = ["overlay.cursor"],
-  verification = "visualization-only; no semantic success claim",
 )]
-pub fn overlay_hide_cursor(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn overlay_hide_cursor() {}
 
 #[invoke_command(
   id = "overlay.shutdown",
   group = "overlay",
   summary = "Shut down the visual-only AUV cursor overlay inside the current process.",
-  driver = "macos.desktop",
-  operation = "overlay_shutdown",
   args = NO_ARGS,
-  disturbance = NONE,
-  max_disturbance = OperationDisturbance::None,
-  artifacts = [],
-  signals = ["overlay.shutdown"],
-  verification = "visualization-only; no semantic success claim",
 )]
-pub fn overlay_shutdown(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn overlay_shutdown() {}

--- a/crates/auv-cli-invoke/src/commands/screen.rs
+++ b/crates/auv-cli-invoke/src/commands/screen.rs
@@ -1,10 +1,7 @@
-use auv_driver::OperationDisturbance;
-
 use crate::{
-  CommandGroup, InvokeCommand, InvokeContext, InvokeDriverDispatch,
+  CommandGroup,
   arg::{IMAGE_TEXT_ARGS, REGION_ARGS, SCREEN_TEXT_ARGS, TARGET_ARGS},
-  command::{NONE, NONE_OR_FOREGROUND, POINTER_WITH_FOREGROUND},
-  default_driver_dispatch, invoke_command,
+  invoke_command,
 };
 
 pub fn group() -> CommandGroup {
@@ -23,155 +20,62 @@ pub fn group() -> CommandGroup {
   id = "screen.captureRegion",
   group = "screen",
   summary = "Capture one display-contained region and emit a coordinate contract. If activate_target_before_capture is true, the target app is foregrounded first.",
-  driver = "macos.desktop",
-  operation = "capture_region",
   args = REGION_ARGS,
-  disturbance = NONE_OR_FOREGROUND,
-  max_disturbance = OperationDisturbance::ForegroundApp,
-  artifacts = ["region-capture", "capture-contract"],
-  signals = [],
-  verification = "capture-only; no semantic success claim",
 )]
-pub fn capture_region(context: InvokeContext<'_>, command: &InvokeCommand) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn capture_region() {}
 
 #[invoke_command(
   id = "screen.findText",
   group = "screen",
   summary = "Capture a screenshot and locate OCR text anchors in screenshot pixel space. If activate_target_before_capture is true, the target app is foregrounded first.",
-  driver = "macos.desktop",
-  operation = "find_screen_text",
   args = SCREEN_TEXT_ARGS,
-  disturbance = NONE_OR_FOREGROUND,
-  max_disturbance = OperationDisturbance::ForegroundApp,
-  artifacts = ["recognition-result"],
-  signals = ["candidate.count"],
-  verification = "recognition-only; no semantic success claim",
 )]
-pub fn find_screen_text(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn find_screen_text() {}
 
 #[invoke_command(
   id = "screen.waitForText",
   group = "screen",
   summary = "Poll live-desktop OCR until a target text anchor appears or the timeout expires. If activate_target_before_capture is true, the target app is foregrounded before each capture attempt.",
-  driver = "macos.desktop",
-  operation = "wait_for_screen_text",
   args = SCREEN_TEXT_ARGS,
-  disturbance = NONE_OR_FOREGROUND,
-  max_disturbance = OperationDisturbance::ForegroundApp,
-  artifacts = ["recognition-result"],
-  signals = ["candidate.count"],
-  verification = "recognition-only; no semantic success claim",
 )]
-pub fn wait_for_screen_text(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn wait_for_screen_text() {}
 
 #[invoke_command(
   id = "screen.findRows",
   group = "screen",
   summary = "Detect visible OCR row bands inside a constrained screen region without depending on one exact anchor string. If activate_target_before_capture is true, the target app is foregrounded first.",
-  driver = "macos.desktop",
-  operation = "find_screen_rows",
   args = TARGET_ARGS,
-  disturbance = NONE_OR_FOREGROUND,
-  max_disturbance = OperationDisturbance::ForegroundApp,
-  artifacts = ["recognition-result"],
-  signals = ["candidate.count"],
-  verification = "recognition-only; no semantic success claim",
 )]
-pub fn find_screen_rows(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn find_screen_rows() {}
 
 #[invoke_command(
   id = "screen.waitForRows",
   group = "screen",
   summary = "Poll live-desktop OCR row detection until at least a target number of visible rows appears or the timeout expires. If activate_target_before_capture is true, the target app is foregrounded before each capture attempt.",
-  driver = "macos.desktop",
-  operation = "wait_for_screen_rows",
   args = TARGET_ARGS,
-  disturbance = NONE_OR_FOREGROUND,
-  max_disturbance = OperationDisturbance::ForegroundApp,
-  artifacts = ["recognition-result"],
-  signals = ["candidate.count"],
-  verification = "recognition-only; no semantic success claim",
 )]
-pub fn wait_for_screen_rows(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn wait_for_screen_rows() {}
 
 #[invoke_command(
   id = "screen.findImageText",
   group = "screen",
   summary = "Locate OCR text anchors inside an existing image artifact without touching the live desktop.",
-  driver = "macos.desktop",
-  operation = "find_image_text",
   args = IMAGE_TEXT_ARGS,
-  disturbance = NONE,
-  max_disturbance = OperationDisturbance::None,
-  artifacts = ["recognition-result"],
-  signals = ["candidate.count"],
-  verification = "recognition-only; no semantic success claim",
 )]
-pub fn find_image_text(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn find_image_text() {}
 
 #[invoke_command(
   id = "screen.clickText",
   group = "screen",
   summary = "Capture a screenshot, resolve an OCR text anchor, and click its projected logical point. If activate_target_before_capture is true, the target app is foregrounded before capture.",
-  driver = "macos.desktop",
-  operation = "click_screen_text",
   args = SCREEN_TEXT_ARGS,
-  disturbance = POINTER_WITH_FOREGROUND,
-  max_disturbance = OperationDisturbance::Pointer,
-  artifacts = ["input-action-result"],
-  signals = ["input.method"],
-  verification = "activation-only; semantic success requires a separate verification result",
 )]
-pub fn click_screen_text(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn click_screen_text() {}
 
 #[invoke_command(
   id = "screen.clickRow",
   group = "screen",
   summary = "Detect visible OCR row bands inside a constrained screen region and click a chosen row-derived point. If activate_target_before_capture is true, the target app is foregrounded before capture.",
-  driver = "macos.desktop",
-  operation = "click_screen_row",
   args = TARGET_ARGS,
-  disturbance = POINTER_WITH_FOREGROUND,
-  max_disturbance = OperationDisturbance::Pointer,
-  artifacts = ["input-action-result"],
-  signals = ["input.method"],
-  verification = "activation-only; semantic success requires a separate verification result",
 )]
-pub fn click_screen_row(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn click_screen_row() {}

--- a/crates/auv-cli-invoke/src/commands/steam.rs
+++ b/crates/auv-cli-invoke/src/commands/steam.rs
@@ -1,9 +1,4 @@
-use auv_driver::OperationDisturbance;
-
-use crate::{
-  CommandGroup, InvokeCommand, InvokeContext, InvokeDriverDispatch, arg::NO_ARGS, command::NONE,
-  default_driver_dispatch, invoke_command,
-};
+use crate::{CommandGroup, arg::NO_ARGS, invoke_command};
 
 pub fn group() -> CommandGroup {
   CommandGroup::new("steam", "STEAM").command(steam_library_list_invoke_command())
@@ -13,18 +8,6 @@ pub fn group() -> CommandGroup {
   id = "steam.library.list.v0",
   group = "steam",
   summary = "List installed Steam library apps from local appmanifest files.",
-  driver = "steam.local",
-  operation = "steam_library_list",
   args = NO_ARGS,
-  disturbance = NONE,
-  max_disturbance = OperationDisturbance::None,
-  artifacts = ["steam-library-list"],
-  signals = ["steam.library.source", "steam.library.status", "steam.library.app_count"],
-  verification = "read-only; verified means local Steam appmanifest data was read",
 )]
-pub fn steam_library_list(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn steam_library_list() {}

--- a/crates/auv-cli-invoke/src/commands/window.rs
+++ b/crates/auv-cli-invoke/src/commands/window.rs
@@ -1,10 +1,7 @@
-use auv_driver::{OperationDisturbance, OperationNamespace};
-
 use crate::{
-  CommandGroup, InvokeCommand, InvokeContext, InvokeDriverDispatch,
+  CommandGroup,
   arg::{NO_ARGS, WINDOW_ARGS, WINDOW_TEXT_ARGS, WINDOW_VERIFY_TEXT_ARGS},
-  command::{CAPTURE_AX_TREE_DISTURBANCE, NONE, NONE_OR_FOREGROUND, POINTER_WITH_FOREGROUND},
-  default_driver_dispatch, invoke_command,
+  invoke_command,
 };
 
 pub fn group() -> CommandGroup {
@@ -28,250 +25,102 @@ pub fn group() -> CommandGroup {
   id = "window.list",
   group = "window",
   summary = "List visible macOS window candidates using the normalized AUV window selector model.",
-  driver = "macos.desktop",
-  operation = "list_windows",
   args = NO_ARGS,
-  disturbance = NONE,
-  max_disturbance = OperationDisturbance::None,
-  artifacts = [],
-  signals = ["window.count"],
-  verification = "read-only; no semantic success claim",
 )]
-pub fn list_windows(context: InvokeContext<'_>, command: &InvokeCommand) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn list_windows() {}
 
 #[invoke_command(
   id = "window.capture",
   group = "window",
   summary = "Capture one single-display window and emit a coordinate contract. If activate_target_before_capture is true, the target app is foregrounded first.",
-  driver = "macos.desktop",
-  operation = "capture_window",
   args = WINDOW_ARGS,
-  disturbance = NONE_OR_FOREGROUND,
-  max_disturbance = OperationDisturbance::ForegroundApp,
-  artifacts = ["window-capture", "capture-contract"],
-  signals = [],
-  verification = "capture-only; no semantic success claim",
 )]
-pub fn capture_window(context: InvokeContext<'_>, command: &InvokeCommand) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn capture_window() {}
 
 #[invoke_command(
   id = "window.captureAxTree",
   group = "window",
   summary = "Capture an AX tree snapshot for a target macOS app window.",
-  driver = "macos.desktop",
-  operation = "capture_ax_tree",
   args = WINDOW_ARGS,
-  disturbance = CAPTURE_AX_TREE_DISTURBANCE,
-  max_disturbance = OperationDisturbance::Keyboard,
-  artifacts = ["ax-tree"],
-  signals = [],
-  verification = "capture-only; no semantic success claim",
 )]
-pub fn capture_ax_tree(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn capture_ax_tree() {}
 
 #[invoke_command(
   id = "window.findText",
   group = "window",
   summary = "Capture a resolved window and locate OCR text anchors in window pixel space.",
-  driver = "macos.desktop",
-  operation = "find_window_text",
   args = WINDOW_TEXT_ARGS,
-  disturbance = NONE,
-  max_disturbance = OperationDisturbance::None,
-  artifacts = ["recognition-result"],
-  signals = ["candidate.count"],
-  verification = "recognition-only; no semantic success claim",
 )]
-pub fn find_window_text(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn find_window_text() {}
 
 #[invoke_command(
   id = "window.waitForText",
   group = "window",
   summary = "Poll resolved-window OCR until a text anchor appears or the timeout expires.",
-  driver = "macos.desktop",
-  operation = "wait_for_window_text",
   args = WINDOW_TEXT_ARGS,
-  disturbance = NONE,
-  max_disturbance = OperationDisturbance::None,
-  artifacts = ["recognition-result"],
-  signals = ["candidate.count"],
-  verification = "recognition-only; no semantic success claim",
 )]
-pub fn wait_for_window_text(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn wait_for_window_text() {}
 
 #[invoke_command(
   id = "window.findRows",
   group = "window",
   summary = "Detect visible OCR row bands inside a resolved window.",
-  driver = "macos.desktop",
-  operation = "find_window_rows",
   args = WINDOW_ARGS,
-  disturbance = NONE,
-  max_disturbance = OperationDisturbance::None,
-  artifacts = ["recognition-result"],
-  signals = ["candidate.count"],
-  verification = "recognition-only; no semantic success claim",
 )]
-pub fn find_window_rows(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn find_window_rows() {}
 
 #[invoke_command(
   id = "window.waitForRows",
   group = "window",
   summary = "Poll resolved-window row detection until enough rows appear or the timeout expires.",
-  driver = "macos.desktop",
-  operation = "wait_for_window_rows",
   args = WINDOW_ARGS,
-  disturbance = NONE,
-  max_disturbance = OperationDisturbance::None,
-  artifacts = ["recognition-result"],
-  signals = ["candidate.count"],
-  verification = "recognition-only; no semantic success claim",
 )]
-pub fn wait_for_window_rows(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn wait_for_window_rows() {}
 
 #[invoke_command(
   id = "window.observeRegion",
   group = "window",
   summary = "Observe OCR row-like content inside a resolved macOS window region without scrolling.",
-  driver = "macos.desktop",
-  operation = "observe_window_region",
   args = WINDOW_ARGS,
-  disturbance = NONE,
-  max_disturbance = OperationDisturbance::None,
-  artifacts = ["recognition-result"],
-  signals = ["candidate.count"],
-  verification = "recognition-only; no semantic success claim",
 )]
-pub fn observe_window_region(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn observe_window_region() {}
 
 #[invoke_command(
   id = "window.findIconMatch",
   group = "window",
   summary = "Match a template image against a resolved macOS window screenshot using NCC and emit a RecognitionResult artifact.",
-  driver = "macos.desktop",
-  operation = "find_icon_match",
   args = WINDOW_ARGS,
-  disturbance = NONE,
-  max_disturbance = OperationDisturbance::None,
-  artifacts = ["recognition-result"],
-  signals = ["candidate.count"],
-  verification = "recognition-only; no semantic success claim",
 )]
-pub fn find_icon_match(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn find_icon_match() {}
 
 #[invoke_command(
   id = "window.scrollRegion",
   group = "window",
   summary = "Scroll at the center of a resolved macOS window region and record scroll evidence.",
-  driver = "macos.desktop",
-  operation = "scroll_window_region",
   args = WINDOW_ARGS,
-  disturbance = POINTER_WITH_FOREGROUND,
-  max_disturbance = OperationDisturbance::Pointer,
-  artifacts = ["input-action-result"],
-  signals = ["input.method"],
-  verification = "activation-only; semantic success requires a separate verification result",
 )]
-pub fn scroll_window_region(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn scroll_window_region() {}
 
 #[invoke_command(
   id = "window.verifyText",
   group = "window",
-  operation_namespace = OperationNamespace::Verify,
   summary = "Verify that a text-bearing AX node exists in the observed tree without relying on screenshot OCR.",
-  driver = "macos.desktop",
-  operation = "verify_ax_text",
   args = WINDOW_VERIFY_TEXT_ARGS,
-  disturbance = NONE,
-  max_disturbance = OperationDisturbance::None,
-  artifacts = ["verification-result"],
-  signals = ["verification.matched"],
-  verification = "AX/window text verification; success requires a typed VerificationResult match",
 )]
-pub fn verify_ax_text(context: InvokeContext<'_>, command: &InvokeCommand) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn verify_ax_text() {}
 
 #[invoke_command(
   id = "window.clickText",
   group = "window",
   summary = "Capture a resolved window, resolve an OCR text anchor, and click its projected logical point.",
-  driver = "macos.desktop",
-  operation = "click_window_text",
   args = WINDOW_TEXT_ARGS,
-  disturbance = POINTER_WITH_FOREGROUND,
-  max_disturbance = OperationDisturbance::Pointer,
-  artifacts = ["input-action-result"],
-  signals = ["input.method"],
-  verification = "activation-only; semantic success requires a separate verification result",
 )]
-pub fn click_window_text(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn click_window_text() {}
 
 #[invoke_command(
   id = "window.clickRow",
   group = "window",
   summary = "Capture a resolved window, detect visible rows, and click a row-derived projected logical point.",
-  driver = "macos.desktop",
-  operation = "click_window_row",
   args = WINDOW_ARGS,
-  disturbance = POINTER_WITH_FOREGROUND,
-  max_disturbance = OperationDisturbance::Pointer,
-  artifacts = ["input-action-result"],
-  signals = ["input.method"],
-  verification = "activation-only; semantic success requires a separate verification result",
 )]
-pub fn click_window_row(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn click_window_row() {}

--- a/crates/auv-cli-invoke/src/help.rs
+++ b/crates/auv-cli-invoke/src/help.rs
@@ -34,9 +34,9 @@ fn render_group_index(help: &mut String, group: &CommandGroup, depth: usize) {
     match child {
       CommandNode::Command(command) => {
         help.push_str(&"  ".repeat(depth + 1));
-        help.push_str(command.operation.id);
+        help.push_str(command.id);
         help.push_str("  ");
-        help.push_str(command.operation.summary);
+        help.push_str(command.summary);
         help.push('\n');
       }
       CommandNode::Group(group) => render_group_index(help, group, depth + 1),
@@ -53,13 +53,11 @@ fn has_commands(group: &CommandGroup) -> bool {
 
 pub fn render_command_help(command: &InvokeCommand) -> String {
   let mut help = format!(
-    "COMMAND\n  {}\n\nUSAGE\n  auv-cli invoke {}{}\n\nDRIVER\n  {}.{}\n\nSUMMARY\n  {}\n",
-    command.operation.id,
-    command.operation.id,
+    "COMMAND\n  {}\n\nUSAGE\n  auv-cli invoke {}{}\n\nSUMMARY\n  {}\n",
+    command.id,
+    command.id,
     render_usage_args(command.args),
-    command.operation.driver_id,
-    command.operation.operation,
-    command.operation.summary
+    command.summary
   );
 
   help.push_str("\nOPTIONS\n");
@@ -81,24 +79,6 @@ pub fn render_command_help(command: &InvokeCommand) -> String {
     }
   }
 
-  help.push_str("\nDISTURBANCE\n");
-  help.push_str("  max: ");
-  help.push_str(command.operation.max_disturbance.as_str());
-  help.push('\n');
-  for disturbance in command.operation.disturbance_classes {
-    help.push_str("  ");
-    help.push_str(disturbance.as_str());
-    help.push('\n');
-  }
-
-  help.push_str("\nARTIFACTS\n");
-  help.push_str(&render_list(command.artifacts));
-  help.push_str("\nSIGNALS\n");
-  help.push_str(&render_list(command.signals));
-  help.push_str("\nVERIFY\n  ");
-  help.push_str(command.verification);
-  help.push('\n');
-
   help
 }
 
@@ -117,18 +97,4 @@ fn render_usage_args(args: &[ArgSpec]) -> String {
     }
   }
   usage
-}
-
-fn render_list(items: &[&str]) -> String {
-  if items.is_empty() {
-    return "  none\n".to_string();
-  }
-
-  let mut output = String::new();
-  for item in items {
-    output.push_str("  ");
-    output.push_str(item);
-    output.push('\n');
-  }
-  output
 }

--- a/crates/auv-cli-invoke/src/lib.rs
+++ b/crates/auv-cli-invoke/src/lib.rs
@@ -1,7 +1,9 @@
 //! Registry-backed CLI invoke metadata and help rendering.
 //!
-//! `auv-driver` owns the operation contract. This crate owns how those
-//! operations are exposed as explicit `auv-cli invoke ...` commands.
+//! This crate owns how invoke-visible commands are described, grouped, and
+//! parsed for `auv-cli invoke ...`.
+
+use std::collections::BTreeMap;
 
 extern crate self as auv_cli_invoke;
 
@@ -13,42 +15,91 @@ pub mod registry;
 
 pub use arg::ArgSpec;
 pub use auv_cli_invoke_macros::invoke_command;
-pub use command::{
-  CommandGroup, CommandNode, InvokeCommand, InvokeCommandHandler, InvokeContext,
-  InvokeDriverDispatch, InvokeNamespace, default_driver_dispatch,
-};
+pub use command::{CommandGroup, CommandNode, InvokeCommand, InvokeNamespace};
 pub use help::{render_command_help, render_help_index};
 pub use registry::{InvokeRegistry, default_registry};
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum InvokeCliParse {
+  Help {
+    command_id: Option<String>,
+  },
+  Invoke {
+    command_id: String,
+    target_application_id: Option<String>,
+    inputs: BTreeMap<String, String>,
+    dry_run: bool,
+  },
+}
+
+pub fn parse_invoke_args(arguments: &[String]) -> Result<InvokeCliParse, String> {
+  if arguments.len() < 2 {
+    return Ok(InvokeCliParse::Help { command_id: None });
+  }
+
+  if matches!(arguments[1].as_str(), "--help" | "-h" | "help") {
+    return Ok(InvokeCliParse::Help { command_id: None });
+  }
+
+  let command_id = arguments[1].clone();
+  if arguments.len() == 3 && matches!(arguments[2].as_str(), "--help" | "-h") {
+    return Ok(InvokeCliParse::Help {
+      command_id: Some(command_id),
+    });
+  }
+
+  let mut target_application_id = None;
+  let mut inputs = BTreeMap::new();
+  let mut dry_run = false;
+  let mut index = 2;
+
+  while index < arguments.len() {
+    let argument = &arguments[index];
+    if !argument.starts_with("--") {
+      return Err(format!("unexpected positional argument {argument}"));
+    }
+
+    if argument == "--dry-run" {
+      dry_run = true;
+      index += 1;
+      continue;
+    }
+
+    if index + 1 >= arguments.len() {
+      return Err(format!("flag {argument} requires a value"));
+    }
+
+    let value = arguments[index + 1].clone();
+    match argument.as_str() {
+      "--target" => {
+        target_application_id = Some(value);
+      }
+      "--label" => {
+        inputs.insert("label".to_string(), value);
+      }
+      other => {
+        let key = other.trim_start_matches("--");
+        inputs.insert(key.to_string(), value);
+      }
+    }
+
+    index += 2;
+  }
+
+  Ok(InvokeCliParse::Invoke {
+    command_id,
+    target_application_id,
+    inputs,
+    dry_run,
+  })
+}
+
 #[cfg(test)]
 mod tests {
-  use auv_driver::{OperationDisturbance, OperationNamespace};
-
   use super::{
-    CommandGroup, InvokeCommand, InvokeContext, InvokeDriverDispatch, InvokeNamespace,
-    InvokeRegistry, default_driver_dispatch, default_registry, invoke_command, render_command_help,
+    CommandGroup, InvokeNamespace, InvokeRegistry, default_registry, render_command_help,
     render_help_index,
   };
-
-  #[invoke_command(
-    id = "test.generated",
-    group = "fixture",
-    summary = "Generated test command.",
-    driver = "fixture.observe",
-    operation = "observe_fixture_scene",
-    args = crate::arg::NO_ARGS,
-    disturbance = crate::command::NONE,
-    max_disturbance = auv_driver::OperationDisturbance::None,
-    artifacts = ["operation-result"],
-    signals = ["fixture.scene"],
-    verification = "read-only; no semantic success claim",
-  )]
-  fn generated_test_command_handler(
-    context: InvokeContext<'_>,
-    command: &InvokeCommand,
-  ) -> InvokeDriverDispatch {
-    default_driver_dispatch(context, command)
-  }
 
   #[test]
   fn help_index_groups_commands_by_namespace() {
@@ -68,56 +119,6 @@ mod tests {
     assert!(!help.contains("debug."));
     assert!(!help.contains("verify."));
     assert!(!help.contains("music."));
-  }
-
-  #[test]
-  fn command_help_describes_arguments_and_verification() {
-    let registry = default_registry();
-    let command = registry
-      .resolve("window.capture")
-      .expect("window.capture should be registered");
-    let help = render_command_help(command);
-
-    assert!(help.contains("COMMAND\n  window.capture"));
-    assert!(help.contains("DRIVER\n  macos.desktop.capture_window"));
-    assert!(help.contains("--target APP  optional"));
-    assert!(help.contains("ARTIFACTS\n  window-capture\n  capture-contract"));
-    assert!(help.contains("VERIFY\n  capture-only; no semantic success claim"));
-  }
-
-  #[test]
-  fn command_help_uses_driver_input_flags_for_concrete_commands() {
-    let registry = default_registry();
-    let command = registry
-      .resolve("input.typeText")
-      .expect("input.typeText should be registered");
-    let help = render_command_help(command);
-
-    assert!(help.contains("USAGE\n  auv-cli invoke input.typeText [--target APP] --text TEXT"));
-    assert!(help.contains("--text TEXT  required"));
-    assert!(help.contains("DISTURBANCE\n  max: keyboard"));
-  }
-
-  #[test]
-  fn default_registry_sets_underlying_operation_namespaces() {
-    let registry = default_registry();
-    for (id, expected) in [
-      ("input.key", OperationNamespace::Action),
-      ("app.activate", OperationNamespace::Action),
-      ("overlay.showCursor", OperationNamespace::Overlay),
-      ("window.verifyText", OperationNamespace::Verify),
-      ("display.list", OperationNamespace::Observe),
-      ("mediaControl.nowPlaying", OperationNamespace::Observe),
-      ("mediaControl.play", OperationNamespace::Action),
-      ("mediaControl.pause", OperationNamespace::Action),
-      ("mediaControl.togglePlayPause", OperationNamespace::Action),
-      ("mediaControl.next", OperationNamespace::Action),
-      ("mediaControl.previous", OperationNamespace::Action),
-      ("steam.library.list.v0", OperationNamespace::Observe),
-    ] {
-      let command = registry.resolve(id).expect("command should be registered");
-      assert_eq!(command.operation.namespace, expected, "{id}");
-    }
   }
 
   #[test]
@@ -152,57 +153,71 @@ mod tests {
   }
 
   #[test]
-  fn command_handler_builds_default_driver_dispatch() {
+  fn command_metadata_preserves_invoke_surface() {
     let registry = default_registry();
     let command = registry
       .resolve("fixture.observe")
       .expect("fixture.observe should be registered");
-    let mut inputs = std::collections::BTreeMap::new();
-    inputs.insert("scene".to_string(), "demo".to_string());
-    let context = crate::InvokeContext {
-      target_application_id: Some("com.example.App"),
-      target_label: Some("Example"),
-      inputs: &inputs,
-    };
 
-    let dispatch = command.dispatch(context);
-
-    assert_eq!(dispatch.command_id, "fixture.observe");
-    assert_eq!(dispatch.driver_id, "fixture.observe");
-    assert_eq!(dispatch.operation, "observe_fixture_scene");
-    assert_eq!(
-      dispatch.target_application_id.as_deref(),
-      Some("com.example.App")
-    );
-    assert_eq!(dispatch.target_label.as_deref(), Some("Example"));
-    assert_eq!(
-      dispatch.inputs.get("scene").map(String::as_str),
-      Some("demo")
-    );
-  }
-
-  #[test]
-  fn invoke_command_macro_generates_export() {
-    let command = generated_test_command_handler_invoke_command();
-
-    assert_eq!(command.operation.id, "test.generated");
+    assert_eq!(command.id, "fixture.observe");
     assert_eq!(command.namespace, InvokeNamespace::Fixture);
-    assert_eq!(command.handler_name, "generated_test_command_handler");
-    assert_eq!(command.artifacts, &["operation-result"]);
-    assert_eq!(command.signals, &["fixture.scene"]);
+    assert_eq!(
+      command.summary,
+      "Emit a deterministic observation result without touching the real UI."
+    );
+    assert_eq!(command.args, crate::arg::NO_ARGS);
   }
 
   #[test]
-  fn all_default_commands_have_named_handlers() {
-    let registry = default_registry();
+  fn parse_invoke_args_preserves_invoke_surface() {
+    let parsed = crate::parse_invoke_args(&[
+      "invoke".to_string(),
+      "input.key".to_string(),
+      "--dry-run".to_string(),
+      "--target".to_string(),
+      "com.example.App".to_string(),
+      "--label".to_string(),
+      "smoke".to_string(),
+      "--key".to_string(),
+      "Return".to_string(),
+    ])
+    .expect("invoke args should parse");
 
-    for command in registry.all() {
-      assert_ne!(
-        command.handler_name, "default_driver_dispatch",
-        "{} should be declared through #[invoke_command]",
-        command.operation.id
-      );
+    match parsed {
+      crate::InvokeCliParse::Invoke {
+        command_id,
+        target_application_id,
+        inputs,
+        dry_run,
+      } => {
+        assert_eq!(command_id, "input.key");
+        assert_eq!(target_application_id.as_deref(), Some("com.example.App"));
+        assert!(dry_run);
+        assert_eq!(inputs.get("label").map(String::as_str), Some("smoke"));
+        assert_eq!(inputs.get("key").map(String::as_str), Some("Return"));
+      }
+      other => panic!("unexpected parse result: {other:?}"),
     }
+  }
+
+  #[test]
+  fn command_help_renders_metadata_only_sections() {
+    let registry = default_registry();
+    let command = registry
+      .resolve("fixture.observe")
+      .expect("fixture.observe should be registered");
+
+    let help = render_command_help(command);
+
+    assert!(help.contains("COMMAND\n  fixture.observe"));
+    assert!(help.contains("USAGE\n  auv-cli invoke fixture.observe"));
+    assert!(help.contains("SUMMARY\n  Emit a deterministic observation result"));
+    assert!(help.contains("OPTIONS\n  none"));
+    assert!(!help.contains("DRIVER\n"));
+    assert!(!help.contains("DISTURBANCE\n"));
+    assert!(!help.contains("ARTIFACTS\n"));
+    assert!(!help.contains("SIGNALS\n"));
+    assert!(!help.contains("VERIFY\n"));
   }
 
   #[test]
@@ -299,76 +314,6 @@ mod tests {
       "fixture.observe",
     ] {
       assert!(registry.resolve(id).is_some(), "{id}");
-    }
-  }
-
-  #[test]
-  fn media_control_commands_advertise_state_and_verification_signals() {
-    let registry = default_registry();
-    for id in [
-      "mediaControl.nowPlaying",
-      "mediaControl.play",
-      "mediaControl.pause",
-      "mediaControl.togglePlayPause",
-      "mediaControl.next",
-      "mediaControl.previous",
-    ] {
-      let command = registry.resolve(id).expect("media command should exist");
-      for signal in [
-        "mediaControl.present",
-        "mediaControl.title",
-        "mediaControl.isPlaying",
-        "mediaControl.sourceBundleId",
-        "mediaControl.verification",
-      ] {
-        assert!(command.signals.contains(&signal), "{id} missing {signal}");
-      }
-    }
-  }
-
-  #[test]
-  fn media_transport_commands_are_mutating_actions() {
-    let registry = default_registry();
-    for id in [
-      "mediaControl.play",
-      "mediaControl.pause",
-      "mediaControl.togglePlayPause",
-      "mediaControl.next",
-      "mediaControl.previous",
-    ] {
-      let command = registry.resolve(id).expect("media command should exist");
-      assert_eq!(
-        command.operation.namespace,
-        OperationNamespace::Action,
-        "{id}"
-      );
-      assert_eq!(
-        command.operation.max_disturbance,
-        OperationDisturbance::Keyboard,
-        "{id}"
-      );
-    }
-  }
-
-  #[test]
-  fn default_registry_has_no_legacy_id_prefixes() {
-    let registry = default_registry();
-    for command in registry.all() {
-      assert!(
-        !command.operation.id.starts_with("debug."),
-        "{} should not use debug.*",
-        command.operation.id
-      );
-      assert!(
-        !command.operation.id.starts_with("verify."),
-        "{} should not use verify.*",
-        command.operation.id
-      );
-      assert!(
-        !command.operation.id.starts_with("music."),
-        "{} should not use music.*",
-        command.operation.id
-      );
     }
   }
 }

--- a/crates/auv-cli-invoke/src/registry.rs
+++ b/crates/auv-cli-invoke/src/registry.rs
@@ -21,7 +21,7 @@ impl InvokeRegistry {
     self
       .commands
       .iter()
-      .find(|command| command.operation.id == command_id)
+      .find(|command| command.id == command_id)
   }
 
   pub fn all(&self) -> &[InvokeCommand] {
@@ -37,9 +37,9 @@ fn assert_unique_command_ids(commands: &[InvokeCommand]) {
   let mut ids = HashSet::new();
   for command in commands {
     assert!(
-      ids.insert(command.operation.id),
+      ids.insert(command.id),
       "duplicate invoke command id registered: {}",
-      command.operation.id
+      command.id
     );
   }
 }

--- a/crates/auv-cli-invoke/tests/invoke_command_macro.rs
+++ b/crates/auv-cli-invoke/tests/invoke_command_macro.rs
@@ -1,33 +1,19 @@
-use auv_cli_invoke::{
-  InvokeCommand, InvokeContext, InvokeDriverDispatch, InvokeNamespace, default_driver_dispatch,
-  invoke_command,
-};
+use auv_cli_invoke::{InvokeNamespace, invoke_command};
 
 #[invoke_command(
   id = "external.generated",
   group = "fixture",
   summary = "External generated test command.",
-  driver = "fixture.observe",
-  operation = "observe_fixture_scene",
   args = auv_cli_invoke::arg::NO_ARGS,
-  disturbance = auv_cli_invoke::command::NONE,
-  max_disturbance = auv_driver::OperationDisturbance::None,
-  artifacts = ["operation-result"],
-  signals = ["fixture.scene"],
-  verification = "read-only; no semantic success claim",
 )]
-fn external_generated_command_handler(
-  context: InvokeContext<'_>,
-  command: &InvokeCommand,
-) -> InvokeDriverDispatch {
-  default_driver_dispatch(context, command)
-}
+fn external_generated_command_handler() {}
 
 #[test]
 fn invoke_command_macro_expands_for_downstream_crates() {
   let command = external_generated_command_handler_invoke_command();
 
-  assert_eq!(command.operation.id, "external.generated");
+  assert_eq!(command.id, "external.generated");
   assert_eq!(command.namespace, InvokeNamespace::Fixture);
-  assert_eq!(command.handler_name, "external_generated_command_handler");
+  assert_eq!(command.summary, "External generated test command.");
+  assert_eq!(command.args, auv_cli_invoke::arg::NO_ARGS);
 }

--- a/docs/ai/references/2026-06-17-auv-cli-invoke-metadata-routing-design.md
+++ b/docs/ai/references/2026-06-17-auv-cli-invoke-metadata-routing-design.md
@@ -1,0 +1,146 @@
+# auv-cli-invoke Metadata Routing Design
+
+Date: 2026-06-17
+
+## Status
+
+Implemented direction for the `auv-cli-invoke` metadata-routing refactor slice.
+This note records the accepted boundary; see
+`2026-06-17-auv-cli-invoke-routing-implementation-plan.md` for the completed
+handoff and verification record.
+
+## Problem
+
+Before this refactor, `auv-cli-invoke` modeled invoke commands as metadata plus
+a handler that returned `InvokeDriverDispatch`. Most command functions only
+called `default_driver_dispatch`, which made the function look executable while
+it was really a metadata-to-driver-call adapter.
+
+That shape has two problems:
+
+- It treats every invoke command as a single driver operation.
+- It makes `#[invoke_command]` responsible for scheduling-facing dispatch
+  details instead of invoke command registration.
+
+The result is a confusing boundary: `auv-cli-invoke` looks like both a command
+catalog and an execution adapter.
+
+## Desired Boundary
+
+`auv-cli-invoke` owns the invoke sub-command surface:
+
+- invoke-visible command registration
+- command id and group routing
+- invoke-specific argument schema
+- invoke help rendering
+- a narrow adapter that `src/main.rs` can use for the `invoke` sub-command
+
+`auv-cli-invoke` does not own:
+
+- global CLI framework behavior
+- platform execution policy
+- generic driver dispatch
+- artifact, signal, verification, or disturbance contracts
+
+Those runtime outputs belong to the command implementation and to the
+capabilities it calls.
+
+This boundary can improve before all legacy root driver adapters are deleted.
+If a command still executes through root runtime compatibility code, that
+compatibility belongs outside `auv-cli-invoke`; it must not leak back into
+`#[invoke_command]` metadata.
+
+## Macro Contract
+
+`#[invoke_command]` marks an invoke command metadata anchor as routable from the
+invoke sub-command registry. The macro standardizes only registration metadata:
+
+```rust
+#[invoke_command(
+  id = "steam.library.list.v0",
+  group = "steam",
+  summary = "List installed Steam library apps from local appmanifest files.",
+  args = NO_ARGS,
+)]
+fn library_list() {}
+```
+
+The generated `library_list_invoke_command()` constructor is public registry
+metadata. The anchor function is not an execution API.
+
+The macro should not require or generate:
+
+- `driver`
+- `operation`
+- `disturbance`
+- `max_disturbance`
+- `artifacts`
+- `signals`
+- `verification`
+- `InvokeDriverDispatch`
+- `default_driver_dispatch`
+
+## Execution Model
+
+The long-term invoke command implementation owns how the command is fulfilled.
+It may call `auv-driver`, `auv-driver-macos`, future platform drivers,
+`auv-media-macos`, or future interaction crates such as `auv-interactions`.
+
+This keeps `auv-cli-invoke` as an external interface wrapper over project
+capabilities instead of a thin hardcoded proxy to `auv-driver`.
+
+Runtime remains responsible for run recording, span ownership, artifact
+persistence, inspection-compatible invoke results, and the temporary legacy
+route table used by commands that have not yet moved to typed domain execution.
+
+## CLI Adapter
+
+`src/main.rs` should stay thin for the `invoke` sub-command. The intended shape
+is that `auv-cli-invoke` exposes invoke-specific parsing/help/routing helpers
+that `src/main.rs` can call directly.
+
+`auv-cli-invoke` may parse invoke command arguments from an argv slice and render
+invoke help, but it should not own the whole process CLI or bind the repository
+to a new CLI framework.
+
+## First Refactor Slice
+
+The first implementation slice should remove the misleading dispatch model from
+`auv-cli-invoke` without trying to delete every legacy driver adapter at the
+same time:
+
+- Delete `InvokeDriverDispatch`.
+- Delete `InvokeCommandHandler`.
+- Delete `InvokeCommand::dispatch`.
+- Delete `InvokeCommand::with_handler`.
+- Delete `default_driver_dispatch`.
+- Narrow `#[invoke_command]` to id, group, summary, and args.
+- Keep any remaining root-runtime execution compatibility outside
+  `auv-cli-invoke` until each command has a typed capability implementation.
+
+Do not introduce a separate "plan" or composite execution abstraction in this
+slice. Future multi-capability commands should be implemented by their command
+function or by a domain crate that the command function calls.
+
+## Directory Shape
+
+The model cleanup should happen before a broad file move.
+
+After the macro and execution boundary are clean, command files can move toward
+domain-owned directories:
+
+```text
+crates/auv-cli-invoke/src/commands/
+  input/
+    mod.rs
+    operations.rs
+    type_text.rs
+    press_key.rs
+  window/
+    mod.rs
+    operations.rs
+    find_text.rs
+```
+
+That directory split is a follow-up slice, not a prerequisite for deleting the
+dispatch abstraction.

--- a/docs/ai/references/2026-06-17-auv-cli-invoke-routing-implementation-plan.md
+++ b/docs/ai/references/2026-06-17-auv-cli-invoke-routing-implementation-plan.md
@@ -1,0 +1,75 @@
+# auv-cli-invoke Metadata Routing Implementation Handoff
+
+Date: 2026-06-17
+
+Status: completed in local worktree branch
+`refactor/auv-cli-invoke-metadata-routing`.
+
+## Goal
+
+Refactor `auv-cli-invoke` so `#[invoke_command]` registers invoke-visible
+command metadata and argument schema without generating driver dispatch
+handlers or carrying execution contract fields.
+
+## Completed Shape
+
+- `auv-cli-invoke` now owns the invoke sub-command surface: command ids,
+  groups, summaries, argument schema, help rendering, registry resolution, and
+  invoke-specific argv parsing.
+- `#[invoke_command]` accepts only `id`, `group`, `summary`, and `args`.
+- Execution metadata fields were removed from the macro and command metadata:
+  `driver`, `operation`, `disturbance`, `max_disturbance`, `artifacts`,
+  `signals`, `verification`, and `operation_namespace`.
+- Annotated functions are private metadata anchors. The generated
+  `*_invoke_command()` constructors remain public so command registries can
+  aggregate metadata without exposing inert command functions.
+- Root runtime no longer depends on `InvokeDriverDispatch`. It keeps a
+  temporary command-id-to-driver-operation table in `src/runtime.rs` with an
+  inline `NOTICE(invoke-runtime-legacy-route)` marker.
+- Root CLI delegates invoke-specific argument parsing to
+  `auv_cli_invoke::parse_invoke_args` while keeping inspect/storage options in
+  root CLI parsing.
+- MCP command metadata serialization was updated to use the reduced invoke
+  metadata while preserving runtime evidence tests.
+
+## Important Boundaries
+
+- `src/driver/macos` was not deleted in this slice. That migration needs typed
+  driver/domain API coverage before the legacy runtime route table can be
+  removed.
+- `auv-cli-invoke` is still the CLI-facing invoke surface, but it is not the
+  execution router.
+- The temporary root runtime route table is intentionally outside
+  `auv-cli-invoke` so command metadata cannot drift back into driver dispatch.
+- Composite skills such as future scroll scan should be implemented as typed
+  domain or interaction capabilities first, then exposed through invoke
+  metadata, instead of making the proc macro schedule execution.
+
+## Verification
+
+The implementation was validated with:
+
+- `cargo fmt --check`
+- `cargo test -p auv-cli-invoke -p auv-cli-invoke-macros`
+- `cargo check`
+- `cargo test parse_invoke -- --nocapture`
+- `cargo test mcp -- --nocapture`
+- `cargo test`
+- `git diff --check`
+- `cargo run --quiet -- invoke --help`
+
+`cargo run --quiet -- list-commands` still exits with the existing tombstone
+error because `list-commands` has been removed by prior project design:
+
+```text
+`list-commands` has been removed; use `auv-cli invoke --help` instead.
+```
+
+## Follow-Ups
+
+- Replace entries in `legacy_invoke_route` with typed runtime/domain capability
+  calls as those APIs become available.
+- Add typed APIs to driver/domain crates for invoke commands that still depend
+  on the root legacy macOS driver path.
+- Delete or quarantine root `src/driver/macos` only after the active invoke
+  commands no longer depend on its legacy operations.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,7 @@
 // File: src/cli.rs
-use std::collections::BTreeMap;
-
 use auv_cli::candidate_action_decision::CandidateActionKind;
 use auv_cli::model::{AuvResult, ExecutionTarget, InvokeRequest};
+use auv_cli_invoke::InvokeCliParse;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum InspectWriteSetting {
@@ -952,73 +951,64 @@ fn parse_inspect_client_option(
 }
 
 fn parse_invoke(arguments: &[String]) -> AuvResult<CliCommand> {
-  if arguments.len() < 2 {
-    return Ok(CliCommand::InvokeHelp { command_id: None });
-  }
-
-  if matches!(arguments[1].as_str(), "--help" | "-h" | "help") {
-    return Ok(CliCommand::InvokeHelp { command_id: None });
-  }
-
-  let command_id = arguments[1].clone();
-  if arguments.len() == 3 && matches!(arguments[2].as_str(), "--help" | "-h") {
-    return Ok(CliCommand::InvokeHelp {
-      command_id: Some(command_id),
-    });
-  }
-
-  let mut target = ExecutionTarget::default();
-  let mut inputs = BTreeMap::new();
-  let mut dry_run = false;
   let mut inspect = InspectClientOptions::default();
-  let mut index = 2;
+  let mut invoke_arguments = Vec::with_capacity(arguments.len());
+  let mut index = 0;
+
+  if let Some(subcommand) = arguments.first() {
+    invoke_arguments.push(subcommand.clone());
+    index = 1;
+  }
+
+  if let Some(command_or_help) = arguments.get(index) {
+    invoke_arguments.push(command_or_help.clone());
+    index += 1;
+  }
 
   while index < arguments.len() {
-    let argument = &arguments[index];
-    if !argument.starts_with("--") {
-      return Err(format!("unexpected positional argument {argument}"));
-    }
-    if argument == "--dry-run" {
-      dry_run = true;
-      index += 1;
-      continue;
-    }
+    let argument = arguments[index].as_str();
     if let Some(consumed) =
-      parse_inspect_client_option(argument.as_str(), arguments.get(index + 1), &mut inspect)?
+      parse_inspect_client_option(argument, arguments.get(index + 1), &mut inspect)?
     {
       index += consumed;
       continue;
     }
-    if index + 1 >= arguments.len() {
-      return Err(format!("flag {argument} requires a value"));
+
+    invoke_arguments.push(arguments[index].clone());
+    if matches!(argument, "--dry-run" | "--help" | "-h") {
+      index += 1;
+      continue;
     }
 
-    let value = arguments[index + 1].clone();
-    match argument.as_str() {
-      "--target" => {
-        target.application_id = Some(value);
-      }
-      "--label" => {
-        inputs.insert("label".to_string(), value);
-      }
-      other => {
-        let key = other.trim_start_matches("--");
-        inputs.insert(key.to_string(), value);
-      }
+    if let Some(value) = arguments.get(index + 1) {
+      invoke_arguments.push(value.clone());
+      index += 2;
+      continue;
     }
 
-    index += 2;
+    index += 1;
   }
 
-  Ok(CliCommand::Invoke {
-    request: InvokeRequest {
+  match auv_cli_invoke::parse_invoke_args(&invoke_arguments)? {
+    InvokeCliParse::Help { command_id } => Ok(CliCommand::InvokeHelp { command_id }),
+    InvokeCliParse::Invoke {
       command_id,
-      target,
+      target_application_id,
       inputs,
       dry_run,
-    },
-    inspect,
-  })
+    } => Ok(CliCommand::Invoke {
+      request: InvokeRequest {
+        command_id,
+        target: ExecutionTarget {
+          application_id: target_application_id,
+          target_label: None,
+        },
+        inputs,
+        dry_run,
+      },
+      inspect,
+    }),
+  }
 }
 
 fn parse_minecraft(arguments: &[String]) -> AuvResult<CliCommand> {
@@ -1672,6 +1662,35 @@ mod tests {
         assert_eq!(inspect.local_write, InspectWriteSetting::Default);
         assert_eq!(inspect.server_write, InspectWriteSetting::Disabled);
         assert_eq!(inspect.server_token_file.as_deref(), Some("/tmp/token"));
+      }
+      other => panic!("unexpected command: {other:?}"),
+    }
+  }
+
+  #[test]
+  fn parse_invoke_preserves_inspect_like_command_input_values() {
+    let command = parse_cli(&[
+      "invoke".to_string(),
+      "input.typeText".to_string(),
+      "--text".to_string(),
+      "--store-root".to_string(),
+      "--label".to_string(),
+      "literal-label".to_string(),
+    ])
+    .expect("invoke input value that looks like an inspect option should parse");
+
+    match command {
+      CliCommand::Invoke { request, inspect } => {
+        assert_eq!(request.command_id, "input.typeText");
+        assert_eq!(
+          request.inputs.get("text").map(String::as_str),
+          Some("--store-root")
+        );
+        assert_eq!(
+          request.inputs.get("label").map(String::as_str),
+          Some("literal-label")
+        );
+        assert_eq!(inspect.store_root, None);
       }
       other => panic!("unexpected command: {other:?}"),
     }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -164,7 +164,7 @@ fn invoke_tool_input_schema() -> Arc<JsonObject> {
   let command_ids = registry
     .all()
     .iter()
-    .map(|command| Value::String(command.operation.id.to_string()))
+    .map(|command| Value::String(command.id.to_string()))
     .collect::<Vec<_>>();
 
   if let Some(command_id_schema) = schema
@@ -198,20 +198,14 @@ fn invoke_tool_input_schema() -> Arc<JsonObject> {
 
 fn invoke_command_metadata(command: &InvokeCommand) -> Value {
   serde_json::json!({
-    "id": command.operation.id,
+    "id": command.id,
     "namespace": command.namespace.as_str(),
-    "summary": command.operation.summary,
-    "driver_id": command.operation.driver_id,
-    "operation": command.operation.operation,
-    "max_disturbance": command.operation.max_disturbance.as_str(),
+    "summary": command.summary,
     "arguments": command
       .args
       .iter()
       .map(invoke_arg_metadata)
       .collect::<Vec<_>>(),
-    "artifacts": command.artifacts,
-    "signals": command.signals,
-    "verification": command.verification,
   })
 }
 
@@ -571,6 +565,13 @@ mod tests {
       .and_then(|value| value.as_str())
       .expect("summary should exist");
     assert_eq!(output_summary, cli_result.output_summary);
+    let status = invoke_json
+      .get("status")
+      .and_then(|value| value.as_str())
+      .expect("status should exist");
+    assert_eq!(status, cli_result.status.as_str());
+    let signals = invoke_json.get("signals").expect("signals should exist");
+    assert_eq!(signals, &serde_json::to_value(&cli_result.signals)?);
     let artifacts = invoke_json
       .get("artifacts")
       .and_then(|value| value.as_array())

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -20,8 +20,7 @@ pub const MINECRAFT_PROJECTION_ARTIFACT_ROLE: &str = "minecraft-projection";
 use crate::contract::ArtifactRef;
 use crate::driver::DriverRegistry;
 use crate::model::{
-  AuvResult, DriverCall, DriverDescriptor, DriverRunContext, ExecutionTarget, InvokeRequest,
-  InvokeResult, RunStatus,
+  AuvResult, DriverCall, DriverDescriptor, DriverRunContext, InvokeRequest, InvokeResult, RunStatus,
 };
 use crate::recording::{MemoryRunRecorder, RunRecorder, RunRecordingBackend};
 use crate::store::LocalStore;
@@ -366,12 +365,7 @@ impl Runtime {
     command: &auv_cli_invoke::InvokeCommand,
   ) -> AuvResult<InvokeResult> {
     self.invoke_in_command_run(|runtime, run, root| {
-      let dispatch = command.dispatch(auv_cli_invoke::InvokeContext {
-        target_application_id: request.target.application_id.as_deref(),
-        target_label: request.target.target_label.as_deref(),
-        inputs: &request.inputs,
-      });
-      runtime.invoke_direct_command_in_span(run, root, &command.operation, dispatch)
+      runtime.invoke_metadata_command_in_span(run, root, command, request)
     })
   }
 
@@ -443,25 +437,33 @@ impl Runtime {
         "unknown command {command_id}; use `auv-cli invoke --help` to inspect available entries"
       )
     })?;
-    let dispatch = command.dispatch(auv_cli_invoke::InvokeContext {
-      target_application_id: request.target.application_id.as_deref(),
-      target_label: request.target.target_label.as_deref(),
-      inputs: &request.inputs,
-    });
-    self.invoke_direct_command_in_span(run, parent, &command.operation, dispatch)
+    self.invoke_metadata_command_in_span(run, parent, command, request)
   }
 
-  fn invoke_direct_command_in_span(
+  fn invoke_metadata_command_in_span(
     &self,
     run: &mut crate::run_builder::RecordingRun,
     parent: &crate::run_builder::SpanRef,
-    command: &auv_driver::OperationSpec,
-    dispatch: auv_cli_invoke::InvokeDriverDispatch,
+    command: &auv_cli_invoke::InvokeCommand,
+    request: InvokeRequest,
   ) -> AuvResult<InvokeResult> {
-    let driver = self.drivers.get(dispatch.driver_id).ok_or_else(|| {
+    let route = legacy_invoke_route(command.id)
+      .ok_or_else(|| format!("command {} has no legacy runtime route", command.id))?;
+    self.invoke_legacy_command_in_span(run, parent, command.id, route, request)
+  }
+
+  fn invoke_legacy_command_in_span(
+    &self,
+    run: &mut crate::run_builder::RecordingRun,
+    parent: &crate::run_builder::SpanRef,
+    command_id: &str,
+    route: LegacyInvokeRoute,
+    request: InvokeRequest,
+  ) -> AuvResult<InvokeResult> {
+    let driver = self.drivers.get(route.driver_id).ok_or_else(|| {
       format!(
         "command {} resolved to missing driver {}",
-        command.id, dispatch.driver_id
+        command_id, route.driver_id
       )
     })?;
 
@@ -470,10 +472,10 @@ impl Runtime {
       crate::run_builder::running_span_record(
         "auv.command.invoke",
         command_attributes(
-          command.id,
-          dispatch.driver_id,
-          dispatch.operation,
-          dispatch.target_application_id.as_deref(),
+          command_id,
+          route.driver_id,
+          route.operation,
+          request.target.application_id.as_deref(),
         ),
       ),
     )?;
@@ -483,7 +485,7 @@ impl Runtime {
       "command.resolved",
       Some(format!(
         "resolved {} -> {}.{}",
-        command.id, dispatch.driver_id, dispatch.operation
+        command_id, route.driver_id, route.operation
       )),
     );
 
@@ -492,10 +494,10 @@ impl Runtime {
       crate::run_builder::running_span_record(
         "auv.driver.invoke",
         command_attributes(
-          command.id,
-          dispatch.driver_id,
-          dispatch.operation,
-          dispatch.target_application_id.as_deref(),
+          command_id,
+          route.driver_id,
+          route.operation,
+          request.target.application_id.as_deref(),
         ),
       ),
     )?;
@@ -503,19 +505,13 @@ impl Runtime {
       run,
       driver_span.id(),
       "driver.invoke",
-      Some(format!(
-        "invoking {}.{}",
-        dispatch.driver_id, dispatch.operation
-      )),
+      Some(format!("invoking {}.{}", route.driver_id, route.operation)),
     );
 
     let call = DriverCall {
-      operation: dispatch.operation.to_string(),
-      target: ExecutionTarget {
-        application_id: dispatch.target_application_id,
-        target_label: dispatch.target_label,
-      },
-      inputs: dispatch.inputs,
+      operation: route.operation.to_string(),
+      target: request.target,
+      inputs: request.inputs,
       working_directory: self.project_root.clone(),
       run_context: DriverRunContext {
         run_id: run.id().to_string(),
@@ -633,6 +629,84 @@ impl Runtime {
   }
 }
 
+#[derive(Clone, Copy)]
+struct LegacyInvokeRoute {
+  driver_id: &'static str,
+  operation: &'static str,
+}
+
+// NOTICE(invoke-runtime-legacy-route): this root-runtime table preserves current invoke execution after auv-cli-invoke stops carrying driver metadata. Move each entry to typed domain capability code before deleting src/driver/macos.
+fn legacy_invoke_route(command_id: &str) -> Option<LegacyInvokeRoute> {
+  let (driver_id, operation) = match command_id {
+    "app.activate" => ("macos.desktop", "activate_app"),
+    "app.probePermissions" => ("macos.desktop", "probe_permissions"),
+    "display.capture" => ("macos.desktop", "capture_display"),
+    "display.identifyPoint" => ("macos.desktop", "identify_point"),
+    "display.list" => ("macos.desktop", "list_displays"),
+    "display.probeCoordinateReadiness" => ("macos.desktop", "probe_coordinate_readiness"),
+    "display.projectScreenshotPoint" => ("macos.desktop", "project_screenshot_point"),
+    "fixture.observe" => ("fixture.observe", "observe_fixture_scene"),
+    "input.axClickWindowText" => ("macos.desktop", "ax_click_window_text"),
+    "input.axFocusText" => ("macos.desktop", "ax_focus_text_input"),
+    "input.axPressButton" => ("macos.desktop", "ax_press_button"),
+    "input.clickPoint" => ("macos.desktop", "click_point"),
+    "input.clickWindowPoint" => ("macos.desktop", "click_window_point"),
+    "input.focusText" => ("macos.desktop", "focus_text_input"),
+    "input.key" => ("macos.desktop", "press_key"),
+    "input.pasteText" => ("macos.desktop", "paste_text_preserve_clipboard"),
+    "input.pressButton" => ("macos.desktop", "press_button"),
+    "input.scrollPoint" => ("macos.desktop", "scroll_point"),
+    "input.smartPress" => ("macos.desktop", "smart_press"),
+    "input.teachClick" => ("macos.desktop", "teach_click"),
+    "input.typeText" => ("macos.desktop", "type_text"),
+    "mediaControl.next" => ("macos.desktop", "media_control_next"),
+    "mediaControl.nowPlaying" => ("macos.desktop", "media_control_now_playing"),
+    "mediaControl.pause" => ("macos.desktop", "media_control_pause"),
+    "mediaControl.play" => ("macos.desktop", "media_control_play"),
+    "mediaControl.previous" => ("macos.desktop", "media_control_previous"),
+    "mediaControl.togglePlayPause" => ("macos.desktop", "media_control_toggle_play_pause"),
+    "overlay.applyCursorBatch" => ("macos.desktop", "overlay_apply_cursor_batch"),
+    "overlay.clickPoint" => ("macos.desktop", "overlay_click_point"),
+    "overlay.flashCursor" => ("macos.desktop", "overlay_flash_cursor"),
+    "overlay.flashCursorById" => ("macos.desktop", "overlay_flash_cursor_by_id"),
+    "overlay.hideCursor" => ("macos.desktop", "overlay_hide_cursor"),
+    "overlay.hideCursorId" => ("macos.desktop", "overlay_hide_cursor_id"),
+    "overlay.moveCursor" => ("macos.desktop", "overlay_move_cursor"),
+    "overlay.moveCursorById" => ("macos.desktop", "overlay_move_cursor_by_id"),
+    "overlay.setCursor" => ("macos.desktop", "overlay_set_cursor"),
+    "overlay.showCursor" => ("macos.desktop", "overlay_show_cursor"),
+    "overlay.showDualCursor" => ("macos.desktop", "overlay_show_dual_cursor"),
+    "overlay.shutdown" => ("macos.desktop", "overlay_shutdown"),
+    "screen.captureRegion" => ("macos.desktop", "capture_region"),
+    "screen.clickRow" => ("macos.desktop", "click_screen_row"),
+    "screen.clickText" => ("macos.desktop", "click_screen_text"),
+    "screen.findImageText" => ("macos.desktop", "find_image_text"),
+    "screen.findRows" => ("macos.desktop", "find_screen_rows"),
+    "screen.findText" => ("macos.desktop", "find_screen_text"),
+    "screen.waitForRows" => ("macos.desktop", "wait_for_screen_rows"),
+    "screen.waitForText" => ("macos.desktop", "wait_for_screen_text"),
+    "steam.library.list.v0" => ("steam.local", "steam_library_list"),
+    "window.capture" => ("macos.desktop", "capture_window"),
+    "window.captureAxTree" => ("macos.desktop", "capture_ax_tree"),
+    "window.clickRow" => ("macos.desktop", "click_window_row"),
+    "window.clickText" => ("macos.desktop", "click_window_text"),
+    "window.findIconMatch" => ("macos.desktop", "find_icon_match"),
+    "window.findRows" => ("macos.desktop", "find_window_rows"),
+    "window.findText" => ("macos.desktop", "find_window_text"),
+    "window.list" => ("macos.desktop", "list_windows"),
+    "window.observeRegion" => ("macos.desktop", "observe_window_region"),
+    "window.scrollRegion" => ("macos.desktop", "scroll_window_region"),
+    "window.verifyText" => ("macos.desktop", "verify_ax_text"),
+    "window.waitForRows" => ("macos.desktop", "wait_for_window_rows"),
+    "window.waitForText" => ("macos.desktop", "wait_for_window_text"),
+    _ => return None,
+  };
+  Some(LegacyInvokeRoute {
+    driver_id,
+    operation,
+  })
+}
+
 fn command_attributes(
   command_id: &str,
   driver_id: &str,
@@ -701,6 +775,22 @@ mod tests {
   const TEST_COMMAND_ID: &str = "fixture.observe";
   const TEST_DRIVER_ID: &str = "fixture.observe";
   const TEST_OPERATION: &str = "observe_fixture_scene";
+
+  #[test]
+  fn default_registry_commands_have_legacy_runtime_routes() {
+    let registry = auv_cli_invoke::default_registry();
+
+    for command in registry.all() {
+      // The coupling belongs in root runtime while the legacy route table exists:
+      // registered invoke commands are user-facing commands, so they must not
+      // appear in help/MCP and then fail before runtime can select execution.
+      assert!(
+        super::legacy_invoke_route(command.id).is_some(),
+        "{} should have a root runtime legacy route until it migrates to typed execution",
+        command.id
+      );
+    }
+  }
 
   impl RunRecorder for FailRunFinishedRecorder {
     fn record(&self, update: RunUpdate) -> AuvResult<()> {


### PR DESCRIPTION
## Summary

- Refactor `auv-cli-invoke` so `#[invoke_command]` registers metadata only: `id`, `group`, `summary`, and `args`.
- Remove invoke-side dispatch concepts and old execution metadata fields from `auv-cli-invoke`.
- Keep temporary legacy command-id to driver-operation routing in root runtime, with tests and documentation marking it as a migration boundary.
- Delegate invoke-specific argv parsing to `auv-cli-invoke` and update MCP metadata serialization for the reduced command shape.

## Why

`auv-cli-invoke` should be the invoke CLI-facing command surface, not the driver dispatch owner. This keeps future composite/domain commands from being constrained by a macro-generated single-driver-operation model.

## Validation

- `cargo fmt --check`
- `cargo test -p auv-cli-invoke -p auv-cli-invoke-macros`
- `cargo test default_registry_commands_have_legacy_runtime_routes -- --nocapture`
- `cargo test`
- `git diff --check`

Known warnings: existing `auv-game-minecraft` deprecation warnings during root tests.

## Notes

`src/runtime.rs::legacy_invoke_route` remains as an intentional temporary compatibility table until typed execution paths replace the legacy driver operation mapping.