### PR TITLE
chore: clear qodana hygiene findings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,7 +353,6 @@ dependencies = [
  "auv-driver-macos",
  "clap",
  "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -364,7 +363,6 @@ dependencies = [
  "auv-driver-macos",
  "clap",
  "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -381,9 +379,7 @@ dependencies = [
  "auv-game-osu",
  "auv-inference-common",
  "auv-media-macos",
- "auv-overlay-macos",
  "auv-scan",
- "auv-steam",
  "auv-tracing-driver",
  "auv-view",
  "axum",
@@ -394,7 +390,6 @@ dependencies = [
  "reqwest 0.12.28",
  "rmcp",
  "schemars",
- "semver",
  "serde",
  "serde_json",
  "swift-bridge-build",
@@ -405,7 +400,6 @@ dependencies = [
  "tonic",
  "tower",
  "tracing",
- "xcap",
 ]
 
 [[package]]
@@ -496,7 +490,6 @@ dependencies = [
  "auv-inference-ultralytics",
  "auv-stage-status",
  "auv-tracing-driver",
- "auv-view",
  "clap",
  "hf-hub",
  "image",
@@ -559,7 +552,6 @@ dependencies = [
  "auv-inference-common",
  "ndarray",
  "ort",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -574,7 +566,6 @@ dependencies = [
  "ndarray",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
  "tokio",
  "tower",
  "ultralytics-inference",
@@ -622,7 +613,6 @@ dependencies = [
  "auv-driver-macos",
  "clap",
  "serde",
- "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,15 +88,12 @@ auv-game-minecraft = { path = "crates/auv-game-minecraft" }
 auv-inference-common = { path = "crates/auv-inference-common" }
 auv-driver = { path = "crates/auv-driver" }
 auv-driver-macos = { path = "crates/auv-driver-macos" }
-auv-overlay-macos = { path = "crates/auv-overlay-macos" }
 auv-cli-invoke = { path = "crates/auv-cli-invoke" }
 auv-api-proto = { path = "crates/auv-api-proto" }
-auv-steam = { path = "crates/auv-steam" }
 auv-tracing-driver = { path = "crates/auv-tracing-driver" }
 auv-scan = { path = "crates/auv-scan" }
 auv-view = { path = "crates/auv-view" }
 axum = { version = "0.8", features = ["ws"] }
-semver = "1"
 serde.workspace = true
 thiserror.workspace = true
 serde_json.workspace = true
@@ -106,7 +103,6 @@ tokio-util = { version = "0.7", features = ["rt"] }
 tokio-stream = "0.1"
 tonic = { version = "0.14", features = ["transport"] }
 tracing = "0.1"
-xcap.workspace = true
 image.workspace = true
 reqwest.workspace = true
 libc = "0.2"

--- a/crates/auv-apple-music/src/app.rs
+++ b/crates/auv-apple-music/src/app.rs
@@ -5,7 +5,6 @@
 //! `AppleMusic.exe`. This module wraps the driver's window selector into a
 //! single typed result so command implementations stay driver-agnostic.
 
-use auv_driver::selector::{App, Window as WindowSel, WindowSelector};
 use auv_driver::window::Window;
 
 /// Default process name for Apple Music on Windows (Microsoft Store edition).
@@ -45,6 +44,7 @@ impl Default for ResolveOptions {
 #[cfg(target_os = "windows")]
 pub fn resolve_window(options: &ResolveOptions) -> Result<Option<AppleMusicWindow>, String> {
   use auv_driver::Driver;
+  use auv_driver::selector::{App, Window as WindowSel, WindowSelector};
   use auv_driver_windows::WindowsDriver;
 
   let session = WindowsDriver::new()

--- a/crates/auv-apple-music/src/commands/launch.rs
+++ b/crates/auv-apple-music/src/commands/launch.rs
@@ -11,11 +11,14 @@
 //! Only step 1 is executed on non-Windows targets; steps 2 and 3 are
 //! Windows-only.
 
+#[cfg(target_os = "windows")]
 use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 
-use crate::app::{APPLE_MUSIC_TITLE, AppleMusicWindow, ResolveOptions, resolve_window};
+#[cfg(target_os = "windows")]
+use crate::app::APPLE_MUSIC_TITLE;
+use crate::app::{AppleMusicWindow, ResolveOptions, resolve_window};
 
 // NOTICE(apple-music-store-aumid): Microsoft Store apps launch by
 // AppUserModelID, not executable path. Prefer `Get-StartApps` at runtime

--- a/crates/auv-apple-notes/Cargo.toml
+++ b/crates/auv-apple-notes/Cargo.toml
@@ -16,4 +16,3 @@ auv-driver = { path = "../auv-driver" }
 auv-driver-macos = { path = "../auv-driver-macos" }
 clap = { version = "4", features = ["derive"] }
 serde.workspace = true
-serde_json.workspace = true

--- a/crates/auv-apple-textedit/Cargo.toml
+++ b/crates/auv-apple-textedit/Cargo.toml
@@ -16,4 +16,3 @@ auv-driver = { path = "../auv-driver" }
 auv-driver-macos = { path = "../auv-driver-macos" }
 clap = { version = "4", features = ["derive"] }
 serde.workspace = true
-serde_json.workspace = true

--- a/crates/auv-driver-macos/src/native/clipboard.rs
+++ b/crates/auv-driver-macos/src/native/clipboard.rs
@@ -65,6 +65,7 @@ fn action_result(operation: &str, response: NativeActionResponse) -> AuvResult<(
 
 #[cfg(test)]
 mod tests {
+  #[cfg(target_os = "macos")]
   use super::*;
 
   #[cfg(target_os = "macos")]

--- a/crates/auv-driver-macos/src/native/input.rs
+++ b/crates/auv-driver-macos/src/native/input.rs
@@ -178,6 +178,7 @@ fn action_result(operation: &str, response: NativeActionResponse) -> AuvResult<(
 
 #[cfg(test)]
 mod tests {
+  #[cfg(target_os = "macos")]
   use super::*;
 
   #[cfg(target_os = "macos")]

--- a/crates/auv-driver-macos/src/native/pointer.rs
+++ b/crates/auv-driver-macos/src/native/pointer.rs
@@ -130,6 +130,7 @@ fn teach_click_result(
 
 #[cfg(test)]
 mod tests {
+  #[cfg(target_os = "macos")]
   use super::*;
 
   #[cfg(target_os = "macos")]

--- a/crates/auv-driver-macos/src/session.rs
+++ b/crates/auv-driver-macos/src/session.rs
@@ -4,6 +4,12 @@ use std::process::Command;
 use std::thread;
 use std::time::Duration;
 
+use crate::driver::MacosDriverSession;
+use crate::native::ocr::NativeOcrTextCapture;
+use crate::native::types::{ObservedRect, ObservedWindow, ObservedWindowSnapshot};
+use crate::native::window::ListWindowsOptions;
+use crate::support::{build_window_candidates, parse_app_selector, resolve_app_ref};
+use crate::types::{WindowRef as NativeWindowRef, WindowSelection};
 use auv_driver::capture::{Activation, Capture, CaptureOptions, DisplayCapture, RegionCapture};
 use auv_driver::display::{Display, ObservedDisplays};
 use auv_driver::error::{DriverError, DriverResult};
@@ -24,14 +30,6 @@ use auv_driver::window::{
   WindowMutationOptions, WindowMutationPath, WindowMutationPolicy, WindowMutationResult,
   WindowMutationVerification, WindowRef, WindowState,
 };
-use image::RgbaImage;
-
-use crate::driver::MacosDriverSession;
-use crate::native::ocr::NativeOcrTextCapture;
-use crate::native::types::{ObservedRect, ObservedWindow, ObservedWindowSnapshot};
-use crate::native::window::ListWindowsOptions;
-use crate::support::{build_window_candidates, parse_app_selector, resolve_app_ref};
-use crate::types::{WindowRef as NativeWindowRef, WindowSelection};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct OcrMatch {
@@ -1763,7 +1761,7 @@ fn capture_display_xcap(selector: Option<&str>) -> DriverResult<DisplayCapture> 
   let image = monitor
     .capture_image()
     .map_err(|error| backend(format!("failed to capture display: {error}")))?;
-  let image = RgbaImage::from_raw(image.width(), image.height(), image.into_raw())
+  let image = image::RgbaImage::from_raw(image.width(), image.height(), image.into_raw())
     .ok_or_else(|| backend("failed to decode captured display RGBA image"))?;
   let capture = Capture {
     image,
@@ -1799,7 +1797,7 @@ fn capture_region_xcap(selector: Option<&str>, region: Rect) -> DriverResult<Reg
   let image = monitor
     .capture_region(local_x, local_y, width, height)
     .map_err(|error| backend(format!("failed to capture display region: {error}")))?;
-  let image = RgbaImage::from_raw(image.width(), image.height(), image.into_raw())
+  let image = image::RgbaImage::from_raw(image.width(), image.height(), image.into_raw())
     .ok_or_else(|| backend("failed to decode captured region RGBA image"))?;
   let capture = Capture {
     image,
@@ -1971,7 +1969,7 @@ fn capture_window_swift(window: &Window) -> DriverResult<Capture> {
     .map_err(|error| backend(format!("native capture returned invalid width: {error}")))?;
   let height = u32::try_from(capture.image_height)
     .map_err(|error| backend(format!("native capture returned invalid height: {error}")))?;
-  let image = RgbaImage::from_raw(width, height, capture.rgba_bytes)
+  let image = image::RgbaImage::from_raw(width, height, capture.rgba_bytes)
     .ok_or_else(|| backend("failed to decode native captured window RGBA image"))?;
   let scale_factor = if window.frame.size.width > 0.0 {
     f64::from(width) / window.frame.size.width
@@ -2014,7 +2012,7 @@ fn capture_window_xcap(window: &Window, fallback_reason: Option<String>) -> Driv
   } else {
     1.0
   };
-  let image = RgbaImage::from_raw(width, height, image.into_raw())
+  let image = image::RgbaImage::from_raw(width, height, image.into_raw())
     .ok_or_else(|| backend("failed to decode captured window RGBA image"))?;
   Ok(Capture {
     image,

--- a/crates/auv-driver-windows/src/capture.rs
+++ b/crates/auv-driver-windows/src/capture.rs
@@ -11,10 +11,14 @@ use auv_driver::display::{Display, ObservedDisplays};
 #[cfg(not(target_os = "windows"))]
 use auv_driver::error::DriverError;
 use auv_driver::error::DriverResult;
-use auv_driver::geometry::{CoordinateSpace, Rect};
+#[cfg(target_os = "windows")]
+use auv_driver::geometry::CoordinateSpace;
+use auv_driver::geometry::Rect;
 use auv_driver::window::Window;
 
-use crate::error::{backend, invalid_input, not_found};
+#[cfg(target_os = "windows")]
+use crate::error::backend;
+use crate::error::{invalid_input, not_found};
 
 /// Capture backend tag recorded on every produced display/region [`Capture`].
 #[cfg(target_os = "windows")]

--- a/crates/auv-driver-windows/src/capture.rs
+++ b/crates/auv-driver-windows/src/capture.rs
@@ -413,7 +413,7 @@ mod window_native {
   }
 }
 
-#[cfg(test)]
+#[cfg(all(test, target_os = "windows"))]
 mod tests {
   use super::*;
 

--- a/crates/auv-driver-windows/src/ocr.rs
+++ b/crates/auv-driver-windows/src/ocr.rs
@@ -5,8 +5,11 @@
 //! image pixel coordinates. Mapping pixel coordinates back into screen or
 //! window space stays with the caller, exactly like the macOS driver.
 
+#[cfg(target_os = "windows")]
 use auv_driver::geometry::Rect;
-use auv_driver::vision::{RecognizedText, TextRecognition, TextRecognitionOptions};
+#[cfg(target_os = "windows")]
+use auv_driver::vision::RecognizedText;
+use auv_driver::vision::{TextRecognition, TextRecognitionOptions};
 
 /// Errors raised while running Windows system OCR.
 #[derive(Debug, thiserror::Error)]

--- a/crates/auv-game-balatro/Cargo.toml
+++ b/crates/auv-game-balatro/Cargo.toml
@@ -24,7 +24,6 @@ auv-driver = { path = "../auv-driver" }
 auv-inference-common = { path = "../auv-inference-common" }
 auv-inference-ort = { path = "../auv-inference-ort", optional = true }
 auv-inference-ultralytics = { path = "../auv-inference-ultralytics" }
-auv-view = { path = "../auv-view" }
 clap = { version = "4.5", features = ["derive"] }
 hf-hub = { version = "1.0.0-rc.1", features = ["blocking", "rustls-tls"] }
 image.workspace = true

--- a/crates/auv-game-balatro/src/cli.rs
+++ b/crates/auv-game-balatro/src/cli.rs
@@ -4735,6 +4735,7 @@ mod tests {
   }
 
   #[test]
+  #[cfg(target_os = "macos")]
   fn deck_atlas_can_load_from_setup_cache() {
     let root = unique_temp_dir("balatro-setup-cache-load");
     let cache_dir = root.join("cache");

--- a/crates/auv-game-osu/src/benchmark.rs
+++ b/crates/auv-game-osu/src/benchmark.rs
@@ -9,7 +9,9 @@ use rosu_map::Beatmap;
 use rosu_map::section::hit_objects::HitObjectKind;
 use serde::{Deserialize, Serialize};
 
-use crate::projection::{PlayfieldProjection, ProjectionArtifact};
+#[cfg(target_os = "macos")]
+use crate::projection::PlayfieldProjection;
+use crate::projection::ProjectionArtifact;
 use crate::visual_eval::{
   DetectorEvalProvenance, FrameDetections, FrameKey, LabelMap, VisualEvalReport,
   evaluate_visual_truth_with_provenance,

--- a/crates/auv-inference-ort/Cargo.toml
+++ b/crates/auv-inference-ort/Cargo.toml
@@ -40,4 +40,3 @@ xnnpack = ["runtime", "ort/xnnpack"]
 auv-inference-common = { path = "../auv-inference-common" }
 ndarray.workspace = true
 ort = { workspace = true, optional = true }
-thiserror.workspace = true

--- a/crates/auv-inference-ultralytics/Cargo.toml
+++ b/crates/auv-inference-ultralytics/Cargo.toml
@@ -46,7 +46,6 @@ auv-inference-common = { path = "../auv-inference-common" }
 image = { workspace = true, features = ["jpeg"] }
 serde.workspace = true
 serde_json.workspace = true
-thiserror.workspace = true
 ultralytics-inference.workspace = true
 
 [dev-dependencies]

--- a/crates/auv-netease-music/src/app.rs
+++ b/crates/auv-netease-music/src/app.rs
@@ -7,7 +7,7 @@ use crate::run_live_scan;
 use crate::views::player::PlayerView;
 #[cfg(target_os = "macos")]
 use crate::views::player::classify_bottom_playback_control_state;
-use crate::views::screen::{self, ScreenView};
+use crate::views::screen::ScreenView;
 use crate::views::sidebar::SidebarView;
 #[cfg(target_os = "macos")]
 use auv_driver::Capture;
@@ -258,7 +258,7 @@ impl LiveObservationProvider {
         )
         .map_err(|error| format!("live observation full-window OCR failed: {error}"))?;
       let recognition = recognition_in_window_space(recognition, &capture);
-      screen::classify_screen(
+      crate::views::screen::classify_screen(
         &recognition,
         Size::new(window.frame.size.width, window.frame.size.height),
       )

--- a/crates/auv-netease-music/src/commands/launch.rs
+++ b/crates/auv-netease-music/src/commands/launch.rs
@@ -1,11 +1,10 @@
 //! Ensure the Windows NetEase Cloud Music application has a visible window.
 
 use std::path::PathBuf;
-use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 
-use crate::windows::{DEFAULT_PROCESS_NAME, ResolveOptions, resolve_window};
+use crate::windows::ResolveOptions;
 
 const POLL_INTERVAL_MS: u64 = 250;
 const FORCE_RENDERER_ACCESSIBILITY_ARG: &str = "--force-renderer-accessibility";
@@ -71,12 +70,15 @@ pub fn run_open_window(inputs: &OpenWindowInputs) -> Result<LaunchResult, String
 
 #[cfg(target_os = "windows")]
 mod platform {
+  use std::path::PathBuf;
   use std::process::Command;
+  use std::time::{Duration, Instant};
 
   use auv_driver::Driver;
   use auv_driver_windows::WindowsDriver;
 
   use super::*;
+  use crate::windows::{DEFAULT_PROCESS_NAME, ResolveOptions, resolve_window};
 
   pub fn run(inputs: &OpenWindowInputs) -> Result<LaunchResult, String> {
     let mut result = LaunchResult::new(inputs);
@@ -192,6 +194,8 @@ mod tests {
 
   #[test]
   fn default_open_window_inputs_target_cloudmusic() {
+    use crate::windows::DEFAULT_PROCESS_NAME;
+
     let inputs = OpenWindowInputs::default();
 
     assert_eq!(inputs.resolve.process_name, DEFAULT_PROCESS_NAME);

--- a/crates/auv-netease-music/src/commands/playback.rs
+++ b/crates/auv-netease-music/src/commands/playback.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::path::PathBuf;
 
 use auv_driver::vision::TextRecognitionOptions;
-use auv_view::{ParserDiagnostic, ScanAppContext, ScanWindowContext, ViewBounds};
+use auv_view::{ParserDiagnostic, ScanAppContext, ScanWindowContext};
 use comfy_table::{Cell, Table, presets::NOTHING};
 use serde::{Deserialize, Serialize};
 
@@ -220,6 +220,7 @@ pub fn run_playback_status_probe(inputs: &PlaybackStatusInputs) -> Result<Playba
     Size, WindowClickStrategy, WindowPoint,
   };
   use auv_driver_macos::MacosDriver;
+  use auv_view::ViewBounds;
 
   std::fs::create_dir_all(&inputs.artifact_dir).map_err(|error| {
     format!(

--- a/crates/auv-netease-music/src/commands/playlist.rs
+++ b/crates/auv-netease-music/src/commands/playlist.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use auv_view::{ParserDiagnostic, ScanAppContext, ScanWindowContext, ViewBounds};
 use serde::{Deserialize, Serialize};
 
-use crate::{Inputs, PlaybackControlState, PlaylistSelectTarget, run_live_scan_until_query};
+use crate::{Inputs, PlaybackControlState, PlaylistSelectTarget};
 
 const PLAYLIST_SELECT_BOTTOM_SAFE_PADDING: f64 = 128.0;
 
@@ -1110,6 +1110,8 @@ fn resolve_playlist_target_for_query(
   ),
   String,
 > {
+  use crate::run_live_scan_until_query;
+
   std::fs::create_dir_all(&inputs.artifact_dir).map_err(|error| {
     format!(
       "failed to create {}: {error}",

--- a/crates/auv-netease-music/src/lib.rs
+++ b/crates/auv-netease-music/src/lib.rs
@@ -53,14 +53,16 @@ use auv_driver::vision::{TextRecognition, TextRecognitionOptions};
 // the `Sidebar*` candidate flavors, the scan-loop functions) stay in this
 // crate because they consume NetEase-shaped observations.
 use auv_driver::{RatioRect, Size};
+#[cfg(target_os = "macos")]
+use auv_view::draw_rect;
 use auv_view::{
   AnchorStrength, BoundaryConfidence, CandidateRole, Confidence, LandmarkUse, ParserDiagnostic,
   ReconstructionOutput, ReconstructionPolicy, ScanAppContext, ScanOptions, ScanWindowContext,
   ScrollBoundarySummary, TopSeekOutcome, VIEW_IR_SCHEMA_VERSION, ViewAction, ViewAnchor, ViewAxis,
   ViewBounds, ViewEvidenceNode, ViewEvidenceSource, ViewLandmark, ViewLayout, ViewNodeKind,
   ViewNodeRecord, ViewObservation, ViewObserver, ViewReconstructionRecord, ViewRegionRecord,
-  ViewScrollable, ViewViewportRecord, confidence_from_ocr, draw_rect, normalize_identity,
-  reconstruct, slug, viewport_contains_center, viewport_fingerprint,
+  ViewScrollable, ViewViewportRecord, confidence_from_ocr, normalize_identity, reconstruct, slug,
+  viewport_contains_center, viewport_fingerprint,
 };
 use clap::ValueEnum;
 use image::{Rgba, RgbaImage};

--- a/crates/auv-netease-music/src/view_parsers/sidebar/target_probe.rs
+++ b/crates/auv-netease-music/src/view_parsers/sidebar/target_probe.rs
@@ -1,7 +1,7 @@
 use image::RgbaImage;
 use serde::{Deserialize, Serialize};
 
-use crate::scroll::policies::detection_motion::{MotionDetectionPolicy, MotionEvidence};
+use crate::scroll::policies::detection_motion::MotionEvidence;
 use crate::view_parsers::sidebar::classify_sidebar_text;
 use crate::{
   SidebarCandidateKind, SidebarViewportCandidate, SidebarViewportObservation, ViewBounds,
@@ -547,6 +547,7 @@ pub(crate) fn capture_sidebar_target_probe(
     &recognition,
   );
   let sidebar_crop = crate::crop_image(&capture.image, sidebar_bounds, capture.scale_factor);
+  use crate::scroll::policies::detection_motion::MotionDetectionPolicy;
   let scroll_motion = previous_sidebar_crop
     .as_ref()
     .map(|previous| MotionDetectionPolicy::default().compare(previous, &sidebar_crop));

--- a/crates/auv-qqmusic/Cargo.toml
+++ b/crates/auv-qqmusic/Cargo.toml
@@ -16,4 +16,3 @@ auv-driver = { path = "../auv-driver" }
 auv-driver-macos = { path = "../auv-driver-macos" }
 clap = { version = "4", features = ["derive"] }
 serde.workspace = true
-serde_json.workspace = true

--- a/src/ax_recognition.rs
+++ b/src/ax_recognition.rs
@@ -1,15 +1,22 @@
+use serde::{Deserialize, Serialize};
+
+#[cfg(target_os = "macos")]
+use serde_json::json;
+#[cfg(target_os = "macos")]
 use std::fs;
+#[cfg(target_os = "macos")]
 use std::path::Path;
 
-use serde::{Deserialize, Serialize};
-use serde_json::json;
-
+#[cfg(target_os = "macos")]
 use crate::candidate_promotion::PromotionProjection;
+#[cfg(target_os = "macos")]
 use crate::contract::{
   ArtifactRef, RecognitionBox, RecognitionResult, RecognitionScope, RecognitionSource,
   RecognitionSurface, RecognizedItem,
 };
+#[cfg(target_os = "macos")]
 use crate::model::{AuvResult, now_millis};
+#[cfg(target_os = "macos")]
 use auv_tracing_driver::recorded_operation::RecordedOperationContext;
 
 #[cfg(target_os = "macos")]

--- a/src/ax_recognition.rs
+++ b/src/ax_recognition.rs
@@ -7,13 +7,12 @@ use std::fs;
 #[cfg(target_os = "macos")]
 use std::path::Path;
 
-#[cfg(target_os = "macos")]
 use crate::candidate_promotion::PromotionProjection;
 #[cfg(target_os = "macos")]
 use crate::contract::{
-  ArtifactRef, RecognitionBox, RecognitionResult, RecognitionScope, RecognitionSource,
-  RecognitionSurface, RecognizedItem,
+  ArtifactRef, RecognitionBox, RecognitionScope, RecognitionSource, RecognitionSurface,
 };
+use crate::contract::{RecognitionResult, RecognizedItem};
 #[cfg(target_os = "macos")]
 use crate::model::{AuvResult, now_millis};
 #[cfg(target_os = "macos")]
@@ -350,6 +349,7 @@ fn window_frame_from_snapshot(snapshot: &ObservedAxTreeSnapshot) -> Option<&Obse
     .map(|node| &node.bounds)
 }
 
+#[cfg(target_os = "macos")]
 fn select_best(
   filtered: &[RecognizedItem],
   policy: &AxRecognitionPolicy,
@@ -435,6 +435,8 @@ fn non_empty_string(value: &str) -> Option<String> {
   }
 }
 
+#[cfg(target_os = "macos")]
+#[cfg(target_os = "macos")]
 fn ax_recognition_temp_json_path(label: &str) -> std::path::PathBuf {
   std::env::temp_dir().join(format!(
     "auv-ax-recognition-{}-{}-{}.json",

--- a/src/ax_recognition.rs
+++ b/src/ax_recognition.rs
@@ -8,11 +8,12 @@ use std::fs;
 use std::path::Path;
 
 use crate::candidate_promotion::PromotionProjection;
+use crate::contract::RecognitionResult;
 #[cfg(target_os = "macos")]
 use crate::contract::{
   ArtifactRef, RecognitionBox, RecognitionScope, RecognitionSource, RecognitionSurface,
+  RecognizedItem,
 };
-use crate::contract::{RecognitionResult, RecognizedItem};
 #[cfg(target_os = "macos")]
 use crate::model::{AuvResult, now_millis};
 #[cfg(target_os = "macos")]

--- a/src/candidate_action_command.rs
+++ b/src/candidate_action_command.rs
@@ -1,34 +1,45 @@
-use std::thread;
-use std::time::Duration;
-
 use serde::{Deserialize, Serialize};
 
+#[cfg(target_os = "macos")]
 use crate::ax_recognition::{AxBestSelectionStrategy, AxRecognitionPolicy};
 #[cfg(target_os = "macos")]
 use crate::ax_recognition::{AxRecognitionRuntimeContext, map_ax_tree_to_recognition_result};
+use crate::candidate_action_decision::CandidateActionKind;
 #[cfg(target_os = "macos")]
 use crate::candidate_action_decision::MacosCandidateActionExecutor;
+#[cfg(target_os = "macos")]
 use crate::candidate_action_decision::{
   CandidateActionDecisionRequest, CandidateActionExecutionConsent,
   CandidateActionExecutionConsentAction, CandidateActionExecutionRequest,
-  CandidateActionExecutionSideEffect, CandidateActionKind, CandidateActionPostActionProbe,
+  CandidateActionExecutionSideEffect, CandidateActionPostActionProbe,
   execute_and_record_single_candidate_action, record_candidate_action_decision_artifact,
 };
 #[cfg(target_os = "macos")]
 use crate::candidate_promotion::ConsentProvenance;
+#[cfg(target_os = "macos")]
 use crate::candidate_promotion::{
   ActionPermission, CandidatePromotion, ConsentGrade, PromotionRefusal,
 };
 #[cfg(target_os = "macos")]
 use crate::candidate_promotion_recording::record_candidate_promotion_artifact_with_recognition_projection;
+#[cfg(target_os = "macos")]
 use crate::candidate_promotion_recording::{
   CandidatePromotionArtifactRequest, CandidatePromotionConsentInput,
   explicit_consent_for_candidate_promotion, freshness_from_capture_backed_recognition,
 };
-use crate::model::{AuvResult, now_millis};
+use crate::model::AuvResult;
+#[cfg(target_os = "macos")]
+use crate::model::now_millis;
+#[cfg(target_os = "macos")]
 use crate::stability::StabilityPolicy;
+#[cfg(target_os = "macos")]
 use auv_driver::Driver;
+#[cfg(target_os = "macos")]
 use auv_tracing_driver::recorded_operation::RecordedOperationContext;
+#[cfg(target_os = "macos")]
+use std::thread;
+#[cfg(target_os = "macos")]
+use std::time::Duration;
 const CANDIDATE_ACTION_PROPOSAL_ARTIFACT_ROLE: &str = "candidate-action-proposal";
 const CANDIDATE_ACTION_PROPOSAL_ARTIFACT_VERSION: &str = "candidate_action_proposal_artifact_v0";
 const OPENAI_RESPONSES_API_URL: &str = "https://api.openai.com/v1/responses";

--- a/src/candidate_action_command.rs
+++ b/src/candidate_action_command.rs
@@ -1,9 +1,9 @@
 use serde::{Deserialize, Serialize};
 
-#[cfg(target_os = "macos")]
 use crate::ax_recognition::{AxBestSelectionStrategy, AxRecognitionPolicy};
 #[cfg(target_os = "macos")]
 use crate::ax_recognition::{AxRecognitionRuntimeContext, map_ax_tree_to_recognition_result};
+use crate::candidate_action_decision::CandidateActionExecutionSideEffect;
 use crate::candidate_action_decision::CandidateActionKind;
 #[cfg(target_os = "macos")]
 use crate::candidate_action_decision::MacosCandidateActionExecutor;
@@ -11,15 +11,14 @@ use crate::candidate_action_decision::MacosCandidateActionExecutor;
 use crate::candidate_action_decision::{
   CandidateActionDecisionRequest, CandidateActionExecutionConsent,
   CandidateActionExecutionConsentAction, CandidateActionExecutionRequest,
-  CandidateActionExecutionSideEffect, CandidateActionPostActionProbe,
-  execute_and_record_single_candidate_action, record_candidate_action_decision_artifact,
+  CandidateActionPostActionProbe, execute_and_record_single_candidate_action,
+  record_candidate_action_decision_artifact,
 };
 #[cfg(target_os = "macos")]
 use crate::candidate_promotion::ConsentProvenance;
+use crate::candidate_promotion::PromotionRefusal;
 #[cfg(target_os = "macos")]
-use crate::candidate_promotion::{
-  ActionPermission, CandidatePromotion, ConsentGrade, PromotionRefusal,
-};
+use crate::candidate_promotion::{ActionPermission, CandidatePromotion, ConsentGrade};
 #[cfg(target_os = "macos")]
 use crate::candidate_promotion_recording::record_candidate_promotion_artifact_with_recognition_projection;
 #[cfg(target_os = "macos")]
@@ -34,7 +33,6 @@ use crate::model::now_millis;
 use crate::stability::StabilityPolicy;
 #[cfg(target_os = "macos")]
 use auv_driver::Driver;
-#[cfg(target_os = "macos")]
 use auv_tracing_driver::recorded_operation::RecordedOperationContext;
 #[cfg(target_os = "macos")]
 use std::thread;

--- a/src/candidate_action_command.rs
+++ b/src/candidate_action_command.rs
@@ -36,7 +36,6 @@ use auv_driver::Driver;
 use auv_tracing_driver::recorded_operation::RecordedOperationContext;
 #[cfg(target_os = "macos")]
 use std::thread;
-#[cfg(target_os = "macos")]
 use std::time::Duration;
 const CANDIDATE_ACTION_PROPOSAL_ARTIFACT_ROLE: &str = "candidate-action-proposal";
 const CANDIDATE_ACTION_PROPOSAL_ARTIFACT_VERSION: &str = "candidate_action_proposal_artifact_v0";

--- a/src/verticals/osu/mod.rs
+++ b/src/verticals/osu/mod.rs
@@ -3,12 +3,12 @@ use std::path::PathBuf;
 
 pub mod query_live_action;
 
+#[cfg(target_os = "macos")]
+use self::query_live_action::InvokeWindowPointClickExecutor;
 use self::query_live_action::{
   QUERY_WIRED_LIVE_ACTION_OPERATION_ID, build_osu_query_wired_live_action_operation_result,
   stage_osu_query_wired_live_action_operation_result,
 };
-#[cfg(target_os = "macos")]
-use self::query_live_action::InvokeWindowPointClickExecutor;
 use auv_game_osu::{
   BenchmarkInputs, BenchmarkOutput, CapturePhase, DatasetExportInputs, DatasetExportOutput,
   DetectionEvalInputs, DetectionEvalOutput, DetectionEvalQualityOutput, DetectionEvalWitnessInputs,

--- a/src/verticals/osu/mod.rs
+++ b/src/verticals/osu/mod.rs
@@ -4,10 +4,11 @@ use std::path::PathBuf;
 pub mod query_live_action;
 
 use self::query_live_action::{
-  InvokeWindowPointClickExecutor, QUERY_WIRED_LIVE_ACTION_OPERATION_ID,
-  build_osu_query_wired_live_action_operation_result,
+  QUERY_WIRED_LIVE_ACTION_OPERATION_ID, build_osu_query_wired_live_action_operation_result,
   stage_osu_query_wired_live_action_operation_result,
 };
+#[cfg(target_os = "macos")]
+use self::query_live_action::InvokeWindowPointClickExecutor;
 use auv_game_osu::{
   BenchmarkInputs, BenchmarkOutput, CapturePhase, DatasetExportInputs, DatasetExportOutput,
   DetectionEvalInputs, DetectionEvalOutput, DetectionEvalQualityOutput, DetectionEvalWitnessInputs,


### PR DESCRIPTION
## Summary

Stacked on #69 (`chore/qodana-suppress-false-positives`). Clears the remaining actionable Qodana findings from report `abdd9c0`:

- **P0:** Gate `deck_atlas_can_load_from_setup_cache` with `#[cfg(target_os = "macos")]` (fixes `RsUnresolvedPath` on Linux)
- **RsUnusedImport (44):** Remove or `cfg`-gate imports flagged on non-macOS/Linux CI analysis across archived lane, drivers, music crates, and osu vertical
- **CargoUnusedDependency (9 verified):** Remove unused `serde_json` / `thiserror` crate deps and root `semver`, `xcap`, `auv-overlay-macos`, `auv-steam`, `auv-view` (balatro) after `cargo check` verification

**Kept:** root `auv-view` dependency — still required by `src/inspect.rs`, `view_parser_read.rs`, etc. (Qodana false positive).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo check`
- [x] `cargo test`
- [x] `cargo test -p auv-game-balatro deck_atlas_can_load_from_setup_cache`
- [x] `git diff --check`
- [ ] Qodana CI green after both PRs merge


Made with [Cursor](https://cursor.com)