### PR TITLE
chore(ci): added check and release workflows

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,35 @@
+name: Check
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  rust:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-24.04
+          - macos-14
+    runs-on: ${{ matrix.os }}
+    name: rust checks ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --check
+      - run: cargo check
+      - run: cargo test
+      - run: cargo run --quiet -- invoke --help
+      - run: git diff --check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,54 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    permissions:
+      contents: write
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-24.04
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
+          - target: x86_64-apple-darwin
+            os: macos-13
+          - target: aarch64-apple-darwin
+            os: macos-14
+    runs-on: ${{ matrix.os }}
+    name: build ${{ matrix.target }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - run: cargo build --release --target ${{ matrix.target }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: auv-cli.${{ matrix.target }}
+          path: target/${{ matrix.target }}/release/auv-cli
+          if-no-files-found: error
+          retention-days: 7
+      - uses: TheDoctor0/zip-release@0.7.6
+        with:
+          type: tar
+          filename: auv-cli.${{ matrix.target }}.tar
+          directory: target/${{ matrix.target }}/release/
+          path: auv-cli
+      - uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          generate_release_notes: true
+          prerelease: ${{ contains(github.ref, '-') }}
+          files: target/${{ matrix.target }}/release/auv-cli.${{ matrix.target }}.tar


### PR DESCRIPTION
## Summary

- Add a GitHub Actions check workflow for PRs, pushes to `main`, and manual runs.
- Add an `ortts`-style release workflow that builds `auv-cli` binaries and publishes draft GitHub Releases for version tags.
- Keep Docker publishing out of scope because AUV currently has no Dockerfile or server-style container release surface.

## Validation

- `cargo fmt --check`
- YAML parse via Ruby `YAML.load_file` for `.github/workflows/*.yml`
- `git diff --check origin/main..HEAD`

Earlier in the same implementation pass, the workflow command set was also validated with `cargo check`, `cargo test`, and `cargo run --quiet -- invoke --help`.