### PR TITLE
feat(auv-cli-invoke): record handler evidence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,6 +383,8 @@ dependencies = [
  "auv-cli-invoke-macros",
  "auv-driver",
  "auv-driver-macos",
+ "auv-tracing-driver",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/auv-cli-invoke/Cargo.toml
+++ b/crates/auv-cli-invoke/Cargo.toml
@@ -15,6 +15,8 @@ repository.workspace = true
 [dependencies]
 auv-cli-invoke-macros = { path = "../auv-cli-invoke-macros" }
 auv-driver = { path = "../auv-driver" }
+auv-tracing-driver = { path = "../auv-tracing-driver" }
+serde_json = "1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 auv-driver-macos = { path = "../auv-driver-macos" }

--- a/crates/auv-cli-invoke/src/command.rs
+++ b/crates/auv-cli-invoke/src/command.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
 use crate::arg::ArgSpec;
+use auv_tracing_driver::ProducedArtifact;
 
 type InvokeCommandHandler = fn(InvokeCommandInput<'_>) -> InvokeCommandResult;
 
@@ -18,6 +19,19 @@ pub struct InvokeCommandOutput {
   pub backend: Option<String>,
   pub signals: BTreeMap<String, String>,
   pub notes: Vec<String>,
+  pub artifacts: Vec<ProducedArtifact>,
+  pub known_limits: Vec<String>,
+  /// Human-readable boundary claim produced by the handler for this execution.
+  ///
+  /// This is intentionally not a structured `VerificationResult`: direct
+  /// invoke commands such as capture/OCR often need to state "capture-only" or
+  /// "recognition-only" without claiming semantic success.
+  // TODO(invoke-boundary-claims): promote this event-backed string into a
+  // first-class read-side boundary-claim model after the shape in
+  // `docs/ai/references/2026-06-18-invoke-direct-command-implementations-handoff.md`
+  // is accepted. Do not map capture-only/recognition-only/activation-only
+  // claims into semantic `VerificationResult`s.
+  pub verification: Option<String>,
 }
 
 impl InvokeCommandOutput {
@@ -27,6 +41,9 @@ impl InvokeCommandOutput {
       backend: None,
       signals: BTreeMap::new(),
       notes: Vec::new(),
+      artifacts: Vec::new(),
+      known_limits: Vec::new(),
+      verification: None,
     }
   }
 }
@@ -124,5 +141,19 @@ pub fn spec(
     summary,
     args,
     handler,
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::InvokeCommandOutput;
+
+  #[test]
+  fn command_output_defaults_evidence_fields_to_empty() {
+    let output = InvokeCommandOutput::new("observed");
+
+    assert!(output.artifacts.is_empty());
+    assert!(output.known_limits.is_empty());
+    assert!(output.verification.is_none());
   }
 }

--- a/crates/auv-cli-invoke/src/commands/app.rs
+++ b/crates/auv-cli-invoke/src/commands/app.rs
@@ -66,6 +66,10 @@ fn probe_permissions_impl() -> InvokeCommandResult {
     "permission.automation_to_system_events".to_string(),
     permissions.automation_to_system_events.as_str().to_string(),
   );
+  output.verification = Some("read-only; no semantic success claim".to_string());
+  output
+    .known_limits
+    .push("app.probePermissions records current permission status only; it does not verify an application workflow.".to_string());
   Ok(output)
 }
 

--- a/crates/auv-cli-invoke/src/commands/display.rs
+++ b/crates/auv-cli-invoke/src/commands/display.rs
@@ -3,6 +3,8 @@ use crate::{
   arg::{NO_ARGS, TARGET_ARGS},
   invoke_command,
 };
+#[cfg(target_os = "macos")]
+use auv_tracing_driver::{ProducedArtifact, now_millis};
 
 pub fn group() -> CommandGroup {
   CommandGroup::new("display", "DISPLAY")
@@ -123,6 +125,10 @@ fn list_displays_impl() -> InvokeCommandResult {
   for (index, display) in displays.displays.iter().take(5).enumerate() {
     insert_display_signals(&mut output, &format!("display.{index}"), display);
   }
+  output.verification = Some("read-only; no semantic success claim".to_string());
+  output
+    .known_limits
+    .push("display.list records the observed display inventory only.".to_string());
   Ok(output)
 }
 
@@ -171,6 +177,26 @@ fn capture_display_impl() -> InvokeCommandResult {
       .signals
       .insert("capture.fallback_reason".to_string(), reason);
   }
+  // TODO(invoke-capture-contract-artifacts): this handler records the screenshot
+  // and coordinate signals, but not the old standalone capture-contract
+  // artifact. Add the contract artifact after its direct-invoke JSON shape is
+  // accepted in `2026-06-18-invoke-direct-command-implementations-handoff.md`.
+  let source_path = invoke_artifact_path("display-capture", "png");
+  result
+    .capture
+    .image
+    .save(&source_path)
+    .map_err(|error| format!("failed to write display.capture screenshot artifact: {error}"))?;
+  output.artifacts.push(ProducedArtifact {
+    kind: "display-screenshot".to_string(),
+    source_path,
+    preferred_name: "display-capture.png".to_string(),
+    note: Some("Screenshot captured by display.capture.".to_string()),
+  });
+  output.verification = Some("capture-only; no semantic success claim".to_string());
+  output
+    .known_limits
+    .push("display.capture records a screenshot and coordinate signals only; it does not verify UI semantics.".to_string());
   Ok(output)
 }
 
@@ -223,6 +249,16 @@ fn format_rect(rect: auv_driver::Rect) -> String {
     "x={:.0},y={:.0},width={:.0},height={:.0}",
     rect.origin.x, rect.origin.y, rect.size.width, rect.size.height
   )
