### PR TITLE
refactor(auv): remove legacy recording

### DIFF
--- a/crates/auv-inference-ultralytics/tests/fixture_parity.rs
+++ b/crates/auv-inference-ultralytics/tests/fixture_parity.rs
@@ -4,15 +4,16 @@ use auv_cli::inference_recognition::{
   BestSelectionStrategy, DetectorRecognitionArtifactRequest, DetectorRecognitionBridgePolicy,
   RuntimeProjection, RuntimeProjectionKind, record_detector_manifest_recognition_artifact,
 };
-use auv_cli::run_builder::RunSpec;
-use auv_cli::trace::RunType;
-use auv_cli::{inspect_server, store::LocalStore};
+use auv_cli::inspect_server;
 use auv_inference_common::{
   BoundingBox, ClassLabelSource, Detection, DetectionCoordinateSpace, DetectionEvidenceManifest,
   DetectionOptions, DetectionSet, ModelId, ModelRunMetadata, ProjectionBasis, SourceImageEvidence,
   SourceImageRef, render_annotated_image,
 };
 use auv_inference_ultralytics::{InferenceDevice, UltralyticsDetector, UltralyticsModelConfig};
+use auv_tracing_driver::run_builder::RunSpec;
+use auv_tracing_driver::store::LocalStore;
+use auv_tracing_driver::trace::RunType;
 use auv_tracing_driver::{BroadcastRunRecorder, RunRecordingBackend};
 use axum::body::{Body, to_bytes};
 use axum::http::{Request, StatusCode};

--- a/crates/auv-inference-ultralytics/tests/slay_the_spire_observe_only_boundary.rs
+++ b/crates/auv-inference-ultralytics/tests/slay_the_spire_observe_only_boundary.rs
@@ -4,13 +4,13 @@ use auv_cli::inference_recognition::{
   BestSelectionStrategy, DetectorRecognitionArtifactRequest, DetectorRecognitionBridgePolicy,
   RuntimeProjection, RuntimeProjectionKind, record_detector_manifest_recognition_artifact,
 };
-use auv_cli::run_builder::RunSpec;
-use auv_cli::trace::RunType;
 use auv_inference_common::{
   BoundingBox, ClassLabelSource, Detection, DetectionCoordinateSpace, DetectionEvidenceManifest,
   DetectionSet, ImageSize, ModelId, ModelRunMetadata, ProjectionBasis, SourceImageEvidence,
   SourceImageRef,
 };
+use auv_tracing_driver::run_builder::RunSpec;
+use auv_tracing_driver::trace::RunType;
 use serde_json::{Value, json};
 use std::error::Error;
 use std::fs;

--- a/examples/netease_play_visible_anchor.rs
+++ b/examples/netease_play_visible_anchor.rs
@@ -2,15 +2,15 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use auv_cli::recorded_operation::RecordedOperationContext;
-use auv_cli::run_builder::{Attributes, RunSpec};
-use auv_cli::trace::{RunType, string_attr};
 use auv_driver::capture::Capture;
 use auv_driver::input::{Click, ClickOptions, TextSubmit, TypeTextOptions, WindowClickStrategy};
 use auv_driver::selector::{App, Window};
 use auv_driver::vision::{RecognizedText, TextRecognition};
 use auv_driver::{Driver, RatioRect, ScreenPoint, WindowPoint};
 use auv_driver_macos::MacosDriver;
+use auv_tracing_driver::recorded_operation::RecordedOperationContext;
+use auv_tracing_driver::run_builder::{Attributes, RunSpec};
+use auv_tracing_driver::trace::{RunType, string_attr};
 
 static TEMP_CAPTURE_COUNTER: AtomicU64 = AtomicU64::new(0);
 

--- a/src/app/analysis.rs
+++ b/src/app/analysis.rs
@@ -15,7 +15,6 @@ use std::path::{Path, PathBuf};
 
 use crate::contract::{CandidateQuery, SelectorScope, SurfaceSelector, SurfaceSelectorClause};
 use crate::model::{AuvResult, RunStatus, now_millis};
