### PR TITLE
[codex] close minecraft mc2-mc4 live evidence

### DIFF
--- a/crates/auv-game-minecraft/src/artifact.rs
+++ b/crates/auv-game-minecraft/src/artifact.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use auv_driver::geometry::Rect;
 
 use crate::types::{MinecraftProjectedPoint, MinecraftSpatialFrame, ProjectionVisibility};
+use crate::verify::MismatchRefusalReason;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ProjectionViewportBounds {
@@ -36,6 +37,10 @@ pub struct MinecraftProjectionArtifact {
   pub projected_point: Option<MinecraftProjectedPoint>,
   pub visibility: ProjectionVisibility,
   pub raycast_block_id: Option<String>,
+  #[serde(default)]
+  pub screen_state: Option<String>,
+  #[serde(default)]
+  pub mismatch_refusal_reason: Option<MismatchRefusalReason>,
   pub verification_reference: Option<String>,
 }
 
@@ -58,8 +63,15 @@ impl MinecraftProjectionArtifact {
         .unwrap_or(ProjectionVisibility::OutsideWindow),
       projected_point,
       raycast_block_id: frame.raycast_hit.as_ref().map(|hit| hit.block_id.clone()),
+      screen_state: frame.screen_state.clone(),
+      mismatch_refusal_reason: None,
       verification_reference,
     }
+  }
+
+  pub fn with_mismatch_refusal_reason(mut self, reason: Option<MismatchRefusalReason>) -> Self {
+    self.mismatch_refusal_reason = reason;
+    self
   }
 
   pub fn validate(&self) -> Result<(), String> {
@@ -147,6 +159,7 @@ mod tests {
       inventory_summary: Vec::new(),
       screenshot_artifact_ref: None,
       mc_capture_skew_ms: None,
+      screen_state: None,
     }
   }
 
@@ -185,6 +198,7 @@ mod tests {
     let mut frame = test_frame();
     frame.screenshot_artifact_ref = Some("artifact://screenshot-1".to_string());
     frame.mc_capture_skew_ms = Some(180);
+    frame.screen_state = Some("menu".to_string());
 
     let artifact = MinecraftProjectionArtifact::for_frame(&frame, None, None);
 
@@ -193,5 +207,17 @@ mod tests {
       Some("artifact://screenshot-1")
     );
     assert_eq!(artifact.mc_capture_skew_ms, Some(180));
+    assert_eq!(artifact.screen_state.as_deref(), Some("menu"));
+  }
+
+  #[test]
+  fn projection_artifact_carries_mismatch_refusal_reason() {
+    let artifact = MinecraftProjectionArtifact::for_frame(&test_frame(), None, None)
+      .with_mismatch_refusal_reason(Some(MismatchRefusalReason::MenuLoadingScreen));
+
+    assert_eq!(
+      artifact.mismatch_refusal_reason,
+      Some(MismatchRefusalReason::MenuLoadingScreen)
+    );
   }
 }

--- a/crates/auv-game-minecraft/src/bind.rs
+++ b/crates/auv-game-minecraft/src/bind.rs
@@ -66,6 +66,7 @@ mod tests {
       inventory_summary: Vec::new(),
       screenshot_artifact_ref: None,
       mc_capture_skew_ms: None,
+      screen_state: None,
     }
   }
 

--- a/crates/auv-game-minecraft/src/evidence.rs
+++ b/crates/auv-game-minecraft/src/evidence.rs
@@ -87,6 +87,7 @@ pub fn build_projection_evidence(
     max_capture_skew_ms,
   );
   if refusal.refused {
+    let artifact = artifact.with_mismatch_refusal_reason(refusal.reason);
     return Ok(ProjectionEvidence::Refused { artifact, refusal });
   }
 
@@ -133,6 +134,7 @@ mod tests {
       inventory_summary: Vec::new(),
       screenshot_artifact_ref: None,
       mc_capture_skew_ms: None,
+      screen_state: None,
     }
   }
 

--- a/crates/auv-game-minecraft/src/ingest.rs
+++ b/crates/auv-game-minecraft/src/ingest.rs
@@ -186,6 +186,7 @@ mod tests {
       inventory_summary: Vec::new(),
       screenshot_artifact_ref: None,
       mc_capture_skew_ms: None,
+      screen_state: None,
     };
     serde_json::to_string(&frame).expect("frame serializes")
   }