+}
+
+#[cfg(target_os = "macos")]
+fn invoke_artifact_path(label: &str, extension: &str) -> std::path::PathBuf {
+  std::env::temp_dir().join(format!(
+    "auv-invoke-{label}-{}-{}.{}",
+    std::process::id(),
+    now_millis(),
+    extension
+  ))
 }
 
 #[cfg(test)]

--- a/crates/auv-cli-invoke/src/commands/fixture.rs
+++ b/crates/auv-cli-invoke/src/commands/fixture.rs
@@ -14,5 +14,10 @@ pub fn group() -> CommandGroup {
   args = NO_ARGS,
 )]
 fn observe(_input: InvokeCommandInput<'_>) -> InvokeCommandResult {
-  Ok(InvokeCommandOutput::new("fixture observed"))
+  let mut output = InvokeCommandOutput::new("fixture observed");
+  output.verification = Some("read-only; no semantic success claim".to_string());
+  output
+    .known_limits
+    .push("fixture.observe records deterministic fixture output only.".to_string());
+  Ok(output)
 }

--- a/crates/auv-cli-invoke/src/commands/input.rs
+++ b/crates/auv-cli-invoke/src/commands/input.rs
@@ -6,6 +6,8 @@ use crate::{
   },
   invoke_command,
 };
+#[cfg(target_os = "macos")]
+use auv_tracing_driver::{ProducedArtifact, now_millis};
 
 pub fn group() -> CommandGroup {
   CommandGroup::new("input", "INPUT")
@@ -199,11 +201,11 @@ fn type_text_impl(input: InvokeCommandInput<'_>) -> InvokeCommandResult {
     .input()
     .type_text(text, TypeTextOptions::default())
     .map_err(|error| error.to_string())?;
-  Ok(input_action_output(
+  input_action_output(
     "typed text into active control",
     "auv-driver-macos.input",
     &result,
-  ))
+  )
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -236,6 +238,15 @@ fn paste_text_preserve_clipboard_impl(input: InvokeCommandInput<'_>) -> InvokeCo
   output
     .signals
     .insert("clipboard_disturbance".to_string(), "temporary".to_string());
+  // TODO(invoke-paste-input-action-result): paste_text currently returns only
+  // success/failure, so this handler cannot persist a typed InputActionResult
+  // artifact like input.typeText/input.key. Extend the typed paste API to
+  // return delivery evidence before claiming full input artifact coverage.
+  output.verification =
+    Some("activation-only; semantic success requires a separate verification result".to_string());
+  output
+    .known_limits
+    .push("input.pasteText records clipboard-based input delivery only; it does not verify target UI state.".to_string());
   Ok(output)
 }
 
@@ -263,11 +274,11 @@ fn press_key_impl(input: InvokeCommandInput<'_>) -> InvokeCommandResult {
       ..KeyPressOptions::default()
     })
     .map_err(|error| error.to_string())?;
-  Ok(input_action_output(
+  input_action_output(
     "pressed key in active app",
     "auv-driver-macos.input",
     &result,
-  ))
+  )
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -308,7 +319,7 @@ fn input_action_output(
   summary: &str,
   backend: &str,
   result: &auv_driver::InputActionResult,
-) -> InvokeCommandOutput {
+) -> InvokeCommandResult {
   let mut output = InvokeCommandOutput::new(summary);
   output.backend = Some(backend.to_string());
   output.signals.insert(
@@ -337,4 +348,34 @@ fn input_action_output(
       .insert("input.fallback_reason".to_string(), reason.clone());
   }
   output
+    .artifacts
+    .push(input_action_artifact(result, "input-action-result")?);
+  output.verification =
+    Some("activation-only; semantic success requires a separate verification result".to_string());
+  output
+    .known_limits
+    .push("input delivery records the selected input path and attempts only; it does not verify target UI state.".to_string());
+  Ok(output)
+}
+
+#[cfg(target_os = "macos")]
+fn input_action_artifact(
+  result: &auv_driver::InputActionResult,
+  label: &str,
+) -> Result<ProducedArtifact, String> {
+  let source_path = std::env::temp_dir().join(format!(
+    "auv-invoke-{label}-{}-{}.json",
+    std::process::id(),
+    now_millis()
+  ));
+  let body = serde_json::to_vec_pretty(result)
+    .map_err(|error| format!("failed to serialize input action artifact: {error}"))?;
+  std::fs::write(&source_path, body)
+    .map_err(|error| format!("failed to write input action artifact: {error}"))?;
+  Ok(ProducedArtifact {
+    kind: "input-action-result".to_string(),
+    source_path,
+    preferred_name: format!("{label}.json"),
+    note: Some("Typed InputActionResult recorded by the invoke handler.".to_string()),
+  })
 }

--- a/crates/auv-cli-invoke/src/commands/screen.rs
+++ b/crates/auv-cli-invoke/src/commands/screen.rs
@@ -3,6 +3,8 @@ use crate::{
   arg::{IMAGE_TEXT_ARGS, REGION_ARGS, SCREEN_TEXT_ARGS, TARGET_ARGS},
   invoke_command,
 };
+#[cfg(target_os = "macos")]
+use auv_tracing_driver::{ProducedArtifact, now_millis};
 
 pub fn group() -> CommandGroup {
   CommandGroup::new("screen", "SCREEN")
@@ -149,6 +151,27 @@ fn capture_region_impl(input: InvokeCommandInput<'_>) -> InvokeCommandResult {
     "capture.height".to_string(),
     capture.capture.image.height().to_string(),
   );
+  // TODO(invoke-capture-contract-artifacts): this records the captured pixels
+  // and basic dimensions, but not the standalone capture-contract artifact.
+  // Add it after the direct-invoke contract JSON shape is accepted in
+  // `2026-06-18-invoke-direct-command-implementations-handoff.md`.
+  let source_path = invoke_artifact_path(input.command_id, "region-capture", "png");
+  capture
+    .capture
+    .image
+    .save(&source_path)
+    .map_err(|error| format!("failed to write screen.captureRegion artifact: {error}"))?;
+  output.artifacts.push(ProducedArtifact {
+    kind: "screen-region-capture".to_string(),
+    source_path,
+    preferred_name: format!("{}-region-capture.png", input.command_id.replace('.', "-")),
+    note: Some("Region screenshot captured by screen.captureRegion.".to_string()),
+  });
+  output.verification = Some("capture-only; no semantic success claim".to_string());
+  output.known_limits.push(
+    "screen.captureRegion records a region screenshot only; it does not verify UI semantics."
+      .to_string(),
+  );
   Ok(output)
 }
 
@@ -194,12 +217,33 @@ fn find_screen_text_impl(input: InvokeCommandInput<'_>, wait: bool) -> InvokeCom
           "screen.waitForText did not find text {query:?} before timeout"
         ));
       }