-use crate::trace::{ArtifactId, EventId, RunId, SpanId};
 use auv_driver_macos::support::{
   group_ocr_matches_into_rows, parse_observed_ax_tree, parse_ocr_text_snapshot, parse_window_line,
   report_value,
@@ -24,6 +23,7 @@ use auv_driver_macos::types::{
   ObservedAxNode, ObservedAxTreeSnapshot, ObservedDisplay, ObservedDisplaySnapshot, ObservedOcrRow,
   ObservedRect, ObservedWindow, OcrTextSnapshot, compute_combined_bounds,
 };
+use auv_tracing_driver::trace::{ArtifactId, EventId, RunId, SpanId};
 use serde_json::Value;
 
 use super::infra::first_non_empty_string;

--- a/src/app/infra.rs
+++ b/src/app/infra.rs
@@ -8,13 +8,13 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::model::{AuvResult, ExecutionTarget, InvokeRequest, RunStatus, now_millis};
-use crate::run_builder::{RecordingRun, RunFinish, SpanFinish, SpanRef};
 use crate::runtime::Runtime;
-use crate::store::sanitized_artifact_name;
-use crate::trace::{
+use auv_tracing_driver::RecordingHandle;
+use auv_tracing_driver::run_builder::{RecordingRun, RunFinish, SpanFinish, SpanRef};
+use auv_tracing_driver::store::sanitized_artifact_name;
+use auv_tracing_driver::trace::{
   SPAN_API_VERSION, SpanRecordV1Alpha1, TraceState, TraceStatusCode, new_span_id, string_attr,
 };
-use auv_tracing_driver::RecordingHandle;
 
 use super::{AppIdentity, AppProbeArtifact, AppProbeStep};
 
@@ -355,7 +355,7 @@ pub(crate) fn finish_failed_app_run<T>(
 
 pub(crate) fn app_span_record(
   name: impl Into<String>,
-  attributes: crate::run_builder::Attributes,
+  attributes: auv_tracing_driver::run_builder::Attributes,
 ) -> SpanRecordV1Alpha1 {
   SpanRecordV1Alpha1 {
     api_version: SPAN_API_VERSION.to_string(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -28,11 +28,11 @@ use serde::{Deserialize, Serialize};
 
 use crate::contract::ArtifactRef;
 use crate::model::{AuvResult, now_millis};
-use crate::run_builder::{RecordingRun, RunFinish, RunSpec, SpanRef};
 use crate::runtime::Runtime;
-use crate::store::sanitized_artifact_name;
-use crate::trace::{RunType, TraceStatusCode};
 use auv_tracing_driver::RecordingHandle;
+use auv_tracing_driver::run_builder::{RecordingRun, RunFinish, RunSpec, SpanRef};
+use auv_tracing_driver::store::sanitized_artifact_name;
+use auv_tracing_driver::trace::{RunType, TraceStatusCode};
 
 const APP_PROBE_VERSION: &str = "v0";
 const APP_ANALYSIS_VERSION: &str = "v0";

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -7,9 +7,9 @@ use crate::contract::{
   ArtifactRef, CandidateQuery, SelectorScope, SurfaceSelector, SurfaceSelectorClause,
 };
 use crate::model::RunStatus;
-use crate::run_builder::RunSpec;
-use crate::store::LocalStore;
-use crate::trace::RunType;
+use auv_tracing_driver::run_builder::RunSpec;
+use auv_tracing_driver::store::LocalStore;
+use auv_tracing_driver::trace::RunType;
 
 #[test]
 fn parse_probe_directory_resolves_probe_json() {
@@ -381,10 +381,10 @@ fn report_analysis_fixture() -> AppAnalysis {
         known_limits: vec!["test query".to_string()],
       }),
       evidence_refs: vec![ArtifactRef {
-        run_id: crate::trace::RunId::new("run_probe"),
-        span_id: crate::trace::SpanId::new("span_probe"),
-        artifact_id: crate::trace::ArtifactId::new("artifact_0001"),
-        captured_event_id: Some(crate::trace::EventId::new("event_probe")),
+        run_id: auv_tracing_driver::trace::RunId::new("run_probe"),
+        span_id: auv_tracing_driver::trace::SpanId::new("span_probe"),
+        artifact_id: auv_tracing_driver::trace::ArtifactId::new("artifact_0001"),
+        captured_event_id: Some(auv_tracing_driver::trace::EventId::new("event_probe")),
       }],
       promotion_gate: Some(AppCandidatePromotionGate {
         status: AppCandidatePromotionStatus::ActionGradeCandidate,

--- a/src/ax_recognition.rs
+++ b/src/ax_recognition.rs
@@ -10,7 +10,7 @@ use crate::contract::{
   RecognitionSurface, RecognizedItem,
 };
 use crate::model::{AuvResult, now_millis};
-use crate::recorded_operation::RecordedOperationContext;
+use auv_tracing_driver::recorded_operation::RecordedOperationContext;
 
 #[cfg(target_os = "macos")]
 use auv_driver_macos::types::{ObservedAxNode, ObservedAxTreeSnapshot, ObservedRect};
@@ -469,9 +469,9 @@ mod tests {
   use crate::build_runtime_with_store_root;
   use crate::candidate_promotion::PromotionProjection;
   use crate::contract::ArtifactRef;
-  use crate::run_builder::RunSpec;
-  use crate::trace::{ArtifactId, EventId, RunId, RunType, SpanId, TraceStatusCode};
   use auv_driver_macos::types::{ObservedAxNode, ObservedAxTreeSnapshot, ObservedRect};
+  use auv_tracing_driver::run_builder::RunSpec;
+  use auv_tracing_driver::trace::{ArtifactId, EventId, RunId, RunType, SpanId, TraceStatusCode};
 
   fn artifact_ref() -> ArtifactRef {
     ArtifactRef {

--- a/src/candidate_action_command.rs
+++ b/src/candidate_action_command.rs
@@ -24,9 +24,9 @@ use crate::candidate_promotion_recording::{
   record_candidate_promotion_artifact_with_recognition_projection,
 };
 use crate::model::{AuvResult, now_millis};
-use crate::recorded_operation::RecordedOperationContext;
 use crate::stability::StabilityPolicy;
 use auv_driver::Driver;
+use auv_tracing_driver::recorded_operation::RecordedOperationContext;
 const CANDIDATE_ACTION_PROPOSAL_ARTIFACT_ROLE: &str = "candidate-action-proposal";
 const CANDIDATE_ACTION_PROPOSAL_ARTIFACT_VERSION: &str = "candidate_action_proposal_artifact_v0";
 const OPENAI_RESPONSES_API_URL: &str = "https://api.openai.com/v1/responses";

--- a/src/candidate_action_decision.rs
+++ b/src/candidate_action_decision.rs
@@ -13,8 +13,8 @@ use crate::contract::{
   VerificationResult,
 };
 use crate::model::{AuvResult, now_millis};
-use crate::recorded_operation::RecordedOperationContext;
-use crate::trace::RunId;
+use auv_tracing_driver::recorded_operation::RecordedOperationContext;
+use auv_tracing_driver::trace::RunId;
 
 pub const CANDIDATE_ACTION_DECISION_ARTIFACT_ROLE: &str = "candidate-action-decision";
 pub const CANDIDATE_ACTION_EXECUTION_ARTIFACT_ROLE: &str = "candidate-action-execution";
@@ -2288,9 +2288,9 @@ mod tests {
     RecognitionScope, RecognitionSource, RecognitionSurface, RecognizedItem, TargetGrounding,
     VerificationMethod,
   };
-  use crate::run_builder::RunSpec;
   use crate::stability::StabilityPolicy;
-  use crate::trace::{ArtifactId, EventId, RunId, RunType, SpanId, TraceStatusCode};
+  use auv_tracing_driver::run_builder::RunSpec;
+  use auv_tracing_driver::trace::{ArtifactId, EventId, RunId, RunType, SpanId, TraceStatusCode};
 
   fn sample_artifact_ref() -> ArtifactRef {
     ArtifactRef {

--- a/src/candidate_promotion.rs
+++ b/src/candidate_promotion.rs
@@ -300,7 +300,7 @@ mod tests {
     ArtifactRef, Candidate, FreshnessBasis, RecognitionBox, RecognitionResult, RecognitionScope,
     RecognitionSource, RecognitionSurface, RecognizedItem,
   };
-  use crate::trace::{ArtifactId, EventId, RunId, SpanId};
+  use auv_tracing_driver::trace::{ArtifactId, EventId, RunId, SpanId};
 
   fn sample_artifact_ref() -> ArtifactRef {
     ArtifactRef {

--- a/src/candidate_promotion_recording.rs
+++ b/src/candidate_promotion_recording.rs
@@ -9,8 +9,8 @@ use crate::candidate_promotion::{
 };
 use crate::contract::{ArtifactRef, FreshnessBasis, RecognitionResult};
 use crate::model::{AuvResult, now_millis};
-use crate::recorded_operation::RecordedOperationContext;
 use crate::stability::{StabilityAssessment, StabilityPolicy, assess_stability};
+use auv_tracing_driver::recorded_operation::RecordedOperationContext;
 
 const CANDIDATE_PROMOTION_ARTIFACT_ROLE: &str = "candidate-promotion";
 const CANDIDATE_PROMOTION_ARTIFACT_VERSION: &str = "candidate_promotion_artifact_v0";
@@ -378,9 +378,9 @@ mod tests {
     ArtifactRef, RecognitionBox, RecognitionResult, RecognitionScope, RecognitionSource,
     RecognitionSurface, RecognizedItem,
   };
-  use crate::run_builder::RunSpec;
   use crate::stability::StabilityPolicy;
-  use crate::trace::{ArtifactId, EventId, RunId, RunType, SpanId, TraceStatusCode};
+  use auv_tracing_driver::run_builder::RunSpec;
+  use auv_tracing_driver::trace::{ArtifactId, EventId, RunId, RunType, SpanId, TraceStatusCode};
 
   fn sample_artifact_ref() -> ArtifactRef {
     ArtifactRef {

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -43,7 +43,7 @@ use serde::{Deserialize, Serialize};
 
 pub use auv_tracing_driver::ArtifactRef;
 
-use crate::trace::{ArtifactId, RunId, SpanId};
+use auv_tracing_driver::trace::{ArtifactId, RunId, SpanId};
 
 // NOTICE(contract-api-version-reader-check): producer-side stamping landed
 // in commit be0aab7 but the reader side does not yet reject artifacts
@@ -102,7 +102,7 @@ pub enum OperationStatus {
 /// # Seam role
 ///
 /// - **Produced by** typed driver / runtime command handlers via
-///   `Runtime::record_operation` (see [`crate::recorded_operation`]).
+///   `Runtime::record_operation` (see [`auv_tracing_driver::recorded_operation`]).
 ///   Action commands record the `InputActionResult` from
 ///   `crates/auv-driver` through the macos `ActionResolverDecision`
 ///   layer, then attach the resulting `OperationResult` here.
@@ -612,7 +612,7 @@ mod tests {
   use super::*;
   use serde_json::json;
 
-  use crate::trace::EventId;
+  use auv_tracing_driver::trace::EventId;
 
   fn artifact_ref() -> ArtifactRef {
     ArtifactRef {

--- a/src/inference_recognition.rs
+++ b/src/inference_recognition.rs
@@ -14,7 +14,7 @@ use crate::contract::{
   RecognizedItem,
 };
 use crate::model::AuvResult;
-use crate::recorded_operation::RecordedOperationContext;
+use auv_tracing_driver::recorded_operation::RecordedOperationContext;
 
 const BRIDGE_POLICY_VERSION: &str = "detector-manifest-recognitionresult.v0";
 const DETECTOR_RECOGNITION_ARTIFACT_ROLE: &str = "detector-recognition";
@@ -445,9 +445,9 @@ mod tests {
   };
   use crate::build_runtime_with_store_root;
   use crate::contract::{ArtifactRef, RatioRegion, RecognitionScope, RecognitionSurface};
-  use crate::run_builder::RunSpec;
-  use crate::trace::{ArtifactId, EventId, RunId, SpanId};
-  use crate::trace::{RunType, TraceStatusCode};
+  use auv_tracing_driver::run_builder::RunSpec;
+  use auv_tracing_driver::trace::{ArtifactId, EventId, RunId, SpanId};
+  use auv_tracing_driver::trace::{RunType, TraceStatusCode};
 
   fn sample_manifest() -> DetectionEvidenceManifest {
     DetectionEvidenceManifest {

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -17,7 +17,7 @@ use crate::run_read::{
   MinecraftTelemetrySampleArtifactLineage, list_minecraft_projection_artifacts,
   list_minecraft_telemetry_sample_artifacts,
 };
-use crate::store::{CanonicalRun, LocalStore};
+use auv_tracing_driver::store::{CanonicalRun, LocalStore};
 
 pub fn read_run(store: &LocalStore, run_id: &str) -> AuvResult<CanonicalRun> {
   crate::run_read::read_run(store, run_id)
@@ -655,8 +655,8 @@ mod tests {
     DetectorRecognitionLineage, DetectorRecognitionLineageStatus,
     MinecraftTelemetrySampleArtifactLineage,
   };
-  use crate::store::CanonicalRun;
-  use crate::trace::{
+  use auv_tracing_driver::store::CanonicalRun;
+  use auv_tracing_driver::trace::{
     ARTIFACT_API_VERSION, ArtifactId, ArtifactRecordV1Alpha1, EVENT_API_VERSION, EventId,
     EventRecordV1Alpha1, RUN_API_VERSION, RunId, RunRecordV1Alpha1, RunType, SPAN_API_VERSION,
     SpanId, SpanRecordV1Alpha1, TraceId, TraceState, TraceStatusCode,
@@ -1035,8 +1035,8 @@ mod tests {
     let minecraft_telemetry_sample_artifacts = vec![MinecraftTelemetrySampleArtifactLineage {
       artifact: crate::run_read::ArtifactRefLineage {
         run_id: run.run.run_id.clone(),
-        artifact_id: crate::trace::ArtifactId::new("artifact_mc1".to_string()),
-        span_id: crate::trace::SpanId::new("span_mc1".to_string()),
+        artifact_id: auv_tracing_driver::trace::ArtifactId::new("artifact_mc1".to_string()),
+        span_id: auv_tracing_driver::trace::SpanId::new("span_mc1".to_string()),
         captured_event_id: None,
         role: Some("telemetry-sample".to_string()),
         path: Some("artifacts/telemetry.jsonl".to_string()),

--- a/src/inspect_server/mod.rs
+++ b/src/inspect_server/mod.rs
@@ -34,8 +34,8 @@ use tokio::sync::{Mutex, OwnedMutexGuard};
 use crate::contract::{ObservationSnapshot, VerificationResult};
 use crate::model::AuvResult;
 use crate::run_read::{CandidatePromotionLineage, DetectorRecognitionLineage};
-use crate::store::{CanonicalRun, LocalStore};
-use crate::trace::{RunId, RunRecordV1Alpha1, TraceState};
+use auv_tracing_driver::store::{CanonicalRun, LocalStore};
+use auv_tracing_driver::trace::{RunId, RunRecordV1Alpha1, TraceState};
 use auv_tracing_driver::{BroadcastRunRecorder, RunRecorder, RunUpdate, WireUpdate};
 
 pub const DEFAULT_INSPECT_HOST: &str = "127.0.0.1";
@@ -704,8 +704,8 @@ fn apply_update(
 }
 
 fn run_immutable_metadata_differs(
-  existing: &crate::trace::RunRecordV1Alpha1,
-  next: &crate::trace::RunRecordV1Alpha1,
+  existing: &auv_tracing_driver::trace::RunRecordV1Alpha1,
+  next: &auv_tracing_driver::trace::RunRecordV1Alpha1,
 ) -> bool {
   existing.api_version != next.api_version
     || existing.run_id != next.run_id
@@ -717,8 +717,8 @@ fn run_immutable_metadata_differs(
 }
 
 fn span_immutable_metadata_differs(
-  existing: &crate::trace::SpanRecordV1Alpha1,
-  next: &crate::trace::SpanRecordV1Alpha1,
+  existing: &auv_tracing_driver::trace::SpanRecordV1Alpha1,
+  next: &auv_tracing_driver::trace::SpanRecordV1Alpha1,
 ) -> bool {
   existing.api_version != next.api_version
     || existing.span_id != next.span_id
@@ -914,8 +914,9 @@ mod tests {
     SectionCandidate, StopEvidence, StopPolicy, StopReason,
   };
   use crate::stability::{StabilityAssessment, StabilityPolicy};
-  use crate::store::{ArtifactFileSource, CanonicalRun, LocalStore};
-  use crate::trace::{
+  use auv_tracing_driver::ArtifactFileSource;
+  use auv_tracing_driver::store::{CanonicalRun, LocalStore};
+  use auv_tracing_driver::trace::{
     ARTIFACT_API_VERSION, ArtifactId, ArtifactRecordV1Alpha1, EVENT_API_VERSION, EventId,
     EventRecordV1Alpha1, RUN_API_VERSION, RunId, RunRecordV1Alpha1, RunType, SPAN_API_VERSION,
     SpanId, SpanRecordV1Alpha1, TraceId, TraceState, TraceStatusCode,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,20 +14,16 @@ pub mod inspect_server;
 pub mod mcp;
 pub mod model;
 pub mod osu;
-pub mod recorded_operation;
-pub mod run_builder;
 mod run_read;
 pub mod runtime;
 pub mod scroll_scan;
 pub mod stability;
-pub mod store;
-pub mod trace;
 
 use std::path::PathBuf;
 
+use auv_tracing_driver::store::LocalStore;
 use model::AuvResult;
 use runtime::Runtime;
-use store::LocalStore;
 
 pub fn build_default_runtime(project_root: PathBuf) -> AuvResult<Runtime> {
   let store_root = default_project_store_root(project_root.clone());

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,11 +16,11 @@ use auv_cli::contract::{
   VerificationResult,
 };
 use auv_cli::model::{InvokeRequest, RunStatus};
-use auv_cli::run_builder::RunSpec;
 use auv_cli::scroll_scan::{
   ScanRegion, ScanTarget, ScanWindowRegionOptions, StopPolicy, scan_window_region,
 };
 use auv_cli::{build_default_runtime, build_runtime_with_store_root};
+use auv_tracing_driver::run_builder::RunSpec;
 use cli::{CliCommand, InspectClientOptions, help_text, parse_cli};
 
 #[tokio::main]
@@ -62,7 +62,7 @@ async fn run() -> Result<(), String> {
   } = &command
   {
     let store_root = resolve_store_root(&project_root, store_root.as_ref());
-    let store = auv_cli::store::LocalStore::new(store_root.clone())?;
+    let store = auv_tracing_driver::store::LocalStore::new(store_root.clone())?;
     let recorder = Arc::new(auv_tracing_driver::BroadcastRunRecorder::new(1024));
     let token = resolve_inspect_serve_write_token(write)?;
     let config = auv_cli::inspect_server::InspectServeConfig {
@@ -567,7 +567,7 @@ fn build_minecraft_world_diff_verification(
 }
 
 fn build_minecraft_operation_result(
-  run_id: &auv_cli::trace::RunId,
+  run_id: &auv_tracing_driver::trace::RunId,
   verification: VerificationResult,
 ) -> OperationResult {
   let evidence_artifacts = verification.evidence.clone();
@@ -587,7 +587,7 @@ fn build_minecraft_operation_result(
 }
 
 fn stage_operation_result_artifact(
-  context: &mut auv_cli::recorded_operation::RecordedOperationContext<'_>,
+  context: &mut auv_tracing_driver::recorded_operation::RecordedOperationContext<'_>,
   operation_result: &OperationResult,
 ) -> Result<(PathBuf, auv_cli::contract::ArtifactRef), String> {
   let artifact_json = serde_json::to_string_pretty(operation_result)
@@ -623,8 +623,10 @@ fn run_minecraft_live_click(
   target_title: &str,
   capture_skew_ms: Option<i64>,
   screenshot_is_minecraft_window: bool,
-) -> Result<auv_cli::recorded_operation::RecordedOperationOutput<MinecraftLiveClickOutput>, String>
-{
+) -> Result<
+  auv_tracing_driver::recorded_operation::RecordedOperationOutput<MinecraftLiveClickOutput>,
+  String,
+> {
   let target_block = parse_block_position(target_block)?;
   let pre_frame = auv_game_minecraft::read_latest_spatial_frame_from_tail(&telemetry_sample)?
     .ok_or_else(|| {
@@ -651,7 +653,10 @@ fn run_minecraft_live_click(
     .to_rgb8();
 
   runtime.run_recorded_operation(
-    RunSpec::new(auv_cli::trace::RunType::Execute, "auv.minecraft.live_click"),
+    RunSpec::new(
+      auv_tracing_driver::trace::RunType::Execute,
+      "auv.minecraft.live_click",
+    ),
     "Minecraft live click",
     |context| {
       let (staged_screenshot_path, screenshot_ref) = context.stage_artifact_file_with_ref(
@@ -783,7 +788,10 @@ fn run_minecraft_projection_bridge(
   target_block: &str,
   capture_skew_ms: Option<i64>,
   screenshot_is_minecraft_window: bool,
-) -> Result<auv_cli::recorded_operation::RecordedOperationOutput<MinecraftBridgeOutput>, String> {
+) -> Result<
+  auv_tracing_driver::recorded_operation::RecordedOperationOutput<MinecraftBridgeOutput>,
+  String,
+> {
   let target_block = parse_block_position(target_block)?;
   let frame = auv_game_minecraft::read_latest_spatial_frame_from_tail(&telemetry_sample)?
     .ok_or_else(|| {
@@ -810,7 +818,10 @@ fn run_minecraft_projection_bridge(
     .to_rgb8();
 
   runtime.run_recorded_operation(
-    auv_cli::run_builder::RunSpec::new(auv_cli::trace::RunType::Execute, "auv.minecraft.bridge"),
+    auv_tracing_driver::run_builder::RunSpec::new(
+      auv_tracing_driver::trace::RunType::Execute,
+      "auv.minecraft.bridge",
+    ),
     "Minecraft projection bridge",
     |context| {
       let (staged_screenshot_path, screenshot_ref) = context.stage_artifact_file_with_ref(
@@ -898,7 +909,7 @@ fn run_minecraft_projection_bridge(
 }
 
 fn stage_minecraft_projection_artifact(
-  context: &mut auv_cli::recorded_operation::RecordedOperationContext<'_>,
+  context: &mut auv_tracing_driver::recorded_operation::RecordedOperationContext<'_>,
   projection_artifact: &auv_game_minecraft::MinecraftProjectionArtifact,
 ) -> Result<(PathBuf, auv_cli::contract::ArtifactRef), String> {
   projection_artifact.validate()?;
@@ -1144,7 +1155,7 @@ fn build_runtime_for_inspect(
   } else {
     temp_runtime_store_root()
   };
-  let store = auv_cli::store::LocalStore::new(store_root.clone())?;
+  let store = auv_tracing_driver::store::LocalStore::new(store_root.clone())?;
   let mut recorders: Vec<Arc<dyn auv_tracing_driver::RunRecorder>> = Vec::new();
 
   if let Some((url, token)) = server_target {

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -36,9 +36,12 @@ impl McpServer {
     }
   }
 
-  fn store(&self, store_root: Option<String>) -> Result<crate::store::LocalStore, McpError> {
+  fn store(
+    &self,
+    store_root: Option<String>,
+  ) -> Result<auv_tracing_driver::store::LocalStore, McpError> {
     let store = match store_root {
-      Some(root) => crate::store::LocalStore::new(PathBuf::from(root)),
+      Some(root) => auv_tracing_driver::store::LocalStore::new(PathBuf::from(root)),
       None => build_default_store(self.project_root.clone()),
     };
     store.map_err(invalid_params)

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,5 +1,5 @@
 // File: src/model.rs
-use crate::trace::{ArtifactRecordV1Alpha1, SpanId};
+use auv_tracing_driver::trace::{ArtifactRecordV1Alpha1, SpanId};
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::process;

--- a/src/osu.rs
+++ b/src/osu.rs
@@ -7,10 +7,10 @@ use auv_game_osu::{
 };
 
 use crate::model::AuvResult;
-use crate::recorded_operation::RecordedOperationOutput;
-use crate::run_builder::RunSpec;
-use crate::trace::RunType;
 use auv_tracing_driver::RecordingHandle;
+use auv_tracing_driver::recorded_operation::RecordedOperationOutput;
+use auv_tracing_driver::run_builder::RunSpec;
+use auv_tracing_driver::trace::RunType;
 
 pub fn run_osu_benchmark(
   recording: &RecordingHandle,
@@ -259,7 +259,7 @@ pub fn run_osu_vision_demo(
 }
 
 fn stage_dataset_dir(
-  context: &mut crate::recorded_operation::RecordedOperationContext<'_>,
+  context: &mut auv_tracing_driver::recorded_operation::RecordedOperationContext<'_>,
   dir: &std::path::Path,
   artifact_kind: &str,
 ) -> Result<(), String> {

--- a/src/recorded_operation.rs
+++ b/src/recorded_operation.rs
@@ -1,1 +1,0 @@
-pub use auv_tracing_driver::recorded_operation::*;

--- a/src/run_builder.rs
+++ b/src/run_builder.rs
@@ -1,1 +1,0 @@
-pub use auv_tracing_driver::run_builder::*;

--- a/src/run_read.rs
+++ b/src/run_read.rs
@@ -26,9 +26,9 @@ use crate::contract::{
 use crate::model::AuvResult;
 use crate::scroll_scan::ScrollScanArtifact;
 use crate::stability::{StabilityAssessment, StabilityRejection};
-use crate::store::{CanonicalRun, LocalStore};
-use crate::trace::ArtifactRecordV1Alpha1;
 use auv_game_minecraft::artifact::MinecraftProjectionArtifact;
+use auv_tracing_driver::store::{CanonicalRun, LocalStore};
+use auv_tracing_driver::trace::ArtifactRecordV1Alpha1;
 
 pub struct MinecraftTelemetrySampleArtifactLineage {
   pub artifact: ArtifactRefLineage,
@@ -58,10 +58,10 @@ pub enum DetectorRecognitionLineageStatus {
 
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize)]
 pub struct DetectorRecognitionArtifactRefLineage {
-  pub run_id: crate::trace::RunId,
-  pub artifact_id: crate::trace::ArtifactId,
-  pub span_id: crate::trace::SpanId,
-  pub captured_event_id: Option<crate::trace::EventId>,
+  pub run_id: auv_tracing_driver::trace::RunId,
+  pub artifact_id: auv_tracing_driver::trace::ArtifactId,
+  pub span_id: auv_tracing_driver::trace::SpanId,
+  pub captured_event_id: Option<auv_tracing_driver::trace::EventId>,
   pub role: Option<String>,
   pub path: Option<String>,
   pub summary: Option<String>,
@@ -1174,7 +1174,7 @@ fn classify_candidate_action_execution_lineage(
 }
 
 fn artifact_record_lineage(
-  run_id: crate::trace::RunId,
+  run_id: auv_tracing_driver::trace::RunId,
   artifact: &ArtifactRecordV1Alpha1,
 ) -> DetectorRecognitionArtifactRefLineage {
   DetectorRecognitionArtifactRefLineage {
@@ -1479,8 +1479,9 @@ mod tests {
     SectionCandidate, StopEvidence, StopPolicy, StopReason,
   };
   use crate::stability::{StabilityAssessment, StabilityPolicy, StabilityRejection};
-  use crate::store::{ArtifactFileSource, CanonicalRun, LocalStore};
-  use crate::trace::{
+  use auv_tracing_driver::ArtifactFileSource;
+  use auv_tracing_driver::store::{CanonicalRun, LocalStore};
+  use auv_tracing_driver::trace::{
     ArtifactId, ArtifactRecordV1Alpha1, EventId, RUN_API_VERSION, RunId, RunRecordV1Alpha1,
     RunType, SPAN_API_VERSION, SpanId, SpanRecordV1Alpha1, TraceId, TraceState, TraceStatusCode,
   };

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -19,8 +19,8 @@ pub const MINECRAFT_PROJECTION_ARTIFACT_ROLE: &str = "minecraft-projection";
 
 use crate::contract::ArtifactRef;
 use crate::model::{AuvResult, InvokeRequest, InvokeResult, RunStatus};
-use crate::store::LocalStore;
-use crate::trace::{RunType, TraceStatusCode, string_attr};
+use auv_tracing_driver::store::LocalStore;
+use auv_tracing_driver::trace::{RunType, TraceStatusCode, string_attr};
 use auv_tracing_driver::{MemoryRunRecorder, RunRecorder, RunRecordingBackend};
 
 pub struct Runtime {
@@ -115,7 +115,7 @@ impl Runtime {
     crate::inspect::inspect_run(self.recording.store(), run_id)
   }
 
-  pub fn read_run(&self, run_id: &str) -> AuvResult<crate::store::CanonicalRun> {
+  pub fn read_run(&self, run_id: &str) -> AuvResult<auv_tracing_driver::store::CanonicalRun> {
     self.recording.read_run(run_id)
   }
 
@@ -156,13 +156,15 @@ impl Runtime {
 
   pub fn run_recorded_operation<T, E, F>(
     &self,
-    spec: crate::run_builder::RunSpec,
+    spec: auv_tracing_driver::run_builder::RunSpec,
     operation_label: impl Into<String>,
     operation: F,
-  ) -> AuvResult<crate::recorded_operation::RecordedOperationOutput<T>>
+  ) -> AuvResult<auv_tracing_driver::recorded_operation::RecordedOperationOutput<T>>
   where
     E: std::fmt::Display,
-    F: FnOnce(&mut crate::recorded_operation::RecordedOperationContext<'_>) -> Result<T, E>,
+    F: FnOnce(
+      &mut auv_tracing_driver::recorded_operation::RecordedOperationContext<'_>,
+    ) -> Result<T, E>,
   {
     self
       .recording
@@ -175,13 +177,16 @@ impl Runtime {
     promotion: &crate::candidate_promotion_recording::CandidatePromotionArtifact,
     request: crate::candidate_action_decision::CandidateActionDecisionRequest,
   ) -> AuvResult<
-    crate::recorded_operation::RecordedOperationOutput<(
+    auv_tracing_driver::recorded_operation::RecordedOperationOutput<(
       ArtifactRef,
       crate::candidate_action_decision::CandidateActionDecisionArtifact,
     )>,
   > {
     self.run_recorded_operation(
-      crate::run_builder::RunSpec::new(RunType::Execute, "auv.candidate.action.decide_only"),
+      auv_tracing_driver::run_builder::RunSpec::new(
+        RunType::Execute,
+        "auv.candidate.action.decide_only",
+      ),
       "Candidate action decide-only artifact recording",
       |context| {
         crate::candidate_action_decision::record_candidate_action_decision_artifact(
@@ -194,7 +199,7 @@ impl Runtime {
   pub fn record_telemetry_sample_artifact(
     &self,
     sample_path: impl Into<PathBuf>,
-  ) -> AuvResult<crate::recorded_operation::RecordedOperationOutput<ArtifactRef>> {
+  ) -> AuvResult<auv_tracing_driver::recorded_operation::RecordedOperationOutput<ArtifactRef>> {
     let sample_path = sample_path.into();
     let preferred_name = sample_path
       .file_name()
@@ -215,7 +220,10 @@ impl Runtime {
     }
 
     self.run_recorded_operation(
-      crate::run_builder::RunSpec::new(RunType::Execute, "auv.minecraft.telemetry.sample"),
+      auv_tracing_driver::run_builder::RunSpec::new(
+        RunType::Execute,
+        "auv.minecraft.telemetry.sample",
+      ),
       "Minecraft telemetry sample artifact recording",
       |context| {
         let artifact_source =
@@ -238,13 +246,16 @@ impl Runtime {
   pub fn record_minecraft_projection_artifact(
     &self,
     projection_artifact: auv_game_minecraft::MinecraftProjectionArtifact,
-  ) -> AuvResult<crate::recorded_operation::RecordedOperationOutput<ArtifactRef>> {
+  ) -> AuvResult<auv_tracing_driver::recorded_operation::RecordedOperationOutput<ArtifactRef>> {
     projection_artifact.validate()?;
     let artifact_json = serde_json::to_string_pretty(&projection_artifact)
       .map_err(|error| format!("failed to serialize minecraft projection artifact: {error}"))?;
 
     self.run_recorded_operation(
-      crate::run_builder::RunSpec::new(RunType::Execute, "auv.minecraft.projection.artifact"),
+      auv_tracing_driver::run_builder::RunSpec::new(
+        RunType::Execute,
+        "auv.minecraft.projection.artifact",
+      ),
       "Minecraft projection artifact recording",
       |context| {
         let temp_root = std::env::temp_dir();
@@ -278,12 +289,15 @@ impl Runtime {
     &self,
     request: crate::candidate_action_command::CandidateActionCommandRequest,
   ) -> AuvResult<
-    crate::recorded_operation::RecordedOperationOutput<
+    auv_tracing_driver::recorded_operation::RecordedOperationOutput<
       crate::candidate_action_command::CandidateActionCommandOutput,
     >,
   > {
     self.run_recorded_operation(
-      crate::run_builder::RunSpec::new(RunType::Execute, "auv.candidate.action.command"),
+      auv_tracing_driver::run_builder::RunSpec::new(
+        RunType::Execute,
+        "auv.candidate.action.command",
+      ),
       "Consent-gated candidate action command",
       |context| {
         crate::candidate_action_command::execute_candidate_action_command(context, &request)
@@ -298,13 +312,16 @@ impl Runtime {
     request: crate::candidate_action_decision::CandidateActionExecutionRequest,
     input_action_result: auv_driver::InputActionResult,
   ) -> AuvResult<
-    crate::recorded_operation::RecordedOperationOutput<(
+    auv_tracing_driver::recorded_operation::RecordedOperationOutput<(
       ArtifactRef,
       crate::candidate_action_decision::CandidateActionExecutionArtifact,
     )>,
   > {
     self.run_recorded_operation(
-      crate::run_builder::RunSpec::new(RunType::Execute, "auv.candidate.action.execute_single"),
+      auv_tracing_driver::run_builder::RunSpec::new(
+        RunType::Execute,
+        "auv.candidate.action.execute_single",
+      ),
       "Candidate action execution artifact recording",
       |context| {
         crate::candidate_action_decision::record_candidate_action_execution_artifact(
@@ -364,24 +381,25 @@ impl Runtime {
     &self,
     invoke: impl FnOnce(
       &Self,
-      &mut crate::run_builder::RecordingRun,
-      &crate::run_builder::SpanRef,
+      &mut auv_tracing_driver::run_builder::RecordingRun,
+      &auv_tracing_driver::run_builder::SpanRef,
     ) -> AuvResult<InvokeResult>,
   ) -> AuvResult<InvokeResult> {
-    let mut run = self
-      .recording
-      .handle()
-      .start_run(crate::run_builder::RunSpec::new(
-        RunType::Command,
-        "auv.command",
-      ))?;
+    let mut run =
+      self
+        .recording
+        .handle()
+        .start_run(auv_tracing_driver::run_builder::RunSpec::new(
+          RunType::Command,
+          "auv.command",
+        ))?;
     let root = run.root_span();
     let result = match invoke(self, &mut run, &root) {
       Ok(result) => result,
       Err(error) => {
         if let Err(finish_error) = self.recording.handle().finish_run(
           run,
-          crate::run_builder::RunFinish {
+          auv_tracing_driver::run_builder::RunFinish {
             status_code: TraceStatusCode::Error,
             summary: Some(format!(
               "Invocation failed. Inspect the run for details: {error}"
@@ -403,7 +421,7 @@ impl Runtime {
     };
     self.recording.handle().finish_run(
       run,
-      crate::run_builder::RunFinish {
+      auv_tracing_driver::run_builder::RunFinish {
         status_code,
         summary: Some(result.output_summary.clone()),
         failure: result.failure_message.clone(),
@@ -414,8 +432,8 @@ impl Runtime {
 
   pub fn invoke_in_span(
     &self,
-    run: &mut crate::run_builder::RecordingRun,
-    parent: &crate::run_builder::SpanRef,
+    run: &mut auv_tracing_driver::run_builder::RecordingRun,
+    parent: &auv_tracing_driver::run_builder::SpanRef,
     request: InvokeRequest,
   ) -> AuvResult<InvokeResult> {
     let command_id = request.command_id.clone();
@@ -433,14 +451,14 @@ impl Runtime {
 
   fn invoke_metadata_command_in_span(
     &self,
-    run: &mut crate::run_builder::RecordingRun,
-    parent: &crate::run_builder::SpanRef,
+    run: &mut auv_tracing_driver::run_builder::RecordingRun,
+    parent: &auv_tracing_driver::run_builder::SpanRef,
     command: &auv_cli_invoke::InvokeCommand,
     request: InvokeRequest,
   ) -> AuvResult<InvokeResult> {
     let command_span = run.start_span(
       parent,
-      crate::run_builder::running_span_record(
+      auv_tracing_driver::run_builder::running_span_record(
         "auv.command.invoke",
         command_attributes(command.id, request.target.application_id.as_deref()),
       ),
@@ -473,7 +491,7 @@ impl Runtime {
         );
         run.finish_span(
           &command_span,
-          crate::run_builder::SpanFinish {
+          auv_tracing_driver::run_builder::SpanFinish {
             status_code: TraceStatusCode::Error,
             summary: Some(output_summary.clone()),
             failure: Some(failure_message.clone()),
@@ -514,7 +532,7 @@ impl Runtime {
 
     run.finish_span(
       &command_span,
-      crate::run_builder::SpanFinish {
+      auv_tracing_driver::run_builder::SpanFinish {
         status_code: TraceStatusCode::Ok,
         summary: Some(output.summary.clone()),
         failure: None,
@@ -537,8 +555,8 @@ impl Runtime {
 fn command_attributes(
   command_id: &str,
   target_application_id: Option<&str>,
-) -> crate::run_builder::Attributes {
-  let mut attributes = crate::run_builder::Attributes::new();
+) -> auv_tracing_driver::run_builder::Attributes {
+  let mut attributes = auv_tracing_driver::run_builder::Attributes::new();
   attributes.insert("command_id".to_string(), string_attr(command_id));
   attributes.insert("auv.command.id".to_string(), string_attr(command_id));
   if let Some(target_application_id) = target_application_id {
@@ -555,8 +573,8 @@ fn command_attributes(
 }
 
 fn record_event(
-  run: &mut crate::run_builder::RecordingRun,
-  span_id: &crate::trace::SpanId,
+  run: &mut auv_tracing_driver::run_builder::RecordingRun,
+  span_id: &auv_tracing_driver::trace::SpanId,
   name: &str,
   message: Option<String>,
 ) {
@@ -578,7 +596,7 @@ mod tests {
     TELEMETRY_SAMPLE_MAX_BYTES,
   };
   use crate::model::{AuvResult, ExecutionTarget, InvokeRequest, RunStatus, now_millis};
-  use crate::store::LocalStore;
+  use auv_tracing_driver::store::LocalStore;
   use auv_tracing_driver::{MemoryRunRecorder, RunRecorder, RunUpdate};
 
   struct FailRunFinishedRecorder;
@@ -813,8 +831,8 @@ mod tests {
     let mut run = runtime
       .recording()
       .handle()
-      .start_run(crate::run_builder::RunSpec::new(
-        crate::trace::RunType::Execute,
+      .start_run(auv_tracing_driver::run_builder::RunSpec::new(
+        auv_tracing_driver::trace::RunType::Execute,
         "auv.execute",
       ))
       .expect("run should start");
@@ -839,8 +857,8 @@ mod tests {
       .handle()
       .finish_run(
         run,
-        crate::run_builder::RunFinish {
-          status_code: crate::trace::TraceStatusCode::Ok,
+        auv_tracing_driver::run_builder::RunFinish {
+          status_code: auv_tracing_driver::trace::TraceStatusCode::Ok,
           summary: Some("done".to_string()),
           failure: None,
         },
@@ -848,7 +866,10 @@ mod tests {
       .expect("run should finish");
 
     let canonical = runtime.read_run(run_id.as_str()).expect("run should read");
-    assert_eq!(canonical.run.run_type, crate::trace::RunType::Execute);
+    assert_eq!(
+      canonical.run.run_type,
+      auv_tracing_driver::trace::RunType::Execute
+    );
     assert!(
       canonical
         .spans
@@ -950,7 +971,10 @@ mod tests {
       Some(&"handler-output".to_string())
     );
     let canonical = runtime.read_run(&result.run_id).expect("run should read");
-    assert_eq!(canonical.run.status_code, crate::trace::TraceStatusCode::Ok);
+    assert_eq!(
+      canonical.run.status_code,
+      auv_tracing_driver::trace::TraceStatusCode::Ok
+    );
     let command_span = canonical
       .spans
       .iter()
@@ -1019,7 +1043,7 @@ mod tests {
     let canonical = runtime.read_run(&result.run_id).expect("run should read");
     assert_eq!(
       canonical.run.status_code,
-      crate::trace::TraceStatusCode::Error
+      auv_tracing_driver::trace::TraceStatusCode::Error
     );
     assert!(canonical.events.iter().any(|event| {
       event.name == "command.failed"
@@ -1062,7 +1086,7 @@ mod tests {
     let canonical = runtime.read_run(run_id.as_str()).expect("run should read");
     assert_eq!(
       canonical.run.status_code,
-      crate::trace::TraceStatusCode::Error
+      auv_tracing_driver::trace::TraceStatusCode::Error
     );
     assert!(
       canonical
@@ -1076,7 +1100,7 @@ mod tests {
       canonical
         .spans
         .iter()
-        .all(|span| span.state == crate::trace::TraceState::Ended)
+        .all(|span| span.state == auv_tracing_driver::trace::TraceState::Ended)
     );
 
     let _ = fs::remove_dir_all(project_root);
@@ -1129,7 +1153,10 @@ mod tests {
     let canonical = runtime
       .read_run(&result.run_id)
       .expect("snapshot should still be persisted");
-    assert_eq!(canonical.run.status_code, crate::trace::TraceStatusCode::Ok);
+    assert_eq!(
+      canonical.run.status_code,
+      auv_tracing_driver::trace::TraceStatusCode::Ok
+    );
 
     let _ = fs::remove_dir_all(project_root);
     let _ = fs::remove_dir_all(store_root);
@@ -1198,8 +1225,8 @@ mod tests {
     let run = runtime
       .recording()
       .handle()
-      .start_run(crate::run_builder::RunSpec::new(
-        crate::trace::RunType::Command,
+      .start_run(auv_tracing_driver::run_builder::RunSpec::new(
+        auv_tracing_driver::trace::RunType::Command,
         "auv.command",
       ))
       .expect("default-spec run should start");
@@ -1211,8 +1238,8 @@ mod tests {
       .handle()
       .finish_run(
         run,
-        crate::run_builder::RunFinish {
-          status_code: crate::trace::TraceStatusCode::Ok,
+        auv_tracing_driver::run_builder::RunFinish {
+          status_code: auv_tracing_driver::trace::TraceStatusCode::Ok,
           summary: Some("default".to_string()),
           failure: None,
         },
@@ -1229,9 +1256,12 @@ mod tests {
     let store_root = temp_dir("runtime-explicit-device-store");
     let runtime = runtime_with_success_driver(project_root.clone(), store_root.clone());
 
-    let spec = crate::run_builder::RunSpec::new(crate::trace::RunType::Command, "auv.command")
-      .with_device(crate::trace::DeviceId::new("remote-mac"))
-      .with_session(crate::trace::SessionId::new("music"));
+    let spec = auv_tracing_driver::run_builder::RunSpec::new(
+      auv_tracing_driver::trace::RunType::Command,
+      "auv.command",
+    )
+    .with_device(auv_tracing_driver::trace::DeviceId::new("remote-mac"))
+    .with_session(auv_tracing_driver::trace::SessionId::new("music"));
     let run = runtime
       .recording()
       .handle()
@@ -1245,8 +1275,8 @@ mod tests {
       .handle()
       .finish_run(
         run,
-        crate::run_builder::RunFinish {
-          status_code: crate::trace::TraceStatusCode::Ok,
+        auv_tracing_driver::run_builder::RunFinish {
+          status_code: auv_tracing_driver::trace::TraceStatusCode::Ok,
           summary: Some("explicit".to_string()),
           failure: None,
         },
@@ -1263,9 +1293,12 @@ mod tests {
     let store_root = temp_dir("runtime-attr-roundtrip-store");
     let runtime = runtime_with_success_driver(project_root.clone(), store_root.clone());
 
-    let spec = crate::run_builder::RunSpec::new(crate::trace::RunType::Command, "auv.command")
-      .with_device(crate::trace::DeviceId::new("local"))
-      .with_session(crate::trace::SessionId::new("scan"));
+    let spec = auv_tracing_driver::run_builder::RunSpec::new(
+      auv_tracing_driver::trace::RunType::Command,
+      "auv.command",
+    )
+    .with_device(auv_tracing_driver::trace::DeviceId::new("local"))
+    .with_session(auv_tracing_driver::trace::SessionId::new("scan"));
     let run = runtime
       .recording()
       .handle()
@@ -1277,8 +1310,8 @@ mod tests {
       .handle()
       .finish_run(
         run,
-        crate::run_builder::RunFinish {
-          status_code: crate::trace::TraceStatusCode::Ok,
+        auv_tracing_driver::run_builder::RunFinish {
+          status_code: auv_tracing_driver::trace::TraceStatusCode::Ok,
           summary: Some("attr".to_string()),
           failure: None,
         },
@@ -1288,11 +1321,11 @@ mod tests {
     let canonical = runtime.read_run(&run_id).expect("run snapshot should read");
     let attrs = &canonical.run.attributes;
     assert_eq!(
-      attrs.get(crate::trace::RUN_ATTR_DEVICE_ID),
+      attrs.get(auv_tracing_driver::trace::RUN_ATTR_DEVICE_ID),
       Some(&json!("local"))
     );
     assert_eq!(
-      attrs.get(crate::trace::RUN_ATTR_SESSION_ID),
+      attrs.get(auv_tracing_driver::trace::RUN_ATTR_SESSION_ID),
       Some(&json!("scan"))
     );
 

--- a/src/scroll_scan/mod.rs
+++ b/src/scroll_scan/mod.rs
@@ -24,8 +24,8 @@ use std::path::{Path, PathBuf};
 
 use crate::contract::{ObservationSnapshot, RecognitionResult, SurfaceNode};
 use crate::model::{AuvResult, ExecutionTarget, InvokeRequest, InvokeResult, RunStatus};
-use crate::trace::{RunId, SpanId};
 use auv_tracing_driver::RecordingHandle;
+use auv_tracing_driver::trace::{RunId, SpanId};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -313,10 +313,10 @@ pub struct ScanWindowRegionOptions {
 pub fn scan_window_region(
   runtime: &crate::runtime::Runtime,
   options: ScanWindowRegionOptions,
-) -> AuvResult<crate::trace::RunId> {
+) -> AuvResult<auv_tracing_driver::trace::RunId> {
   let recording = runtime.recording().handle();
-  let mut run = recording.start_run(crate::run_builder::RunSpec::new(
-    crate::trace::RunType::Execute,
+  let mut run = recording.start_run(auv_tracing_driver::run_builder::RunSpec::new(
+    auv_tracing_driver::trace::RunType::Execute,
     "auv.scan.window_region",
   ))?;
   let root = run.root_span();
@@ -324,8 +324,8 @@ pub fn scan_window_region(
   match scan_window_region_into_run(&recording, runtime, &mut run, &root, options) {
     Ok(summary) => recording.finish_run(
       run,
-      crate::run_builder::RunFinish {
-        status_code: crate::trace::TraceStatusCode::Ok,
+      auv_tracing_driver::run_builder::RunFinish {
+        status_code: auv_tracing_driver::trace::TraceStatusCode::Ok,
         summary: Some(summary),
         failure: None,
       },
@@ -333,8 +333,8 @@ pub fn scan_window_region(
     Err(error) => {
       let finish_result = recording.finish_run(
         run,
-        crate::run_builder::RunFinish {
-          status_code: crate::trace::TraceStatusCode::Error,
+        auv_tracing_driver::run_builder::RunFinish {
+          status_code: auv_tracing_driver::trace::TraceStatusCode::Error,
           summary: Some(format!("Window region scan failed: {error}")),
           failure: Some(error.clone()),
         },
@@ -352,8 +352,8 @@ pub fn scan_window_region(
 fn scan_window_region_into_run(
   recording: &RecordingHandle,
   runtime: &crate::runtime::Runtime,
-  run: &mut crate::run_builder::RecordingRun,
-  root: &crate::run_builder::SpanRef,
+  run: &mut auv_tracing_driver::run_builder::RecordingRun,
+  root: &auv_tracing_driver::run_builder::SpanRef,
   options: ScanWindowRegionOptions,
 ) -> AuvResult<String> {
   // TODO(controller): This scan loop is still a script-shaped orchestration
@@ -710,8 +710,8 @@ fn region_inputs(target: &ScanTarget) -> BTreeMap<String, String> {
 fn scan_window_region_page(
   recording: &RecordingHandle,
   runtime: &crate::runtime::Runtime,
-  run: &mut crate::run_builder::RecordingRun,
-  root: &crate::run_builder::SpanRef,
+  run: &mut auv_tracing_driver::run_builder::RecordingRun,
+  root: &auv_tracing_driver::run_builder::SpanRef,
   page_index: usize,
   options: &ScanWindowRegionOptions,
   state: &mut ScanWindowRegionState,
@@ -1157,8 +1157,8 @@ fn scroll_boundary_name(boundary: ScrollBoundary) -> &'static str {
 fn invoke_scan_command(
   _recording: &RecordingHandle,
   runtime: &crate::runtime::Runtime,
-  run: &mut crate::run_builder::RecordingRun,
-  root: &crate::run_builder::SpanRef,
+  run: &mut auv_tracing_driver::run_builder::RecordingRun,
+  root: &auv_tracing_driver::run_builder::SpanRef,
   request: InvokeRequest,
   label: &str,
 ) -> AuvResult<InvokeResult> {
@@ -1243,7 +1243,7 @@ fn first_artifact_with_extension(result: &InvokeResult, extension: &str) -> Opti
 fn first_artifact_record_with_extension<'a>(
   result: &'a InvokeResult,
   extension: &str,
-) -> Option<&'a crate::trace::ArtifactRecordV1Alpha1> {
+) -> Option<&'a auv_tracing_driver::trace::ArtifactRecordV1Alpha1> {
   result.artifacts.iter().find(|artifact| {
     std::path::Path::new(&artifact.path)
       .extension()
@@ -1335,8 +1335,8 @@ impl ListItemCandidateContextArtifact {
 fn enrich_list_item_observations_with_crops(
   recording: &RecordingHandle,
   _runtime: &crate::runtime::Runtime,
-  run: &mut crate::run_builder::RecordingRun,
-  root: &crate::run_builder::SpanRef,
+  run: &mut auv_tracing_driver::run_builder::RecordingRun,
+  root: &auv_tracing_driver::run_builder::SpanRef,
   page_index: usize,
   screenshot_artifact: Option<&Path>,
   options: &ScanWindowRegionOptions,
@@ -1638,8 +1638,8 @@ fn sanitize_scan_artifact_component(raw: &str) -> String {
 
 fn stage_scan_artifact(
   recording: &RecordingHandle,
-  run: &mut crate::run_builder::RecordingRun,
-  root: &crate::run_builder::SpanRef,
+  run: &mut auv_tracing_driver::run_builder::RecordingRun,
+  root: &auv_tracing_driver::run_builder::SpanRef,
   artifact: &ScrollScanArtifact,
 ) -> AuvResult<PathBuf> {
   let temp_path = write_scan_artifact(artifact)?;
@@ -1682,7 +1682,7 @@ mod tests {
   use std::fs;
   use std::sync::atomic::{AtomicU64, Ordering};
 
-  use crate::store::LocalStore;
+  use auv_tracing_driver::store::LocalStore;
 
   static TEST_ARTIFACT_COUNTER: AtomicU64 = AtomicU64::new(0);
 

--- a/src/scroll_scan/observation.rs
+++ b/src/scroll_scan/observation.rs
@@ -10,7 +10,7 @@ use crate::contract::{
   RecognitionSurface, RecognizedItem, SurfaceNode,
 };
 use crate::model::{AuvResult, now_millis};
-use crate::trace::{ArtifactRecordV1Alpha1, RunId, SpanId};
+use auv_tracing_driver::trace::{ArtifactRecordV1Alpha1, RunId, SpanId};
 
 use super::{CollectionObservation, ObservationCluster, ScanRect, ScanTarget};
 
@@ -558,7 +558,7 @@ mod tests {
   };
   use crate::contract::ObservationSource;
   use crate::scroll_scan::{CollectionObservation, ScanRect, ScanRegion, ScanTarget};
-  use crate::trace::{RunId, SpanId};
+  use auv_tracing_driver::trace::{RunId, SpanId};
 
   fn sample_target() -> ScanTarget {
     ScanTarget {

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,2 +1,0 @@
-pub use auv_tracing_driver::store::*;
-pub use auv_tracing_driver::{ArtifactFileSource, ProducedArtifact};

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -1,1 +1,0 @@
-pub use auv_tracing_driver::trace::*;


### PR DESCRIPTION
## Summary

Removes the root `auv-cli` shim modules for tracing-owned types:

- `src/recorded_operation.rs`
- `src/run_builder.rs`
- `src/store.rs`
- `src/trace.rs`

Call sites now import the owning `auv-tracing-driver` modules directly instead of going through `auv_cli::{recorded_operation, run_builder, store, trace}`.

## Validation

- `cargo fmt --check`
- `cargo check`
- `git diff --check`
- `cargo test`

Notes: `cargo check`/`cargo test` still emit existing warnings about deprecated Minecraft ingest helpers and unused `action_resolver_decision` items.