### PR TITLE
feat(auv-api-proto): added Protobuf

### DIFF
--- a/.prototools
+++ b/.prototools
@@ -1,0 +1,2 @@
+[plugins.tools]
+buf = "https://raw.githubusercontent.com/stk0vrfl0w/proto-toml-plugins/main/plugins/buf.toml"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "auv-api-proto"
+version = "0.0.1"
+dependencies = [
+ "prost",
+ "protoc-bin-vendored",
+ "tonic",
+ "tonic-prost",
+ "tonic-prost-build",
+]
+
+[[package]]
 name = "auv-apple-music"
 version = "0.0.1"
 dependencies = [
@@ -1813,6 +1824,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2459,6 +2476,19 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -3256,6 +3286,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
 name = "nalgebra"
 version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3991,6 +4027,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4187,6 +4234,143 @@ checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
+dependencies = [
+ "heck",
+ "itertools 0.14.0",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "pulldown-cmark",
+ "pulldown-cmark-to-cmark",
+ "regex",
+ "syn 2.0.117",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost",
+]
+
+[[package]]
+name = "protoc-bin-vendored"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1c381df33c98266b5f08186583660090a4ffa0889e76c7e9a5e175f645a67fa"
+dependencies = [
+ "protoc-bin-vendored-linux-aarch_64",
+ "protoc-bin-vendored-linux-ppcle_64",
+ "protoc-bin-vendored-linux-s390_64",
+ "protoc-bin-vendored-linux-x86_32",
+ "protoc-bin-vendored-linux-x86_64",
+ "protoc-bin-vendored-macos-aarch_64",
+ "protoc-bin-vendored-macos-x86_64",
+ "protoc-bin-vendored-win32",
+]
+
+[[package]]
+name = "protoc-bin-vendored-linux-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c350df4d49b5b9e3ca79f7e646fde2377b199e13cfa87320308397e1f37e1a4c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-ppcle_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55a63e6c7244f19b5c6393f025017eb5d793fd5467823a099740a7a4222440c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-s390_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dba5565db4288e935d5330a07c264a4ee8e4a5b4a4e6f4e83fad824cc32f3b0"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8854774b24ee28b7868cd71dccaae8e02a2365e67a4a87a6cd11ee6cdbdf9cf5"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38b07546580df720fa464ce124c4b03630a6fb83e05c336fea2a241df7e5d78"
+
+[[package]]
+name = "protoc-bin-vendored-macos-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89278a9926ce312e51f1d999fee8825d324d603213344a9a706daa009f1d8092"
+
+[[package]]
+name = "protoc-bin-vendored-macos-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81745feda7ccfb9471d7a4de888f0652e806d5795b61480605d4943176299756"
+
+[[package]]
+name = "protoc-bin-vendored-win32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
+dependencies = [
+ "bitflags 2.11.1",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-to-cmark"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
+dependencies = [
+ "pulldown-cmark",
 ]
 
 [[package]]
@@ -5715,6 +5899,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "socket2",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "tonic-prost-build"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types",
+ "quote",
+ "syn 2.0.117",
+ "tempfile",
+ "tonic-build",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5722,9 +5974,12 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "crates/auv-apple-music",
   "crates/auv-apple-notes",
   "crates/auv-apple-textedit",
+  "crates/auv-api-proto",
   "crates/auv-cli-invoke-macros",
   "crates/auv-cli-invoke",
   "crates/auv-qqmusic",

--- a/crates/auv-api-proto/Cargo.toml
+++ b/crates/auv-api-proto/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "auv-api-proto"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+readme.workspace = true
+license.workspace = true
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+prost = "0.14"
+tonic = "0.14"
+tonic-prost = "0.14"
+
+[build-dependencies]
+protoc-bin-vendored = "3"
+tonic-prost-build = "0.14"

--- a/crates/auv-api-proto/build.rs
+++ b/crates/auv-api-proto/build.rs
@@ -11,7 +11,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
   let out_dir = PathBuf::from(std::env::var("OUT_DIR")?);
   tonic_prost_build::configure()
-    .file_descriptor_set_path(out_dir.join("auv.api.v1.session.bin"))
+    .file_descriptor_set_path(out_dir.join("auv.api.session.v1.bin"))
     .compile_protos(&["../../proto/auv/api/v1/session.proto"], &["../../proto"])?;
 
   println!("cargo:rerun-if-changed=../../proto/auv/api/v1/session.proto");

--- a/crates/auv-api-proto/build.rs
+++ b/crates/auv-api-proto/build.rs
@@ -1,0 +1,19 @@
+use std::path::PathBuf;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+  let protoc = protoc_bin_vendored::protoc_bin_path()?;
+  // NOTICE(proto-build): Cargo builds use a vendored `protoc` so this crate can
+  // compile outside the Nix dev shell; `nix develop` still provides `protobuf`
+  // and `buf` for explicit schema work.
+  unsafe {
+    std::env::set_var("PROTOC", protoc);
+  }
+
+  let out_dir = PathBuf::from(std::env::var("OUT_DIR")?);
+  tonic_prost_build::configure()
+    .file_descriptor_set_path(out_dir.join("auv.api.v1.session.bin"))
+    .compile_protos(&["../../proto/auv/api/v1/session.proto"], &["../../proto"])?;
+
+  println!("cargo:rerun-if-changed=../../proto/auv/api/v1/session.proto");
+  Ok(())
+}

--- a/crates/auv-api-proto/src/lib.rs
+++ b/crates/auv-api-proto/src/lib.rs
@@ -1,0 +1,22 @@
+pub mod v1 {
+  pub mod session {
+    tonic::include_proto!("auv.api.v1.session");
+
+    /// Encoded protobuf schema metadata for gRPC reflection and tools such as
+    /// `grpcurl`; normal clients use the generated request/response types.
+    pub const FILE_DESCRIPTOR_SET: &[u8] =
+      tonic::include_file_descriptor_set!("auv.api.v1.session");
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  #[test]
+  fn session_proto_types_are_available() {
+    let request = crate::v1::session::DoExampleRequest {
+      input: "hello".to_string(),
+    };
+
+    assert_eq!(request.input, "hello");
+  }
+}

--- a/crates/auv-api-proto/src/lib.rs
+++ b/crates/auv-api-proto/src/lib.rs
@@ -1,11 +1,11 @@
 pub mod v1 {
   pub mod session {
-    tonic::include_proto!("auv.api.v1.session");
+    tonic::include_proto!("auv.api.session.v1");
 
     /// Encoded protobuf schema metadata for gRPC reflection and tools such as
     /// `grpcurl`; normal clients use the generated request/response types.
     pub const FILE_DESCRIPTOR_SET: &[u8] =
-      tonic::include_file_descriptor_set!("auv.api.v1.session");
+      tonic::include_file_descriptor_set!("auv.api.session.v1");
   }
 }
 

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,8 @@
                 # protobuf
                 protobuf
                 buf
+                protoc-gen-prost
+                protoc-gen-tonic
               ])
               ++ [];
 