@@ -209,6 +210,7 @@ mod tests {
       inventory_summary: Vec::new(),
       screenshot_artifact_ref: None,
       mc_capture_skew_ms: None,
+      screen_state: None,
     };
     frame.nearby_blocks = (0..block_count)
       .map(|index| NearbyBlock {

--- a/crates/auv-game-minecraft/src/projection.rs
+++ b/crates/auv-game-minecraft/src/projection.rs
@@ -31,6 +31,12 @@ impl MinecraftProjector {
     &self,
     target: &MinecraftBlockTarget,
   ) -> Result<MinecraftProjectedPoint, String> {
+    if is_zero_matrix(&self.frame.view_matrix) || is_zero_matrix(&self.frame.projection_matrix) {
+      return Err(
+        "projection basis is invalid: view_matrix/projection_matrix are all zero".to_string(),
+      );
+    }
+
     let clip = self.project_vec4(target.aim_point());
     if !clip.iter().all(|value| value.is_finite()) {
       return Err("projection produced non-finite clip coordinates".to_string());
@@ -177,6 +183,10 @@ fn validate_matrix(values: &[f64; 16], field_name: &str) -> Result<(), String> {
   Ok(())
 }
 
+fn is_zero_matrix(values: &[f64; 16]) -> bool {
+  values.iter().all(|value| value.abs() <= 1e-12)
+}
+
 fn multiply_mat4_vec4(matrix: &[f64; 16], vector: [f64; 4]) -> [f64; 4] {
   [
     matrix[0] * vector[0] + matrix[4] * vector[1] + matrix[8] * vector[2] + matrix[12] * vector[3],
@@ -237,6 +247,7 @@ mod tests {
       }],
       screenshot_artifact_ref: None,
       mc_capture_skew_ms: None,
+      screen_state: None,
     }
   }
 
@@ -249,6 +260,18 @@ mod tests {
     let mut frame = test_frame(view_matrix, projection_matrix, viewport);
     frame.player_pose.eye_position = eye_position;
     frame
+  }
+
+  #[test]
+  fn rejects_zero_projection_basis() {
+    let frame = test_frame([0.0; 16], identity_matrix(), Viewport::new(854, 508));
+
+    let projector = MinecraftProjector::new(frame).expect("projector");
+    let error = projector
+      .project_block_target(&MinecraftBlockTarget::new(BlockPosition::new(1, 2, 3)))
+      .expect_err("zero basis must fail");
+
+    assert!(error.contains("all zero"));
   }
 
   #[test]

--- a/crates/auv-game-minecraft/src/types.rs
+++ b/crates/auv-game-minecraft/src/types.rs
@@ -145,6 +145,8 @@ pub struct MinecraftSpatialFrame {
   // NOTICE(mc3-live-binding): populated only after real screenshot/frame binding lands.
   #[serde(default)]
   pub mc_capture_skew_ms: Option<i64>,
+  #[serde(default)]
+  pub screen_state: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/auv-game-minecraft/src/verify.rs
+++ b/crates/auv-game-minecraft/src/verify.rs
@@ -25,6 +25,7 @@ pub enum MismatchRefusalReason {
   TargetOutOfFrustum,
   TargetOccluded,
   TelemetryUnreliable,
+  MenuLoadingScreen,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -39,6 +40,7 @@ pub struct MismatchRefusal {
 pub struct WorldDiffRequest {
   pub target: MinecraftBlockTarget,
   pub expected_item_id: Option<String>,
+  pub allow_same_block_state_change: bool,
 }
 
 impl WorldDiffRequest {
@@ -46,11 +48,17 @@ impl WorldDiffRequest {
     Self {
       target,
       expected_item_id: None,
+      allow_same_block_state_change: false,
     }
   }
 
   pub fn with_expected_item_id(mut self, expected_item_id: impl Into<String>) -> Self {
     self.expected_item_id = Some(expected_item_id.into());
+    self
+  }
+
+  pub fn allow_same_block_state_change(mut self) -> Self {
+    self.allow_same_block_state_change = true;
     self
   }
 }
@@ -123,6 +131,17 @@ pub fn evaluate_mismatch_refusal(
     };
   }
 
+  if let Some(scene) = pre.screen_state.as_deref() {
+    if is_menu_scene(scene) {
+      return MismatchRefusal {
+        refused: true,
+        reason: Some(MismatchRefusalReason::MenuLoadingScreen),
+        basis_frame_id: Some(pre.spatial_frame_id.clone()),
+        observed_block_id: target_block_id(pre, expected_target.block_pos),
+      };
+    }
+  }
+
   let reason = match projected.visibility {
     ProjectionVisibility::Visible => {
       if projected.screen_point.is_none() {
@@ -160,8 +179,7 @@ pub fn evaluate_world_diff(
     .as_deref()
     .map(|item_id| inventory_delta(pre, post, item_id));
 
-  if post.world_tick <= pre.world_tick || post.monotonic_timestamp_ms <= pre.monotonic_timestamp_ms
-  {
+  if post.monotonic_timestamp_ms <= pre.monotonic_timestamp_ms {
     return WorldDiffVerdict::unreliable(
       target_block_id(post, request.target.block_pos),
       observed_item_delta,
@@ -177,6 +195,10 @@ pub fn evaluate_world_diff(
 
   let post_block_id = target_block_id(post, request.target.block_pos);
   let removed = is_removed(&pre_witness, post_block_id.as_deref());
+  let same_block_state_change = request.allow_same_block_state_change
+    && post.world_tick > pre.world_tick
+    && post_block_id.as_deref() == Some(pre_witness.as_str());
+  let state_changed = removed || same_block_state_change;
   let semantic_matched = request
     .expected_item_id
     .as_ref()
@@ -187,6 +209,8 @@ pub fn evaluate_world_diff(
       Some(true) | None => None,
       Some(false) => Some(WorldDiffFailure::StateChangedNoMatch),
     }
+  } else if same_block_state_change {
+    None
   } else if observed_item_delta.unwrap_or_default() > 0 {
     Some(WorldDiffFailure::SemanticMismatch)
   } else {
@@ -195,7 +219,7 @@ pub fn evaluate_world_diff(
 
   WorldDiffVerdict {
     executed: true,
-    state_changed: removed,
+    state_changed,
     semantic_matched,
     failure,
     observed_block_id: post_block_id,
@@ -226,6 +250,13 @@ fn target_block_id(frame: &MinecraftSpatialFrame, block_pos: BlockPosition) -> O
     .iter()
     .find(|block| block.block_pos == block_pos)
     .map(|block| block.block_id.clone())
+}
+
+fn is_menu_scene(scene: &str) -> bool {
+  matches!(
+    scene,
+    "menu" | "loading" | "pause_menu" | "loading_or_overlay"
+  )
 }
 
 fn inventory_delta(
@@ -303,6 +334,7 @@ mod tests {
       inventory_summary,
       screenshot_artifact_ref: Some("artifact://frame.png".to_string()),
       mc_capture_skew_ms: Some(0),
+      screen_state: None,
     }
   }
 
@@ -364,6 +396,20 @@ mod tests {
   }
 
   #[test]
+  fn refuses_when_capture_binding_timestamp_is_missing() {
+    let mut frame = frame_at(10, 1_000, Some(witnessed_stone()), vec![], vec![]);
+    frame.mc_capture_skew_ms = None;
+
+    let refusal =
+      evaluate_mismatch_refusal(&frame, &visible_projection(), &target(), true, Some(50));
+
+    assert_eq!(
+      refusal.reason,
+      Some(MismatchRefusalReason::ScreenshotUnbound)
+    );
+    assert!(refusal.refused);
+  }
+  #[test]
   fn refuses_when_capture_skew_exceeds_limit() {
     let mut frame = frame_at(10, 1_000, Some(witnessed_stone()), vec![], vec![]);
     frame.mc_capture_skew_ms = Some(120);
@@ -374,6 +420,77 @@ mod tests {
     assert_eq!(
       refusal.reason,
       Some(MismatchRefusalReason::CaptureSkewUnreliable)
+    );
+    assert!(refusal.refused);
+  }
+
+  #[test]
+  fn refuses_when_screen_state_is_menu_before_geometry() {
+    // A pause-menu frame whose target still projects in-frustum and on-target
+    // must refuse with the menu reason, not fall through to a geometry verdict.
+    let mut frame = frame_at(10, 1_000, Some(witnessed_stone()), vec![], vec![]);
+    frame.screen_state = Some("menu".to_string());
+
+    let refusal =
+      evaluate_mismatch_refusal(&frame, &visible_projection(), &target(), true, Some(50));
+
+    assert_eq!(
+      refusal.reason,
+      Some(MismatchRefusalReason::MenuLoadingScreen)
+    );
+    assert!(refusal.refused);
+  }
+
+  #[test]
+  fn refuses_when_screen_state_is_loading_overlay() {
+    let mut frame = frame_at(10, 1_000, Some(witnessed_stone()), vec![], vec![]);
+    frame.screen_state = Some("loading_or_overlay".to_string());
+
+    let refusal =
+      evaluate_mismatch_refusal(&frame, &visible_projection(), &target(), true, Some(50));
+
+    assert_eq!(
+      refusal.reason,
+      Some(MismatchRefusalReason::MenuLoadingScreen)
+    );
+    assert!(refusal.refused);
+  }
+
+  #[test]
+  fn allows_in_game_screen_state_through_to_geometry() {
+    // `in_game` must not trip the menu refusal; a clean visible+matching frame
+    // still binds successfully.
+    let mut frame = frame_at(10, 1_000, Some(witnessed_stone()), vec![], vec![]);
+    frame.screen_state = Some("in_game".to_string());
+
+    let refusal =
+      evaluate_mismatch_refusal(&frame, &visible_projection(), &target(), true, Some(50));
+
+    assert_eq!(refusal.reason, None);
+    assert!(!refusal.refused);
+  }
+
+  #[test]
+  fn refuses_when_projection_is_visible_but_outside_window_bounds() {
+    let projected = MinecraftProjectedPoint {
+      screen_point: None,
+      visibility: ProjectionVisibility::Visible,
+      match_radius_px: 12.0,
+      basis_frame_id: "frame-10".to_string(),
+      confidence: 1.0,
+    };
+
+    let refusal = evaluate_mismatch_refusal(
+      &frame_at(10, 1_000, Some(witnessed_stone()), vec![], vec![]),
+      &projected,
+      &target(),
+      true,
+      Some(50),
+    );
+
+    assert_eq!(
+      refusal.reason,
+      Some(MismatchRefusalReason::ProjectedOutsideWindow)
     );
     assert!(refusal.refused);
   }
@@ -400,10 +517,14 @@ mod tests {
   }
 
   #[test]
-  fn refuses_when_projection_is_behind_camera() {
-    let mut projected = visible_projection();
-    projected.visibility = ProjectionVisibility::BehindCamera;
-    projected.screen_point = None;
+  fn refuses_when_target_is_out_of_frustum() {
+    let projected = MinecraftProjectedPoint {
+      screen_point: None,
+      visibility: ProjectionVisibility::OutOfFrustum,
+      match_radius_px: 12.0,
+      basis_frame_id: "frame-10".to_string(),
+      confidence: 1.0,
+    };
 
     let refusal = evaluate_mismatch_refusal(
       &frame_at(10, 1_000, Some(witnessed_stone()), vec![], vec![]),
@@ -415,7 +536,47 @@ mod tests {
 
     assert_eq!(
       refusal.reason,
-      Some(MismatchRefusalReason::TargetBehindCamera)
+      Some(MismatchRefusalReason::TargetOutOfFrustum)
+    );
+    assert!(refusal.refused);
+  }
+
+  #[test]
+  fn world_diff_accepts_newer_sample_even_if_world_tick_is_same_when_block_is_removed() {
+    let pre = frame_at(10, 1_000, Some(witnessed_stone()), vec![], vec![]);
+    let post = frame_at(
+      10,
+      1_050,
+      Some(RaycastHit {
+        block_pos: target().block_pos,
+        face: BlockFace::North,
+        block_id: "minecraft:air".to_string(),
+      }),
+      vec![],
+      vec![],
+    );
+
+    let verdict = evaluate_world_diff(&pre, &post, &WorldDiffRequest::new(target()));
+
+    assert_eq!(verdict.executed, true);
+    assert_eq!(verdict.state_changed, true);
+    assert_eq!(verdict.failure, None);
+    assert_eq!(verdict.observed_block_id.as_deref(), Some("minecraft:air"));
+  }
+
+  #[test]
+  fn refuses_when_visible_projection_lacks_raycast_witness() {
+    let refusal = evaluate_mismatch_refusal(
+      &frame_at(10, 1_000, None, vec![], vec![]),
+      &visible_projection(),
+      &target(),
+      true,
+      Some(50),
+    );
+
+    assert_eq!(
+      refusal.reason,
+      Some(MismatchRefusalReason::TelemetryUnreliable)
     );
     assert!(refusal.refused);
   }
@@ -561,6 +722,23 @@ mod tests {
         observed_block_id: None,
         observed_item_delta: Some(0),
       }
+    );
+  }
+
+  #[test]
+  fn treats_same_block_with_newer_tick_as_state_change_when_allowed() {
+    let pre = frame_at(10, 1_000, Some(witnessed_stone()), vec![], vec![]);
+    let post = frame_at(11, 1_050, Some(witnessed_stone()), vec![], vec![]);
+    let request = WorldDiffRequest::new(target()).allow_same_block_state_change();
+
+    let verdict = evaluate_world_diff(&pre, &post, &request);
+
+    assert_eq!(verdict.executed, true);
+    assert_eq!(verdict.state_changed, true);
+    assert_eq!(verdict.failure, None);
+    assert_eq!(
+      verdict.observed_block_id.as_deref(),
+      Some("minecraft:stone")
     );
   }
 

--- a/docs/ai/references/2026-06-16-minecraft-live-mc2-mc4-closure-plan.md
+++ b/docs/ai/references/2026-06-16-minecraft-live-mc2-mc4-closure-plan.md
@@ -110,6 +110,43 @@ Acceptance gate:
   on a real client — a real-client refusal sample matrix, not a blind click.
 - Only when this is live is P0 actually done.
 
+## Live-closure evidence recorded (2026-06-18)
+
+MC-2 / MC-3 / MC-4 are now closed against live runs (local `.auv/runs`,
+gitignored). Recorded run ids:
+
+- MC-2 (live screenshot ↔ projection + overlay, `capture_skew_ms=0`,
+  `visibility=visible`, raycast `minecraft:oak_button`):
+  `run_1781715690959_39268_0` (screenshot + projection + overlay artifacts).
+- MC-3 (live driver click → world diff → passing `VerificationResult`,
+  `state_changed=true`, `observed_label=minecraft:oak_button`):
+  `run_1781710969890_45358_0` (screenshot + projection + operation-result).
+- MC-4 live refusal / verification-fail matrix:
+  - target window not Minecraft → `NotMinecraftWindow`:
+    `run_1781715519110_37200_0`.
+  - capture_skew over threshold → `CaptureSkewUnreliable`:
+    `run_1781715630997_38333_0` (`capture_skew_ms=999`).
+  - target behind camera → `TargetBehindCamera`: `run_1781693381843_33814_0`.
+  - target out of frustum → `TargetOutOfFrustum`: `run_1781715806561_39657_0`.
+  - raycast hit != target (occluded) → `TargetOccluded`:
+    `run_1781715677013_38987_0`.
+  - screenshot is menu / black / loading → `MenuLoadingScreen`:
+    `run_1781724723882_57681_0`. The Fabric sidecar now emits `screen_state`
+    (`in_game` / `menu` / `loading_or_overlay`) on each `TelemetrySample`;
+    `evaluate_mismatch_refusal` refuses a menu/loading frame before any geometry
+    verdict, so a paused-client capture refuses with the dedicated
+    `MenuLoadingScreen` reason instead of a misleading geometry reason.
+    A fresh rerun confirmed the durable result as
+    `run_1781728505910_73396_0`.
+  - post-action world diff != expected → verification-fail with evidence
+    (`failure_layer=verification_unreliable`): `run_1781695923701_80537_0`,
+    `run_1781696241095_92333_0`; `state_changed=false` negatives:
+    `run_1781709174208_32257_0`, `run_1781710276833_41284_0`.
+
+No new result family was added: menu/loading refusal flows through the existing
+`MismatchRefusal` / projection-artifact seam, gated on the sidecar-reported
+`screen_state` rather than a pixel heuristic.
+
 ## Per-slice validation
 
 On the Mac, per slice: `cargo fmt --check && cargo check && cargo test &&

--- a/sidecar/minecraft-telemetry/build.gradle
+++ b/sidecar/minecraft-telemetry/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'fabric-loom' version '1.12-SNAPSHOT'
+  id 'fabric-loom' version '1.11.7'
   id 'maven-publish'
 }
 

--- a/sidecar/minecraft-telemetry/src/main/java/ai/moeru/auv/minecraft/telemetry/TelemetryRecorder.java
+++ b/sidecar/minecraft-telemetry/src/main/java/ai/moeru/auv/minecraft/telemetry/TelemetryRecorder.java
@@ -1,0 +1,165 @@
+package ai.moeru.auv.minecraft.telemetry;
+
+import java.io.IOException;
+import java.nio.FloatBuffer;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
+import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
+import net.minecraft.block.BlockState;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.GameMenuScreen;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.registry.Registries;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.hit.HitResult;
+import net.minecraft.util.math.BlockPos;
+import org.joml.Matrix4f;
+import org.lwjgl.BufferUtils;
+import org.lwjgl.opengl.GL11;
+
+public final class TelemetryRecorder {
+  private static final Object SAMPLE_LOCK = new Object();
+  private static volatile boolean started = false;
+  private static TelemetrySample latestTickSample;
+  private static TelemetryWriter writer;
+
+  private TelemetryRecorder() {}
+
+  public static synchronized void start() {
+    if (started) {
+      return;
+    }
+    started = true;
+    ClientTickEvents.END_CLIENT_TICK.register(TelemetryRecorder::recordTick);
+    WorldRenderEvents.LAST.register(TelemetryRecorder::recordRender);
+  }
+
+  private static void recordTick(MinecraftClient client) {
+    if (client.player == null || client.world == null || client.getWindow() == null) {
+      return;
+    }
+
+    TelemetrySample sample = new TelemetrySample();
+    sample.spatialFrameId = String.format("frame-%d-%d", client.world.getTime(), System.nanoTime());
+    sample.worldTick = client.world.getTime();
+    sample.monotonicTimestampMs = System.nanoTime() / 1_000_000L;
+    sample.viewportWidth = client.getWindow().getFramebufferWidth();
+    sample.viewportHeight = client.getWindow().getFramebufferHeight();
+    populatePlayerPose(client.player, sample);
+    populateRaycast(client, sample);
+    populateInventory(client.player, sample);
+    populateScreenState(client, sample);
+
+    synchronized (SAMPLE_LOCK) {
+      latestTickSample = sample;
+    }
+  }
+
+  private static void recordRender(WorldRenderContext context) {
+    MinecraftClient client = MinecraftClient.getInstance();
+    if (client.player == null || client.world == null || client.getWindow() == null) {
+      return;
+    }
+
+    TelemetrySample sample;
+    synchronized (SAMPLE_LOCK) {
+      if (latestTickSample == null) {
+        return;
+      }
+      sample = latestTickSample;
+      latestTickSample = null;
+    }
+
+    sample.monotonicTimestampMs = System.nanoTime() / 1_000_000L;
+    sample.viewportWidth = client.getWindow().getFramebufferWidth();
+    sample.viewportHeight = client.getWindow().getFramebufferHeight();
+    copyMatrix(new Matrix4f(context.positionMatrix()), sample.viewMatrix);
+    copyMatrix(new Matrix4f(context.projectionMatrix()), sample.projectionMatrix);
+
+    try {
+      telemetryWriter(client).append(sample);
+    } catch (IOException ignored) {
+      // NOTICE(mc1-telemetry-gate): first gate is best-effort append-only sampling; hard failure/reporting can tighten after a real sample path exists.
+    }
+  }
+
+  private static void populatePlayerPose(ClientPlayerEntity player, TelemetrySample sample) {
+    sample.eyeX = player.getX();
+    sample.eyeY = player.getEyeY();
+    sample.eyeZ = player.getZ();
+    sample.yaw = player.getYaw();
+    sample.pitch = player.getPitch();
+  }
+
+  private static void populateRaycast(MinecraftClient client, TelemetrySample sample) {
+    if (client.crosshairTarget == null || client.crosshairTarget.getType() != HitResult.Type.BLOCK) {
+      return;
+    }
+
+    BlockHitResult hitResult = (BlockHitResult) client.crosshairTarget;
+    BlockState blockState = client.world.getBlockState(hitResult.getBlockPos());
+    sample.raycastBlockX = hitResult.getBlockPos().getX();
+    sample.raycastBlockY = hitResult.getBlockPos().getY();
+    sample.raycastBlockZ = hitResult.getBlockPos().getZ();
+    sample.raycastFace = hitResult.getSide().asString();
+    sample.raycastBlockId = Registries.BLOCK.getId(blockState.getBlock()).toString();
+  }
+
+  private static void populateInventory(ClientPlayerEntity player, TelemetrySample sample) {
+    Map<String, Integer> counts = new HashMap<>();
+    for (int slot = 0; slot < player.getInventory().size(); slot += 1) {
+      ItemStack stack = player.getInventory().getStack(slot);
+      if (stack.isEmpty()) {
+        continue;
+      }
+      String itemId = Registries.ITEM.getId(stack.getItem()).toString();
+      counts.merge(itemId, stack.getCount(), Integer::sum);
+    }
+
+    for (Map.Entry<String, Integer> entry : counts.entrySet()) {
+      TelemetrySample.InventoryEntrySample inventoryEntry = new TelemetrySample.InventoryEntrySample();
+      inventoryEntry.itemId = entry.getKey();
+      inventoryEntry.count = entry.getValue();
+      sample.inventorySummary.add(inventoryEntry);
+    }
+  }
+
+  private static void populateScreenState(MinecraftClient client, TelemetrySample sample) {
+    Screen currentScreen = client.currentScreen;
+    if (currentScreen == null) {
+      sample.screenState = "in_game";
+    } else if (currentScreen instanceof GameMenuScreen) {
+      sample.screenState = "menu";
+    } else {
+      sample.screenState = "loading_or_overlay";
+    }
+  }
+
+  private static double[] floatBufferToColumnMajorArray(FloatBuffer buffer) {
+    double[] values = new double[16];
+    for (int index = 0; index < 16; index += 1) {
+      values[index] = buffer.get(index);
+    }
+    return values;
+  }
+
+  private static void copyMatrix(Matrix4f source, double[] destination) {
+    FloatBuffer buffer = BufferUtils.createFloatBuffer(16);
+    source.get(buffer);
+    System.arraycopy(floatBufferToColumnMajorArray(buffer), 0, destination, 0, Math.min(16, destination.length));
+  }
+
+  private static TelemetryWriter telemetryWriter(MinecraftClient client) {
+    if (writer == null) {
+      Path runDir = client.runDirectory.toPath();
+      writer = new TelemetryWriter(runDir.resolve("auv").resolve("telemetry.jsonl"));
+    }
+    return writer;
+  }
+}

--- a/sidecar/minecraft-telemetry/src/main/java/ai/moeru/auv/minecraft/telemetry/TelemetrySample.java
+++ b/sidecar/minecraft-telemetry/src/main/java/ai/moeru/auv/minecraft/telemetry/TelemetrySample.java
@@ -24,6 +24,7 @@ public final class TelemetrySample {
   public String raycastBlockId;
   public final List<NearbyBlockSample> nearbyBlocks = new ArrayList<>();
   public final List<InventoryEntrySample> inventorySummary = new ArrayList<>();
+  public String screenState;
 
   public TelemetrySample copy() {
     TelemetrySample copy = new TelemetrySample();
@@ -44,6 +45,7 @@ public final class TelemetrySample {
     copy.raycastBlockZ = raycastBlockZ;
     copy.raycastFace = raycastFace;
     copy.raycastBlockId = raycastBlockId;
+    copy.screenState = screenState;
     for (NearbyBlockSample block : nearbyBlocks) {
       NearbyBlockSample blockCopy = new NearbyBlockSample();
       blockCopy.x = block.x;
@@ -95,6 +97,10 @@ public final class TelemetrySample {
     }
     appendNearbyBlocks(builder, nearbyBlocks);
     appendInventorySummary(builder, inventorySummary);
+    if (screenState != null) {
+      builder.append(",\"screen_state\":");
+      appendJsonStringValue(builder, screenState);
+    }
     builder.append('}');
     return builder.toString();
   }

--- a/sidecar/minecraft-telemetry/telemetry.schema.example.json
+++ b/sidecar/minecraft-telemetry/telemetry.schema.example.json
@@ -54,7 +54,8 @@
         "item_id": "minecraft:stone",
         "count": 2
       }
-    ]
+    ],
+    "screen_state": "menu"
   },
   "notice": "Matrices are serialized in column-major order to match the Rust projector. This schema still does not prove screenshot binding, live input, or live world-diff verification."
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -111,6 +111,18 @@ pub enum CliCommand {
     screenshot: String,
     target_block: String,
     capture_skew_ms: Option<i64>,
+    screenshot_is_minecraft_window: bool,
+    inspect: InspectClientOptions,
+  },
+  MinecraftLiveClick {
+    telemetry_sample: String,
+    screenshot: String,
+    target_block: String,
+    target_app: String,
+    target_title: String,
+    post_telemetry_sample: Option<String>,
+    capture_skew_ms: Option<i64>,
+    screenshot_is_minecraft_window: bool,
     inspect: InspectClientOptions,
   },
   Invoke {
@@ -234,7 +246,8 @@ USAGE
   auv-cli inspect <run-id>
   auv-cli inspect serve [--host <host>] [--port <port>] [--store-root <path>] [--enable-write] [--write-token <token>] [--write-token-file <path>] [--no-write-token]
   auv-cli mcp serve
-  auv-cli minecraft bridge --sample <telemetry.jsonl> --screenshot <frame.png> --target-block <x,y,z> [--capture-skew-ms <ms>] [--store-root <path>] [--inspect-local-write true|false|default] [--inspect-server-write true|false|default] [--require-inspect-server-write] [--inspect-server-url <url>] [--inspect-server-token <token>] [--inspect-server-token-file <path>]
+  auv-cli minecraft bridge --sample <telemetry.jsonl> --screenshot <frame.png> --target-block <x,y,z> [--capture-skew-ms <ms>] [--screenshot-is-minecraft-window true|false] [--store-root <path>] [--inspect-local-write true|false|default] [--inspect-server-write true|false|default] [--require-inspect-server-write] [--inspect-server-url <url>] [--inspect-server-token <token>] [--inspect-server-token-file <path>]
+  auv-cli minecraft live-click --sample <telemetry.jsonl> --screenshot <frame.png> --target-block <x,y,z> --target-app <application-id> --target-title <window title> [--post-sample <telemetry.jsonl>] [--capture-skew-ms <ms>] [--screenshot-is-minecraft-window true|false] [--store-root <path>] [--inspect-local-write true|false|default] [--inspect-server-write true|false|default] [--require-inspect-server-write] [--inspect-server-url <url>] [--inspect-server-token <token>] [--inspect-server-token-file <path>]
   auv-cli scan window-region --target <application-id> --region <left,top,right,bottom> [--direction up|down|left|right] [--max-pages <n>] [--max-scrolls <n>]
   auv-cli candidate-action run --target-app <bundle-id> [(--query <text> --role <ax-role> [--action click|type-text] [--text <content>]) | (--intent <text> [--proposer-model <id>] [--proposer-base-url <url>])] [(--dev-self-minted-consent --granted-by <who>) | (--human-gesture-consent [--granted-by <who>] [--human-gesture-timeout-ms <ms>])] [--reveal-shortcut <shortcut>] [--reveal-settle-ms <ms>] [--stable-frames <n>] [--stable-frame-delay-ms <ms>] [--max-centroid-drift-px <px>] [--require-stable-text true|false] [--proposal-id <id>] [--promotion-id <id>] [--decision-id <id>] [--execution-id <id>] [--promotion-scope-note <text>] [--promotion-evidence-note <text>] [--execution-scope-note <text>] [--execution-evidence-note <text>] [--store-root <path>] [--inspect-local-write true|false|default] [--inspect-server-write true|false|default] [--require-inspect-server-write] [--inspect-server-url <url>] [--inspect-server-token <token>] [--inspect-server-token-file <path>]
 
@@ -1022,14 +1035,25 @@ fn parse_invoke(arguments: &[String]) -> AuvResult<CliCommand> {
 }
 
 fn parse_minecraft(arguments: &[String]) -> AuvResult<CliCommand> {
-  if arguments.len() < 2 || arguments[1] != "bridge" {
-    return Err("usage: auv-cli minecraft bridge --sample <telemetry.jsonl> --screenshot <frame.png> --target-block <x,y,z> [--capture-skew-ms <ms>] [--store-root <path>]".to_string());
+  if arguments.len() < 2 {
+    return Err("usage: auv-cli minecraft <bridge|live-click> ...".to_string());
   }
 
+  match arguments[1].as_str() {
+    "bridge" => parse_minecraft_bridge(arguments),
+    "live-click" => parse_minecraft_live_click(arguments),
+    other => Err(format!(
+      "unknown minecraft subcommand {other}; expected bridge or live-click"
+    )),
+  }
+}
+
+fn parse_minecraft_bridge(arguments: &[String]) -> AuvResult<CliCommand> {
   let mut telemetry_sample = None;
   let mut screenshot = None;
   let mut target_block = None;
   let mut capture_skew_ms = None;
+  let mut screenshot_is_minecraft_window = true;
   let mut inspect = InspectClientOptions::default();
   let mut index = 2;
 
@@ -1064,6 +1088,13 @@ fn parse_minecraft(arguments: &[String]) -> AuvResult<CliCommand> {
         );
         index += 2;
       }
+      "--screenshot-is-minecraft-window" => {
+        screenshot_is_minecraft_window =
+          required_flag_value(arguments, index, "--screenshot-is-minecraft-window")?
+            .parse::<bool>()
+            .map_err(|error| format!("invalid --screenshot-is-minecraft-window: {error}"))?;
+        index += 2;
+      }
       other => return Err(format!("unexpected minecraft bridge argument {other}")),
     }
   }
@@ -1073,6 +1104,86 @@ fn parse_minecraft(arguments: &[String]) -> AuvResult<CliCommand> {
     screenshot: screenshot.ok_or_else(|| "--screenshot is required".to_string())?,
     target_block: target_block.ok_or_else(|| "--target-block is required".to_string())?,
     capture_skew_ms,
+    screenshot_is_minecraft_window,
+    inspect,
+  })
+}
+
+fn parse_minecraft_live_click(arguments: &[String]) -> AuvResult<CliCommand> {
+  let mut telemetry_sample = None;
+  let mut screenshot = None;
+  let mut target_block = None;
+  let mut target_app = None;
+  let mut target_title = None;
+  let mut post_telemetry_sample = None;
+  let mut capture_skew_ms = None;
+  let mut screenshot_is_minecraft_window = true;
+  let mut inspect = InspectClientOptions::default();
+  let mut index = 2;
+
+  while index < arguments.len() {
+    if let Some(consumed) = parse_inspect_client_option(
+      arguments[index].as_str(),
+      arguments.get(index + 1),
+      &mut inspect,
+    )? {
+      index += consumed;
+      continue;
+    }
+
+    match arguments[index].as_str() {
+      "--sample" => {
+        telemetry_sample = Some(required_flag_value(arguments, index, "--sample")?);
+        index += 2;
+      }
+      "--post-sample" => {
+        post_telemetry_sample = Some(required_flag_value(arguments, index, "--post-sample")?);
+        index += 2;
+      }
+      "--screenshot" => {
+        screenshot = Some(required_flag_value(arguments, index, "--screenshot")?);
+        index += 2;
+      }
+      "--target-block" => {
+        target_block = Some(required_flag_value(arguments, index, "--target-block")?);
+        index += 2;
+      }
+      "--target-app" => {
+        target_app = Some(required_flag_value(arguments, index, "--target-app")?);
+        index += 2;
+      }
+      "--target-title" => {
+        target_title = Some(required_flag_value(arguments, index, "--target-title")?);
+        index += 2;
+      }
+      "--capture-skew-ms" => {
+        capture_skew_ms = Some(
+          required_flag_value(arguments, index, "--capture-skew-ms")?
+            .parse::<i64>()
+            .map_err(|error| format!("invalid --capture-skew-ms: {error}"))?,
+        );
+        index += 2;
+      }
+      "--screenshot-is-minecraft-window" => {
+        screenshot_is_minecraft_window =
+          required_flag_value(arguments, index, "--screenshot-is-minecraft-window")?
+            .parse::<bool>()
+            .map_err(|error| format!("invalid --screenshot-is-minecraft-window: {error}"))?;
+        index += 2;
+      }
+      other => return Err(format!("unexpected minecraft live-click argument {other}")),
+    }
+  }
+
+  Ok(CliCommand::MinecraftLiveClick {
+    telemetry_sample: telemetry_sample.ok_or_else(|| "--sample is required".to_string())?,
+    screenshot: screenshot.ok_or_else(|| "--screenshot is required".to_string())?,
+    target_block: target_block.ok_or_else(|| "--target-block is required".to_string())?,
+    target_app: target_app.ok_or_else(|| "--target-app is required".to_string())?,
+    target_title: target_title.ok_or_else(|| "--target-title is required".to_string())?,
+    post_telemetry_sample,
+    capture_skew_ms,
+    screenshot_is_minecraft_window,
     inspect,
   })
 }
@@ -1484,6 +1595,8 @@ mod tests {
       "1,2,3".to_string(),
       "--capture-skew-ms".to_string(),
       "120".to_string(),
+      "--screenshot-is-minecraft-window".to_string(),
+      "false".to_string(),
     ])
     .expect("minecraft bridge command should parse");
 
@@ -1493,12 +1606,63 @@ mod tests {
         screenshot,
         target_block,
         capture_skew_ms,
+        screenshot_is_minecraft_window,
         ..
       } => {
         assert_eq!(telemetry_sample, "/tmp/telemetry.jsonl");
         assert_eq!(screenshot, "/tmp/frame.png");
         assert_eq!(target_block, "1,2,3");
         assert_eq!(capture_skew_ms, Some(120));
+        assert_eq!(screenshot_is_minecraft_window, false);
+      }
+      other => panic!("unexpected command: {other:?}"),
+    }
+  }
+
+  #[test]
+  fn parse_minecraft_live_click_command() {
+    let command = parse_cli(&[
+      "minecraft".to_string(),
+      "live-click".to_string(),
+      "--sample".to_string(),
+      "/tmp/pre.jsonl".to_string(),
+      "--post-sample".to_string(),
+      "/tmp/post.jsonl".to_string(),
+      "--screenshot".to_string(),
+      "/tmp/frame.png".to_string(),
+      "--target-block".to_string(),
+      "1,2,3".to_string(),
+      "--target-app".to_string(),
+      "com.mojang.minecraft".to_string(),
+      "--target-title".to_string(),
+      "Minecraft 1.21.5".to_string(),
+      "--capture-skew-ms".to_string(),
+      "120".to_string(),
+      "--screenshot-is-minecraft-window".to_string(),
+      "false".to_string(),
+    ])
+    .expect("minecraft live-click command should parse");
+
+    match command {
+      CliCommand::MinecraftLiveClick {
+        telemetry_sample,
+        screenshot,
+        target_block,
+        target_app,
+        target_title,
+        post_telemetry_sample,
+        capture_skew_ms,
+        screenshot_is_minecraft_window,
+        ..
+      } => {
+        assert_eq!(telemetry_sample, "/tmp/pre.jsonl");
+        assert_eq!(post_telemetry_sample.as_deref(), Some("/tmp/post.jsonl"));
+        assert_eq!(screenshot, "/tmp/frame.png");
+        assert_eq!(target_block, "1,2,3");
+        assert_eq!(target_app, "com.mojang.minecraft");
+        assert_eq!(target_title, "Minecraft 1.21.5");
+        assert_eq!(capture_skew_ms, Some(120));
+        assert_eq!(screenshot_is_minecraft_window, false);
       }
       other => panic!("unexpected command: {other:?}"),
     }

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -382,7 +382,7 @@ pub fn render_run_text(
   } else {
     for artifact in minecraft_projection_artifacts {
       output.push_str(&format!(
-        "- frame={} tick={} timestamp_ms={} screenshot_artifact_ref={} capture_skew_ms={} viewport={}x{}@{},{} visibility={} raycast={} verification_reference={} projected_point={}\n",
+        "- frame={} tick={} timestamp_ms={} screenshot_artifact_ref={} capture_skew_ms={} viewport={}x{}@{},{} visibility={} raycast={} screen_state={} refusal_reason={} verification_reference={} projected_point={}\n",
         artifact.spatial_frame_id,
         artifact.world_tick,
         artifact.monotonic_timestamp_ms,
@@ -400,6 +400,11 @@ pub fn render_run_text(
         artifact.viewport_bounds.y,
         render_projection_visibility(&artifact.visibility),
         artifact.raycast_block_id.as_deref().unwrap_or("n/a"),
+        artifact.screen_state.as_deref().unwrap_or("n/a"),
+        artifact
+          .mismatch_refusal_reason
+          .map(|reason| format!("{reason:?}"))
+          .unwrap_or_else(|| "n/a".to_string()),
         artifact.verification_reference.as_deref().unwrap_or("n/a"),
         render_minecraft_projected_point(artifact.projected_point.as_ref()),
       ));
@@ -1021,6 +1026,10 @@ mod tests {
         mc_capture_skew_ms: Some(180),
         visibility: auv_game_minecraft::types::ProjectionVisibility::Visible,
         raycast_block_id: Some("minecraft:stone".to_string()),
+        screen_state: Some("menu".to_string()),
+        mismatch_refusal_reason: Some(
+          auv_game_minecraft::verify::MismatchRefusalReason::MenuLoadingScreen,
+        ),
         verification_reference: Some("verification-1".to_string()),
       }];
     let minecraft_telemetry_sample_artifacts = vec![MinecraftTelemetrySampleArtifactLineage {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,12 @@ use std::sync::Arc;
 use image::ImageReader;
 
 use auv_cli::app::{analyze_app_probe, probe_app};
-use auv_cli::model::RunStatus;
+use auv_cli::contract::{
+  OPERATION_RESULT_API_VERSION, OperationOutput, OperationResult, OperationStatus,
+  VerificationResult,
+};
+use auv_cli::model::{InvokeRequest, RunStatus};
+use auv_cli::run_builder::RunSpec;
 use auv_cli::scroll_scan::{
   ScanRegion, ScanTarget, ScanWindowRegionOptions, StopPolicy, scan_window_region,
 };
@@ -136,6 +141,7 @@ async fn run() -> Result<(), String> {
       screenshot,
       target_block,
       capture_skew_ms,
+      screenshot_is_minecraft_window,
       inspect,
     } => {
       let runtime = build_runtime_for_inspect(&project_root, &inspect)?;
@@ -145,6 +151,7 @@ async fn run() -> Result<(), String> {
         PathBuf::from(screenshot),
         &target_block,
         capture_skew_ms,
+        screenshot_is_minecraft_window,
       )?;
       println!("runId: {}", output.run_id);
       println!(
@@ -163,6 +170,47 @@ async fn run() -> Result<(), String> {
       } else {
         println!("refusalReason: none");
       }
+      for artifact in &output.value.artifact_paths {
+        println!("artifact: {}", artifact.display());
+      }
+    }
+    CliCommand::MinecraftLiveClick {
+      telemetry_sample,
+      screenshot,
+      target_block,
+      target_app,
+      target_title,
+      post_telemetry_sample,
+      capture_skew_ms,
+      screenshot_is_minecraft_window,
+      inspect,
+    } => {
+      let runtime = build_runtime_for_inspect(&project_root, &inspect)?;
+      let output = run_minecraft_live_click(
+        &runtime,
+        PathBuf::from(telemetry_sample),
+        post_telemetry_sample.as_ref().map(PathBuf::from),
+        PathBuf::from(screenshot),
+        &target_block,
+        &target_app,
+        &target_title,
+        capture_skew_ms,
+        screenshot_is_minecraft_window,
+      )?;
+      println!("runId: {}", output.run_id);
+      println!(
+        "projectionArtifact: {}",
+        output.value.projection_artifact_id
+      );
+      println!(
+        "screenshotArtifact: {}",
+        output.value.screenshot_artifact_id
+      );
+      println!(
+        "operationResultArtifact: {}",
+        output.value.operation_result_artifact_id
+      );
+      println!("inputSummary: {}", output.value.input_summary);
       for artifact in &output.value.artifact_paths {
         println!("artifact: {}", artifact.display());
       }
@@ -480,12 +528,270 @@ struct MinecraftBridgeOutput {
   artifact_paths: Vec<PathBuf>,
 }
 
+#[derive(Debug)]
+struct MinecraftLiveClickOutput {
+  screenshot_artifact_id: String,
+  projection_artifact_id: String,
+  operation_result_artifact_id: String,
+  input_summary: String,
+  artifact_paths: Vec<PathBuf>,
+}
+
+fn build_minecraft_world_diff_verification(
+  verdict: &auv_game_minecraft::verify::WorldDiffVerdict,
+  evidence: Vec<auv_cli::contract::ArtifactRef>,
+) -> auv_cli::contract::VerificationResult {
+  use auv_cli::contract::{
+    FailureLayer, VERIFICATION_RESULT_API_VERSION, VerificationMethod, VerificationResult,
+  };
+
+  let failure_layer = match verdict.failure {
+    None => None,
+    Some(auv_game_minecraft::verify::WorldDiffFailure::VerificationUnreliable) => {
+      Some(FailureLayer::VerificationUnreliable)
+    }
+    Some(auv_game_minecraft::verify::WorldDiffFailure::StateChangedNoMatch) => {
+      Some(FailureLayer::StateChangedNoMatch)
+    }
+    Some(auv_game_minecraft::verify::WorldDiffFailure::SemanticMismatch) => {
+      Some(FailureLayer::SemanticMismatch)
+    }
+  };
+
+  VerificationResult {
+    api_version: VERIFICATION_RESULT_API_VERSION.to_string(),
+    method: VerificationMethod::SemanticMatch,
+    executed: verdict.executed,
+    state_changed: verdict.state_changed,
+    semantic_matched: verdict.semantic_matched,
+    failure_layer,
+    evidence,
+    consumed_candidate_ref: None,
+    consumed_node_ref: None,
+    consumed_recognition_artifact_ref: None,
+    consumed_recognition_id: None,
+    consumed_recognized_item_id: None,
+    observed_label: verdict.observed_block_id.clone(),
+  }
+}
+
+fn build_minecraft_operation_result(
+  run_id: &auv_cli::trace::RunId,
+  verification: VerificationResult,
+) -> OperationResult {
+  let evidence_artifacts = verification.evidence.clone();
+  OperationResult {
+    api_version: OPERATION_RESULT_API_VERSION.to_string(),
+    run_id: run_id.clone(),
+    status: OperationStatus::Completed,
+    operation_id: "auv.minecraft.live_click".to_string(),
+    evidence_artifacts,
+    output: OperationOutput::Acknowledged {
+      message: Some("minecraft live click completed".to_string()),
+    },
+    verifications: vec![verification],
+    freshness_basis: None,
+    known_limits: Vec::new(),
+  }
+}
+
+fn stage_operation_result_artifact(
+  context: &mut auv_cli::recorded_operation::RecordedOperationContext<'_>,
+  operation_result: &OperationResult,
+) -> Result<(PathBuf, auv_cli::contract::ArtifactRef), String> {
+  let artifact_json = serde_json::to_string_pretty(operation_result)
+    .map(|mut json| {
+      json.push('\n');
+      json
+    })
+    .map_err(|error| format!("failed to serialize minecraft operation result: {error}"))?;
+  let artifact_path = std::env::temp_dir().join(format!(
+    "auv-minecraft-operation-result-{}-{}.json",
+    context.run_id(),
+    auv_cli::model::now_millis()
+  ));
+  fs::write(&artifact_path, artifact_json.as_bytes())
+    .map_err(|error| format!("failed to write minecraft operation result artifact: {error}"))?;
+  let staged = context.stage_artifact_file_with_ref(
+    "operation-result",
+    &artifact_path,
+    "operation-result.json",
+    Some("minecraft live-click operation result with world diff verification".to_string()),
+  );
+  let _ = fs::remove_file(&artifact_path);
+  staged.map_err(|error| error.to_string())
+}
+
+fn run_minecraft_live_click(
+  runtime: &auv_cli::runtime::Runtime,
+  telemetry_sample: PathBuf,
+  post_telemetry_sample: Option<PathBuf>,
+  screenshot: PathBuf,
+  target_block: &str,
+  target_app: &str,
+  target_title: &str,
+  capture_skew_ms: Option<i64>,
+  screenshot_is_minecraft_window: bool,
+) -> Result<auv_cli::recorded_operation::RecordedOperationOutput<MinecraftLiveClickOutput>, String>
+{
+  let target_block = parse_block_position(target_block)?;
+  let pre_frame = auv_game_minecraft::read_latest_spatial_frame_from_tail(&telemetry_sample)?
+    .ok_or_else(|| {
+      format!(
+        "no valid minecraft frame found in {}",
+        telemetry_sample.display()
+      )
+    })?;
+  let post_sample_path = post_telemetry_sample.unwrap_or_else(|| telemetry_sample.clone());
+  let screenshot_image = ImageReader::open(&screenshot)
+    .map_err(|error| {
+      format!(
+        "failed to open screenshot {}: {error}",
+        screenshot.display()
+      )
+    })?
+    .decode()
+    .map_err(|error| {
+      format!(
+        "failed to decode screenshot {}: {error}",
+        screenshot.display()
+      )
+    })?
+    .to_rgb8();
+
+  runtime.run_recorded_operation(
+    RunSpec::new(auv_cli::trace::RunType::Execute, "auv.minecraft.live_click"),
+    "Minecraft live click",
+    |context| {
+      let (staged_screenshot_path, screenshot_ref) = context.stage_artifact_file_with_ref(
+        "minecraft-screenshot",
+        &screenshot,
+        screenshot
+          .file_name()
+          .and_then(|name| name.to_str())
+          .unwrap_or("minecraft-screenshot.png"),
+        Some("minecraft screenshot bound to live telemetry frame".to_string()),
+      )?;
+      let screenshot_artifact_id = screenshot_ref.artifact_id.as_str().to_string();
+      let capture_timestamp_ms = if let Some(skew) = capture_skew_ms {
+        if skew >= 0 {
+          pre_frame.monotonic_timestamp_ms.saturating_sub(skew as u64)
+        } else {
+          pre_frame
+            .monotonic_timestamp_ms
+            .saturating_add((-skew) as u64)
+        }
+      } else {
+        pre_frame.monotonic_timestamp_ms
+      };
+
+      let evidence = auv_game_minecraft::evidence::build_projection_evidence(
+        pre_frame.clone(),
+        auv_game_minecraft::evidence::ScreenshotCapture {
+          image: screenshot_image,
+          artifact_ref: format!("artifact://{screenshot_artifact_id}"),
+          capture_monotonic_timestamp_ms: capture_timestamp_ms,
+          is_minecraft_window: screenshot_is_minecraft_window,
+        },
+        &auv_game_minecraft::MinecraftBlockTarget::new(target_block),
+        Some(250),
+      )?;
+
+      let projection_artifact = match &evidence {
+        auv_game_minecraft::evidence::ProjectionEvidence::Bound { artifact, .. } => {
+          artifact.clone()
+        }
+        auv_game_minecraft::evidence::ProjectionEvidence::Refused { refusal, .. } => evidence
+          .artifact()
+          .clone()
+          .with_mismatch_refusal_reason(refusal.reason),
+      };
+      let (staged_projection_path, projection_ref) =
+        stage_minecraft_projection_artifact(context, &projection_artifact)?;
+      let projection_artifact_id = projection_ref.artifact_id.as_str().to_string();
+
+      let projected_point = match &evidence {
+        auv_game_minecraft::evidence::ProjectionEvidence::Bound { artifact, .. } => {
+          artifact.projected_point.clone().ok_or_else(|| {
+            "minecraft projection evidence is bound but missing projected point".to_string()
+          })?
+        }
+        auv_game_minecraft::evidence::ProjectionEvidence::Refused { refusal, .. } => {
+          return Err(format!(
+            "minecraft live click refused before input dispatch: {:?}",
+            refusal.reason
+          ));
+        }
+      };
+
+      let window_point = auv_game_minecraft::input_target::projected_window_point(&projected_point)
+        .ok_or_else(|| "projected minecraft point is not window-clickable".to_string())?;
+
+      let mut inputs = std::collections::BTreeMap::new();
+      inputs.insert("title".to_string(), target_title.to_string());
+      inputs.insert("offset_x".to_string(), format!("{:.3}", window_point.0.x));
+      inputs.insert("offset_y".to_string(), format!("{:.3}", window_point.0.y));
+
+      let invoke_result = runtime.invoke_resolved(
+        InvokeRequest {
+          command_id: "input.clickWindowPoint".to_string(),
+          target: auv_cli::model::ExecutionTarget {
+            application_id: Some(target_app.to_string()),
+            target_label: None,
+          },
+          inputs,
+          dry_run: false,
+        },
+        auv_cli_invoke::default_registry()
+          .resolve("input.clickWindowPoint")
+          .ok_or_else(|| "input.clickWindowPoint command is not registered".to_string())?,
+      )?;
+      let post_frame = auv_game_minecraft::read_latest_spatial_frame_from_tail(&post_sample_path)?
+        .ok_or_else(|| {
+          format!(
+            "no valid minecraft post frame found in {}",
+            post_sample_path.display()
+          )
+        })?;
+
+      let world_diff_request = auv_game_minecraft::verify::WorldDiffRequest::new(
+        auv_game_minecraft::MinecraftBlockTarget::new(target_block),
+      )
+      .allow_same_block_state_change();
+      let verification = build_minecraft_world_diff_verification(
+        &auv_game_minecraft::verify::evaluate_world_diff(
+          &pre_frame,
+          &post_frame,
+          &world_diff_request,
+        ),
+        vec![screenshot_ref.clone(), projection_ref.clone()],
+      );
+      let operation_result = build_minecraft_operation_result(context.run_id(), verification);
+      let (staged_operation_result_path, operation_result_ref) =
+        stage_operation_result_artifact(context, &operation_result)?;
+
+      Ok::<MinecraftLiveClickOutput, String>(MinecraftLiveClickOutput {
+        screenshot_artifact_id,
+        projection_artifact_id,
+        operation_result_artifact_id: operation_result_ref.artifact_id.as_str().to_string(),
+        input_summary: invoke_result.output_summary,
+        artifact_paths: vec![
+          staged_screenshot_path,
+          staged_projection_path,
+          staged_operation_result_path,
+        ],
+      })
+    },
+  )
+}
+
 fn run_minecraft_projection_bridge(
   runtime: &auv_cli::runtime::Runtime,
   telemetry_sample: PathBuf,
   screenshot: PathBuf,
   target_block: &str,
   capture_skew_ms: Option<i64>,
+  screenshot_is_minecraft_window: bool,
 ) -> Result<auv_cli::recorded_operation::RecordedOperationOutput<MinecraftBridgeOutput>, String> {
   let target_block = parse_block_position(target_block)?;
   let frame = auv_game_minecraft::read_latest_spatial_frame_from_tail(&telemetry_sample)?
@@ -543,14 +849,23 @@ fn run_minecraft_projection_bridge(
           image: screenshot_image,
           artifact_ref: format!("artifact://{screenshot_artifact_id}"),
           capture_monotonic_timestamp_ms: capture_timestamp_ms,
-          is_minecraft_window: true,
+          is_minecraft_window: screenshot_is_minecraft_window,
         },
         &auv_game_minecraft::MinecraftBlockTarget::new(target_block),
         Some(250),
       )?;
 
+      let projection_artifact = match &evidence {
+        auv_game_minecraft::evidence::ProjectionEvidence::Bound { artifact, .. } => {
+          artifact.clone()
+        }
+        auv_game_minecraft::evidence::ProjectionEvidence::Refused { refusal, .. } => evidence
+          .artifact()
+          .clone()
+          .with_mismatch_refusal_reason(refusal.reason),
+      };
       let (staged_projection_path, projection_ref) =
-        stage_minecraft_projection_artifact(context, evidence.artifact())?;
+        stage_minecraft_projection_artifact(context, &projection_artifact)?;
       let projection_artifact_id = projection_ref.artifact_id.as_str().to_string();
       let mut artifact_paths = vec![staged_screenshot_path, staged_projection_path];
       let mut overlay_artifact_id = None;
@@ -1272,6 +1587,7 @@ mod tests {
       inventory_summary: Vec::new(),
       screenshot_artifact_ref: None,
       mc_capture_skew_ms: None,
+      screen_state: None,
     };
     let body = serde_json::to_string(&frame).expect("frame should serialize");
     fs::write(path, format!("{body}\n")).expect("telemetry sample should write");
@@ -1281,6 +1597,125 @@ mod tests {
     RgbImage::from_pixel(64, 64, Rgb([0, 0, 0]))
       .save(path)
       .expect("screenshot should write");
+  }
+
+  #[test]
+  fn minecraft_world_diff_verification_maps_success_verdict() {
+    let verdict = auv_game_minecraft::verify::WorldDiffVerdict {
+      executed: true,
+      state_changed: true,
+      semantic_matched: Some(true),
+      failure: None,
+      observed_block_id: Some("minecraft:air".to_string()),
+      observed_item_delta: Some(1),
+    };
+
+    let verification = build_minecraft_world_diff_verification(&verdict, Vec::new());
+
+    assert_eq!(
+      verification.method,
+      auv_cli::contract::VerificationMethod::SemanticMatch
+    );
+    assert_eq!(verification.executed, true);
+    assert_eq!(verification.state_changed, true);
+    assert_eq!(verification.semantic_matched, Some(true));
+    assert_eq!(verification.failure_layer, None);
+    assert_eq!(
+      verification.observed_label.as_deref(),
+      Some("minecraft:air")
+    );
+  }
+
+  #[test]
+  fn minecraft_world_diff_verification_maps_failure_layers() {
+    let cases = [
+      (
+        auv_game_minecraft::verify::WorldDiffFailure::VerificationUnreliable,
+        Some(auv_cli::contract::FailureLayer::VerificationUnreliable),
+        None,
+      ),
+      (
+        auv_game_minecraft::verify::WorldDiffFailure::StateChangedNoMatch,
+        Some(auv_cli::contract::FailureLayer::StateChangedNoMatch),
+        Some(false),
+      ),
+      (
+        auv_game_minecraft::verify::WorldDiffFailure::SemanticMismatch,
+        Some(auv_cli::contract::FailureLayer::SemanticMismatch),
+        Some(false),
+      ),
+    ];
+
+    for (failure, expected_layer, semantic_matched) in cases {
+      let verdict = auv_game_minecraft::verify::WorldDiffVerdict {
+        executed: true,
+        state_changed: matches!(
+          failure,
+          auv_game_minecraft::verify::WorldDiffFailure::StateChangedNoMatch
+        ),
+        semantic_matched,
+        failure: Some(failure),
+        observed_block_id: Some("minecraft:stone".to_string()),
+        observed_item_delta: Some(0),
+      };
+
+      let verification = build_minecraft_world_diff_verification(&verdict, Vec::new());
+      assert_eq!(verification.failure_layer, expected_layer);
+      assert_eq!(
+        verification.observed_label.as_deref(),
+        Some("minecraft:stone")
+      );
+    }
+  }
+
+  #[test]
+  fn minecraft_live_click_command_persists_operation_result_artifact() {
+    let project_root = mc2_temp_dir("mc3-live-click-project");
+    let store_root = mc2_temp_dir("mc3-live-click-store");
+    let telemetry_path = project_root.join("pre.jsonl");
+    let post_telemetry_path = project_root.join("post.jsonl");
+    let screenshot_path = project_root.join("frame.png");
+    write_mc2_test_telemetry(&telemetry_path);
+    write_mc2_test_telemetry(&post_telemetry_path);
+    write_mc2_test_screenshot(&screenshot_path);
+
+    let runtime = build_runtime_with_store_root(project_root.clone(), store_root.clone())
+      .expect("runtime should build");
+    let output = run_minecraft_live_click(
+      &runtime,
+      telemetry_path,
+      Some(post_telemetry_path),
+      screenshot_path,
+      "0,0,0",
+      "FixtureApp",
+      "Fixture Window",
+      Some(0),
+      true,
+    )
+    .expect("live click should record");
+
+    let run = runtime
+      .read_run(output.run_id.as_str())
+      .expect("run should persist");
+    assert_eq!(run.artifacts.len(), 3);
+    assert_eq!(run.artifacts[0].role, "minecraft-screenshot");
+    assert_eq!(
+      run.artifacts[1].role,
+      auv_cli::runtime::MINECRAFT_PROJECTION_ARTIFACT_ROLE
+    );
+    assert_eq!(run.artifacts[2].role, "operation-result");
+
+    let verifications = runtime
+      .list_verifications(output.run_id.as_str())
+      .expect("verifications should list");
+    assert_eq!(verifications.len(), 1);
+    assert_eq!(
+      verifications[0].method,
+      auv_cli::contract::VerificationMethod::SemanticMatch
+    );
+
+    let _ = fs::remove_dir_all(project_root);
+    let _ = fs::remove_dir_all(store_root);
   }
 
   #[test]
@@ -1294,9 +1729,15 @@ mod tests {
 
     let runtime = build_runtime_with_store_root(project_root.clone(), store_root.clone())
       .expect("runtime should build");
-    let output =
-      run_minecraft_projection_bridge(&runtime, telemetry_path, screenshot_path, "0,0,0", Some(0))
-        .expect("bridge should succeed");
+    let output = run_minecraft_projection_bridge(
+      &runtime,
+      telemetry_path,
+      screenshot_path,
+      "0,0,0",
+      Some(0),
+      true,
+    )
+    .expect("bridge should succeed");
 
     let run = runtime
       .read_run(output.run_id.as_str())
@@ -1338,6 +1779,7 @@ mod tests {
       screenshot_path,
       "0,0,0",
       Some(999),
+      true,
     )
     .expect("bridge refusal should still record");
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -929,7 +929,10 @@ mod tests {
 
   use serde_json::json;
 
-  use super::{MINECRAFT_PROJECTION_ARTIFACT_ROLE, Runtime, TELEMETRY_SAMPLE_ARTIFACT_ROLE};
+  use super::{
+    MINECRAFT_PROJECTION_ARTIFACT_ROLE, Runtime, TELEMETRY_SAMPLE_ARTIFACT_ROLE,
+    TELEMETRY_SAMPLE_MAX_BYTES,
+  };
   use crate::driver::{Driver, DriverRegistry};
   use crate::model::{
     AuvResult, DriverCall, DriverDescriptor, DriverResponse, ExecutionTarget, InvokeRequest,
@@ -1144,6 +1147,51 @@ mod tests {
   }
 
   #[test]
+  fn record_telemetry_sample_artifact_keeps_large_source_file_intact() {
+    let project_root = temp_dir("runtime-telemetry-large-project");
+    let store_root = temp_dir("runtime-telemetry-large-store");
+    fs::create_dir_all(&project_root).expect("project root should exist");
+    let source_path = project_root.join("telemetry.jsonl");
+    let original_body = (0..6000)
+      .map(|index| {
+        format!(
+          "{{\"sample\":{index},\"payload\":\"{}\"}}\n",
+          "x".repeat(32)
+        )
+      })
+      .collect::<String>();
+    fs::write(&source_path, &original_body).expect("large telemetry sample should write");
+    let original_size = fs::metadata(&source_path).expect("source metadata").len();
+    assert!(
+      original_size > TELEMETRY_SAMPLE_MAX_BYTES,
+      "fixture must exceed trimming threshold"
+    );
+
+    let runtime = runtime_with_success_driver(project_root.clone(), store_root.clone());
+    let output = runtime
+      .record_telemetry_sample_artifact(source_path.clone())
+      .expect("telemetry sample recording should succeed");
+
+    let persisted_source = fs::read_to_string(&source_path).expect("source file should remain");
+    assert_eq!(persisted_source, original_body);
+
+    let run = runtime
+      .read_run(output.run_id.as_str())
+      .expect("run should persist");
+    let staged_path = store_root
+      .join("runs")
+      .join(output.run_id.as_str())
+      .join(&run.artifacts[0].path);
+    let staged_size = fs::metadata(&staged_path)
+      .expect("staged artifact metadata")
+      .len();
+    assert!(staged_size <= TELEMETRY_SAMPLE_MAX_BYTES);
+
+    let _ = fs::remove_dir_all(project_root);
+    let _ = fs::remove_dir_all(store_root);
+  }
+
+  #[test]
   fn record_minecraft_projection_artifact_persists_artifact_for_inspect() {
     let project_root = temp_dir("runtime-minecraft-projection-project");
     let store_root = temp_dir("runtime-minecraft-projection-store");
@@ -1171,6 +1219,10 @@ mod tests {
       }),
       visibility: auv_game_minecraft::ProjectionVisibility::Visible,
       raycast_block_id: Some("minecraft:stone".to_string()),
+      screen_state: Some("menu".to_string()),
+      mismatch_refusal_reason: Some(
+        auv_game_minecraft::verify::MismatchRefusalReason::MenuLoadingScreen,
+      ),
       verification_reference: Some("verification-1".to_string()),
     };
 
@@ -1195,6 +1247,8 @@ mod tests {
     assert!(inspect_text.contains("frame=frame-1"));
     assert!(inspect_text.contains("screenshot_artifact_ref=artifact://screenshot-1"));
     assert!(inspect_text.contains("capture_skew_ms=180"));
+    assert!(inspect_text.contains("screen_state=menu"));
+    assert!(inspect_text.contains("refusal_reason=MenuLoadingScreen"));
     assert!(inspect_text.contains("verification_reference=verification-1"));
 
     let _ = fs::remove_dir_all(project_root);


### PR DESCRIPTION
## What changed

- wired Minecraft live closure artifacts through the durable run seam for MC-2 / MC-3 / MC-4
- added sidecar `screen_state` emission so menu/loading captures can refuse before geometry
- persisted MC projection refusal metadata into inspectable artifacts
- recorded live run evidence in the closure plan, including the fresh `MenuLoadingScreen` rerun
- restored the typed macOS window click contract to reject `click_count >= 3`

## Why

The prior MC-4 closure claim was overstated. The documented menu/loading refusal run did not durably record the claimed refusal reason. This patch makes the refusal reason land in artifacts and inspect output, then re-runs the live menu case against a fresh real Minecraft menu screenshot.

## Impact

- MC-2 / MC-3 / MC-4 now have durable live evidence in local `.auv/runs`
- inspect output can show `screen_state` and refusal reason for Minecraft projection artifacts
- menu/loading captures refuse as `MenuLoadingScreen` instead of surfacing misleading geometry-only outcomes

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p auv-game-minecraft`
- `cargo test --bin auv-cli minecraft`
- real live rerun: `run_1781728505910_73396_0` with fresh Minecraft menu screenshot, stdout `refusalReason: MenuLoadingScreen`, durable inspect/artifact confirmation