-      return Ok(text_matches_output(
+      let mut output = text_matches_output(
         input.command_id,
         "auv-driver-macos.vision",
         matches.matches.len(),
         matches.best_match().map(|matched| matched.text.as_str()),
-      ));
+      );
+      // TODO(invoke-recognition-result-artifacts): this records the OCR source
+      // screenshot and scalar match signals, but not a structured
+      // recognition-result artifact with query/bounds/confidence. Add that
+      // after the artifact shape is accepted in the direct-command handoff.
+      let source_path = invoke_artifact_path(input.command_id, "ocr-screenshot", "png");
+      capture
+        .capture
+        .image
+        .save(&source_path)
+        .map_err(|error| format!("failed to write screen OCR screenshot artifact: {error}"))?;
+      output.artifacts.push(ProducedArtifact {
+        kind: "screen-ocr-screenshot".to_string(),
+        source_path,
+        preferred_name: format!("{}-ocr-screenshot.png", input.command_id.replace('.', "-")),
+        note: Some("Screenshot used for screen OCR matching.".to_string()),
+      });
+      output.verification = Some("recognition-only; no semantic success claim".to_string());
+      output
+        .known_limits
+        .push("screen OCR recognition records text matches and source screenshot only; it does not verify downstream UI state.".to_string());
+      return Ok(output);
     }
     thread::sleep(wait_options.poll_interval);
   }
@@ -245,12 +289,33 @@ fn click_screen_text_impl(input: InvokeCommandInput<'_>) -> InvokeCommandResult 
     matches.matches.len(),
     Some(matched.text.as_str()),
   );
+  // TODO(invoke-recognition-result-artifacts): clickText records the OCR
+  // source screenshot used for target resolution, but not the structured
+  // recognition-result artifact. Add it with screen.findText once the
+  // direct-invoke recognition artifact shape is accepted.
+  let source_path = invoke_artifact_path(input.command_id, "ocr-screenshot", "png");
+  capture
+    .capture
+    .image
+    .save(&source_path)
+    .map_err(|error| format!("failed to write screen click OCR screenshot artifact: {error}"))?;
+  output.artifacts.push(ProducedArtifact {
+    kind: "screen-ocr-screenshot".to_string(),
+    source_path,
+    preferred_name: format!("{}-ocr-screenshot.png", input.command_id.replace('.', "-")),
+    note: Some("Screenshot used to resolve screen.clickText OCR target.".to_string()),
+  });
   output
     .signals
     .insert("click.x".to_string(), point.x.to_string());
   output
     .signals
     .insert("click.y".to_string(), point.y.to_string());
+  output.verification =
+    Some("activation-only; semantic success requires a separate verification result".to_string());
+  output
+    .known_limits
+    .push("screen.clickText records OCR resolution and input delivery only; it does not verify post-click UI state.".to_string());
   Ok(output)
 }
 
@@ -292,6 +357,17 @@ fn reject_target_activation(
 
 fn dry_run_output(command_id: &str) -> InvokeCommandOutput {
   InvokeCommandOutput::new(format!("dry run: {command_id}"))
+}
+
+#[cfg(target_os = "macos")]
+fn invoke_artifact_path(command_id: &str, label: &str, extension: &str) -> std::path::PathBuf {
+  std::env::temp_dir().join(format!(
+    "auv-invoke-{}-{label}-{}-{}.{}",
+    command_id.replace('.', "-"),
+    std::process::id(),
+    now_millis(),
+    extension
+  ))
 }
 
 fn text_matches_output(

--- a/crates/auv-cli-invoke/src/commands/window.rs
+++ b/crates/auv-cli-invoke/src/commands/window.rs
@@ -3,6 +3,8 @@ use crate::{
   arg::{NO_ARGS, WINDOW_ARGS, WINDOW_TEXT_ARGS, WINDOW_VERIFY_TEXT_ARGS},
   invoke_command,
 };
+#[cfg(target_os = "macos")]
+use auv_tracing_driver::{ProducedArtifact, now_millis};
 
 pub fn group() -> CommandGroup {
   CommandGroup::new("window", "WINDOW")
@@ -203,6 +205,10 @@ fn list_windows_impl(input: InvokeCommandInput<'_>) -> InvokeCommandResult {
         .insert("window.first.app_name".to_string(), app_name.clone());
     }
   }
+  output.verification = Some("read-only; no semantic success claim".to_string());
+  output
+    .known_limits
+    .push("window.list records the observed visible window inventory only.".to_string());
   Ok(output)
 }
 
@@ -241,6 +247,31 @@ fn capture_window_impl(input: InvokeCommandInput<'_>) -> InvokeCommandResult {
     "capture.height".to_string(),
     capture.image.height().to_string(),
   );
+  // TODO(invoke-window-capture-backend): live testing on 2026-06-18 showed
+  // ScreenCaptureKit single-window capture can time out and xcap fallback can
+  // fail for Chrome/NetEase windows. Stabilize the typed window capture backend
+  // before treating window.* evidence as reliably available.
+  //
+  // TODO(invoke-capture-contract-artifacts): this records the window screenshot
+  // and scalar capture signals, but not a standalone capture-contract artifact.
+  // Add it after the direct-invoke contract JSON shape is accepted in
+  // `2026-06-18-invoke-direct-command-implementations-handoff.md`.
+  let source_path = invoke_artifact_path(input.command_id, "window-capture", "png");
+  capture
+    .image
+    .save(&source_path)
+    .map_err(|error| format!("failed to write window.capture artifact: {error}"))?;
+  output.artifacts.push(ProducedArtifact {
+    kind: "window-capture".to_string(),
+    source_path,
+    preferred_name: format!("{}-window-capture.png", input.command_id.replace('.', "-")),
+    note: Some("Window screenshot captured by window.capture.".to_string()),
+  });
+  output.verification = Some("capture-only; no semantic success claim".to_string());
+  output.known_limits.push(
+    "window.capture records a resolved window screenshot only; it does not verify UI semantics."
+      .to_string(),
+  );
   Ok(output)
 }
 