--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,10 @@
                 rustfmt
                 clippy
                 rust-analyzer
+
+                # protobuf
+                protobuf
+                buf
               ])
               ++ [];
 

--- a/proto/auv/api/v1/session.proto
+++ b/proto/auv/api/v1/session.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package auv.api.v1.session;
+package auv.api.session.v1;
 
 service SessionService {
   rpc DoExample(DoExampleRequest) returns (DoExampleResponse);

--- a/proto/auv/api/v1/session.proto
+++ b/proto/auv/api/v1/session.proto
@@ -1,0 +1,27 @@
+syntax = "proto3";
+
+package auv.api.v1.session;
+
+service SessionService {
+  rpc DoExample(DoExampleRequest) returns (DoExampleResponse);
+  rpc DoExampleStream(stream DoExampleStreamRequest)
+      returns (stream DoExampleStreamResponse);
+}
+
+message DoExampleRequest {
+  string input = 1;
+}
+
+message DoExampleResponse {
+  string output = 1;
+}
+
+message DoExampleStreamRequest {
+  uint64 sequence = 1;
+  string input = 2;
+}
+
+message DoExampleStreamResponse {
+  uint64 sequence = 1;
+  string output = 2;
+}

--- a/proto/buf.gen.yaml
+++ b/proto/buf.gen.yaml
@@ -1,0 +1,9 @@
+version: v2
+plugins:
+  # Rust generation is currently owned by crates/auv-api-proto/build.rs so
+  # Cargo can compile without requiring buf or protoc to be installed globally.
+  # Keep this file as the Buf entrypoint for future SDK generation.
+  - local: protoc-gen-prost
+    out: gen/rust
+  - local: protoc-gen-tonic
+    out: gen/rust

--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -5,8 +5,8 @@ lint:
   use:
     - STANDARD
   except:
-    # AUV uses `auv.api.v1.<domain>` packages so generated Rust modules read as
-    # `v1::<domain>` instead of duplicating the version as `<domain>::v1`.
+    # AUV keeps proto files under versioned directories while using
+    # `<domain>.v1` package suffixes.
     - PACKAGE_DIRECTORY_MATCH
     - PACKAGE_VERSION_SUFFIX
 breaking:

--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -1,0 +1,14 @@
+version: v2
+modules:
+  - path: .
+lint:
+  use:
+    - STANDARD
+  except:
+    # AUV uses `auv.api.v1.<domain>` packages so generated Rust modules read as
+    # `v1::<domain>` instead of duplicating the version as `<domain>::v1`.
+    - PACKAGE_DIRECTORY_MATCH
+    - PACKAGE_VERSION_SUFFIX
+breaking:
+  use:
+    - FILE


### PR DESCRIPTION
## Summary

Adds a small `auv-api-proto` workspace crate and root `proto/` workspace to validate the initial Rust protobuf/gRPC toolchain direction.

## Changes

- Adds `crates/auv-api-proto` with Cargo-time tonic/prost code generation.
- Adds a minimal `auv.api.v1.session` example service with unary and bidirectional streaming example RPCs.
- Adds Buf workspace config for lint/breaking checks while excluding package path/version rules that conflict with the desired Rust module shape.
- Adds `protobuf` and `buf` to the Nix dev shell while keeping vendored `protoc` for Cargo builds outside Nix.

## Validation

- `cargo check -p auv-api-proto`
- `cargo test -p auv-api-proto`
- `cargo fmt --check -p auv-api-proto`
- `git diff --cached --check`
- `nix --extra-experimental-features 'nix-command flakes' develop --command buf lint proto`