### PR TITLE
fix(auv-api-proto): align proto package tooling

### DIFF
--- a/.prototools
+++ b/.prototools
@@ -1,0 +1,2 @@
+[plugins.tools]
+buf = "https://raw.githubusercontent.com/stk0vrfl0w/proto-toml-plugins/main/plugins/buf.toml"

--- a/crates/auv-api-proto/build.rs
+++ b/crates/auv-api-proto/build.rs
@@ -11,7 +11,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
   let out_dir = PathBuf::from(std::env::var("OUT_DIR")?);
   tonic_prost_build::configure()
-    .file_descriptor_set_path(out_dir.join("auv.api.v1.session.bin"))
+    .file_descriptor_set_path(out_dir.join("auv.api.session.v1.bin"))
     .compile_protos(&["../../proto/auv/api/v1/session.proto"], &["../../proto"])?;
 
   println!("cargo:rerun-if-changed=../../proto/auv/api/v1/session.proto");

--- a/crates/auv-api-proto/src/lib.rs
+++ b/crates/auv-api-proto/src/lib.rs
@@ -1,11 +1,11 @@
 pub mod v1 {
   pub mod session {
-    tonic::include_proto!("auv.api.v1.session");
+    tonic::include_proto!("auv.api.session.v1");
 
     /// Encoded protobuf schema metadata for gRPC reflection and tools such as
     /// `grpcurl`; normal clients use the generated request/response types.
     pub const FILE_DESCRIPTOR_SET: &[u8] =
-      tonic::include_file_descriptor_set!("auv.api.v1.session");
+      tonic::include_file_descriptor_set!("auv.api.session.v1");
   }
 }
 

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,8 @@
                 # protobuf
                 protobuf
                 buf
+                protoc-gen-prost
+                protoc-gen-tonic
               ])
               ++ [];
 

--- a/proto/auv/api/v1/session.proto
+++ b/proto/auv/api/v1/session.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package auv.api.v1.session;
+package auv.api.session.v1;
 
 service SessionService {
   rpc DoExample(DoExampleRequest) returns (DoExampleResponse);

--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -5,8 +5,8 @@ lint:
   use:
     - STANDARD
   except:
-    # AUV uses `auv.api.v1.<domain>` packages so generated Rust modules read as
-    # `v1::<domain>` instead of duplicating the version as `<domain>::v1`.
+    # AUV keeps proto files under versioned directories while using
+    # `<domain>.v1` package suffixes.
     - PACKAGE_DIRECTORY_MATCH
     - PACKAGE_VERSION_SUFFIX
 breaking:


### PR DESCRIPTION
## Summary

- Rename the session proto package to `auv.api.session.v1` and update Rust generated-code includes/descriptors to match.
- Add Buf local codegen plugins to the Nix dev shell so `proto/buf.gen.yaml` can run.
- Add `.prototools` with the Buf plugin source configuration.
- Document proto usage in `README.md` and add `.github/CONTRIBUTING.md` with Rust, Nix, and Buf setup notes.

## Validation

- `cargo check -p auv-api-proto`
- `cargo test -p auv-api-proto`
- `cargo fmt --check -p auv-api-proto`
- `git diff --check HEAD~1..HEAD`
- `nix --extra-experimental-features nix-command --extra-experimental-features flakes develop --command buf lint proto`
- `nix --extra-experimental-features nix-command --extra-experimental-features flakes develop --command buf generate proto --template proto/buf.gen.yaml`