### PR TITLE
feat(auv-game-osu): add osu WQ1 witness and quality evidence

### DIFF
--- a/crates/auv-game-osu/src/detection_eval_quality.rs
+++ b/crates/auv-game-osu/src/detection_eval_quality.rs
@@ -1,0 +1,518 @@
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use auv_file::{
+  JsonFileReadError, JsonFileWriteError, JsonWriteOptions, read_json_file as read_json_file_helper,
+  write_json_file as write_json_file_helper,
+};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+
+use crate::detection_eval_witness::{
+  DetectionEvalWitnessManifest, DetectionEvalWitnessReason, DetectionEvalWitnessStatus,
+};
+
+pub type DetectionEvalQualityResult<T> = Result<T, String>;
+
+pub const DETECTION_EVAL_QUALITY_MANIFEST_SCHEMA_VERSION: u32 = 1;
+pub const DETECTION_EVAL_QUALITY_INSPECT_REPORT_SCHEMA_VERSION: u32 = 1;
+
+pub const OSU_WQ1_V1_QUALITY_KNOWN_LIMIT: &str = "osu WQ1 quality records detection measurement evidence only; it does not claim model usefulness, gameplay success, or pass/fail thresholds";
+
+const WITNESS_MANIFEST_FILE: &str = "osu-detection-eval-witness.json";
+const QUALITY_MANIFEST_FILE: &str = "osu-detection-eval-quality.json";
+const QUALITY_INSPECT_FILE: &str = "osu-detection-eval-quality-inspect.json";
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct DetectionEvalQualityInputs {
+  pub witness_manifest_path: PathBuf,
+  pub output_dir: PathBuf,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct DetectionEvalQualityOutput {
+  pub output_dir: PathBuf,
+  pub manifest_path: PathBuf,
+  pub inspect_report_path: PathBuf,
+  pub manifest: DetectionEvalQualityManifest,
+  pub inspect_report: DetectionEvalQualityInspectReport,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct DetectionEvalQualityMetrics {
+  pub total_frames: usize,
+  pub label_matched_frames: usize,
+  pub label_missing_frames: usize,
+  pub label_unmapped_frames: usize,
+  pub spatial_matched_frames: usize,
+  pub spatial_missing_frames: usize,
+  pub spatial_unscored_frames: usize,
+  pub spurious_detection_count: usize,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub label_recall: Option<f32>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub spatial_recall: Option<f32>,
+  pub projection_kind: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct DetectionEvalQualityManifest {
+  pub schema_version: u32,
+  pub generated_at_millis: u64,
+  pub detection_eval_witness_manifest_path: String,
+  pub source_visual_eval_report_path: String,
+  pub source_run_artifact_dir: String,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub detector_model_id: Option<String>,
+  pub witness_status: DetectionEvalWitnessStatus,
+  pub status: DetectionEvalQualityStatus,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub reason: Option<DetectionEvalQualityReason>,
+  pub verdict: DetectionEvalQualityVerdict,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub metrics: Option<DetectionEvalQualityMetrics>,
+  pub known_limits: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct DetectionEvalQualityInspectReport {
+  pub schema_version: u32,
+  pub generated_at_millis: u64,
+  pub detection_eval_quality_manifest_path: String,
+  pub detection_eval_witness_manifest_path: String,
+  pub source_visual_eval_report_path: String,
+  pub witness_status: DetectionEvalWitnessStatus,
+  pub status: DetectionEvalQualityStatus,
+  pub verdict: DetectionEvalQualityVerdict,
+  pub label_recall_available: bool,
+  pub spatial_recall_available: bool,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub metrics: Option<DetectionEvalQualityMetrics>,
+  pub warnings: Vec<String>,
+  pub known_limits: Vec<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DetectionEvalQualityStatus {
+  Ready,
+  Blocked,
+  Failed,
+}
+
+impl DetectionEvalQualityStatus {
+  pub fn as_str(self) -> &'static str {
+    match self {
+      Self::Ready => "ready",
+      Self::Blocked => "blocked",
+      Self::Failed => "failed",
+    }
+  }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DetectionEvalQualityReason {
+  MissingWitnessManifest,
+  WitnessManifestParseFailed,
+  WitnessNotReady,
+  WitnessBlocked,
+  WitnessFailed,
+}
+
+impl DetectionEvalQualityReason {
+  pub fn as_str(self) -> &'static str {
+    match self {
+      Self::MissingWitnessManifest => "missing_witness_manifest",
+      Self::WitnessManifestParseFailed => "witness_manifest_parse_failed",
+      Self::WitnessNotReady => "witness_not_ready",
+      Self::WitnessBlocked => "witness_blocked",
+      Self::WitnessFailed => "witness_failed",
+    }
+  }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DetectionEvalQualityVerdict {
+  MeasuredOnly,
+  MetricPartial,
+  Blocked,
+  Failed,
+}
+
+impl DetectionEvalQualityVerdict {
+  pub fn as_str(self) -> &'static str {
+    match self {
+      Self::MeasuredOnly => "measured_only",
+      Self::MetricPartial => "metric_partial",
+      Self::Blocked => "blocked",
+      Self::Failed => "failed",
+    }
+  }
+}
+
+pub fn build_detection_eval_quality(
+  inputs: &DetectionEvalQualityInputs,
+) -> DetectionEvalQualityResult<DetectionEvalQualityOutput> {
+  fs::create_dir_all(&inputs.output_dir).map_err(|error| {
+    format!(
+      "failed to create detection eval quality output dir {}: {error}",
+      inputs.output_dir.display()
+    )
+  })?;
+
+  let generated_at_millis = auv_tracing_driver::now_millis();
+  let known_limits = BTreeSet::from([OSU_WQ1_V1_QUALITY_KNOWN_LIMIT.to_string()]);
+  let mut warnings = BTreeSet::new();
+
+  let gate = evaluate_quality_gate(&inputs.witness_manifest_path, &mut warnings);
+  let witness = gate.witness_manifest.as_ref();
+
+  let outcome = witness
+    .map(derive_quality_outcome)
+    .unwrap_or(QualityOutcome {
+      status: gate.quality_status,
+      reason: gate.quality_reason,
+      verdict: gate.verdict,
+      metrics: None,
+    });
+
+  let manifest = DetectionEvalQualityManifest {
+    schema_version: DETECTION_EVAL_QUALITY_MANIFEST_SCHEMA_VERSION,
+    generated_at_millis,
+    detection_eval_witness_manifest_path: inputs.witness_manifest_path.display().to_string(),
+    source_visual_eval_report_path: witness
+      .map(|w| w.source_visual_eval_report_path.clone())
+      .unwrap_or_default(),
+    source_run_artifact_dir: witness
+      .map(|w| w.source_run_artifact_dir.clone())
+      .unwrap_or_default(),
+    detector_model_id: witness.and_then(|w| w.detector_model_id.clone()),
+    witness_status: witness
+      .map(|w| w.status)
+      .unwrap_or(DetectionEvalWitnessStatus::Blocked),
+    status: outcome.status,
+    reason: outcome.reason,
+    verdict: outcome.verdict,
+    metrics: outcome.metrics.clone(),
+    known_limits: known_limits.into_iter().collect(),
+  };
+
+  let manifest_path = inputs.output_dir.join(QUALITY_MANIFEST_FILE);
+  write_json_file(&manifest_path, &manifest)?;
+
+  let inspect_report = DetectionEvalQualityInspectReport {
+    schema_version: DETECTION_EVAL_QUALITY_INSPECT_REPORT_SCHEMA_VERSION,
+    generated_at_millis,
+    detection_eval_quality_manifest_path: manifest_path.display().to_string(),
+    detection_eval_witness_manifest_path: manifest.detection_eval_witness_manifest_path.clone(),
+    source_visual_eval_report_path: manifest.source_visual_eval_report_path.clone(),
+    witness_status: manifest.witness_status,
+    status: manifest.status,
+    verdict: manifest.verdict,
+    label_recall_available: manifest
+      .metrics
+      .as_ref()
+      .and_then(|m| m.label_recall)
+      .is_some(),
+    spatial_recall_available: manifest
+      .metrics
+      .as_ref()
+      .and_then(|m| m.spatial_recall)
+      .is_some(),
+    metrics: manifest.metrics.clone(),
+    warnings: warnings.into_iter().collect(),
+    known_limits: manifest.known_limits.clone(),
+  };
+
+  let inspect_report_path = inputs.output_dir.join(QUALITY_INSPECT_FILE);
+  write_json_file(&inspect_report_path, &inspect_report)?;
+
+  Ok(DetectionEvalQualityOutput {
+    output_dir: inputs.output_dir.clone(),
+    manifest_path,
+    inspect_report_path,
+    manifest,
+    inspect_report,
+  })
+}
+
+pub fn build_detection_eval_quality_from_witness_dir(
+  witness_output_dir: &Path,
+  output_dir: PathBuf,
+) -> DetectionEvalQualityResult<DetectionEvalQualityOutput> {
+  build_detection_eval_quality(&DetectionEvalQualityInputs {
+    witness_manifest_path: witness_output_dir.join(WITNESS_MANIFEST_FILE),
+    output_dir,
+  })
+}
+
+pub fn derive_detection_eval_quality_verdict(
+  witness: &DetectionEvalWitnessManifest,
+) -> DetectionEvalQualityVerdict {
+  derive_quality_outcome(witness).verdict
+}
+
+struct QualityGateEvaluation {
+  quality_status: DetectionEvalQualityStatus,
+  quality_reason: Option<DetectionEvalQualityReason>,
+  verdict: DetectionEvalQualityVerdict,
+  witness_manifest: Option<DetectionEvalWitnessManifest>,
+}
+
+struct QualityOutcome {
+  status: DetectionEvalQualityStatus,
+  reason: Option<DetectionEvalQualityReason>,
+  verdict: DetectionEvalQualityVerdict,
+  metrics: Option<DetectionEvalQualityMetrics>,
+}
+
+fn evaluate_quality_gate(
+  witness_manifest_path: &Path,
+  warnings: &mut BTreeSet<String>,
+) -> QualityGateEvaluation {
+  if !witness_manifest_path.is_file() {
+    return QualityGateEvaluation {
+      quality_status: DetectionEvalQualityStatus::Blocked,
+      quality_reason: Some(DetectionEvalQualityReason::MissingWitnessManifest),
+      verdict: DetectionEvalQualityVerdict::Blocked,
+      witness_manifest: None,
+    };
+  }
+
+  let witness_manifest = match read_json_file::<DetectionEvalWitnessManifest>(
+    witness_manifest_path,
+    "osu detection eval witness manifest",
+  ) {
+    Ok(manifest) => Some(manifest),
+    Err(error) => {
+      warnings.insert(error);
+      return QualityGateEvaluation {
+        quality_status: DetectionEvalQualityStatus::Failed,
+        quality_reason: Some(DetectionEvalQualityReason::WitnessManifestParseFailed),
+        verdict: DetectionEvalQualityVerdict::Failed,
+        witness_manifest: None,
+      };
+    }
+  };
+
+  let Some(witness) = witness_manifest.as_ref() else {
+    return QualityGateEvaluation {
+      quality_status: DetectionEvalQualityStatus::Failed,
+      quality_reason: Some(DetectionEvalQualityReason::WitnessManifestParseFailed),
+      verdict: DetectionEvalQualityVerdict::Failed,
+      witness_manifest,
+    };
+  };
+
+  match witness.status {
+    DetectionEvalWitnessStatus::Blocked => QualityGateEvaluation {
+      quality_status: DetectionEvalQualityStatus::Blocked,
+      quality_reason: witness.reason.map(|reason| match reason {
+        DetectionEvalWitnessReason::MissingVisualEvalReport
+        | DetectionEvalWitnessReason::MissingDetectionEvalManifest
+        | DetectionEvalWitnessReason::EmptyFrames => DetectionEvalQualityReason::WitnessBlocked,
+        _ => DetectionEvalQualityReason::WitnessNotReady,
+      }),
+      verdict: DetectionEvalQualityVerdict::Blocked,
+      witness_manifest,
+    },
+    DetectionEvalWitnessStatus::Failed => QualityGateEvaluation {
+      quality_status: DetectionEvalQualityStatus::Failed,
+      quality_reason: Some(DetectionEvalQualityReason::WitnessFailed),
+      verdict: DetectionEvalQualityVerdict::Failed,
+      witness_manifest,
+    },
+    DetectionEvalWitnessStatus::Ready => {
+      let outcome = derive_quality_outcome(witness);
+      QualityGateEvaluation {
+        quality_status: outcome.status,
+        quality_reason: outcome.reason,
+        verdict: outcome.verdict,
+        witness_manifest,
+      }
+    }
+  }
+}
+
+fn derive_quality_outcome(witness: &DetectionEvalWitnessManifest) -> QualityOutcome {
+  let metrics = metrics_from_witness(witness);
+  let verdict = if witness.projection_kind == "playfield_to_pixels"
+    && witness.spatial_unscored_frames == 0
+    && witness.total_frames > 0
+  {
+    DetectionEvalQualityVerdict::MeasuredOnly
+  } else if witness.total_frames > 0 {
+    DetectionEvalQualityVerdict::MetricPartial
+  } else {
+    DetectionEvalQualityVerdict::Blocked
+  };
+
+  QualityOutcome {
+    status: DetectionEvalQualityStatus::Ready,
+    reason: None,
+    verdict,
+    metrics: Some(metrics),
+  }
+}
+
+fn metrics_from_witness(witness: &DetectionEvalWitnessManifest) -> DetectionEvalQualityMetrics {
+  let label_scorable = witness.label_matched_frames + witness.label_missing_frames;
+  let label_recall = if label_scorable == 0 {
+    None
+  } else {
+    Some(witness.label_matched_frames as f32 / label_scorable as f32)
+  };
+
+  let spatial_scorable = witness.spatial_matched_frames + witness.spatial_missing_frames;
+  let spatial_recall = if spatial_scorable == 0 {
+    None
+  } else {
+    Some(witness.spatial_matched_frames as f32 / spatial_scorable as f32)
+  };
+
+  DetectionEvalQualityMetrics {
+    total_frames: witness.total_frames,
+    label_matched_frames: witness.label_matched_frames,
+    label_missing_frames: witness.label_missing_frames,
+    label_unmapped_frames: witness.label_unmapped_frames,
+    spatial_matched_frames: witness.spatial_matched_frames,
+    spatial_missing_frames: witness.spatial_missing_frames,
+    spatial_unscored_frames: witness.spatial_unscored_frames,
+    spurious_detection_count: witness.spurious_detection_count,
+    label_recall,
+    spatial_recall,
+    projection_kind: witness.projection_kind.clone(),
+  }
+}
+
+fn read_json_file<T: DeserializeOwned>(path: &Path, label: &str) -> Result<T, String> {
+  read_json_file_helper(path).map_err(|error| match error {
+    JsonFileReadError::Open(error) => {
+      format!("failed to open {label} {}: {error}", path.display())
+    }
+    JsonFileReadError::Parse(error) => {
+      format!("failed to parse {label} {}: {error}", path.display())
+    }
+  })
+}
+
+fn write_json_file<T: Serialize>(path: &Path, value: &T) -> Result<(), String> {
+  write_json_file_helper(path, value, JsonWriteOptions::default()).map_err(|error| match error {
+    JsonFileWriteError::CreateParent(error) | JsonFileWriteError::Write(error) => {
+      format!("failed to write {}: {error}", path.display())
+    }
+    JsonFileWriteError::Serialize(error) => {
+      format!("failed to serialize {}: {error}", path.display())
+    }
+  })
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::detection_eval_witness::{
+    DetectionEvalWitnessInputs, DetectionEvalWitnessManifest, DetectionEvalWitnessStatus,
+    build_detection_eval_witness,
+  };
+  use std::path::PathBuf;
+
+  fn fixture_witness_manifest() -> (tempfile::TempDir, PathBuf) {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let manifest_dir =
+      PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/osu_eval_run_artifacts");
+    let detections_path =
+      PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/osu_eval_detection");
+    let eval_output = temp.path().join("eval");
+    crate::evaluate_detection_fixture(&crate::DetectionEvalInputs {
+      run_artifact_dir: manifest_dir,
+      detections_path,
+      output_dir: eval_output.clone(),
+    })
+    .expect("eval");
+    let witness_output = temp.path().join("witness");
+    let witness = build_detection_eval_witness(&DetectionEvalWitnessInputs {
+      detection_eval_output_dir: eval_output,
+      output_dir: witness_output.clone(),
+    })
+    .expect("witness");
+    (temp, witness.manifest_path)
+  }
+
+  #[test]
+  fn quality_from_fixture_witness_records_metrics_and_measured_only_verdict() {
+    let (temp, witness_path) = fixture_witness_manifest();
+    let quality_output = build_detection_eval_quality(&DetectionEvalQualityInputs {
+      witness_manifest_path: witness_path,
+      output_dir: temp.path().join("quality"),
+    })
+    .expect("quality");
+
+    assert_eq!(
+      quality_output.manifest.status,
+      DetectionEvalQualityStatus::Ready
+    );
+    assert_eq!(
+      quality_output.manifest.verdict,
+      DetectionEvalQualityVerdict::MeasuredOnly
+    );
+    let metrics = quality_output.manifest.metrics.as_ref().expect("metrics");
+    assert_eq!(metrics.total_frames, 3);
+    assert_eq!(metrics.label_matched_frames, 1);
+    assert_eq!(metrics.spatial_matched_frames, 1);
+    assert!(metrics.label_recall.is_some());
+    assert!(metrics.spatial_recall.is_some());
+    assert!(quality_output.manifest_path.exists());
+    assert!(quality_output.inspect_report_path.exists());
+  }
+
+  #[test]
+  fn quality_metric_partial_when_spatial_unscored() {
+    let witness = DetectionEvalWitnessManifest {
+      schema_version: 1,
+      generated_at_millis: 0,
+      source_visual_eval_report_path: "report.json".to_string(),
+      source_detection_eval_manifest_path: "manifest.json".to_string(),
+      source_run_artifact_dir: "run".to_string(),
+      source_visual_truth_manifest_path: "truth.json".to_string(),
+      source_projection_path: "projection.json".to_string(),
+      detector_model_id: None,
+      total_frames: 2,
+      label_matched_frames: 1,
+      label_missing_frames: 1,
+      label_unmapped_frames: 0,
+      spatial_matched_frames: 0,
+      spatial_missing_frames: 0,
+      spatial_unscored_frames: 2,
+      spurious_detection_count: 0,
+      projection_kind: "unavailable".to_string(),
+      frame_witnesses: vec![],
+      status: DetectionEvalWitnessStatus::Ready,
+      reason: None,
+      known_limits: vec![],
+    };
+    assert_eq!(
+      derive_detection_eval_quality_verdict(&witness),
+      DetectionEvalQualityVerdict::MetricPartial
+    );
+  }
+
+  #[test]
+  fn quality_blocked_when_witness_manifest_missing() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let output = build_detection_eval_quality(&DetectionEvalQualityInputs {
+      witness_manifest_path: temp.path().join("missing.json"),
+      output_dir: temp.path().join("quality"),
+    })
+    .expect("quality");
+
+    assert_eq!(output.manifest.status, DetectionEvalQualityStatus::Blocked);
+    assert_eq!(
+      output.manifest.verdict,
+      DetectionEvalQualityVerdict::Blocked
+    );
+    assert!(output.manifest.metrics.is_none());
+  }
+}

--- a/crates/auv-game-osu/src/detection_eval_witness.rs
+++ b/crates/auv-game-osu/src/detection_eval_witness.rs
@@ -1,0 +1,527 @@
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use auv_file::{
+  JsonFileReadError, JsonFileWriteError, JsonWriteOptions, read_json_file as read_json_file_helper,
+  write_json_file as write_json_file_helper,
+};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+
+use crate::benchmark::DetectionEvalManifest;
+use crate::visual_eval::{
+  EvalProjection, FrameEvaluation, FrameLabelOutcome, FrameSpatialOutcome, VisualEvalReport,
+};
+
+pub type DetectionEvalWitnessResult<T> = Result<T, String>;
+
+pub const DETECTION_EVAL_WITNESS_MANIFEST_SCHEMA_VERSION: u32 = 1;
+pub const DETECTION_EVAL_WITNESS_INSPECT_REPORT_SCHEMA_VERSION: u32 = 1;
+
+pub const OSU_WQ1_V1_WITNESS_KNOWN_LIMIT: &str = "osu WQ1 witness records per-frame detection-vs-truth alignment from visual_eval_report; it is not action verification or gameplay success";
+
+const VISUAL_EVAL_REPORT_FILE: &str = "visual_eval_report.json";
+const DETECTION_EVAL_MANIFEST_FILE: &str = "detection_eval_manifest.json";
+const WITNESS_MANIFEST_FILE: &str = "osu-detection-eval-witness.json";
+const WITNESS_INSPECT_FILE: &str = "osu-detection-eval-witness-inspect.json";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DetectionEvalWitnessInputs {
+  pub detection_eval_output_dir: PathBuf,
+  pub output_dir: PathBuf,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DetectionEvalWitnessOutput {
+  pub output_dir: PathBuf,
+  pub manifest_path: PathBuf,
+  pub inspect_report_path: PathBuf,
+  pub manifest: DetectionEvalWitnessManifest,
+  pub inspect_report: DetectionEvalWitnessInspectReport,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DetectionEvalFrameWitness {
+  pub object_index: usize,
+  pub capture_phase: String,
+  pub capture_file_name: String,
+  pub object_kind: String,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub expected_label: Option<String>,
+  pub label_outcome: String,
+  pub spatial_outcome: String,
+  pub spurious_detection_count: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DetectionEvalWitnessManifest {
+  pub schema_version: u32,
+  pub generated_at_millis: u64,
+  pub source_visual_eval_report_path: String,
+  pub source_detection_eval_manifest_path: String,
+  pub source_run_artifact_dir: String,
+  pub source_visual_truth_manifest_path: String,
+  pub source_projection_path: String,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub detector_model_id: Option<String>,
+  pub total_frames: usize,
+  pub label_matched_frames: usize,
+  pub label_missing_frames: usize,
+  pub label_unmapped_frames: usize,
+  pub spatial_matched_frames: usize,
+  pub spatial_missing_frames: usize,
+  pub spatial_unscored_frames: usize,
+  pub spurious_detection_count: usize,
+  pub projection_kind: String,
+  pub frame_witnesses: Vec<DetectionEvalFrameWitness>,
+  pub status: DetectionEvalWitnessStatus,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub reason: Option<DetectionEvalWitnessReason>,
+  pub known_limits: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DetectionEvalWitnessInspectReport {
+  pub schema_version: u32,
+  pub generated_at_millis: u64,
+  pub detection_eval_witness_manifest_path: String,
+  pub source_visual_eval_report_path: String,
+  pub source_detection_eval_manifest_path: String,
+  pub source_run_artifact_dir: String,
+  pub source_visual_truth_manifest_path: String,
+  pub source_projection_path: String,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub detector_model_id: Option<String>,
+  pub total_frames: usize,
+  pub label_matched_frames: usize,
+  pub label_missing_frames: usize,
+  pub spatial_matched_frames: usize,
+  pub spatial_missing_frames: usize,
+  pub spatial_unscored_frames: usize,
+  pub spurious_detection_count: usize,
+  pub projection_kind: String,
+  pub frame_witness_count: usize,
+  pub visual_eval_report_readable: bool,
+  pub detection_eval_manifest_readable: bool,
+  pub status: DetectionEvalWitnessStatus,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub reason: Option<DetectionEvalWitnessReason>,
+  pub warnings: Vec<String>,
+  pub known_limits: Vec<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DetectionEvalWitnessStatus {
+  Ready,
+  Blocked,
+  Failed,
+}
+
+impl DetectionEvalWitnessStatus {
+  pub fn as_str(self) -> &'static str {
+    match self {
+      Self::Ready => "ready",
+      Self::Blocked => "blocked",
+      Self::Failed => "failed",
+    }
+  }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DetectionEvalWitnessReason {
+  MissingVisualEvalReport,
+  MissingDetectionEvalManifest,
+  VisualEvalReportParseFailed,
+  DetectionEvalManifestParseFailed,
+  EmptyFrames,
+}
+
+impl DetectionEvalWitnessReason {
+  pub fn as_str(self) -> &'static str {
+    match self {
+      Self::MissingVisualEvalReport => "missing_visual_eval_report",
+      Self::MissingDetectionEvalManifest => "missing_detection_eval_manifest",
+      Self::VisualEvalReportParseFailed => "visual_eval_report_parse_failed",
+      Self::DetectionEvalManifestParseFailed => "detection_eval_manifest_parse_failed",
+      Self::EmptyFrames => "empty_frames",
+    }
+  }
+}
+
+pub fn build_detection_eval_witness(
+  inputs: &DetectionEvalWitnessInputs,
+) -> DetectionEvalWitnessResult<DetectionEvalWitnessOutput> {
+  fs::create_dir_all(&inputs.output_dir).map_err(|error| {
+    format!(
+      "failed to create detection eval witness output dir {}: {error}",
+      inputs.output_dir.display()
+    )
+  })?;
+
+  let generated_at_millis = auv_tracing_driver::now_millis();
+  let source_visual_eval_report_path = inputs
+    .detection_eval_output_dir
+    .join(VISUAL_EVAL_REPORT_FILE);
+  let source_detection_eval_manifest_path = inputs
+    .detection_eval_output_dir
+    .join(DETECTION_EVAL_MANIFEST_FILE);
+
+  let known_limits = BTreeSet::from([OSU_WQ1_V1_WITNESS_KNOWN_LIMIT.to_string()]);
+  let mut warnings = BTreeSet::new();
+
+  let gate = evaluate_witness_gate(
+    &source_visual_eval_report_path,
+    &source_detection_eval_manifest_path,
+    &mut warnings,
+  );
+
+  let (source_run_artifact_dir, source_visual_truth_manifest_path, source_projection_path) = gate
+    .detection_eval_manifest
+    .as_ref()
+    .map(|manifest| {
+      (
+        manifest.source_run_artifact_dir.clone(),
+        format!(
+          "{}/visual_truth_manifest.json",
+          manifest.source_run_artifact_dir
+        ),
+        format!("{}/projection.json", manifest.source_run_artifact_dir),
+      )
+    })
+    .unwrap_or_default();
+
+  let detector_model_id = gate
+    .detection_eval_manifest
+    .as_ref()
+    .map(|manifest| manifest.detector_model_id.clone());
+
+  let report = gate.visual_eval_report.as_ref();
+  let projection_kind = report
+    .map(|report| projection_kind_label(&report.projection))
+    .unwrap_or_else(|| "unknown".to_string());
+
+  let frame_witnesses = report.map(frame_witnesses_from_report).unwrap_or_default();
+
+  let manifest = DetectionEvalWitnessManifest {
+    schema_version: DETECTION_EVAL_WITNESS_MANIFEST_SCHEMA_VERSION,
+    generated_at_millis,
+    source_visual_eval_report_path: source_visual_eval_report_path.display().to_string(),
+    source_detection_eval_manifest_path: source_detection_eval_manifest_path.display().to_string(),
+    source_run_artifact_dir,
+    source_visual_truth_manifest_path,
+    source_projection_path,
+    detector_model_id: detector_model_id.clone(),
+    total_frames: report.map(|r| r.total_frames).unwrap_or(0),
+    label_matched_frames: report.map(|r| r.label_matched_frames).unwrap_or(0),
+    label_missing_frames: report.map(|r| r.label_missing_frames).unwrap_or(0),
+    label_unmapped_frames: report.map(|r| r.label_unmapped_frames).unwrap_or(0),
+    spatial_matched_frames: report.map(|r| r.spatial_matched_frames).unwrap_or(0),
+    spatial_missing_frames: report.map(|r| r.spatial_missing_frames).unwrap_or(0),
+    spatial_unscored_frames: report.map(|r| r.spatial_unscored_frames).unwrap_or(0),
+    spurious_detection_count: report.map(|r| r.spurious_detection_count).unwrap_or(0),
+    projection_kind,
+    frame_witnesses,
+    status: gate.status,
+    reason: gate.reason,
+    known_limits: known_limits.into_iter().collect(),
+  };
+
+  let manifest_path = inputs.output_dir.join(WITNESS_MANIFEST_FILE);
+  write_json_file(&manifest_path, &manifest)?;
+
+  let inspect_report = DetectionEvalWitnessInspectReport {
+    schema_version: DETECTION_EVAL_WITNESS_INSPECT_REPORT_SCHEMA_VERSION,
+    generated_at_millis,
+    detection_eval_witness_manifest_path: manifest_path.display().to_string(),
+    source_visual_eval_report_path: manifest.source_visual_eval_report_path.clone(),
+    source_detection_eval_manifest_path: manifest.source_detection_eval_manifest_path.clone(),
+    source_run_artifact_dir: manifest.source_run_artifact_dir.clone(),
+    source_visual_truth_manifest_path: manifest.source_visual_truth_manifest_path.clone(),
+    source_projection_path: manifest.source_projection_path.clone(),
+    detector_model_id,
+    total_frames: manifest.total_frames,
+    label_matched_frames: manifest.label_matched_frames,
+    label_missing_frames: manifest.label_missing_frames,
+    spatial_matched_frames: manifest.spatial_matched_frames,
+    spatial_missing_frames: manifest.spatial_missing_frames,
+    spatial_unscored_frames: manifest.spatial_unscored_frames,
+    spurious_detection_count: manifest.spurious_detection_count,
+    projection_kind: manifest.projection_kind.clone(),
+    frame_witness_count: manifest.frame_witnesses.len(),
+    visual_eval_report_readable: gate.visual_eval_report.is_some(),
+    detection_eval_manifest_readable: gate.detection_eval_manifest.is_some(),
+    status: manifest.status,
+    reason: manifest.reason,
+    warnings: warnings.into_iter().collect(),
+    known_limits: manifest.known_limits.clone(),
+  };
+
+  let inspect_report_path = inputs.output_dir.join(WITNESS_INSPECT_FILE);
+  write_json_file(&inspect_report_path, &inspect_report)?;
+
+  Ok(DetectionEvalWitnessOutput {
+    output_dir: inputs.output_dir.clone(),
+    manifest_path,
+    inspect_report_path,
+    manifest,
+    inspect_report,
+  })
+}
+
+struct WitnessGateEvaluation {
+  status: DetectionEvalWitnessStatus,
+  reason: Option<DetectionEvalWitnessReason>,
+  visual_eval_report: Option<VisualEvalReport>,
+  detection_eval_manifest: Option<DetectionEvalManifest>,
+}
+
+fn evaluate_witness_gate(
+  visual_eval_report_path: &Path,
+  detection_eval_manifest_path: &Path,
+  warnings: &mut BTreeSet<String>,
+) -> WitnessGateEvaluation {
+  if !visual_eval_report_path.is_file() {
+    return WitnessGateEvaluation {
+      status: DetectionEvalWitnessStatus::Blocked,
+      reason: Some(DetectionEvalWitnessReason::MissingVisualEvalReport),
+      visual_eval_report: None,
+      detection_eval_manifest: None,
+    };
+  }
+
+  if !detection_eval_manifest_path.is_file() {
+    return WitnessGateEvaluation {
+      status: DetectionEvalWitnessStatus::Blocked,
+      reason: Some(DetectionEvalWitnessReason::MissingDetectionEvalManifest),
+      visual_eval_report: None,
+      detection_eval_manifest: None,
+    };
+  }
+
+  let visual_eval_report =
+    match read_json_file::<VisualEvalReport>(visual_eval_report_path, "osu visual eval report") {
+      Ok(report) => Some(report),
+      Err(error) => {
+        warnings.insert(error);
+        return WitnessGateEvaluation {
+          status: DetectionEvalWitnessStatus::Failed,
+          reason: Some(DetectionEvalWitnessReason::VisualEvalReportParseFailed),
+          visual_eval_report: None,
+          detection_eval_manifest: None,
+        };
+      }
+    };
+
+  let detection_eval_manifest = match read_json_file::<DetectionEvalManifest>(
+    detection_eval_manifest_path,
+    "osu detection eval manifest",
+  ) {
+    Ok(manifest) => Some(manifest),
+    Err(error) => {
+      warnings.insert(error);
+      return WitnessGateEvaluation {
+        status: DetectionEvalWitnessStatus::Failed,
+        reason: Some(DetectionEvalWitnessReason::DetectionEvalManifestParseFailed),
+        visual_eval_report,
+        detection_eval_manifest: None,
+      };
+    }
+  };
+
+  let Some(report) = visual_eval_report.as_ref() else {
+    return WitnessGateEvaluation {
+      status: DetectionEvalWitnessStatus::Failed,
+      reason: Some(DetectionEvalWitnessReason::VisualEvalReportParseFailed),
+      visual_eval_report,
+      detection_eval_manifest,
+    };
+  };
+
+  if report.total_frames == 0 {
+    return WitnessGateEvaluation {
+      status: DetectionEvalWitnessStatus::Blocked,
+      reason: Some(DetectionEvalWitnessReason::EmptyFrames),
+      visual_eval_report,
+      detection_eval_manifest,
+    };
+  }
+
+  WitnessGateEvaluation {
+    status: DetectionEvalWitnessStatus::Ready,
+    reason: None,
+    visual_eval_report,
+    detection_eval_manifest,
+  }
+}
+
+fn frame_witnesses_from_report(report: &VisualEvalReport) -> Vec<DetectionEvalFrameWitness> {
+  report
+    .frames
+    .iter()
+    .map(frame_witness_from_evaluation)
+    .collect()
+}
+
+fn frame_witness_from_evaluation(frame: &FrameEvaluation) -> DetectionEvalFrameWitness {
+  DetectionEvalFrameWitness {
+    object_index: frame.frame.object_index,
+    capture_phase: frame.frame.phase.clone(),
+    capture_file_name: frame.frame.capture_file_name.clone(),
+    object_kind: format!("{:?}", frame.object_kind).to_lowercase(),
+    expected_label: frame.expected_label.clone(),
+    label_outcome: label_outcome_label(frame.label_outcome).to_string(),
+    spatial_outcome: spatial_outcome_label(frame.spatial_outcome).to_string(),
+    spurious_detection_count: frame.spurious_detection_count,
+  }
+}
+
+fn label_outcome_label(outcome: FrameLabelOutcome) -> &'static str {
+  match outcome {
+    FrameLabelOutcome::Matched => "matched",
+    FrameLabelOutcome::Missing => "missing",
+    FrameLabelOutcome::Unmapped => "unmapped",
+  }
+}
+
+fn spatial_outcome_label(outcome: FrameSpatialOutcome) -> &'static str {
+  match outcome {
+    FrameSpatialOutcome::Matched => "matched",
+    FrameSpatialOutcome::Missing => "missing",
+    FrameSpatialOutcome::NotScored => "not_scored",
+  }
+}
+
+fn projection_kind_label(projection: &EvalProjection) -> String {
+  match projection {
+    EvalProjection::Unavailable { .. } => "unavailable".to_string(),
+    EvalProjection::PlayfieldToPixels { .. } => "playfield_to_pixels".to_string(),
+  }
+}
+
+fn read_json_file<T: DeserializeOwned>(path: &Path, label: &str) -> Result<T, String> {
+  read_json_file_helper(path).map_err(|error| match error {
+    JsonFileReadError::Open(error) => {
+      format!("failed to open {label} {}: {error}", path.display())
+    }
+    JsonFileReadError::Parse(error) => {
+      format!("failed to parse {label} {}: {error}", path.display())
+    }
+  })
+}
+
+fn write_json_file<T: Serialize>(path: &Path, value: &T) -> Result<(), String> {
+  write_json_file_helper(path, value, JsonWriteOptions::default()).map_err(|error| match error {
+    JsonFileWriteError::CreateParent(error) | JsonFileWriteError::Write(error) => {
+      format!("failed to write {}: {error}", path.display())
+    }
+    JsonFileWriteError::Serialize(error) => {
+      format!("failed to serialize {}: {error}", path.display())
+    }
+  })
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::visual_eval::{FrameEvaluation, FrameKey, FrameLabelOutcome, FrameSpatialOutcome};
+  use crate::{CapturePhase, ObjectKind};
+  use std::path::PathBuf;
+
+  fn fixture_eval_dir() -> (tempfile::TempDir, PathBuf) {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let manifest_dir =
+      PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/osu_eval_run_artifacts");
+    let detections_path =
+      PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/osu_eval_detection");
+    let eval_output = temp.path().join("eval");
+    crate::evaluate_detection_fixture(&crate::DetectionEvalInputs {
+      run_artifact_dir: manifest_dir,
+      detections_path,
+      output_dir: eval_output.clone(),
+    })
+    .expect("eval");
+    (temp, eval_output)
+  }
+
+  #[test]
+  fn witness_from_fixture_eval_records_frame_outcomes_and_lineage() {
+    let (temp, eval_output) = fixture_eval_dir();
+    let witness_output = temp.path().join("witness");
+    let output = build_detection_eval_witness(&DetectionEvalWitnessInputs {
+      detection_eval_output_dir: eval_output.clone(),
+      output_dir: witness_output,
+    })
+    .expect("witness");
+
+    assert_eq!(output.manifest.status, DetectionEvalWitnessStatus::Ready);
+    assert_eq!(output.manifest.total_frames, 3);
+    assert_eq!(output.manifest.label_matched_frames, 1);
+    assert_eq!(output.manifest.spatial_matched_frames, 1);
+    assert_eq!(output.manifest.frame_witnesses.len(), 3);
+    assert!(
+      output
+        .manifest
+        .source_visual_eval_report_path
+        .contains("visual_eval_report.json")
+    );
+    assert_eq!(
+      output.manifest.detector_model_id.as_deref(),
+      Some("test-osu-fixture-detector")
+    );
+    assert!(output.manifest_path.exists());
+    assert!(output.inspect_report_path.exists());
+  }
+
+  #[test]
+  fn witness_blocked_when_visual_eval_report_missing() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let output = build_detection_eval_witness(&DetectionEvalWitnessInputs {
+      detection_eval_output_dir: temp.path().to_path_buf(),
+      output_dir: temp.path().join("witness"),
+    })
+    .expect("witness");
+
+    assert_eq!(output.manifest.status, DetectionEvalWitnessStatus::Blocked);
+    assert_eq!(
+      output.manifest.reason,
+      Some(DetectionEvalWitnessReason::MissingVisualEvalReport)
+    );
+    assert_eq!(output.manifest.frame_witnesses.len(), 0);
+  }
+
+  #[test]
+  fn witness_maps_label_and_spatial_outcomes_from_report_frames() {
+    use crate::visual_eval::{EvalProjection, VisualEvalReport};
+
+    let report = VisualEvalReport {
+      total_frames: 1,
+      label_matched_frames: 1,
+      label_missing_frames: 0,
+      label_unmapped_frames: 0,
+      spatial_matched_frames: 0,
+      spatial_missing_frames: 0,
+      spatial_unscored_frames: 1,
+      spurious_detection_count: 0,
+      projection: EvalProjection::Unavailable {
+        reason: "test".to_string(),
+      },
+      frames: vec![FrameEvaluation {
+        frame: FrameKey::from_parts(0, CapturePhase::AfterDispatch, "frame.png"),
+        object_kind: ObjectKind::Circle,
+        expected_label: Some("hit_circle".to_string()),
+        label_outcome: FrameLabelOutcome::Matched,
+        spatial_outcome: FrameSpatialOutcome::NotScored,
+        spurious_detection_count: 0,
+      }],
+      known_limits: vec![],
+      detector_provenance: None,
+    };
+    let witnesses = frame_witnesses_from_report(&report);
+    assert_eq!(witnesses.len(), 1);
+    assert_eq!(witnesses[0].label_outcome, "matched");
+    assert_eq!(witnesses[0].spatial_outcome, "not_scored");
+  }
+}

--- a/crates/auv-game-osu/src/lib.rs
+++ b/crates/auv-game-osu/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod benchmark;
 pub mod dataset;
+pub mod detection_eval_quality;
+pub mod detection_eval_witness;
 pub mod projection;
 pub mod visual_eval;
 pub mod visual_truth;
@@ -30,6 +32,18 @@ pub use visual_truth::{
   build_visual_truth_manifest,
 };
 
+pub use detection_eval_quality::{
+  DetectionEvalQualityInputs, DetectionEvalQualityInspectReport, DetectionEvalQualityManifest,
+  DetectionEvalQualityMetrics, DetectionEvalQualityOutput, DetectionEvalQualityReason,
+  DetectionEvalQualityStatus, DetectionEvalQualityVerdict, OSU_WQ1_V1_QUALITY_KNOWN_LIMIT,
+  build_detection_eval_quality, build_detection_eval_quality_from_witness_dir,
+  derive_detection_eval_quality_verdict,
+};
+pub use detection_eval_witness::{
+  DetectionEvalFrameWitness, DetectionEvalWitnessInputs, DetectionEvalWitnessInspectReport,
+  DetectionEvalWitnessManifest, DetectionEvalWitnessOutput, DetectionEvalWitnessReason,
+  DetectionEvalWitnessStatus, OSU_WQ1_V1_WITNESS_KNOWN_LIMIT, build_detection_eval_witness,
+};
 pub use visual_truth_semantic::{
   VisualTruthSemanticInspectReport, VisualTruthSemanticManifest, VisualTruthSemanticReason,
   VisualTruthSemanticStatus, VisualTruthSemanticValidationInputs,

--- a/crates/auv-game-osu/tests/detection_eval_witness_quality.rs
+++ b/crates/auv-game-osu/tests/detection_eval_witness_quality.rs
@@ -1,0 +1,47 @@
+use std::path::PathBuf;
+
+use auv_game_osu::{
+  DetectionEvalQualityInputs, DetectionEvalWitnessInputs, build_detection_eval_quality,
+  build_detection_eval_witness, evaluate_detection_fixture,
+};
+
+#[test]
+fn detection_eval_witness_quality_chain_from_fixture() {
+  let manifest_dir =
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/osu_eval_run_artifacts");
+  let detections_path =
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/osu_eval_detection");
+  let output_dir = tempfile::tempdir().expect("tempdir");
+  let eval_output = output_dir.path().join("eval");
+
+  let eval = evaluate_detection_fixture(&auv_game_osu::DetectionEvalInputs {
+    run_artifact_dir: manifest_dir,
+    detections_path,
+    output_dir: eval_output.clone(),
+  })
+  .expect("eval");
+
+  let witness = build_detection_eval_witness(&DetectionEvalWitnessInputs {
+    detection_eval_output_dir: eval_output.clone(),
+    output_dir: eval_output.join("witness"),
+  })
+  .expect("witness");
+
+  let quality = build_detection_eval_quality(&DetectionEvalQualityInputs {
+    witness_manifest_path: witness.manifest_path.clone(),
+    output_dir: eval_output.join("quality"),
+  })
+  .expect("quality");
+
+  assert_eq!(
+    eval.visual_eval_report.total_frames,
+    witness.manifest.total_frames
+  );
+  assert_eq!(witness.manifest.frame_witnesses.len(), 3);
+  assert_eq!(
+    quality.manifest.verdict,
+    auv_game_osu::DetectionEvalQualityVerdict::MeasuredOnly
+  );
+  assert!(witness.manifest_path.exists());
+  assert!(quality.manifest_path.exists());
+}

--- a/docs/ai/references/2026-06-27-auv-core-spatial-result-consumption-proof-matrix.md
+++ b/docs/ai/references/2026-06-27-auv-core-spatial-result-consumption-proof-matrix.md
@@ -66,7 +66,7 @@ If any one of these fails, the candidate stays local.
 | Query status triad | `TrainingResultSpatialQueryStatus` | One non-Minecraft vertical must expose target-conditioned answers where `answered` must stay distinct from readiness or semantic success. | Show a real case where query answers are naturally boolean or where `answered` adds no information. If true, this stays app-local. | Shared query-status enum only. | Main matrix verdict unchanged pending owner acceptance of graduation review; osu adds probe-local recurrence only — see graduation review (admissibility-only, defer extraction). | `candidate, not admissible yet`¹ |
 | Provider comparison verdict | `TrainingResultSpatialQueryComparisonVerdict` | Another vertical must actually run dual-backend answer compare and need the same `match / divergent / provider_only / reference_only / not_comparable` split in persisted evidence. | Show a real compare seam where ordering, partiality, or uncertainty needs extra states beyond the five-label set. | Shared compare-verdict enum or helper. | Only Minecraft provider/reference compare exists. | `candidate, not admissible yet` |
 | Action readiness view | `TrainingResultSpatialQueryActionEligibility`, `TrainingResultSpatialQueryActionReadiness`, `derive_action_readiness`, `derive_minecraft_training_result_spatial_query_action_readiness` | Another vertical must need a **derived** action-facing view over persisted answer artifacts, with at least one `click_ready`-like path and one honest non-actionable path. | Show a real case where action-facing consumption must mutate producer truth or where dispatch and readiness cannot be kept separate. | Shared derived read-model contract only; no runtime dispatch wiring. | Main matrix verdict unchanged pending owner acceptance of graduation review; osu adds derived-shape recurrence only — capture-space, not dispatch-safe — see graduation review. | `candidate, not admissible yet`¹ |
-| Quality measurement verdict | `HoldoutRenderQualityVerdict` | Another vertical must measure witness-bound quality evidence and need the same split between `measured_only`, `metric_partial`, `blocked`, and `failed`. | Show a real measurement seam where thresholds are inseparable from measurement evidence, or where partial measurement is meaningless. | Shared evidence-verdict enum only. | Only MC-17 photometric evidence exists, and it is single-vertical. | `candidate, not admissible yet` |
+| Quality measurement verdict | `HoldoutRenderQualityVerdict` | Another vertical must measure witness-bound quality evidence and need the same split between `measured_only`, `metric_partial`, `blocked`, and `failed`. | Show a real measurement seam where thresholds are inseparable from measurement evidence, or where partial measurement is meaningless. | Shared evidence-verdict enum only. | Only MC-17 photometric evidence exists in main matrix; osu WQ1 adds **candidate** second-vertical probe-local recurrence only — see osu probe footnote²; **not** admissible graduation. | `candidate, not admissible yet` |
 | Persisted backend label discipline | `HoldoutRenderQualityBackend`, `TrainingResultSpatialQueryBackend` | Another vertical must persist backend provenance and independently hit the same rule: stable backend labels belong in artifacts, raw runtime command text does not. | Show a real vertical where backend provenance cannot be represented by stable labels alone. | Shared label-discipline rule or tiny backend-label trait bound, if ever needed. | Current proof is policy-level only; no second donor. | `candidate, not admissible yet` |
 
 
@@ -77,8 +77,9 @@ Companion evidence:
 
 This probe closes **MC-14-analog derived consumption** on osu! only (query→
 readiness shape recurrence, not full MC-14 window-readiness parity). It does not
-graduate types into core and does not claim witness, quality, or live-click
-wiring.
+graduate types into core; WQ1 witness/quality evidence is **candidate**
+probe-local only (footnote²), not admissible graduation. Live-click wiring
+remains out of scope.
 
 | Candidate contract | Verdict after osu probe | Notes |
 | --- | --- | --- |
@@ -86,7 +87,7 @@ wiring.
 | Action readiness view | **satisfied as second-vertical probe-local recurrence** | Derived triad without dispatch; **capture-space consumability**, not click authority. |
 | Stage status triad | **partial (structurally shallow)** | Semantic + query only; no staged-consumption family expansion — not near-complete partial. |
 | Provider comparison verdict | **not satisfied** | Dual-backend compare intentionally deferred. |
-| Quality measurement verdict | **out of scope** | Excluded by osu probe design. |
+| Quality measurement verdict | **candidate probe-local recurrence (OSU-WQ1)** | `DetectionEvalQualityVerdict` on detection-eval witness; evidence-only; not extraction-pressure. |
 | Persisted backend label discipline | **partial (second vertical)** | `playfield_projection_reference` persisted; no second backend family yet. |
 
 Rows marked probe-local remain **non-admissible for Core-B extraction**.
@@ -101,6 +102,12 @@ next slice, and does not lift extraction pressure — default remains **defer**.
 `docs/ai/references/2026-06-27-auv-core-a-query-readiness-graduation-review.md`:
 may record **helper-only admissible (review language only)** for these two rows
 after owner acceptance — **not** an extraction recommendation; default **defer**.
+
+² OSU-WQ1 **candidate** probe-local evidence (not admissible graduation):
+`docs/ai/references/2026-06-28-osu-wq1-witness-quality-evidence-design.md` and
+`docs/ai/references/2026-06-27-auv-second-vertical-consumption-probe-osu-evidence.md`
+(WQ1 section). Default remains **defer** extraction; recurrence does not lift
+matrix admissibility.
 
 ## What does not need a second vertical
 

--- a/docs/ai/references/2026-06-27-auv-second-vertical-consumption-probe-osu-evidence.md
+++ b/docs/ai/references/2026-06-27-auv-second-vertical-consumption-probe-osu-evidence.md
@@ -27,7 +27,7 @@ Positive/negative paths are covered by `auv-game-osu` unit tests and frozen fixt
 | Action readiness view | **satisfied as second-vertical probe-local recurrence** | Derived triad + inspect section without dispatch. **Capture-space consumability only** — not dispatch-safe or authority-bearing readiness. |
 | Stage status triad | **partial (structurally shallow)** | Semantic + query persisted stages only; no witness/quality/compare/provider stage family — not "almost done" partial |
 | Provider comparison verdict | **not satisfied** | dual-backend compare intentionally deferred |
-| Quality measurement verdict | **out of scope** | excluded by design |
+| Quality measurement verdict | **candidate (OSU-WQ1)** | witness→quality on `visual_eval_report`; MC-17-shaped verdict; evidence-only; not matrix graduation |
 | Backend label discipline | **partial** | `query_backend=playfield_projection_reference` persisted; no second vertical backend family yet |
 
 ## Admissibility vs extraction pressure
@@ -48,3 +48,16 @@ These row verdicts are **proof-appendix conclusions** only. They support
 
 - Design: `docs/ai/references/2026-06-27-auv-second-vertical-consumption-probe-osu-design.md`
 - Matrix: `docs/ai/references/2026-06-27-auv-core-spatial-result-consumption-proof-matrix.md`
+
+
+## OSU-WQ1 update (2026-06-28)
+
+Witness + quality evidence chain landed as a **separate slice** on detection eval
+(`visual_eval_report.json` → witness → quality). This is **candidate**
+second-vertical recurrence for the quality measurement verdict row only; it does
+**not** upgrade Core-A proof-matrix verdicts or recommend core extraction.
+
+Design: `docs/ai/references/2026-06-28-osu-wq1-witness-quality-evidence-design.md`
+
+Non-claims unchanged for probe Slice 1–2; WQ1 adds witness/quality wiring but
+still excludes action verification, usefulness claims, and core graduation.

--- a/docs/ai/references/2026-06-28-osu-visual-truth-query-wired-live-action-design.md
+++ b/docs/ai/references/2026-06-28-osu-visual-truth-query-wired-live-action-design.md
@@ -103,6 +103,8 @@ use stub executor + capture-derived projection in unit/integration tests only.
 
 - Osu second-vertical probe:
   [`2026-06-27-auv-second-vertical-consumption-probe-osu-design.md`](2026-06-27-auv-second-vertical-consumption-probe-osu-design.md)
+- OSU-WQ1 witness + quality:
+  [`2026-06-28-osu-wq1-witness-quality-evidence-design.md`](2026-06-28-osu-wq1-witness-quality-evidence-design.md)
 - Core-C1 admission design:
   [`2026-06-28-auv-core-c1-action-attempt-admission-design.md`](2026-06-28-auv-core-c1-action-attempt-admission-design.md)
 - MC-19 wiring template:

--- a/docs/ai/references/2026-06-28-osu-wq1-witness-quality-evidence-design.md
+++ b/docs/ai/references/2026-06-28-osu-wq1-witness-quality-evidence-design.md
@@ -1,0 +1,46 @@
+# 2026-06-28 osu WQ1 witness + quality evidence design
+
+Date: 2026-06-28
+
+Status: **OSU-WQ1 owner slice** — closes second-vertical witness + quality
+evidence on top of existing `visual_eval_report` / `osu eval-detections`. Evidence
+and derived verdict only; **not** Core-B, MC-20, controller, or shared runtime
+abstraction.
+
+## One-line summary
+
+Osu closes `semantic → query → readiness → wired action → witness → quality
+evidence` by consuming persisted `visual_eval_report.json` into W1 witness
+artifacts and Q1 quality measurement evidence, with a thin read-side derived
+verdict (`measured_only | metric_partial | blocked | failed`).
+
+## Chain placement
+
+```text
+visual_truth + projection + offline detections
+        │
+        ▼
+visual_eval_report.json  (existing P7 / osu eval-detections)
+        │
+        ▼ W1
+osu-detection-eval-witness.json + inspect
+        │
+        ▼ Q1
+osu-detection-eval-quality.json + inspect
+        │
+        ▼ read-side (optional)
+derive_osu_detection_eval_quality_verdict_summary
+```
+
+## W1 / Q1 / non-goals
+
+See `detection_eval_witness.rs` and `detection_eval_quality.rs` for manifest
+fields. Witness is not action verification. Quality is evidence-only (no model
+usefulness). No core extraction.
+
+## Cross-links
+
+- [`2026-06-27-auv-second-vertical-consumption-probe-osu-evidence.md`](2026-06-27-auv-second-vertical-consumption-probe-osu-evidence.md)
+- [`2026-06-28-osu-visual-truth-query-wired-live-action-design.md`](2026-06-28-osu-visual-truth-query-wired-live-action-design.md)
+- [`2026-06-27-minecraft-mc17-holdout-render-quality-design.md`](2026-06-27-minecraft-mc17-holdout-render-quality-design.md)
+- [`2026-06-27-auv-core-spatial-result-consumption-proof-matrix.md`](2026-06-27-auv-core-spatial-result-consumption-proof-matrix.md)

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -30,13 +30,16 @@ use crate::run_read::{
   MinecraftTrainingResultSemanticInspectReportLineage,
   MinecraftTrainingResultSemanticManifestLineage,
   MinecraftTrainingResultSpatialQueryInspectReportLineage,
-  MinecraftTrainingResultSpatialQueryManifestLineage, OsuQueryWiredLiveActionSummary,
+  MinecraftTrainingResultSpatialQueryManifestLineage, OsuDetectionEvalQualityInspectReportLineage,
+  OsuDetectionEvalQualityManifestLineage, OsuDetectionEvalWitnessInspectReportLineage,
+  OsuDetectionEvalWitnessManifestLineage, OsuQueryWiredLiveActionSummary,
   OsuVisualTruthSemanticInspectReportLineage, OsuVisualTruthSemanticManifestLineage,
   OsuVisualTruthSpatialQueryInspectReportLineage, OsuVisualTruthSpatialQueryManifestLineage,
   collect_quality_baseline_evidence_for_run,
   derive_minecraft_training_result_quality_baseline_report,
   derive_minecraft_training_result_quality_verdict,
   derive_minecraft_training_result_spatial_query_action_readiness,
+  derive_osu_detection_eval_quality_verdict_summary,
   derive_osu_visual_truth_spatial_query_action_readiness,
   list_minecraft_holdout_render_quality_inspect_reports,
   list_minecraft_holdout_render_quality_manifests, list_minecraft_projection_artifacts,
@@ -54,6 +57,8 @@ use crate::run_read::{
   list_minecraft_training_result_semantic_manifests,
   list_minecraft_training_result_spatial_query_inspect_reports,
   list_minecraft_training_result_spatial_query_manifests,
+  list_osu_detection_eval_quality_inspect_reports, list_osu_detection_eval_quality_manifests,
+  list_osu_detection_eval_witness_inspect_reports, list_osu_detection_eval_witness_manifests,
   list_osu_query_wired_live_action_summaries, list_osu_visual_truth_semantic_inspect_reports,
   list_osu_visual_truth_semantic_manifests, list_osu_visual_truth_spatial_query_inspect_reports,
   list_osu_visual_truth_spatial_query_manifests, quality_baseline_profile_v1,
@@ -224,6 +229,14 @@ pub fn inspect_run(store: &LocalStore, run_id: &str) -> AuvResult<String> {
     list_minecraft_query_wired_live_action_summaries(store, run_id)?;
   let osu_query_wired_live_action_summaries =
     list_osu_query_wired_live_action_summaries(store, run_id)?;
+  let osu_detection_eval_witness_manifests =
+    list_osu_detection_eval_witness_manifests(store, run_id)?;
+  let osu_detection_eval_witness_inspect_reports =
+    list_osu_detection_eval_witness_inspect_reports(store, run_id)?;
+  let osu_detection_eval_quality_manifests =
+    list_osu_detection_eval_quality_manifests(store, run_id)?;
+  let osu_detection_eval_quality_inspect_reports =
+    list_osu_detection_eval_quality_inspect_reports(store, run_id)?;
   let quality_baseline_report = quality_baseline_profile_v1().ok().and_then(|profile| {
     collect_quality_baseline_evidence_for_run(store, run_id, &profile)
       .ok()
@@ -283,6 +296,10 @@ pub fn inspect_run(store: &LocalStore, run_id: &str) -> AuvResult<String> {
     &osu_visual_truth_spatial_query_manifests,
     &osu_visual_truth_spatial_query_inspect_reports,
     &osu_query_wired_live_action_summaries,
+    &osu_detection_eval_witness_manifests,
+    &osu_detection_eval_witness_inspect_reports,
+    &osu_detection_eval_quality_manifests,
+    &osu_detection_eval_quality_inspect_reports,
     quality_baseline_report.as_ref(),
     quality_verdict_probe.as_ref(),
     quality_verdict_trained_render.as_ref(),
@@ -363,6 +380,10 @@ pub fn render_run_text(
   osu_visual_truth_spatial_query_manifests: &[OsuVisualTruthSpatialQueryManifestLineage],
   osu_visual_truth_spatial_query_inspect_reports: &[OsuVisualTruthSpatialQueryInspectReportLineage],
   osu_query_wired_live_action_summaries: &[OsuQueryWiredLiveActionSummary],
+  osu_detection_eval_witness_manifests: &[OsuDetectionEvalWitnessManifestLineage],
+  osu_detection_eval_witness_inspect_reports: &[OsuDetectionEvalWitnessInspectReportLineage],
+  osu_detection_eval_quality_manifests: &[OsuDetectionEvalQualityManifestLineage],
+  osu_detection_eval_quality_inspect_reports: &[OsuDetectionEvalQualityInspectReportLineage],
   quality_baseline_report: Option<&MinecraftTrainingResultQualityBaselineReportSummary>,
   quality_verdict_probe: Option<&MinecraftTrainingResultQualityVerdictSummary>,
   quality_verdict_trained_render: Option<&MinecraftTrainingResultQualityVerdictSummary>,
@@ -2321,6 +2342,91 @@ pub fn render_run_text(
     }
   }
 
+  output.push_str("\nOsu Detection Eval Witness:\n");
+  if osu_detection_eval_witness_manifests.is_empty()
+    && osu_detection_eval_witness_inspect_reports.is_empty()
+  {
+    output.push_str("- none\n");
+  } else {
+    for manifest_lineage in osu_detection_eval_witness_manifests {
+      if let Some(manifest) = &manifest_lineage.manifest {
+        output.push_str(&format!(
+          "- witness_artifact={} status={} reason={} total_frames={} label_matched={} spatial_matched={} spatial_unscored={} spurious={} projection_kind={} frame_witness_count={} detector_model_id={} issue={}\n",
+          manifest_lineage.artifact.artifact_id,
+          manifest.status,
+          manifest.reason.as_deref().unwrap_or("n/a"),
+          manifest.total_frames,
+          manifest.label_matched_frames,
+          manifest.spatial_matched_frames,
+          manifest.spatial_unscored_frames,
+          manifest.spurious_detection_count,
+          manifest.projection_kind,
+          manifest.frame_witness_count,
+          manifest.detector_model_id.as_deref().unwrap_or("n/a"),
+          manifest_lineage.issue.as_deref().unwrap_or("n/a"),
+        ));
+      }
+    }
+    for report_lineage in osu_detection_eval_witness_inspect_reports {
+      if let Some(report) = &report_lineage.report {
+        output.push_str(&format!(
+          "- witness_inspect_artifact={} status={} frame_witness_count={} warnings={} issue={}\n",
+          report_lineage.artifact.artifact_id,
+          report.status,
+          report.frame_witness_count,
+          report.warnings.len(),
+          report_lineage.issue.as_deref().unwrap_or("n/a"),
+        ));
+      }
+    }
+  }
+
+  output.push_str("\nOsu Detection Eval Quality:\n");
+  if osu_detection_eval_quality_manifests.is_empty()
+    && osu_detection_eval_quality_inspect_reports.is_empty()
+  {
+    output.push_str("- none\n");
+  } else {
+    for manifest_lineage in osu_detection_eval_quality_manifests {
+      if let Some(manifest) = &manifest_lineage.manifest {
+        let derived = derive_osu_detection_eval_quality_verdict_summary(manifest_lineage);
+        output.push_str(&format!(
+          "- quality_artifact={} witness_status={} status={} verdict={} label_recall={} spatial_recall={} spurious={} derived_verdict={} issue={}\n",
+          manifest_lineage.artifact.artifact_id,
+          manifest.witness_status,
+          manifest.status,
+          manifest.verdict,
+          manifest
+            .label_recall
+            .map(|value| format!("{value:.3}"))
+            .unwrap_or_else(|| "n/a".to_string()),
+          manifest
+            .spatial_recall
+            .map(|value| format!("{value:.3}"))
+            .unwrap_or_else(|| "n/a".to_string()),
+          manifest
+            .spurious_detection_count
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "n/a".to_string()),
+          derived.verdict,
+          manifest_lineage.issue.as_deref().unwrap_or("n/a"),
+        ));
+      }
+    }
+    for report_lineage in osu_detection_eval_quality_inspect_reports {
+      if let Some(report) = &report_lineage.report {
+        output.push_str(&format!(
+          "- quality_inspect_artifact={} verdict={} label_recall_available={} spatial_recall_available={} issue={}\n",
+          report_lineage.artifact.artifact_id,
+          report.verdict,
+          report.label_recall_available,
+          report.spatial_recall_available,
+          report_lineage.issue.as_deref().unwrap_or("n/a"),
+        ));
+      }
+    }
+  }
+
   output.push_str("\nMC-19 Query Wired Live Action:\n");
   if minecraft_query_wired_live_action_summaries.is_empty() {
     output.push_str("- none\n");
@@ -3874,6 +3980,10 @@ mod tests {
       &[],
       &[],
       &[],
+      &[],
+      &[],
+      &[],
+      &[],
       None,
       None,
       None,
@@ -4183,6 +4293,10 @@ mod tests {
       &[],
       &[],
       &[],
+      &[],
+      &[],
+      &[],
+      &[],
       None,
       None,
       None,
@@ -4362,6 +4476,10 @@ mod tests {
       &[],
       &[],
       &[],
+      &[],
+      &[],
+      &[],
+      &[],
       None,
       None,
       None,
@@ -4511,6 +4629,10 @@ mod tests {
       &manifests,
       &[],
       &[],
+      &[],
+      &[],
+      &[],
+      &[],
       None,
       None,
       None,
@@ -4638,6 +4760,10 @@ mod tests {
       &[],
       &[],
       &summaries,
+      &[],
+      &[],
+      &[],
+      &[],
       &[],
       &[],
       &[],
@@ -4776,6 +4902,10 @@ mod tests {
       &[],
       &[],
       &summaries,
+      &[],
+      &[],
+      &[],
+      &[],
       None,
       None,
       None,
@@ -4940,6 +5070,10 @@ mod tests {
       &[],
       &[launch_manifest],
       &duplicate_reports,
+      &[],
+      &[],
+      &[],
+      &[],
       &[],
       &[],
       &[],
@@ -5163,6 +5297,10 @@ mod tests {
       &[],
       &[],
       &[],
+      &[],
+      &[],
+      &[],
+      &[],
       None,
       None,
       None,
@@ -5339,6 +5477,10 @@ mod tests {
       &[],
       &[package_manifest],
       &duplicate_reports,
+      &[],
+      &[],
+      &[],
+      &[],
       &[],
       &[],
       &[],
@@ -5544,6 +5686,10 @@ mod tests {
       &[],
       &[result_manifest],
       &duplicate_reports,
+      &[],
+      &[],
+      &[],
+      &[],
       &[],
       &[],
       &[],
@@ -5771,6 +5917,10 @@ mod tests {
       &[],
       &[],
       &[],
+      &[],
+      &[],
+      &[],
+      &[],
       None,
       None,
       None,
@@ -5862,6 +6012,10 @@ mod tests {
 
     let output = render_run_text(
       &run,
+      &[],
+      &[],
+      &[],
+      &[],
       &[],
       &[],
       &[],

--- a/src/osu.rs
+++ b/src/osu.rs
@@ -8,12 +8,13 @@ use crate::osu_query_live_action::{
 };
 use auv_game_osu::{
   BenchmarkInputs, BenchmarkOutput, CapturePhase, DatasetExportInputs, DatasetExportOutput,
-  DetectionEvalInputs, DetectionEvalOutput, FrameDetections, ObjectKind, PlayfieldProjection,
-  RunMode, VisualTruthManifest, VisualTruthQueryActionWiringOutcome,
-  VisualTruthQueryLiveClickExecutor, VisualTruthSemanticValidationInputs,
-  VisualTruthSpatialQueryInputs, VisualTruthSpatialQueryOutput, evaluate_detection_fixture,
-  export_dataset, query_visual_truth_spatial, run_benchmark, validate_visual_truth_semantic,
-  visual_truth_query_action_wiring_lineage_from_manifest,
+  DetectionEvalInputs, DetectionEvalOutput, DetectionEvalQualityOutput, DetectionEvalWitnessInputs,
+  DetectionEvalWitnessOutput, FrameDetections, ObjectKind, PlayfieldProjection, RunMode,
+  VisualTruthManifest, VisualTruthQueryActionWiringOutcome, VisualTruthQueryLiveClickExecutor,
+  VisualTruthSemanticValidationInputs, VisualTruthSpatialQueryInputs,
+  VisualTruthSpatialQueryOutput, build_detection_eval_quality, build_detection_eval_witness,
+  evaluate_detection_fixture, export_dataset, query_visual_truth_spatial, run_benchmark,
+  validate_visual_truth_semantic, visual_truth_query_action_wiring_lineage_from_manifest,
   wire_visual_truth_spatial_query_manifest_to_action,
 };
 
@@ -35,6 +36,10 @@ pub const OSU_VISUAL_TRUTH_SEMANTIC_INSPECT_ROLE: &str = "osu-visual-truth-seman
 pub const OSU_VISUAL_TRUTH_SPATIAL_QUERY_ROLE: &str = "osu-visual-truth-spatial-query";
 pub const OSU_VISUAL_TRUTH_SPATIAL_QUERY_INSPECT_ROLE: &str =
   "osu-visual-truth-spatial-query-inspect";
+pub const OSU_DETECTION_EVAL_WITNESS_ROLE: &str = "osu-detection-eval-witness";
+pub const OSU_DETECTION_EVAL_WITNESS_INSPECT_ROLE: &str = "osu-detection-eval-witness-inspect";
+pub const OSU_DETECTION_EVAL_QUALITY_ROLE: &str = "osu-detection-eval-quality";
+pub const OSU_DETECTION_EVAL_QUALITY_INSPECT_ROLE: &str = "osu-detection-eval-quality-inspect";
 
 pub fn run_osu_benchmark(
   recording: &RecordingHandle,
@@ -205,11 +210,122 @@ pub fn run_osu_detection_eval(
             )?;
           }
         }
+        stage_osu_detection_eval_witness_quality_artifacts(context, &result.output_dir)?;
         Ok::<_, String>(())
       })?;
       Ok::<_, String>(result)
     },
   )
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct DetectionEvalWitnessQualityOutput {
+  pub witness: DetectionEvalWitnessOutput,
+  pub quality: DetectionEvalQualityOutput,
+}
+
+pub fn run_osu_detection_eval_witness_quality(
+  recording: &RecordingHandle,
+  detection_eval_output_dir: PathBuf,
+) -> AuvResult<RecordedOperationOutput<DetectionEvalWitnessQualityOutput>> {
+  recording.run_recorded_operation(
+    RunSpec::new(RunType::Execute, "auv.osu.eval_detections_witness_quality"),
+    "osu detection eval witness and quality evidence",
+    |context| {
+      context.record_event(
+        "osu.eval_detections_witness_quality.inputs",
+        Some(format!(
+          "detection_eval_output_dir={}",
+          detection_eval_output_dir.display(),
+        )),
+      );
+      let witness = build_detection_eval_witness(&DetectionEvalWitnessInputs {
+        detection_eval_output_dir: detection_eval_output_dir.clone(),
+        output_dir: detection_eval_output_dir.join("witness"),
+      })?;
+      let quality = build_detection_eval_quality(&auv_game_osu::DetectionEvalQualityInputs {
+        witness_manifest_path: witness.manifest_path.clone(),
+        output_dir: detection_eval_output_dir.join("quality"),
+      })?;
+      context.in_span("osu.eval_detections_witness_quality.artifacts", |context| {
+        stage_osu_detection_eval_witness_quality_artifacts(context, &detection_eval_output_dir)?;
+        Ok::<_, String>(())
+      })?;
+      Ok::<_, String>(DetectionEvalWitnessQualityOutput { witness, quality })
+    },
+  )
+}
+
+fn stage_osu_detection_eval_witness_quality_artifacts(
+  context: &mut auv_tracing_driver::recorded_operation::RecordedOperationContext<'_>,
+  detection_eval_output_dir: &std::path::Path,
+) -> Result<(), String> {
+  let witness_dir = detection_eval_output_dir.join("witness");
+  let quality_dir = detection_eval_output_dir.join("quality");
+  let witness_manifest_path = witness_dir.join("osu-detection-eval-witness.json");
+  if !witness_manifest_path.exists() {
+    let witness = build_detection_eval_witness(&DetectionEvalWitnessInputs {
+      detection_eval_output_dir: detection_eval_output_dir.to_path_buf(),
+      output_dir: witness_dir.clone(),
+    })?;
+    let _quality = build_detection_eval_quality(&auv_game_osu::DetectionEvalQualityInputs {
+      witness_manifest_path: witness.manifest_path.clone(),
+      output_dir: quality_dir.clone(),
+    })?;
+  } else if !quality_dir.join("osu-detection-eval-quality.json").exists() {
+    let _quality = build_detection_eval_quality(&auv_game_osu::DetectionEvalQualityInputs {
+      witness_manifest_path: witness_manifest_path,
+      output_dir: quality_dir.clone(),
+    })?;
+  }
+
+  for (artifact_name, role) in [
+    (
+      "osu-detection-eval-witness.json",
+      OSU_DETECTION_EVAL_WITNESS_ROLE,
+    ),
+    (
+      "osu-detection-eval-witness-inspect.json",
+      OSU_DETECTION_EVAL_WITNESS_INSPECT_ROLE,
+    ),
+  ] {
+    let artifact_path = witness_dir.join(artifact_name);
+    if artifact_path.exists() {
+      context.stage_artifact_file(
+        role,
+        &artifact_path,
+        artifact_name,
+        Some(format!(
+          "osu detection eval witness artifact {artifact_name}"
+        )),
+      )?;
+    }
+  }
+
+  for (artifact_name, role) in [
+    (
+      "osu-detection-eval-quality.json",
+      OSU_DETECTION_EVAL_QUALITY_ROLE,
+    ),
+    (
+      "osu-detection-eval-quality-inspect.json",
+      OSU_DETECTION_EVAL_QUALITY_INSPECT_ROLE,
+    ),
+  ] {
+    let artifact_path = quality_dir.join(artifact_name);
+    if artifact_path.exists() {
+      context.stage_artifact_file(
+        role,
+        &artifact_path,
+        artifact_name,
+        Some(format!(
+          "osu detection eval quality artifact {artifact_name}"
+        )),
+      )?;
+    }
+  }
+
+  Ok(())
 }
 
 pub fn run_osu_visual_truth_semantic_validation(
@@ -801,8 +917,8 @@ mod tests {
     use auv_tracing_driver::store::LocalStore;
 
     use crate::osu::{
-      OSU_VISUAL_TRUTH_SPATIAL_QUERY_INSPECT_ROLE, OSU_VISUAL_TRUTH_SPATIAL_QUERY_ROLE,
-      QueryWiredLiveActionInputs, run_osu_query_wired_live_action_with_executor,
+      OSU_VISUAL_TRUTH_SPATIAL_QUERY_ROLE, QueryWiredLiveActionInputs,
+      run_osu_query_wired_live_action_with_executor,
     };
     use crate::osu_query_live_action::QUERY_WIRED_LIVE_ACTION_OPERATION_ID;
     use auv_game_osu::CapturePhase;
@@ -963,8 +1079,7 @@ mod tests {
       .expect("ok");
       assert!(!output.value.wiring.attempted);
       assert_eq!(executor.calls.get(), 0);
-      let run = recording.read_run(output.run_id.as_str()).expect("run");
-      let operation_result = read_operation_result_artifact(&store, &run);
+      let _run = recording.read_run(output.run_id.as_str()).expect("run");
       assert_eq!(
         output.value.wiring.action_eligibility.as_str(),
         "not_consumable"

--- a/src/run_read.rs
+++ b/src/run_read.rs
@@ -42,6 +42,8 @@ use auv_game_minecraft::{
   TrainingResultSpatialQueryManifest, derive_action_readiness,
 };
 use auv_game_osu::{
+  DetectionEvalQualityInspectReport, DetectionEvalQualityManifest,
+  DetectionEvalWitnessInspectReport, DetectionEvalWitnessManifest,
   VisualTruthSemanticInspectReport, VisualTruthSemanticManifest,
   VisualTruthSpatialQueryInspectReport, VisualTruthSpatialQueryManifest,
   derive_visual_truth_spatial_query_action_readiness,
@@ -269,6 +271,92 @@ pub struct OsuQueryWiredLiveActionSummary {
   pub dispatch_command: Option<String>,
   pub dispatch_outcome: Option<String>,
   pub readiness_class: Option<String>,
+  pub issue: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, serde::Serialize)]
+pub struct OsuDetectionEvalWitnessManifestLineage {
+  pub artifact: ArtifactRefLineage,
+  pub manifest: Option<OsuDetectionEvalWitnessManifestSummary>,
+  pub issue: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, serde::Serialize)]
+pub struct OsuDetectionEvalWitnessInspectReportLineage {
+  pub artifact: ArtifactRefLineage,
+  pub report: Option<OsuDetectionEvalWitnessInspectReportSummary>,
+  pub issue: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, serde::Serialize)]
+pub struct OsuDetectionEvalQualityManifestLineage {
+  pub artifact: ArtifactRefLineage,
+  pub manifest: Option<OsuDetectionEvalQualityManifestSummary>,
+  pub issue: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, serde::Serialize)]
+pub struct OsuDetectionEvalQualityInspectReportLineage {
+  pub artifact: ArtifactRefLineage,
+  pub report: Option<OsuDetectionEvalQualityInspectReportSummary>,
+  pub issue: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct OsuDetectionEvalWitnessManifestSummary {
+  pub schema_version: u32,
+  pub source_visual_eval_report_path: String,
+  pub source_run_artifact_dir: String,
+  pub detector_model_id: Option<String>,
+  pub total_frames: usize,
+  pub label_matched_frames: usize,
+  pub spatial_matched_frames: usize,
+  pub spatial_unscored_frames: usize,
+  pub spurious_detection_count: usize,
+  pub projection_kind: String,
+  pub frame_witness_count: usize,
+  pub status: String,
+  pub reason: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct OsuDetectionEvalWitnessInspectReportSummary {
+  pub schema_version: u32,
+  pub detection_eval_witness_manifest_path: String,
+  pub total_frames: usize,
+  pub frame_witness_count: usize,
+  pub status: String,
+  pub warnings: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct OsuDetectionEvalQualityManifestSummary {
+  pub schema_version: u32,
+  pub detection_eval_witness_manifest_path: String,
+  pub source_visual_eval_report_path: String,
+  pub witness_status: String,
+  pub status: String,
+  pub verdict: String,
+  pub label_recall: Option<f32>,
+  pub spatial_recall: Option<f32>,
+  pub spurious_detection_count: Option<usize>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct OsuDetectionEvalQualityInspectReportSummary {
+  pub schema_version: u32,
+  pub detection_eval_quality_manifest_path: String,
+  pub witness_status: String,
+  pub status: String,
+  pub verdict: String,
+  pub label_recall_available: bool,
+  pub spatial_recall_available: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, serde::Serialize)]
+pub struct OsuDetectionEvalQualityVerdictSummary {
+  pub verdict: String,
+  pub derived_from_witness_status: String,
   pub issue: Option<String>,
 }
 
@@ -1556,6 +1644,238 @@ pub(crate) fn extract_osu_visual_truth_spatial_query_inspect_reports(
     }
   }
   Ok(reports)
+}
+
+pub(crate) fn list_osu_detection_eval_witness_manifests(
+  store: &LocalStore,
+  run_id: &str,
+) -> AuvResult<Vec<OsuDetectionEvalWitnessManifestLineage>> {
+  let run = store.read_run(run_id)?;
+  extract_osu_detection_eval_witness_manifests(store, &run)
+}
+
+pub(crate) fn list_osu_detection_eval_witness_inspect_reports(
+  store: &LocalStore,
+  run_id: &str,
+) -> AuvResult<Vec<OsuDetectionEvalWitnessInspectReportLineage>> {
+  let run = store.read_run(run_id)?;
+  extract_osu_detection_eval_witness_inspect_reports(store, &run)
+}
+
+pub(crate) fn list_osu_detection_eval_quality_manifests(
+  store: &LocalStore,
+  run_id: &str,
+) -> AuvResult<Vec<OsuDetectionEvalQualityManifestLineage>> {
+  let run = store.read_run(run_id)?;
+  extract_osu_detection_eval_quality_manifests(store, &run)
+}
+
+pub(crate) fn list_osu_detection_eval_quality_inspect_reports(
+  store: &LocalStore,
+  run_id: &str,
+) -> AuvResult<Vec<OsuDetectionEvalQualityInspectReportLineage>> {
+  let run = store.read_run(run_id)?;
+  extract_osu_detection_eval_quality_inspect_reports(store, &run)
+}
+
+pub(crate) fn extract_osu_detection_eval_witness_manifests(
+  store: &LocalStore,
+  run: &CanonicalRun,
+) -> AuvResult<Vec<OsuDetectionEvalWitnessManifestLineage>> {
+  let mut manifests = Vec::new();
+  for artifact in &run.artifacts {
+    if artifact.role != crate::osu::OSU_DETECTION_EVAL_WITNESS_ROLE {
+      continue;
+    }
+    let artifact_ref = artifact_record_lineage(run.run.run_id.clone(), artifact);
+    if !is_json_mime(&artifact.mime_type) {
+      manifests.push(OsuDetectionEvalWitnessManifestLineage {
+        artifact: artifact_ref,
+        manifest: None,
+        issue: Some(format!(
+          "osu detection eval witness manifest mime_type {} is not JSON",
+          artifact.mime_type
+        )),
+      });
+      continue;
+    }
+    let parsed = read_artifact_json::<DetectionEvalWitnessManifest>(
+      store,
+      run.run.run_id.as_str(),
+      artifact,
+      crate::osu::OSU_DETECTION_EVAL_WITNESS_ROLE,
+    )
+    .map(|manifest| OsuDetectionEvalWitnessManifestSummary::from(&manifest));
+    match parsed {
+      Ok(manifest) => manifests.push(OsuDetectionEvalWitnessManifestLineage {
+        artifact: artifact_ref,
+        manifest: Some(manifest),
+        issue: None,
+      }),
+      Err(error) => manifests.push(OsuDetectionEvalWitnessManifestLineage {
+        artifact: artifact_ref,
+        manifest: None,
+        issue: Some(error),
+      }),
+    }
+  }
+  Ok(manifests)
+}
+
+pub(crate) fn extract_osu_detection_eval_witness_inspect_reports(
+  store: &LocalStore,
+  run: &CanonicalRun,
+) -> AuvResult<Vec<OsuDetectionEvalWitnessInspectReportLineage>> {
+  let mut reports = Vec::new();
+  for artifact in &run.artifacts {
+    if artifact.role != crate::osu::OSU_DETECTION_EVAL_WITNESS_INSPECT_ROLE {
+      continue;
+    }
+    let artifact_ref = artifact_record_lineage(run.run.run_id.clone(), artifact);
+    if !is_json_mime(&artifact.mime_type) {
+      reports.push(OsuDetectionEvalWitnessInspectReportLineage {
+        artifact: artifact_ref,
+        report: None,
+        issue: Some(format!(
+          "osu detection eval witness inspect mime_type {} is not JSON",
+          artifact.mime_type
+        )),
+      });
+      continue;
+    }
+    let parsed = read_artifact_json::<DetectionEvalWitnessInspectReport>(
+      store,
+      run.run.run_id.as_str(),
+      artifact,
+      crate::osu::OSU_DETECTION_EVAL_WITNESS_INSPECT_ROLE,
+    )
+    .map(|report| OsuDetectionEvalWitnessInspectReportSummary::from(&report));
+    match parsed {
+      Ok(report) => reports.push(OsuDetectionEvalWitnessInspectReportLineage {
+        artifact: artifact_ref,
+        report: Some(report),
+        issue: None,
+      }),
+      Err(error) => reports.push(OsuDetectionEvalWitnessInspectReportLineage {
+        artifact: artifact_ref,
+        report: None,
+        issue: Some(error),
+      }),
+    }
+  }
+  Ok(reports)
+}
+
+pub(crate) fn extract_osu_detection_eval_quality_manifests(
+  store: &LocalStore,
+  run: &CanonicalRun,
+) -> AuvResult<Vec<OsuDetectionEvalQualityManifestLineage>> {
+  let mut manifests = Vec::new();
+  for artifact in &run.artifacts {
+    if artifact.role != crate::osu::OSU_DETECTION_EVAL_QUALITY_ROLE {
+      continue;
+    }
+    let artifact_ref = artifact_record_lineage(run.run.run_id.clone(), artifact);
+    if !is_json_mime(&artifact.mime_type) {
+      manifests.push(OsuDetectionEvalQualityManifestLineage {
+        artifact: artifact_ref,
+        manifest: None,
+        issue: Some(format!(
+          "osu detection eval quality manifest mime_type {} is not JSON",
+          artifact.mime_type
+        )),
+      });
+      continue;
+    }
+    let parsed = read_artifact_json::<DetectionEvalQualityManifest>(
+      store,
+      run.run.run_id.as_str(),
+      artifact,
+      crate::osu::OSU_DETECTION_EVAL_QUALITY_ROLE,
+    )
+    .map(|manifest| OsuDetectionEvalQualityManifestSummary::from(&manifest));
+    match parsed {
+      Ok(manifest) => manifests.push(OsuDetectionEvalQualityManifestLineage {
+        artifact: artifact_ref,
+        manifest: Some(manifest),
+        issue: None,
+      }),
+      Err(error) => manifests.push(OsuDetectionEvalQualityManifestLineage {
+        artifact: artifact_ref,
+        manifest: None,
+        issue: Some(error),
+      }),
+    }
+  }
+  Ok(manifests)
+}
+
+pub(crate) fn extract_osu_detection_eval_quality_inspect_reports(
+  store: &LocalStore,
+  run: &CanonicalRun,
+) -> AuvResult<Vec<OsuDetectionEvalQualityInspectReportLineage>> {
+  let mut reports = Vec::new();
+  for artifact in &run.artifacts {
+    if artifact.role != crate::osu::OSU_DETECTION_EVAL_QUALITY_INSPECT_ROLE {
+      continue;
+    }
+    let artifact_ref = artifact_record_lineage(run.run.run_id.clone(), artifact);
+    if !is_json_mime(&artifact.mime_type) {
+      reports.push(OsuDetectionEvalQualityInspectReportLineage {
+        artifact: artifact_ref,
+        report: None,
+        issue: Some(format!(
+          "osu detection eval quality inspect mime_type {} is not JSON",
+          artifact.mime_type
+        )),
+      });
+      continue;
+    }
+    let parsed = read_artifact_json::<DetectionEvalQualityInspectReport>(
+      store,
+      run.run.run_id.as_str(),
+      artifact,
+      crate::osu::OSU_DETECTION_EVAL_QUALITY_INSPECT_ROLE,
+    )
+    .map(|report| OsuDetectionEvalQualityInspectReportSummary::from(&report));
+    match parsed {
+      Ok(report) => reports.push(OsuDetectionEvalQualityInspectReportLineage {
+        artifact: artifact_ref,
+        report: Some(report),
+        issue: None,
+      }),
+      Err(error) => reports.push(OsuDetectionEvalQualityInspectReportLineage {
+        artifact: artifact_ref,
+        report: None,
+        issue: Some(error),
+      }),
+    }
+  }
+  Ok(reports)
+}
+
+pub fn derive_osu_detection_eval_quality_verdict_summary(
+  lineage: &OsuDetectionEvalQualityManifestLineage,
+) -> OsuDetectionEvalQualityVerdictSummary {
+  if let Some(issue) = &lineage.issue {
+    return OsuDetectionEvalQualityVerdictSummary {
+      verdict: "n/a".to_string(),
+      derived_from_witness_status: "n/a".to_string(),
+      issue: Some(issue.clone()),
+    };
+  }
+  let Some(summary) = &lineage.manifest else {
+    return OsuDetectionEvalQualityVerdictSummary {
+      verdict: "n/a".to_string(),
+      derived_from_witness_status: "n/a".to_string(),
+      issue: Some("osu detection eval quality manifest summary missing".to_string()),
+    };
+  };
+  OsuDetectionEvalQualityVerdictSummary {
+    verdict: summary.verdict.clone(),
+    derived_from_witness_status: summary.witness_status.clone(),
+    issue: None,
+  }
 }
 
 pub fn derive_osu_visual_truth_spatial_query_action_readiness(
@@ -5632,6 +5952,72 @@ impl From<TrainingPackageInspectReport> for MinecraftTrainingPackageInspectRepor
       compatibility_views: value.compatibility_views,
       warnings: value.warnings,
       known_limits: value.known_limits,
+    }
+  }
+}
+
+impl From<&DetectionEvalWitnessManifest> for OsuDetectionEvalWitnessManifestSummary {
+  fn from(manifest: &DetectionEvalWitnessManifest) -> Self {
+    Self {
+      schema_version: manifest.schema_version,
+      source_visual_eval_report_path: manifest.source_visual_eval_report_path.clone(),
+      source_run_artifact_dir: manifest.source_run_artifact_dir.clone(),
+      detector_model_id: manifest.detector_model_id.clone(),
+      total_frames: manifest.total_frames,
+      label_matched_frames: manifest.label_matched_frames,
+      spatial_matched_frames: manifest.spatial_matched_frames,
+      spatial_unscored_frames: manifest.spatial_unscored_frames,
+      spurious_detection_count: manifest.spurious_detection_count,
+      projection_kind: manifest.projection_kind.clone(),
+      frame_witness_count: manifest.frame_witnesses.len(),
+      status: manifest.status.as_str().to_string(),
+      reason: manifest.reason.map(|reason| reason.as_str().to_string()),
+    }
+  }
+}
+
+impl From<&DetectionEvalWitnessInspectReport> for OsuDetectionEvalWitnessInspectReportSummary {
+  fn from(report: &DetectionEvalWitnessInspectReport) -> Self {
+    Self {
+      schema_version: report.schema_version,
+      detection_eval_witness_manifest_path: report.detection_eval_witness_manifest_path.clone(),
+      total_frames: report.total_frames,
+      frame_witness_count: report.frame_witness_count,
+      status: report.status.as_str().to_string(),
+      warnings: report.warnings.clone(),
+    }
+  }
+}
+
+impl From<&DetectionEvalQualityManifest> for OsuDetectionEvalQualityManifestSummary {
+  fn from(manifest: &DetectionEvalQualityManifest) -> Self {
+    Self {
+      schema_version: manifest.schema_version,
+      detection_eval_witness_manifest_path: manifest.detection_eval_witness_manifest_path.clone(),
+      source_visual_eval_report_path: manifest.source_visual_eval_report_path.clone(),
+      witness_status: manifest.witness_status.as_str().to_string(),
+      status: manifest.status.as_str().to_string(),
+      verdict: manifest.verdict.as_str().to_string(),
+      label_recall: manifest.metrics.as_ref().and_then(|m| m.label_recall),
+      spatial_recall: manifest.metrics.as_ref().and_then(|m| m.spatial_recall),
+      spurious_detection_count: manifest
+        .metrics
+        .as_ref()
+        .map(|m| m.spurious_detection_count),
+    }
+  }
+}
+
+impl From<&DetectionEvalQualityInspectReport> for OsuDetectionEvalQualityInspectReportSummary {
+  fn from(report: &DetectionEvalQualityInspectReport) -> Self {
+    Self {
+      schema_version: report.schema_version,
+      detection_eval_quality_manifest_path: report.detection_eval_quality_manifest_path.clone(),
+      witness_status: report.witness_status.as_str().to_string(),
+      status: report.status.as_str().to_string(),
+      verdict: report.verdict.as_str().to_string(),
+      label_recall_available: report.label_recall_available,
+      spatial_recall_available: report.spatial_recall_available,
     }
   }
 }


### PR DESCRIPTION
## Summary
- add osu detection-eval witness and quality evidence chain
- wire read-side inspect consumers for witness/quality artifacts
- update osu evidence and proof-matrix notes without upgrading core verdicts

## Validation
- cargo fmt --check
- cargo test -p auv-game-osu detection_eval_witness_quality -- --nocapture
- cargo test -p auv-cli osu -- --nocapture
- git diff --check

## Stack
- base PR: feat/osu-visual-truth-query-wired-live-action
- this PR should merge after the wired-live base lands