@@ -252,6 +283,7 @@ fn capture_window_impl(_input: InvokeCommandInput<'_>) -> InvokeCommandResult {
 #[cfg(target_os = "macos")]
 fn find_window_text_impl(input: InvokeCommandInput<'_>, wait: bool) -> InvokeCommandResult {
   use auv_driver::{Driver, RatioRect, WaitOptions};
+  use std::{thread, time::Instant};
 
   if input.dry_run {
     return Ok(dry_run_output(input.command_id));
@@ -264,36 +296,54 @@ fn find_window_text_impl(input: InvokeCommandInput<'_>, wait: bool) -> InvokeCom
     .window()
     .resolve(window_selector(&input))
     .map_err(|error| error.to_string())?;
-  let matches = if wait {
-    session
+  let wait_options = WaitOptions::default();
+  let started = Instant::now();
+  loop {
+    let capture = session
       .window()
-      .wait_text(
-        &window,
-        query,
-        RatioRect::new(0.0, 0.0, 1.0, 1.0),
-        WaitOptions::default(),
-      )
-      .map_err(|error| error.to_string())?
-  } else {
-    session
-      .window()
-      .find_text(
-        &window,
-        query,
-        RatioRect::new(0.0, 0.0, 1.0, 1.0),
-        WaitOptions::default(),
-      )
-      .map_err(|error| error.to_string())?
-  };
+      .capture(&window)
+      .map_err(|error| error.to_string())?;
+    let matches = session
+      .vision()
+      .find_text_in_capture(&capture, query, RatioRect::new(0.0, 0.0, 1.0, 1.0))
+      .map_err(|error| error.to_string())?;
+    if !matches.matches.is_empty() || !wait || started.elapsed() >= wait_options.timeout {
+      if wait && matches.matches.is_empty() {
+        return Err(format!(
+          "window.waitForText did not find text {query:?} before timeout"
+        ));
+      }
 
-  let mut output = text_matches_output(
-    input.command_id,
-    "auv-driver-macos.window.vision",
-    matches.matches.len(),
-    matches.best_match().map(|matched| matched.text.as_str()),
-  );
-  add_window_signals(&mut output, &window);
-  Ok(output)
+      let mut output = text_matches_output(
+        input.command_id,
+        "auv-driver-macos.window.vision",
+        matches.matches.len(),
+        matches.best_match().map(|matched| matched.text.as_str()),
+      );
+      add_window_signals(&mut output, &window);
+      // TODO(invoke-recognition-result-artifacts): this records the window OCR
+      // source screenshot and scalar match signals, but not a structured
+      // recognition-result artifact with query/bounds/confidence. Add it after
+      // the artifact shape is accepted in the direct-command handoff.
+      let source_path = invoke_artifact_path(input.command_id, "ocr-screenshot", "png");
+      capture
+        .image
+        .save(&source_path)
+        .map_err(|error| format!("failed to write window OCR screenshot artifact: {error}"))?;
+      output.artifacts.push(ProducedArtifact {
+        kind: "window-ocr-screenshot".to_string(),
+        source_path,
+        preferred_name: format!("{}-ocr-screenshot.png", input.command_id.replace('.', "-")),
+        note: Some("Window screenshot used for OCR matching.".to_string()),
+      });
+      output.verification = Some("recognition-only; no semantic success claim".to_string());
+      output
+        .known_limits
+        .push("window OCR recognition records text matches and source screenshot only; it does not verify downstream UI state.".to_string());
+      return Ok(output);
+    }
+    thread::sleep(wait_options.poll_interval);
+  }
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -303,7 +353,7 @@ fn find_window_text_impl(_input: InvokeCommandInput<'_>, _wait: bool) -> InvokeC
 
 #[cfg(target_os = "macos")]
 fn click_window_text_impl(input: InvokeCommandInput<'_>) -> InvokeCommandResult {
-  use auv_driver::{ClickOptions, Driver, RatioRect, ScreenPoint, WaitOptions};
+  use auv_driver::{ClickOptions, Driver, RatioRect, ScreenPoint};
 
   if input.dry_run {
     return Ok(dry_run_output(input.command_id));
@@ -316,14 +366,13 @@ fn click_window_text_impl(input: InvokeCommandInput<'_>) -> InvokeCommandResult 
     .window()
     .resolve(window_selector(&input))
     .map_err(|error| error.to_string())?;
-  let matches = session
+  let capture = session
     .window()
-    .find_text(
-      &window,
-      query,
-      RatioRect::new(0.0, 0.0, 1.0, 1.0),
-      WaitOptions::default(),
-    )
+    .capture(&window)
+    .map_err(|error| error.to_string())?;
+  let matches = session
+    .vision()
+    .find_text_in_capture(&capture, query, RatioRect::new(0.0, 0.0, 1.0, 1.0))
     .map_err(|error| error.to_string())?;
   let matched = matches
     .best_match()
@@ -345,6 +394,21 @@ fn click_window_text_impl(input: InvokeCommandInput<'_>) -> InvokeCommandResult 
     Some(matched.text.as_str()),
   );
   add_window_signals(&mut output, &window);
+  // TODO(invoke-recognition-result-artifacts): clickText records the OCR source
+  // screenshot used for target resolution, but not the structured
+  // recognition-result artifact. Add it with window.findText once the
+  // direct-invoke recognition artifact shape is accepted.
+  let source_path = invoke_artifact_path(input.command_id, "ocr-screenshot", "png");
+  capture
+    .image
+    .save(&source_path)
+    .map_err(|error| format!("failed to write window click OCR screenshot artifact: {error}"))?;
+  output.artifacts.push(ProducedArtifact {
+    kind: "window-ocr-screenshot".to_string(),
+    source_path,
+    preferred_name: format!("{}-ocr-screenshot.png", input.command_id.replace('.', "-")),
+    note: Some("Window screenshot used to resolve window.clickText OCR target.".to_string()),
+  });
   output.signals.insert(
     "input.selected_path".to_string(),
     format!("{:?}", action.selected_path),
@@ -357,6 +421,11 @@ fn click_window_text_impl(input: InvokeCommandInput<'_>) -> InvokeCommandResult 
     "click.window_y".to_string(),
     window_point.point().y.to_string(),
   );
+  output.verification =
+    Some("activation-only; semantic success requires a separate verification result".to_string());
+  output
+    .known_limits
+    .push("window.clickText records OCR resolution and input delivery only; it does not verify post-click UI state.".to_string());
   Ok(output)
 }
 
@@ -404,6 +473,17 @@ fn required_input<'a>(input: &'a InvokeCommandInput<'_>, name: &str) -> Result<&
 
 fn dry_run_output(command_id: &str) -> InvokeCommandOutput {
   InvokeCommandOutput::new(format!("dry run: {command_id}"))
+}
+
+#[cfg(target_os = "macos")]
+fn invoke_artifact_path(command_id: &str, label: &str, extension: &str) -> std::path::PathBuf {
+  std::env::temp_dir().join(format!(
+    "auv-invoke-{}-{label}-{}-{}.{}",
+    command_id.replace('.', "-"),
+    std::process::id(),
+    now_millis(),
+    extension
+  ))
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/auv-tracing-driver/src/artifact.rs
+++ b/crates/auv-tracing-driver/src/artifact.rs
@@ -10,7 +10,7 @@ pub struct ArtifactRef {
   pub captured_event_id: Option<EventId>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ProducedArtifact {
   pub kind: String,
   pub source_path: PathBuf,

--- a/docs/ai/references/2026-06-18-invoke-direct-command-implementations-handoff.md
+++ b/docs/ai/references/2026-06-18-invoke-direct-command-implementations-handoff.md
@@ -43,6 +43,78 @@ These commands now call typed APIs or produce deterministic direct output:
 - `input.pasteText`
 - `input.key`
 
+## Remaining Evidence TODOs
+
+The current direct invoke evidence lane is intentionally handler-owned: command
+functions construct `InvokeCommandOutput { signals, artifacts, known_limits,
+verification }`, and runtime only records what the handler returns. The
+following gaps are known and intentionally left visible at the code site with
+`TODO:` markers.
+
+### Boundary Claim Model
+
+- Code marker: `TODO(invoke-boundary-claims)`.
+- Current state: `InvokeCommandOutput::verification` is a human-readable command
+  boundary claim recorded as `command.verification` and rendered under
+  `Command Boundary Claims`.
+- Deferred gap: this is not yet a first-class read-side model separate from
+  typed semantic `VerificationResult`.
+- Reason: capture-only, recognition-only, read-only, and activation-only claims
+  must not be misrepresented as semantic verification results.
+- Reopen trigger: define an accepted boundary-claim schema for inspect CLI,
+  inspect server, and future viewer APIs.
+
+### Capture Contract Artifacts
+
+- Code marker: `TODO(invoke-capture-contract-artifacts)`.
+- Current state: `display.capture`, `screen.captureRegion`, and
+  `window.capture` return screenshot artifacts plus scalar capture/display
+  signals.
+- Deferred gap: they do not yet emit standalone capture-contract artifacts.
+- Reason: the old root adapter had capture-contract artifacts, but direct invoke
+  needs an accepted JSON shape that is independent of the removed driver
+  operation route.
+- Reopen trigger: accept the direct-invoke capture-contract JSON shape, then add
+  artifacts from each capture handler without reintroducing macro metadata.
+
+### Recognition Result Artifacts
+
+- Code marker: `TODO(invoke-recognition-result-artifacts)`.
+- Current state: screen/window OCR commands record source screenshots when the
+  handler has a capture and expose match count / best text as signals.
+- Deferred gap: they do not yet emit a structured `recognition-result` artifact
+  containing query, all matches, bounds, confidence, source capture reference,
+  and coordinate-space metadata.
+- Reason: this should be a durable artifact contract consumed by inspection and
+  candidate promotion, not a one-off JSON dump local to `auv-cli-invoke`.
+- Reopen trigger: accept the recognition-result artifact shape and wire the
+  screen/window OCR handlers to emit it.
+
+### Paste Input Action Result
+
+- Code marker: `TODO(invoke-paste-input-action-result)`.
+- Current state: `input.pasteText` records activation-only boundary text,
+  clipboard disturbance signal, and known limits.
+- Deferred gap: it does not persist a typed `InputActionResult` artifact.
+- Reason: the typed paste API currently returns success/failure only, unlike
+  `input.typeText` and `input.key`, which return `InputActionResult`.
+- Reopen trigger: extend the typed paste API to return delivery evidence, then
+  persist it as an `input-action-result` artifact.
+
+### Window Capture Backend Stability
+
+- Code marker: `TODO(invoke-window-capture-backend)`.
+- Current state: window capture/OCR handlers are wired to produce boundary
+  claims and artifacts when capture succeeds.
+- Deferred gap: live verification on 2026-06-18 reproduced single-window capture
+  failures for Chrome and NetEase Cloud Music:
+  ScreenCaptureKit timed out after 10 seconds and xcap fallback failed to copy
+  window data.
+- Reason: this is a typed window capture backend reliability problem, not an
+  invoke evidence-shape problem.
+- Reopen trigger: stabilize or replace the typed window capture backend, then
+  rerun the live window.capture/window.findText/window.clickText smoke checks.
+
 ## Explicit Typed-API Gaps
 
 These commands intentionally return explicit errors instead of routing through

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -152,6 +152,36 @@ pub fn render_run_text(
     output.push_str(&format!("- … {} more\n", run.artifacts.len() - 20));
   }
 
+  let command_boundary_claims = run
+    .events
+    .iter()
+    .filter(|event| event.name == "command.verification")
+    .collect::<Vec<_>>();
+  let command_known_limits = run
+    .events
+    .iter()
+    .filter(|event| event.name == "command.known_limit")
+    .collect::<Vec<_>>();
+  output.push_str("\nCommand Boundary Claims:\n");
+  if command_boundary_claims.is_empty() && command_known_limits.is_empty() {
+    output.push_str("- none\n");
+  } else {
+    for event in command_boundary_claims {
+      output.push_str(&format!(
+        "- verification={} span={}\n",
+        event.message.as_deref().unwrap_or("n/a"),
+        event.span_id
+      ));
+    }
+    for event in command_known_limits {
+      output.push_str(&format!(
+        "- known_limit={} span={}\n",
+        event.message.as_deref().unwrap_or("n/a"),
+        event.span_id
+      ));
+    }
+  }
+
   output.push_str("\nVerifications:\n");
   if verifications.is_empty() {
     output.push_str("- none\n");
@@ -696,16 +726,40 @@ mod tests {
         summary: None,
         failure: None,
       }],
-      events: vec![EventRecordV1Alpha1 {
-        api_version: EVENT_API_VERSION.to_string(),
-        event_id,
-        span_id: root_span_id.clone(),
-        name: "inspect.event".to_string(),
-        timestamp_millis: 1,
-        attributes: BTreeMap::new(),
-        message: Some("event message".to_string()),
-        artifact_ids: vec![artifact_id.clone()],
-      }],
+      events: vec![
+        EventRecordV1Alpha1 {
+          api_version: EVENT_API_VERSION.to_string(),
+          event_id,
+          span_id: root_span_id.clone(),
+          name: "inspect.event".to_string(),
+          timestamp_millis: 1,
+          attributes: BTreeMap::new(),
+          message: Some("event message".to_string()),
+          artifact_ids: vec![artifact_id.clone()],
+        },
+        EventRecordV1Alpha1 {
+          api_version: EVENT_API_VERSION.to_string(),
+          event_id: EventId::new("event_command_verification"),
+          span_id: root_span_id.clone(),
+          name: "command.verification".to_string(),
+          timestamp_millis: 1,
+          attributes: BTreeMap::new(),
+          message: Some(
+            "activation-only; semantic success requires a separate verification result".to_string(),
+          ),
+          artifact_ids: Vec::new(),
+        },
+        EventRecordV1Alpha1 {
+          api_version: EVENT_API_VERSION.to_string(),
+          event_id: EventId::new("event_command_known_limit"),
+          span_id: root_span_id.clone(),
+          name: "command.known_limit".to_string(),
+          timestamp_millis: 1,
+          attributes: BTreeMap::new(),
+          message: Some("input delivery does not verify target UI state".to_string()),
+          artifact_ids: Vec::new(),
+        },
+      ],
       artifacts: vec![ArtifactRecordV1Alpha1 {
         api_version: ARTIFACT_API_VERSION.to_string(),
         artifact_id: artifact_id.clone(),
@@ -1066,6 +1120,11 @@ mod tests {
     assert!(output.contains("auv.inspect.span"));
     assert!(output.contains("inspect.event"));
     assert!(output.contains("artifact_test"));
+    assert!(output.contains("Command Boundary Claims:"));
+    assert!(output.contains(
+      "verification=activation-only; semantic success requires a separate verification result"
+    ));
+    assert!(output.contains("known_limit=input delivery does not verify target UI state"));
     assert!(output.contains("Verifications:"));
     assert!(output.contains("method=semantic_match"));
     assert!(output.contains("Observations:"));

--- a/src/inspect_server/mod.rs
+++ b/src/inspect_server/mod.rs
@@ -331,9 +331,11 @@ async fn get_run(
   let candidate_action_execution_lineage =
     crate::run_read::extract_candidate_action_execution_lineage(state.store.as_ref(), &run)
       .map_err(InspectHttpError::from_store)?;
+  let command_boundary_claims = extract_command_boundary_claims(&run);
   Ok(
     Json(InspectRunResponse {
       run: run.run,
+      command_boundary_claims,
       verifications,
       observation_snapshots,
       detector_recognition_lineage,
@@ -343,6 +345,26 @@ async fn get_run(
     })
     .into_response(),
   )
+}
+
+fn extract_command_boundary_claims(run: &CanonicalRun) -> Vec<CommandBoundaryClaim> {
+  run
+    .events
+    .iter()
+    .filter_map(|event| match event.name.as_str() {
+      "command.verification" => Some(CommandBoundaryClaim {
+        span_id: event.span_id.clone(),
+        kind: "verification".to_string(),
+        message: event.message.clone().unwrap_or_default(),
+      }),
+      "command.known_limit" => Some(CommandBoundaryClaim {
+        span_id: event.span_id.clone(),
+        kind: "known_limit".to_string(),
+        message: event.message.clone().unwrap_or_default(),
+      }),
+      _ => None,
+    })
+    .collect()
 }
 
 async fn get_spans(
@@ -510,6 +532,8 @@ struct InspectRunResponse {
   #[serde(flatten)]
   run: RunRecordV1Alpha1,
   #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  command_boundary_claims: Vec<CommandBoundaryClaim>,
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
   verifications: Vec<VerificationResult>,
   #[serde(default, skip_serializing_if = "Vec::is_empty")]
   observation_snapshots: Vec<ObservationSnapshot>,
@@ -521,6 +545,13 @@ struct InspectRunResponse {
   candidate_action_decision_lineage: Vec<crate::run_read::CandidateActionDecisionLineage>,
   #[serde(default, skip_serializing_if = "Vec::is_empty")]
   candidate_action_execution_lineage: Vec<crate::run_read::CandidateActionExecutionLineage>,
+}
+
+#[derive(serde::Serialize)]
+struct CommandBoundaryClaim {
+  span_id: auv_tracing_driver::trace::SpanId,
+  kind: String,
+  message: String,
 }
 
 #[allow(clippy::result_large_err)]
@@ -1869,6 +1900,12 @@ mod tests {
       .expect("body should read");
     let run: serde_json::Value = serde_json::from_slice(&run_body).expect("run should be json");
     assert_eq!(run["run_id"], "run_inspect_server_contracts");
+    assert_eq!(run["command_boundary_claims"][0]["kind"], "verification");
+    assert_eq!(
+      run["command_boundary_claims"][0]["message"],
+      "activation-only; semantic success requires a separate verification result"
+    );
+    assert_eq!(run["command_boundary_claims"][1]["kind"], "known_limit");
     assert_eq!(run["verifications"][0]["method"]["kind"], "semantic_match");
     assert_eq!(
       run["observation_snapshots"][0]["snapshot_id"],
@@ -3383,7 +3420,31 @@ mod tests {
       .write_run_snapshot(&CanonicalRun {
         run,
         spans: vec![span],
-        events: Vec::new(),
+        events: vec![
+          EventRecordV1Alpha1 {
+            api_version: EVENT_API_VERSION.to_string(),
+            event_id: EventId::new("event_command_verification"),
+            span_id: span_id.clone(),
+            name: "command.verification".to_string(),
+            timestamp_millis: 100,
+            attributes: BTreeMap::new(),
+            message: Some(
+              "activation-only; semantic success requires a separate verification result"
+                .to_string(),
+            ),
+            artifact_ids: Vec::new(),
+          },
+          EventRecordV1Alpha1 {
+            api_version: EVENT_API_VERSION.to_string(),
+            event_id: EventId::new("event_command_known_limit"),
+            span_id: span_id.clone(),
+            name: "command.known_limit".to_string(),
+            timestamp_millis: 100,
+            attributes: BTreeMap::new(),
+            message: Some("input delivery does not verify target UI state".to_string()),
+            artifact_ids: Vec::new(),
+          },
+        ],
         artifacts,
       })
       .expect("run should persist");

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -523,6 +523,60 @@ impl Runtime {
       record_event(run, command_span.id(), "command.note", Some(note.clone()));
     }
 
+    if let Some(verification) = &output.verification {
+      record_event(
+        run,
+        command_span.id(),
+        "command.verification",
+        Some(verification.clone()),
+      );
+    }
+
+    for known_limit in &output.known_limits {
+      record_event(
+        run,
+        command_span.id(),
+        "command.known_limit",
+        Some(known_limit.clone()),
+      );
+    }
+
+    let artifact_result =
+      self
+        .recording
+        .record_produced_artifacts(run, &command_span, output.artifacts);
+    let (artifact_records, artifact_paths) = match artifact_result {
+      Ok(recorded) => (recorded.records, recorded.paths),
+      Err(failure) => {
+        let failure_message = format!(
+          "command {} artifact recording failed: {}",
+          command.id, failure.message
+        );
+        let output_summary = format!(
+          "Command invocation produced output, but artifact recording failed. Inspect {} for the recorded trace.",
+          run.id()
+        );
+        run.finish_span(
+          &command_span,
+          auv_tracing_driver::run_builder::SpanFinish {
+            status_code: TraceStatusCode::Error,
+            summary: Some(output_summary.clone()),
+            failure: Some(failure_message.clone()),
+          },
+        )?;
+        return Ok(InvokeResult {
+          run_id: run.id().to_string(),
+          producer_span_id: command_span.id().clone(),
+          status: RunStatus::Failed,
+          output_summary,
+          signals: output.signals,
+          artifacts: failure.recorded.records,
+          artifact_paths: failure.recorded.paths,
+          failure_message: Some(failure_message),
+        });
+      }
+    };
+
     record_event(
       run,
       command_span.id(),
@@ -545,8 +599,8 @@ impl Runtime {
       status: RunStatus::Completed,
       output_summary: output.summary,
       signals: output.signals,
-      artifacts: Vec::new(),
-      artifact_paths: Vec::new(),
+      artifacts: artifact_records,
+      artifact_paths,
       failure_message: None,
     })
   }
@@ -589,6 +643,7 @@ mod tests {
   use std::path::PathBuf;
   use std::sync::Arc;
 
+  use auv_tracing_driver::ProducedArtifact;
   use serde_json::json;
 
   use super::{
@@ -936,6 +991,26 @@ mod tests {
     Err("handler refused test command".to_string())
   }
 
+  fn artifact_registered_handler_command(
+    input: auv_cli_invoke::InvokeCommandInput<'_>,
+  ) -> auv_cli_invoke::InvokeCommandResult {
+    let source_path = temp_dir("runtime-direct-handler-artifact").join("source.txt");
+    fs::write(&source_path, "direct handler artifact\n").expect("artifact source should write");
+
+    let mut output = auv_cli_invoke::InvokeCommandOutput::new("direct artifact completed");
+    output.artifacts.push(ProducedArtifact {
+      kind: "direct-handler-report".to_string(),
+      source_path,
+      preferred_name: format!("{}-report.txt", input.command_id.replace('.', "-")),
+      note: Some("Direct handler artifact.".to_string()),
+    });
+    output
+      .known_limits
+      .push("fixture direct handler evidence only".to_string());
+    output.verification = Some("fixture-only; no semantic success claim".to_string());
+    Ok(output)
+  }
+
   #[test]
   fn invoke_resolved_records_direct_command_output_without_driver_span() {
     let project_root = temp_dir("runtime-resolved-project");
@@ -1004,6 +1079,58 @@ mod tests {
           .message
           .as_deref()
           .is_some_and(|message| message.contains("handler note"))
+    }));
+
+    let _ = fs::remove_dir_all(project_root);
+    let _ = fs::remove_dir_all(store_root);
+  }
+
+  #[test]
+  fn invoke_resolved_records_direct_handler_artifacts() {
+    let project_root = temp_dir("runtime-resolved-artifact-project");
+    let store_root = temp_dir("runtime-resolved-artifact-store");
+    let runtime = runtime_with_success_driver(project_root.clone(), store_root.clone());
+    let command = auv_cli_invoke::command::spec(
+      REGISTERED_HANDLER_COMMAND_ID,
+      auv_cli_invoke::InvokeNamespace::Fixture,
+      "Test registered command handler artifacts.",
+      auv_cli_invoke::arg::NO_ARGS,
+      artifact_registered_handler_command,
+    );
+
+    let result = runtime
+      .invoke_resolved(
+        InvokeRequest {
+          command_id: REGISTERED_HANDLER_COMMAND_ID.to_string(),
+          ..InvokeRequest::default()
+        },
+        &command,
+      )
+      .expect("resolved invoke should record direct handler artifacts");
+
+    assert_eq!(result.status, RunStatus::Completed);
+    assert_eq!(result.artifacts.len(), 1);
+    assert_eq!(result.artifacts[0].role, "direct-handler-report");
+    assert_eq!(result.artifact_paths.len(), 1);
+    let canonical = runtime.read_run(&result.run_id).expect("run should read");
+    assert_eq!(canonical.artifacts.len(), 1);
+    assert!(canonical.events.iter().any(|event| {
+      event.name == "artifact.captured"
+        && event.artifact_ids == vec![result.artifacts[0].artifact_id.clone()]
+    }));
+    assert!(canonical.events.iter().any(|event| {
+      event.name == "command.verification"
+        && event
+          .message
+          .as_deref()
+          .is_some_and(|message| message.contains("fixture-only"))
+    }));
+    assert!(canonical.events.iter().any(|event| {
+      event.name == "command.known_limit"
+        && event
+          .message
+          .as_deref()
+          .is_some_and(|message| message.contains("evidence only"))
     }));
 
     let _ = fs::remove_dir_all(project_root);


### PR DESCRIPTION
## Summary
- add handler-owned invoke evidence fields for artifacts, known limits, and boundary verification claims
- persist handler-produced artifacts through runtime recording and surface command boundary claims in inspect CLI/server output
- add live handler evidence for display/screen/window/input/read-only invoke commands, with TODO markers and handoff notes for remaining capture-contract, recognition-result, paste-result, and window-capture backend gaps

## Verification
- cargo test -p auv-cli-invoke command_output_defaults_evidence_fields_to_empty
- cargo test runtime::tests::invoke_resolved_records_direct_handler_artifacts
- cargo test inspect::tests::render_run_text_includes_run_span_event_artifact_verification_and_observation_records
- cargo test inspect_server::tests::run_route_includes_read_side_verifications_and_observation_snapshots
- cargo check
- cargo fmt --check
- git diff --check

## Live smoke
- app.probePermissions: completed, read-only boundary claim rendered
- display.list: completed, listed 2 displays
- window.list: completed, listed 53 windows
- display.capture: completed with screenshot artifact
- screen.captureRegion: completed with region screenshot artifact
- screen.findText --query Chrome: completed with OCR screenshot artifact and recognition-only boundary claim; matched 0 regions on this desktop state
- window.capture/window.findText against Chrome and NetEase: failed in typed window capture backend with ScreenCaptureKit timeout and xcap fallback copy failure; recorded in TODO(invoke-window-capture-backend)
- input.key/input.typeText: dry-run only to avoid typing into the active user app