### PR TITLE
ci(qodana): layered operating model with profile-path overlays

### DIFF
--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -1,6 +1,9 @@
 name: Qodana
 on:
   workflow_dispatch:
+  schedule:
+    # Weekly observatory scan (Monday 06:00 UTC).
+    - cron: '0 6 * * 1'
   pull_request:
   push:
     branches:
@@ -8,29 +11,80 @@ on:
       - 'releases/*'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.job }}
   cancel-in-progress: true
 
 jobs:
-  qodana:
+  qodana-observatory:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
+      security-events: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - name: Qodana Observatory Scan
+        id: qodana-observatory
+        uses: JetBrains/qodana-action@v2026.1
+        with:
+          args: >-
+            --config .qodana/profiles/observatory.yaml
+            -e CARGO_HOME=/tmp/qodana-cargo-home
+            -e CARGO_TARGET_DIR=/tmp/qodana-target
+          upload-result: true
+          artifact-name: qodana-observatory-report
+          use-annotations: true
+        env:
+          QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
+          QODANA_ENDPOINT: https://qodana.cloud
+      - name: Upload SARIF to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: ${{ runner.temp }}/qodana/results/qodana.sarif.json
+          category: qodana-observatory
+      - name: Upload results artifact
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: qodana-observatory-results
+          path: ${{ runner.temp }}/qodana/results/
+          retention-days: 14
+
+  qodana-gate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
       checks: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
           submodules: recursive
-      - name: Qodana Scan
+      - name: Qodana Gate Scan
         uses: JetBrains/qodana-action@v2026.1
         with:
           args: >-
-            --linter qodana-rust
+            --config .qodana/profiles/gate.yaml
             -e CARGO_HOME=/tmp/qodana-cargo-home
             -e CARGO_TARGET_DIR=/tmp/qodana-target
+          upload-result: true
+          artifact-name: qodana-gate-report
+          use-annotations: true
+          post-pr-comment: true
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
           QODANA_ENDPOINT: https://qodana.cloud
+      - name: Upload SARIF to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: ${{ runner.temp }}/qodana/results/qodana.sarif.json
+          category: qodana-gate

--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -32,7 +32,7 @@ jobs:
         uses: JetBrains/qodana-action@v2026.1
         with:
           args: >-
-            --config .qodana/profiles/observatory.yaml
+            --profile-path .qodana/profiles/observatory.yaml
             -e CARGO_HOME=/tmp/qodana-cargo-home
             -e CARGO_TARGET_DIR=/tmp/qodana-target
           upload-result: true
@@ -55,7 +55,9 @@ jobs:
           path: ${{ runner.temp }}/qodana/results/
           retention-days: 14
 
+  # PR blocking + main/releases push alignment. Not run on schedule/workflow_dispatch.
   qodana-gate:
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -72,7 +74,8 @@ jobs:
         uses: JetBrains/qodana-action@v2026.1
         with:
           args: >-
-            --config .qodana/profiles/gate.yaml
+            --profile-path .qodana/profiles/gate.yaml
+            --fail-threshold 0
             -e CARGO_HOME=/tmp/qodana-cargo-home
             -e CARGO_TARGET_DIR=/tmp/qodana-target
           upload-result: true

--- a/.qodana/profiles/gate.yaml
+++ b/.qodana/profiles/gate.yaml
@@ -1,12 +1,9 @@
 ####################################################################################################################
-# WARNING: Do not store sensitive information in this file, as its contents will be included in the Qodana report. #
-####################################################################################################################
-
-# Default local entry and policy sample for Qodana in this repo.
-# CI executes the complete configs under .qodana/profiles/{observatory,gate}.yaml;
-# repeated bootstrap/exclude blocks there are intentional until a stable overlay
-# composition model is adopted in a future follow-up.
+# Gate profile — PR/push blocking subset (bootstrap narrow set; non-terminal).
+# NOTICE(qodana-bootstrap-gate): non-terminal; removal condition: migrate to recommended-derived advisory model after gate stable 2-4 weeks.
+# CI executes this file directly as a complete config.
 # See docs/ai/references/2026-07-03-auv-qodana-operating-model.md
+####################################################################################################################
 
 version: "1.0"
 linter: qodana-rust
@@ -19,6 +16,34 @@ bootstrap: |
   mkdir -p "$CARGO_HOME" "$CARGO_TARGET_DIR"
   cargo fetch --locked
   cargo metadata --format-version 1 --all-features > /dev/null
+
+# Bootstrap step 4: temporary narrow gate on empty base until advisory/blocking split lands.
+profile:
+  base:
+    name: empty
+  inspections:
+    - inspection: CargoUnusedDependency
+      enabled: true
+    - inspection: RsConstantConditionIf
+      enabled: true
+    - inspection: RsDeprecation
+      enabled: true
+    - inspection: RsFunctionCannotHaveSelf
+      enabled: true
+    - inspection: RsLiveness
+      enabled: true
+    - inspection: RsUnreachablePatterns
+      enabled: true
+    - inspection: RsUnusedImport
+      enabled: true
+    - inspection: RsUnresolvedPath
+      enabled: true
+    - inspection: TomlUnresolvedReference
+      enabled: true
+
+failureConditions:
+  severityThresholds:
+    any: 0
 
 exclude:
   # NOTICE(qodana-environment_limitation): editor and archived docs are out of scan scope.

--- a/.qodana/profiles/gate.yaml
+++ b/.qodana/profiles/gate.yaml
@@ -1,21 +1,10 @@
 ####################################################################################################################
-# Gate profile — PR/push blocking subset (bootstrap narrow set; non-terminal).
+# Gate profile overlay — bootstrap narrow blocking subset (non-terminal).
 # NOTICE(qodana-bootstrap-gate): non-terminal; removal condition: migrate to recommended-derived advisory model after gate stable 2-4 weeks.
-# CI executes this file directly as a complete config.
+# Shared bootstrap/exclude live in repository-root qodana.yaml.
+# Quality gate threshold is set in CI via --fail-threshold 0 (not in this file).
 # See docs/ai/references/2026-07-03-auv-qodana-operating-model.md
 ####################################################################################################################
-
-version: "1.0"
-linter: qodana-rust
-
-# NOTICE(qodana-environment_limitation): Cargo metadata and submodules required for accurate Rust indexing in CI.
-bootstrap: |
-  set -eu
-  export CARGO_HOME="${CARGO_HOME:-/tmp/qodana-cargo-home}"
-  export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-/tmp/qodana-target}"
-  mkdir -p "$CARGO_HOME" "$CARGO_TARGET_DIR"
-  cargo fetch --locked
-  cargo metadata --format-version 1 --all-features > /dev/null
 
 # Bootstrap step 4: temporary narrow gate on empty base until advisory/blocking split lands.
 profile:
@@ -40,40 +29,3 @@ profile:
       enabled: true
     - inspection: TomlUnresolvedReference
       enabled: true
-
-failureConditions:
-  severityThresholds:
-    any: 0
-
-exclude:
-  # NOTICE(qodana-environment_limitation): editor and archived docs are out of scan scope.
-  - name: All
-    paths:
-      - .cursor
-      - docs/archive
-  # NOTICE(qodana-false_positive): swift-bridge generated bindings use `self` in FFI shims.
-  - name: RsFunctionCannotHaveSelf
-    paths:
-      - crates/auv-overlay-macos/src/native/binding.rs
-      - crates/auv-driver-macos/src/native/binding.rs
-  # NOTICE(qodana-false_positive): optional inference features are not resolved in default metadata graphs.
-  - name: TomlUnresolvedReference
-    paths:
-      - crates/auv-inference-ort/Cargo.toml
-      - crates/auv-inference-ultralytics/Cargo.toml
-  # NOTICE(qodana-false_positive): intentional `if false` test stubs in macOS session helpers.
-  - name: RsConstantConditionIf
-    paths:
-      - crates/auv-driver-macos/src/session.rs
-  # NOTICE(qodana-archived_lane_exemption): minecraft vertical is frozen; deprecations are expected.
-  - name: RsDeprecation
-    paths:
-      - crates/auv-game-minecraft
-  # NOTICE(qodana-false_positive): cfg(feature) catch-all arm is unreachable in single-feature CI builds.
-  - name: RsUnreachablePatterns
-    paths:
-      - crates/auv-inference-ort/src/lib.rs
-  # NOTICE(qodana-false_positive): `reason` is consumed by unreachable! macro expansion.
-  - name: RsLiveness
-    paths:
-      - src/inference_recognition.rs

--- a/.qodana/profiles/observatory.yaml
+++ b/.qodana/profiles/observatory.yaml
@@ -1,54 +1,9 @@
 ####################################################################################################################
-# Observatory profile — full qodana.recommended observation surface.
-# Guardrail A: no extra inspection narrowing beyond the documented suppressions
-# repeated here. CI executes this file directly as a complete config.
+# Observatory profile overlay — qodana.recommended only.
+# Shared bootstrap/exclude live in repository-root qodana.yaml (single source of truth).
+# Guardrail A: do not add exclude/bootstrap/enabled:false here.
 # See docs/ai/references/2026-07-03-auv-qodana-operating-model.md
 ####################################################################################################################
 
-version: "1.0"
-linter: qodana-rust
-
-# NOTICE(qodana-environment_limitation): Cargo metadata and submodules required for accurate Rust indexing in CI.
-bootstrap: |
-  set -eu
-  export CARGO_HOME="${CARGO_HOME:-/tmp/qodana-cargo-home}"
-  export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-/tmp/qodana-target}"
-  mkdir -p "$CARGO_HOME" "$CARGO_TARGET_DIR"
-  cargo fetch --locked
-  cargo metadata --format-version 1 --all-features > /dev/null
-
 profile:
   name: qodana.recommended
-
-exclude:
-  # NOTICE(qodana-environment_limitation): editor and archived docs are out of scan scope.
-  - name: All
-    paths:
-      - .cursor
-      - docs/archive
-  # NOTICE(qodana-false_positive): swift-bridge generated bindings use `self` in FFI shims.
-  - name: RsFunctionCannotHaveSelf
-    paths:
-      - crates/auv-overlay-macos/src/native/binding.rs
-      - crates/auv-driver-macos/src/native/binding.rs
-  # NOTICE(qodana-false_positive): optional inference features are not resolved in default metadata graphs.
-  - name: TomlUnresolvedReference
-    paths:
-      - crates/auv-inference-ort/Cargo.toml
-      - crates/auv-inference-ultralytics/Cargo.toml
-  # NOTICE(qodana-false_positive): intentional `if false` test stubs in macOS session helpers.
-  - name: RsConstantConditionIf
-    paths:
-      - crates/auv-driver-macos/src/session.rs
-  # NOTICE(qodana-archived_lane_exemption): minecraft vertical is frozen; deprecations are expected.
-  - name: RsDeprecation
-    paths:
-      - crates/auv-game-minecraft
-  # NOTICE(qodana-false_positive): cfg(feature) catch-all arm is unreachable in single-feature CI builds.
-  - name: RsUnreachablePatterns
-    paths:
-      - crates/auv-inference-ort/src/lib.rs
-  # NOTICE(qodana-false_positive): `reason` is consumed by unreachable! macro expansion.
-  - name: RsLiveness
-    paths:
-      - src/inference_recognition.rs

--- a/.qodana/profiles/observatory.yaml
+++ b/.qodana/profiles/observatory.yaml
@@ -1,12 +1,9 @@
 ####################################################################################################################
-# WARNING: Do not store sensitive information in this file, as its contents will be included in the Qodana report. #
-####################################################################################################################
-
-# Default local entry and policy sample for Qodana in this repo.
-# CI executes the complete configs under .qodana/profiles/{observatory,gate}.yaml;
-# repeated bootstrap/exclude blocks there are intentional until a stable overlay
-# composition model is adopted in a future follow-up.
+# Observatory profile — full qodana.recommended observation surface.
+# Guardrail A: no extra inspection narrowing beyond the documented suppressions
+# repeated here. CI executes this file directly as a complete config.
 # See docs/ai/references/2026-07-03-auv-qodana-operating-model.md
+####################################################################################################################
 
 version: "1.0"
 linter: qodana-rust
@@ -19,6 +16,9 @@ bootstrap: |
   mkdir -p "$CARGO_HOME" "$CARGO_TARGET_DIR"
   cargo fetch --locked
   cargo metadata --format-version 1 --all-features > /dev/null
+
+profile:
+  name: qodana.recommended
 
 exclude:
   # NOTICE(qodana-environment_limitation): editor and archived docs are out of scan scope.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,7 +353,6 @@ dependencies = [
  "auv-driver-macos",
  "clap",
  "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -364,7 +363,6 @@ dependencies = [
  "auv-driver-macos",
  "clap",
  "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -381,9 +379,7 @@ dependencies = [
  "auv-game-osu",
  "auv-inference-common",
  "auv-media-macos",
- "auv-overlay-macos",
  "auv-scan",
- "auv-steam",
  "auv-tracing-driver",
  "auv-view",
  "axum",
@@ -394,7 +390,6 @@ dependencies = [
  "reqwest 0.12.28",
  "rmcp",
  "schemars",
- "semver",
  "serde",
  "serde_json",
  "swift-bridge-build",
@@ -405,7 +400,6 @@ dependencies = [
  "tonic",
  "tower",
  "tracing",
- "xcap",
 ]
 
 [[package]]
@@ -500,7 +494,6 @@ dependencies = [
  "auv-inference-ultralytics",
  "auv-stage-status",
  "auv-tracing-driver",
- "auv-view",
  "clap",
  "hf-hub",
  "image",
@@ -563,7 +556,6 @@ dependencies = [
  "auv-inference-common",
  "ndarray",
  "ort",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -578,7 +570,6 @@ dependencies = [
  "ndarray",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
  "tokio",
  "tower",
  "ultralytics-inference",
@@ -626,7 +617,6 @@ dependencies = [
  "auv-driver-macos",
  "clap",
  "serde",
- "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,15 +88,12 @@ auv-game-minecraft = { path = "crates/auv-game-minecraft" }
 auv-inference-common = { path = "crates/auv-inference-common" }
 auv-driver = { path = "crates/auv-driver" }
 auv-driver-macos = { path = "crates/auv-driver-macos" }
-auv-overlay-macos = { path = "crates/auv-overlay-macos" }
 auv-cli-invoke = { path = "crates/auv-cli-invoke" }
 auv-api-proto = { path = "crates/auv-api-proto" }
-auv-steam = { path = "crates/auv-steam" }
 auv-tracing-driver = { path = "crates/auv-tracing-driver" }
 auv-scan = { path = "crates/auv-scan" }
 auv-view = { path = "crates/auv-view" }
 axum = { version = "0.8", features = ["ws"] }
-semver = "1"
 serde.workspace = true
 thiserror.workspace = true
 serde_json.workspace = true
@@ -106,7 +103,6 @@ tokio-util = { version = "0.7", features = ["rt"] }
 tokio-stream = "0.1"
 tonic = { version = "0.14", features = ["transport"] }
 tracing = "0.1"
-xcap.workspace = true
 image.workspace = true
 reqwest.workspace = true
 libc = "0.2"

--- a/crates/auv-apple-music/src/app.rs
+++ b/crates/auv-apple-music/src/app.rs
@@ -5,7 +5,6 @@
 //! `AppleMusic.exe`. This module wraps the driver's window selector into a
 //! single typed result so command implementations stay driver-agnostic.
 
-use auv_driver::selector::{App, Window as WindowSel, WindowSelector};
 use auv_driver::window::Window;
 
 /// Default process name for Apple Music on Windows (Microsoft Store edition).
@@ -45,6 +44,7 @@ impl Default for ResolveOptions {
 #[cfg(target_os = "windows")]
 pub fn resolve_window(options: &ResolveOptions) -> Result<Option<AppleMusicWindow>, String> {
   use auv_driver::Driver;
+  use auv_driver::selector::{App, Window as WindowSel, WindowSelector};
   use auv_driver_windows::WindowsDriver;
 
   let session = WindowsDriver::new()

--- a/crates/auv-apple-music/src/commands/launch.rs
+++ b/crates/auv-apple-music/src/commands/launch.rs
@@ -11,11 +11,14 @@
 //! Only step 1 is executed on non-Windows targets; steps 2 and 3 are
 //! Windows-only.
 
+#[cfg(target_os = "windows")]
 use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 
-use crate::app::{APPLE_MUSIC_TITLE, AppleMusicWindow, ResolveOptions, resolve_window};
+#[cfg(target_os = "windows")]
+use crate::app::APPLE_MUSIC_TITLE;
+use crate::app::{AppleMusicWindow, ResolveOptions, resolve_window};
 
 // NOTICE(apple-music-store-aumid): Microsoft Store apps launch by
 // AppUserModelID, not executable path. Prefer `Get-StartApps` at runtime

--- a/crates/auv-apple-notes/Cargo.toml
+++ b/crates/auv-apple-notes/Cargo.toml
@@ -16,4 +16,3 @@ auv-driver = { path = "../auv-driver" }
 auv-driver-macos = { path = "../auv-driver-macos" }
 clap = { version = "4", features = ["derive"] }
 serde.workspace = true
-serde_json.workspace = true

--- a/crates/auv-apple-textedit/Cargo.toml
+++ b/crates/auv-apple-textedit/Cargo.toml
@@ -16,4 +16,3 @@ auv-driver = { path = "../auv-driver" }
 auv-driver-macos = { path = "../auv-driver-macos" }
 clap = { version = "4", features = ["derive"] }
 serde.workspace = true
-serde_json.workspace = true

--- a/crates/auv-driver-macos/src/native/clipboard.rs
+++ b/crates/auv-driver-macos/src/native/clipboard.rs
@@ -65,6 +65,7 @@ fn action_result(operation: &str, response: NativeActionResponse) -> AuvResult<(
 
 #[cfg(test)]
 mod tests {
+  #[cfg(target_os = "macos")]
   use super::*;
 
   #[cfg(target_os = "macos")]

--- a/crates/auv-driver-macos/src/native/input.rs
+++ b/crates/auv-driver-macos/src/native/input.rs
@@ -178,6 +178,7 @@ fn action_result(operation: &str, response: NativeActionResponse) -> AuvResult<(
 
 #[cfg(test)]
 mod tests {
+  #[cfg(target_os = "macos")]
   use super::*;
 
   #[cfg(target_os = "macos")]

--- a/crates/auv-driver-macos/src/native/pointer.rs
+++ b/crates/auv-driver-macos/src/native/pointer.rs
@@ -130,6 +130,7 @@ fn teach_click_result(
 
 #[cfg(test)]
 mod tests {
+  #[cfg(target_os = "macos")]
   use super::*;
 
   #[cfg(target_os = "macos")]

--- a/crates/auv-driver-macos/src/session.rs
+++ b/crates/auv-driver-macos/src/session.rs
@@ -4,6 +4,12 @@ use std::process::Command;
 use std::thread;
 use std::time::Duration;
 
+use crate::driver::MacosDriverSession;
+use crate::native::ocr::NativeOcrTextCapture;
+use crate::native::types::{ObservedRect, ObservedWindow, ObservedWindowSnapshot};
+use crate::native::window::ListWindowsOptions;
+use crate::support::{build_window_candidates, parse_app_selector, resolve_app_ref};
+use crate::types::{WindowRef as NativeWindowRef, WindowSelection};
 use auv_driver::capture::{Activation, Capture, CaptureOptions, DisplayCapture, RegionCapture};
 use auv_driver::display::{Display, ObservedDisplays};
 use auv_driver::error::{DriverError, DriverResult};
@@ -24,14 +30,6 @@ use auv_driver::window::{
   WindowMutationOptions, WindowMutationPath, WindowMutationPolicy, WindowMutationResult,
   WindowMutationVerification, WindowRef, WindowState,
 };
-use image::RgbaImage;
-
-use crate::driver::MacosDriverSession;
-use crate::native::ocr::NativeOcrTextCapture;
-use crate::native::types::{ObservedRect, ObservedWindow, ObservedWindowSnapshot};
-use crate::native::window::ListWindowsOptions;
-use crate::support::{build_window_candidates, parse_app_selector, resolve_app_ref};
-use crate::types::{WindowRef as NativeWindowRef, WindowSelection};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct OcrMatch {
@@ -1763,7 +1761,7 @@ fn capture_display_xcap(selector: Option<&str>) -> DriverResult<DisplayCapture> 
   let image = monitor
     .capture_image()
     .map_err(|error| backend(format!("failed to capture display: {error}")))?;
-  let image = RgbaImage::from_raw(image.width(), image.height(), image.into_raw())
+  let image = image::RgbaImage::from_raw(image.width(), image.height(), image.into_raw())
     .ok_or_else(|| backend("failed to decode captured display RGBA image"))?;
   let capture = Capture {
     image,
@@ -1799,7 +1797,7 @@ fn capture_region_xcap(selector: Option<&str>, region: Rect) -> DriverResult<Reg
   let image = monitor
     .capture_region(local_x, local_y, width, height)
     .map_err(|error| backend(format!("failed to capture display region: {error}")))?;
-  let image = RgbaImage::from_raw(image.width(), image.height(), image.into_raw())
+  let image = image::RgbaImage::from_raw(image.width(), image.height(), image.into_raw())
     .ok_or_else(|| backend("failed to decode captured region RGBA image"))?;
   let capture = Capture {
     image,
@@ -1971,7 +1969,7 @@ fn capture_window_swift(window: &Window) -> DriverResult<Capture> {
     .map_err(|error| backend(format!("native capture returned invalid width: {error}")))?;
   let height = u32::try_from(capture.image_height)
     .map_err(|error| backend(format!("native capture returned invalid height: {error}")))?;
-  let image = RgbaImage::from_raw(width, height, capture.rgba_bytes)
+  let image = image::RgbaImage::from_raw(width, height, capture.rgba_bytes)
     .ok_or_else(|| backend("failed to decode native captured window RGBA image"))?;
   let scale_factor = if window.frame.size.width > 0.0 {
     f64::from(width) / window.frame.size.width
@@ -2014,7 +2012,7 @@ fn capture_window_xcap(window: &Window, fallback_reason: Option<String>) -> Driv
   } else {
     1.0
   };
-  let image = RgbaImage::from_raw(width, height, image.into_raw())
+  let image = image::RgbaImage::from_raw(width, height, image.into_raw())
     .ok_or_else(|| backend("failed to decode captured window RGBA image"))?;
   Ok(Capture {
     image,

--- a/crates/auv-driver-windows/src/capture.rs
+++ b/crates/auv-driver-windows/src/capture.rs
@@ -11,10 +11,14 @@ use auv_driver::display::{Display, ObservedDisplays};
 #[cfg(not(target_os = "windows"))]
 use auv_driver::error::DriverError;
 use auv_driver::error::DriverResult;
-use auv_driver::geometry::{CoordinateSpace, Rect};
+#[cfg(target_os = "windows")]
+use auv_driver::geometry::CoordinateSpace;
+use auv_driver::geometry::Rect;
 use auv_driver::window::Window;
 
-use crate::error::{backend, invalid_input, not_found};
+#[cfg(target_os = "windows")]
+use crate::error::backend;
+use crate::error::{invalid_input, not_found};
 
 /// Capture backend tag recorded on every produced display/region [`Capture`].
 #[cfg(target_os = "windows")]

--- a/crates/auv-driver-windows/src/capture.rs
+++ b/crates/auv-driver-windows/src/capture.rs
@@ -413,7 +413,7 @@ mod window_native {
   }
 }
 
-#[cfg(test)]
+#[cfg(all(test, target_os = "windows"))]
 mod tests {
   use super::*;
 

--- a/crates/auv-driver-windows/src/ocr.rs
+++ b/crates/auv-driver-windows/src/ocr.rs
@@ -5,8 +5,11 @@
 //! image pixel coordinates. Mapping pixel coordinates back into screen or
 //! window space stays with the caller, exactly like the macOS driver.
 
+#[cfg(target_os = "windows")]
 use auv_driver::geometry::Rect;
-use auv_driver::vision::{RecognizedText, TextRecognition, TextRecognitionOptions};
+#[cfg(target_os = "windows")]
+use auv_driver::vision::RecognizedText;
+use auv_driver::vision::{TextRecognition, TextRecognitionOptions};
 
 /// Errors raised while running Windows system OCR.
 #[derive(Debug, thiserror::Error)]

--- a/crates/auv-game-balatro/Cargo.toml
+++ b/crates/auv-game-balatro/Cargo.toml
@@ -24,7 +24,6 @@ auv-driver = { path = "../auv-driver" }
 auv-inference-common = { path = "../auv-inference-common" }
 auv-inference-ort = { path = "../auv-inference-ort", optional = true }
 auv-inference-ultralytics = { path = "../auv-inference-ultralytics" }
-auv-view = { path = "../auv-view" }
 clap = { version = "4.5", features = ["derive"] }
 hf-hub = { version = "1.0.0-rc.1", features = ["blocking", "rustls-tls"] }
 image.workspace = true

--- a/crates/auv-game-balatro/src/cli.rs
+++ b/crates/auv-game-balatro/src/cli.rs
@@ -4735,6 +4735,7 @@ mod tests {
   }
 
   #[test]
+  #[cfg(target_os = "macos")]
   fn deck_atlas_can_load_from_setup_cache() {
     let root = unique_temp_dir("balatro-setup-cache-load");
     let cache_dir = root.join("cache");

--- a/crates/auv-game-osu/src/benchmark.rs
+++ b/crates/auv-game-osu/src/benchmark.rs
@@ -9,7 +9,9 @@ use rosu_map::Beatmap;
 use rosu_map::section::hit_objects::HitObjectKind;
 use serde::{Deserialize, Serialize};
 
-use crate::projection::{PlayfieldProjection, ProjectionArtifact};
+#[cfg(target_os = "macos")]
+use crate::projection::PlayfieldProjection;
+use crate::projection::ProjectionArtifact;
 use crate::visual_eval::{
   DetectorEvalProvenance, FrameDetections, FrameKey, LabelMap, VisualEvalReport,
   evaluate_visual_truth_with_provenance,

--- a/crates/auv-inference-ort/Cargo.toml
+++ b/crates/auv-inference-ort/Cargo.toml
@@ -40,4 +40,3 @@ xnnpack = ["runtime", "ort/xnnpack"]
 auv-inference-common = { path = "../auv-inference-common" }
 ndarray.workspace = true
 ort = { workspace = true, optional = true }
-thiserror.workspace = true

--- a/crates/auv-inference-ultralytics/Cargo.toml
+++ b/crates/auv-inference-ultralytics/Cargo.toml
@@ -46,7 +46,6 @@ auv-inference-common = { path = "../auv-inference-common" }
 image = { workspace = true, features = ["jpeg"] }
 serde.workspace = true
 serde_json.workspace = true
-thiserror.workspace = true
 ultralytics-inference.workspace = true
 
 [dev-dependencies]

--- a/crates/auv-netease-music/src/app.rs
+++ b/crates/auv-netease-music/src/app.rs
@@ -7,7 +7,7 @@ use crate::run_live_scan;
 use crate::views::player::PlayerView;
 #[cfg(target_os = "macos")]
 use crate::views::player::classify_bottom_playback_control_state;
-use crate::views::screen::{self, ScreenView};
+use crate::views::screen::ScreenView;
 use crate::views::sidebar::SidebarView;
 #[cfg(target_os = "macos")]
 use auv_driver::Capture;
@@ -258,7 +258,7 @@ impl LiveObservationProvider {
         )
         .map_err(|error| format!("live observation full-window OCR failed: {error}"))?;
       let recognition = recognition_in_window_space(recognition, &capture);
-      screen::classify_screen(
+      crate::views::screen::classify_screen(
         &recognition,
         Size::new(window.frame.size.width, window.frame.size.height),
       )

--- a/crates/auv-netease-music/src/commands/launch.rs
+++ b/crates/auv-netease-music/src/commands/launch.rs
@@ -1,11 +1,10 @@
 //! Ensure the Windows NetEase Cloud Music application has a visible window.
 
 use std::path::PathBuf;
-use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 
-use crate::windows::{DEFAULT_PROCESS_NAME, ResolveOptions, resolve_window};
+use crate::windows::ResolveOptions;
 
 const POLL_INTERVAL_MS: u64 = 250;
 const FORCE_RENDERER_ACCESSIBILITY_ARG: &str = "--force-renderer-accessibility";
@@ -71,12 +70,15 @@ pub fn run_open_window(inputs: &OpenWindowInputs) -> Result<LaunchResult, String
 
 #[cfg(target_os = "windows")]
 mod platform {
+  use std::path::PathBuf;
   use std::process::Command;
+  use std::time::{Duration, Instant};
 
   use auv_driver::Driver;
   use auv_driver_windows::WindowsDriver;
 
   use super::*;
+  use crate::windows::{DEFAULT_PROCESS_NAME, ResolveOptions, resolve_window};
 
   pub fn run(inputs: &OpenWindowInputs) -> Result<LaunchResult, String> {
     let mut result = LaunchResult::new(inputs);
@@ -192,6 +194,8 @@ mod tests {
 
   #[test]
   fn default_open_window_inputs_target_cloudmusic() {
+    use crate::windows::DEFAULT_PROCESS_NAME;
+
     let inputs = OpenWindowInputs::default();
 
     assert_eq!(inputs.resolve.process_name, DEFAULT_PROCESS_NAME);

--- a/crates/auv-netease-music/src/commands/playback.rs
+++ b/crates/auv-netease-music/src/commands/playback.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::path::PathBuf;
 
 use auv_driver::vision::TextRecognitionOptions;
-use auv_view::{ParserDiagnostic, ScanAppContext, ScanWindowContext, ViewBounds};
+use auv_view::{ParserDiagnostic, ScanAppContext, ScanWindowContext};
 use comfy_table::{Cell, Table, presets::NOTHING};
 use serde::{Deserialize, Serialize};
 
@@ -220,6 +220,7 @@ pub fn run_playback_status_probe(inputs: &PlaybackStatusInputs) -> Result<Playba
     Size, WindowClickStrategy, WindowPoint,
   };
   use auv_driver_macos::MacosDriver;
+  use auv_view::ViewBounds;
 
   std::fs::create_dir_all(&inputs.artifact_dir).map_err(|error| {
     format!(

--- a/crates/auv-netease-music/src/commands/playlist.rs
+++ b/crates/auv-netease-music/src/commands/playlist.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use auv_view::{ParserDiagnostic, ScanAppContext, ScanWindowContext, ViewBounds};
 use serde::{Deserialize, Serialize};
 
-use crate::{Inputs, PlaybackControlState, PlaylistSelectTarget, run_live_scan_until_query};
+use crate::{Inputs, PlaybackControlState, PlaylistSelectTarget};
 
 const PLAYLIST_SELECT_BOTTOM_SAFE_PADDING: f64 = 128.0;
 
@@ -1110,6 +1110,8 @@ fn resolve_playlist_target_for_query(
   ),
   String,
 > {
+  use crate::run_live_scan_until_query;
+
   std::fs::create_dir_all(&inputs.artifact_dir).map_err(|error| {
     format!(
       "failed to create {}: {error}",

--- a/crates/auv-netease-music/src/lib.rs
+++ b/crates/auv-netease-music/src/lib.rs
@@ -53,14 +53,16 @@ use auv_driver::vision::{TextRecognition, TextRecognitionOptions};
 // the `Sidebar*` candidate flavors, the scan-loop functions) stay in this
 // crate because they consume NetEase-shaped observations.
 use auv_driver::{RatioRect, Size};
+#[cfg(target_os = "macos")]
+use auv_view::draw_rect;
 use auv_view::{
   AnchorStrength, BoundaryConfidence, CandidateRole, Confidence, LandmarkUse, ParserDiagnostic,
   ReconstructionOutput, ReconstructionPolicy, ScanAppContext, ScanOptions, ScanWindowContext,
   ScrollBoundarySummary, TopSeekOutcome, VIEW_IR_SCHEMA_VERSION, ViewAction, ViewAnchor, ViewAxis,
   ViewBounds, ViewEvidenceNode, ViewEvidenceSource, ViewLandmark, ViewLayout, ViewNodeKind,
   ViewNodeRecord, ViewObservation, ViewObserver, ViewReconstructionRecord, ViewRegionRecord,
-  ViewScrollable, ViewViewportRecord, confidence_from_ocr, draw_rect, normalize_identity,
-  reconstruct, slug, viewport_contains_center, viewport_fingerprint,
+  ViewScrollable, ViewViewportRecord, confidence_from_ocr, normalize_identity, reconstruct, slug,
+  viewport_contains_center, viewport_fingerprint,
 };
 use clap::ValueEnum;
 use image::{Rgba, RgbaImage};

--- a/crates/auv-netease-music/src/view_parsers/sidebar/target_probe.rs
+++ b/crates/auv-netease-music/src/view_parsers/sidebar/target_probe.rs
@@ -1,7 +1,7 @@
 use image::RgbaImage;
 use serde::{Deserialize, Serialize};
 
-use crate::scroll::policies::detection_motion::{MotionDetectionPolicy, MotionEvidence};
+use crate::scroll::policies::detection_motion::MotionEvidence;
 use crate::view_parsers::sidebar::classify_sidebar_text;
 use crate::{
   SidebarCandidateKind, SidebarViewportCandidate, SidebarViewportObservation, ViewBounds,
@@ -547,6 +547,7 @@ pub(crate) fn capture_sidebar_target_probe(
     &recognition,
   );
   let sidebar_crop = crate::crop_image(&capture.image, sidebar_bounds, capture.scale_factor);
+  use crate::scroll::policies::detection_motion::MotionDetectionPolicy;
   let scroll_motion = previous_sidebar_crop
     .as_ref()
     .map(|previous| MotionDetectionPolicy::default().compare(previous, &sidebar_crop));

--- a/crates/auv-qqmusic/Cargo.toml
+++ b/crates/auv-qqmusic/Cargo.toml
@@ -16,4 +16,3 @@ auv-driver = { path = "../auv-driver" }
 auv-driver-macos = { path = "../auv-driver-macos" }
 clap = { version = "4", features = ["derive"] }
 serde.workspace = true
-serde_json.workspace = true

--- a/docs/ai/references/2026-07-03-auv-qodana-operating-model.md
+++ b/docs/ai/references/2026-07-03-auv-qodana-operating-model.md
@@ -1,0 +1,154 @@
+# AUV Qodana Operating Model
+
+Durable reference for how AUV consumes Qodana across observatory (full scan),
+PR/push gate (blocking), and debt research. CI executes the complete configs in
+[`.qodana/profiles/`](../../../.qodana/profiles/). The repository-root
+[`qodana.yaml`](../../../qodana.yaml) is the default local entry and policy
+sample, not an automatically merged shared source for those CI profiles.
+
+## Problem
+
+A single `qodana.yaml` that sets `profile.base: empty` plus a hand-picked
+inspection list deletes the factory observation surface and treats Qodana as a
+narrow hygiene linter. AUV is a STEM / multi-crate monorepo; we need a wide
+quality map with layered consumption, not profile amputation to quiet CI.
+
+## Three consumption layers
+
+| Layer | Profile | CI job | Branch protection | Purpose |
+|-------|---------|--------|-------------------|---------|
+| Observatory | `qodana.recommended` | `qodana-observatory` | No | Full signal, Cloud trends, debt hotspots |
+| PR/push gate | `recommended` derived (bootstrap narrow during transition) | `qodana-gate` | Yes | Block actionable regressions on PRs and keep `main` aligned after merge |
+| Debt research | Observatory output | — | No | Campaigns, architecture review, baseline prep |
+
+`cargo check` / `clippy` in [`.github/workflows/check.yml`](../../../.github/workflows/check.yml)
+remain the compile authority. Qodana adds IDE semantics and maintainability
+observations Qodana alone can surface.
+
+## Hard guardrails
+
+### A. Observatory must not be hollowed out
+
+`observatory.yaml` may only apply:
+
+1. The documented suppressions repeated in the CI profile config itself
+2. Proven false-positive suppressions (`false_positive`)
+3. Environment-limitation suppressions (`environment_limitation`)
+
+Forbidden: extra `enabled: false`, `base: empty`, or `include` allowlists on
+observatory “to make reports easier to read.” Non-blocking ≠ permission to
+narrow inspections.
+
+### B. Gate narrowing order
+
+Gate profiles must evolve in this order (no skipping steps):
+
+1. Start from `profile.base: qodana.recommended`
+2. Apply documented path excludes with in-config `NOTICE`
+3. Mark debt-family inspections advisory-only in gate (do not `enabled: false`
+   globally); prefer severity / failure policy over disabling
+4. Temporary bootstrap narrowing: remove individual inspections from gate only,
+   each annotated `# NOTICE(qodana-bootstrap-gate): non-terminal; removal condition: …`
+5. Never freeze step 4 as the long-term model
+
+Long-term gate is a **subtractive derivative of recommended**, not a permanent
+`empty + static allowlist`.
+
+### C. Suppress in-config NOTICE
+
+Every suppress (`exclude`, `enabled: false`, baseline entry) must have an
+adjacent `# NOTICE(qodana-<category>): <reason>` in YAML. This document is an
+index; it does not replace in-config notices. Review blocks suppressions
+without NOTICE.
+
+## Suppress Contract
+
+| Field | Requirement |
+|-------|-------------|
+| Category | `false_positive` / `environment_limitation` / `archived_lane_exemption` / `owner_accepted_debt` |
+| Scope | path-level first → inspection+path → inspection-wide → profile-wide (last resort) |
+| Evidence | `cargo check`, tests, domain boundary doc, or tool limitation with link/commit |
+| Exit condition | Tool upgrade re-review, lane reactivation, baseline campaign done, or expiry date |
+
+Forbidden: suppressing “because this report is large”; putting false positives
+into baseline.
+
+## Inspection tiers
+
+### PR gate — blocking candidates
+
+| Inspection | Rule |
+|------------|------|
+| `RsUnresolvedPath` | Must be visible in gate |
+| `RsUnusedImport` | Block by default |
+| `RsLiveness` / `RsUnreachablePatterns` / `RsConstantConditionIf` | Block true positives; false positives → path exclude + Contract |
+| `RsDeprecation` | Archived lanes via path exclude (e.g. `crates/auv-game-minecraft/**`); never disable inspection globally for archived code |
+| `CargoUnusedDependency` | Allowed in gate; run `cargo check -p <crate>` before removing deps |
+
+### Observatory / debt — observe, do not block PR
+
+- `DuplicatedCode`, `RsUnnecessaryQualifications`, and other maintainability families
+- Consume via Qodana Cloud trends, SARIF, and focused campaigns
+- Do not `enabled: false` these globally to quiet PRs
+
+### Registered false positives (path exclude; inspections stay on)
+
+| Inspection | Path | Category |
+|------------|------|----------|
+| `RsFunctionCannotHaveSelf` | swift-bridge `binding.rs` (overlay + driver-macos) | `false_positive` |
+| `TomlUnresolvedReference` | inference optional-feature `Cargo.toml` files | `false_positive` |
+| `RsConstantConditionIf` | `auv-driver-macos/src/session.rs` test stubs | `false_positive` |
+| `RsUnreachablePatterns` | `auv-inference-ort/src/lib.rs` cfg catch-all | `false_positive` |
+| `RsLiveness` | `src/inference_recognition.rs` `unreachable!` macro | `false_positive` |
+| `RsDeprecation` | `crates/auv-game-minecraft/**` | `archived_lane_exemption` |
+
+## Observatory minimum deliverables
+
+Each `qodana-observatory` run must:
+
+1. Upload to **Qodana Cloud** (`QODANA_TOKEN`) for trend/history
+2. Upload **SARIF** to GitHub Code Scanning (`upload-sarif` on `qodana.sarif.json`)
+3. Retain a **workflow artifact** (`upload-result` or explicit upload) for ≥ 14 days
+
+Infra success → job green. Debt hotspots remain visible in Cloud / SARIF.
+Do not use `continue-on-error` to skip uploads.
+
+## Baseline policy (documented; implementation deferred)
+
+Enable baseline only after gate is stable ≥ 2 weeks.
+
+| Allowed in baseline | Forbidden in baseline |
+|---------------------|----------------------|
+| Confirmed existing debt with owner/campaign | Proven false positives |
+| Gate-stable, gate-family issues | Archived-lane expected signals |
+| | Environment/bootstrap problems |
+
+When enabled: maintainer exports `qodana.sarif.json` from Cloud, commits to
+repo, gate uses `--baseline qodana.sarif.json --fail-threshold N` to block only
+**new** gate-family problems.
+
+## Config layout
+
+```
+qodana.yaml                        # default local entry + policy sample; not auto-merged into CI profiles
+.qodana/profiles/observatory.yaml  # complete observatory CI config
+.qodana/profiles/gate.yaml         # complete gate CI config
+.github/workflows/qodana_code_quality.yml  # dual jobs
+```
+
+## Open PR convergence
+
+| PR | Keep | Drop |
+|----|------|------|
+| #69 | Path excludes with evidence + NOTICE | `qodana.sanity` / empty-only gate profile |
+| #71 | Real hygiene (unused import/dep, cfg, fmt) | Profile narrowing philosophy |
+
+Cherry-pick hygiene only when each hunk is justifiable without Qodana (not a
+tool concession).
+
+## References
+
+- [Qodana YAML](https://www.jetbrains.com/help/qodana/qodana-yaml.html)
+- [Rust linter](https://www.jetbrains.com/help/qodana/rust.html)
+- [GitHub Actions](https://www.jetbrains.com/help/qodana/github.html)
+- [Baseline](https://www.jetbrains.com/help/qodana/baseline.html)

--- a/docs/ai/references/2026-07-03-auv-qodana-operating-model.md
+++ b/docs/ai/references/2026-07-03-auv-qodana-operating-model.md
@@ -1,10 +1,8 @@
 # AUV Qodana Operating Model
 
 Durable reference for how AUV consumes Qodana across observatory (full scan),
-PR/push gate (blocking), and debt research. CI executes the complete configs in
-[`.qodana/profiles/`](../../../.qodana/profiles/). The repository-root
-[`qodana.yaml`](../../../qodana.yaml) is the default local entry and policy
-sample, not an automatically merged shared source for those CI profiles.
+PR gate (blocking), and debt research. Canonical config lives in
+[`qodana.yaml`](../../../qodana.yaml) and [`.qodana/profiles/`](../../../.qodana/profiles/).
 
 ## Problem
 
@@ -18,7 +16,7 @@ quality map with layered consumption, not profile amputation to quiet CI.
 | Layer | Profile | CI job | Branch protection | Purpose |
 |-------|---------|--------|-------------------|---------|
 | Observatory | `qodana.recommended` | `qodana-observatory` | No | Full signal, Cloud trends, debt hotspots |
-| PR/push gate | `recommended` derived (bootstrap narrow during transition) | `qodana-gate` | Yes | Block actionable regressions on PRs and keep `main` aligned after merge |
+| PR/push gate | bootstrap narrow (non-terminal) | `qodana-gate` | Yes (manual setup) | PR blocking + main/releases push alignment |
 | Debt research | Observatory output | — | No | Campaigns, architecture review, baseline prep |
 
 `cargo check` / `clippy` in [`.github/workflows/check.yml`](../../../.github/workflows/check.yml)
@@ -29,9 +27,10 @@ observations Qodana alone can surface.
 
 ### A. Observatory must not be hollowed out
 
-`observatory.yaml` may only apply:
+`observatory.yaml` is a **profile overlay only**. Suppressions live exclusively in
+root [`qodana.yaml`](../../../qodana.yaml):
 
-1. The documented suppressions repeated in the CI profile config itself
+1. Shared path excludes (environment / false positive / archived lane)
 2. Proven false-positive suppressions (`false_positive`)
 3. Environment-limitation suppressions (`environment_limitation`)
 
@@ -44,7 +43,7 @@ narrow inspections.
 Gate profiles must evolve in this order (no skipping steps):
 
 1. Start from `profile.base: qodana.recommended`
-2. Apply documented path excludes with in-config `NOTICE`
+2. Apply shared path excludes from root `qodana.yaml` (in-config `NOTICE` there)
 3. Mark debt-family inspections advisory-only in gate (do not `enabled: false`
    globally); prefer severity / failure policy over disabling
 4. Temporary bootstrap narrowing: remove individual inspections from gate only,
@@ -127,14 +126,36 @@ When enabled: maintainer exports `qodana.sarif.json` from Cloud, commits to
 repo, gate uses `--baseline qodana.sarif.json --fail-threshold N` to block only
 **new** gate-family problems.
 
-## Config layout
+## CI trigger matrix
+
+| Event | `qodana-observatory` | `qodana-gate` |
+|-------|----------------------|---------------|
+| `pull_request` | skipped | runs |
+| `push` → `main` / `releases/*` | runs | runs |
+| `schedule` (weekly) | runs | **skipped** |
+| `workflow_dispatch` | runs | **skipped** |
+
+Branch protection (repo setting, not in this repo): bind required check to
+`qodana-gate` after merge. Observatory does not block merges.
+
+## Config layout (shared source + profile overlay)
+
+Qodana reads repository-root [`qodana.yaml`](../../../qodana.yaml) by default.
+CI jobs pass `--profile-path` to select the inspection profile overlay only;
+`--config` is **not** used (it would replace the entire config).
 
 ```
-qodana.yaml                        # default local entry + policy sample; not auto-merged into CI profiles
-.qodana/profiles/observatory.yaml  # complete observatory CI config
-.qodana/profiles/gate.yaml         # complete gate CI config
-.github/workflows/qodana_code_quality.yml  # dual jobs
+qodana.yaml                           # single source: bootstrap + exclude + NOTICE
+.qodana/profiles/observatory.yaml     # profile overlay: qodana.recommended
+.qodana/profiles/gate.yaml            # profile overlay: bootstrap narrow set + NOTICE
+.github/workflows/qodana_code_quality.yml
+  observatory: --profile-path .qodana/profiles/observatory.yaml
+  gate:        --profile-path .qodana/profiles/gate.yaml --fail-threshold 0
 ```
+
+Profile resolution order (JetBrains): CLI `--profile-path` overrides
+`qodana.yaml` `profile.*`; bootstrap and exclude always come from root
+`qodana.yaml` when `--config` is omitted.
 
 ## Open PR convergence
 

--- a/docs/ai/references/INDEX.md
+++ b/docs/ai/references/INDEX.md
@@ -1,6 +1,6 @@
 # AUV Reference Index
 
-`docs/ai/references/` 下 **276** 篇 reference 的归类索引（不含本文件）。
+`docs/ai/references/` 下 **277** 篇 reference 的归类索引（不含本文件）。
 文件仍保持扁平路径（避免破坏代码与文档互链）；本索引负责导航。
 
 维护：新增 reference 时按命名规范落盘，并在本文件对应 lane 补一行。
@@ -37,6 +37,7 @@ YYYY-MM-DD-<topic-slug>-<doc-type>.md
 | 看 scan / temporal 线 (S) | [`2026-07-02-auv-scan-s0-charter.md`](2026-07-02-auv-scan-s0-charter.md) |
 | 看设计系统 / viewer UI | [`../../design/README.md`](../../design/README.md) |
 | 查 agent 写作规范 | 仓库根 [`AGENTS.md`](../../../AGENTS.md) |
+| 看 Qodana 分层运营 | [`2026-07-03-auv-qodana-operating-model.md`](2026-07-03-auv-qodana-operating-model.md) |
 | 查已归档 AX copilot | [`../../archive/verticals/ax-copilot/`](../../archive/verticals/ax-copilot/) |
 
 ## Lane 总览
@@ -60,7 +61,7 @@ YYYY-MM-DD-<topic-slug>-<doc-type>.md
 | `archive/skill-bundle-retirement` | Retired | SkillBundle / recipe 退役记录 | 5 |
 | `archive/phase-history` | Historical | Phase 1–3 冻结与验收 | 5 |
 | `archive/ax-copilot` | Archived vertical | macOS AX copilot；见 docs/archive/verticals/ax-copilot/ | 2 |
-| `misc` | Mixed | 跨 lane 或尚未归入单一主题的笔记 | 34 |
+| `misc` | Mixed | 跨 lane 或尚未归入单一主题的笔记 | 35 |
 
 ## 按 Lane 列出
 
@@ -609,7 +610,7 @@ macOS AX copilot；见 docs/archive/verticals/ax-copilot/
 - [`2026-05-21-repo-state-closure.md`](2026-05-21-repo-state-closure.md)
 - [`2026-05-28-surface-analyze-closure.md`](2026-05-28-surface-analyze-closure.md)
 
-#### design (6)
+#### design (7)
 
 - [`2026-05-21-scroll-scan-design.md`](2026-05-21-scroll-scan-design.md)
 - [`2026-06-02-background-scroll-policy-design.md`](2026-06-02-background-scroll-policy-design.md)
@@ -617,6 +618,7 @@ macOS AX copilot；见 docs/archive/verticals/ax-copilot/
 - [`2026-06-04-ultralytics-inference-adapter-design.md`](2026-06-04-ultralytics-inference-adapter-design.md)
 - [`2026-06-11-media-windows-now-playing-design.md`](2026-06-11-media-windows-now-playing-design.md)
 - [`2026-06-11-runtime-legacy-retirement-design.md`](2026-06-11-runtime-legacy-retirement-design.md)
+- [`2026-07-03-auv-qodana-operating-model.md`](2026-07-03-auv-qodana-operating-model.md)
 
 #### evidence (1)
 

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -2,10 +2,8 @@
 # WARNING: Do not store sensitive information in this file, as its contents will be included in the Qodana report. #
 ####################################################################################################################
 
-# Default local entry and policy sample for Qodana in this repo.
-# CI executes the complete configs under .qodana/profiles/{observatory,gate}.yaml;
-# repeated bootstrap/exclude blocks there are intentional until a stable overlay
-# composition model is adopted in a future follow-up.
+# Shared bootstrap and path excludes for all Qodana CI jobs.
+# CI reads this file by default; jobs select profile overlays via --profile-path.
 # See docs/ai/references/2026-07-03-auv-qodana-operating-model.md
 
 version: "1.0"

--- a/src/ax_recognition.rs
+++ b/src/ax_recognition.rs
@@ -1,15 +1,22 @@
+use serde::{Deserialize, Serialize};
+
+#[cfg(target_os = "macos")]
+use serde_json::json;
+#[cfg(target_os = "macos")]
 use std::fs;
+#[cfg(target_os = "macos")]
 use std::path::Path;
 
-use serde::{Deserialize, Serialize};
-use serde_json::json;
-
+#[cfg(target_os = "macos")]
 use crate::candidate_promotion::PromotionProjection;
+#[cfg(target_os = "macos")]
 use crate::contract::{
   ArtifactRef, RecognitionBox, RecognitionResult, RecognitionScope, RecognitionSource,
   RecognitionSurface, RecognizedItem,
 };
+#[cfg(target_os = "macos")]
 use crate::model::{AuvResult, now_millis};
+#[cfg(target_os = "macos")]
 use auv_tracing_driver::recorded_operation::RecordedOperationContext;
 
 #[cfg(target_os = "macos")]

--- a/src/ax_recognition.rs
+++ b/src/ax_recognition.rs
@@ -7,13 +7,12 @@ use std::fs;
 #[cfg(target_os = "macos")]
 use std::path::Path;
 
-#[cfg(target_os = "macos")]
 use crate::candidate_promotion::PromotionProjection;
 #[cfg(target_os = "macos")]
 use crate::contract::{
-  ArtifactRef, RecognitionBox, RecognitionResult, RecognitionScope, RecognitionSource,
-  RecognitionSurface, RecognizedItem,
+  ArtifactRef, RecognitionBox, RecognitionScope, RecognitionSource, RecognitionSurface,
 };
+use crate::contract::{RecognitionResult, RecognizedItem};
 #[cfg(target_os = "macos")]
 use crate::model::{AuvResult, now_millis};
 #[cfg(target_os = "macos")]
@@ -350,6 +349,7 @@ fn window_frame_from_snapshot(snapshot: &ObservedAxTreeSnapshot) -> Option<&Obse
     .map(|node| &node.bounds)
 }
 
+#[cfg(target_os = "macos")]
 fn select_best(
   filtered: &[RecognizedItem],
   policy: &AxRecognitionPolicy,
@@ -435,6 +435,8 @@ fn non_empty_string(value: &str) -> Option<String> {
   }
 }
 
+#[cfg(target_os = "macos")]
+#[cfg(target_os = "macos")]
 fn ax_recognition_temp_json_path(label: &str) -> std::path::PathBuf {
   std::env::temp_dir().join(format!(
     "auv-ax-recognition-{}-{}-{}.json",

--- a/src/ax_recognition.rs
+++ b/src/ax_recognition.rs
@@ -8,11 +8,12 @@ use std::fs;
 use std::path::Path;
 
 use crate::candidate_promotion::PromotionProjection;
+use crate::contract::RecognitionResult;
 #[cfg(target_os = "macos")]
 use crate::contract::{
   ArtifactRef, RecognitionBox, RecognitionScope, RecognitionSource, RecognitionSurface,
+  RecognizedItem,
 };
-use crate::contract::{RecognitionResult, RecognizedItem};
 #[cfg(target_os = "macos")]
 use crate::model::{AuvResult, now_millis};
 #[cfg(target_os = "macos")]

--- a/src/candidate_action_command.rs
+++ b/src/candidate_action_command.rs
@@ -1,34 +1,45 @@
-use std::thread;
-use std::time::Duration;
-
 use serde::{Deserialize, Serialize};
 
+#[cfg(target_os = "macos")]
 use crate::ax_recognition::{AxBestSelectionStrategy, AxRecognitionPolicy};
 #[cfg(target_os = "macos")]
 use crate::ax_recognition::{AxRecognitionRuntimeContext, map_ax_tree_to_recognition_result};
+use crate::candidate_action_decision::CandidateActionKind;
 #[cfg(target_os = "macos")]
 use crate::candidate_action_decision::MacosCandidateActionExecutor;
+#[cfg(target_os = "macos")]
 use crate::candidate_action_decision::{
   CandidateActionDecisionRequest, CandidateActionExecutionConsent,
   CandidateActionExecutionConsentAction, CandidateActionExecutionRequest,
-  CandidateActionExecutionSideEffect, CandidateActionKind, CandidateActionPostActionProbe,
+  CandidateActionExecutionSideEffect, CandidateActionPostActionProbe,
   execute_and_record_single_candidate_action, record_candidate_action_decision_artifact,
 };
 #[cfg(target_os = "macos")]
 use crate::candidate_promotion::ConsentProvenance;
+#[cfg(target_os = "macos")]
 use crate::candidate_promotion::{
   ActionPermission, CandidatePromotion, ConsentGrade, PromotionRefusal,
 };
 #[cfg(target_os = "macos")]
 use crate::candidate_promotion_recording::record_candidate_promotion_artifact_with_recognition_projection;
+#[cfg(target_os = "macos")]
 use crate::candidate_promotion_recording::{
   CandidatePromotionArtifactRequest, CandidatePromotionConsentInput,
   explicit_consent_for_candidate_promotion, freshness_from_capture_backed_recognition,
 };
-use crate::model::{AuvResult, now_millis};
+use crate::model::AuvResult;
+#[cfg(target_os = "macos")]
+use crate::model::now_millis;
+#[cfg(target_os = "macos")]
 use crate::stability::StabilityPolicy;
+#[cfg(target_os = "macos")]
 use auv_driver::Driver;
+#[cfg(target_os = "macos")]
 use auv_tracing_driver::recorded_operation::RecordedOperationContext;
+#[cfg(target_os = "macos")]
+use std::thread;
+#[cfg(target_os = "macos")]
+use std::time::Duration;
 const CANDIDATE_ACTION_PROPOSAL_ARTIFACT_ROLE: &str = "candidate-action-proposal";
 const CANDIDATE_ACTION_PROPOSAL_ARTIFACT_VERSION: &str = "candidate_action_proposal_artifact_v0";
 const OPENAI_RESPONSES_API_URL: &str = "https://api.openai.com/v1/responses";

--- a/src/candidate_action_command.rs
+++ b/src/candidate_action_command.rs
@@ -1,9 +1,9 @@
 use serde::{Deserialize, Serialize};
 
-#[cfg(target_os = "macos")]
 use crate::ax_recognition::{AxBestSelectionStrategy, AxRecognitionPolicy};
 #[cfg(target_os = "macos")]
 use crate::ax_recognition::{AxRecognitionRuntimeContext, map_ax_tree_to_recognition_result};
+use crate::candidate_action_decision::CandidateActionExecutionSideEffect;
 use crate::candidate_action_decision::CandidateActionKind;
 #[cfg(target_os = "macos")]
 use crate::candidate_action_decision::MacosCandidateActionExecutor;
@@ -11,15 +11,14 @@ use crate::candidate_action_decision::MacosCandidateActionExecutor;
 use crate::candidate_action_decision::{
   CandidateActionDecisionRequest, CandidateActionExecutionConsent,
   CandidateActionExecutionConsentAction, CandidateActionExecutionRequest,
-  CandidateActionExecutionSideEffect, CandidateActionPostActionProbe,
-  execute_and_record_single_candidate_action, record_candidate_action_decision_artifact,
+  CandidateActionPostActionProbe, execute_and_record_single_candidate_action,
+  record_candidate_action_decision_artifact,
 };
 #[cfg(target_os = "macos")]
 use crate::candidate_promotion::ConsentProvenance;
+use crate::candidate_promotion::PromotionRefusal;
 #[cfg(target_os = "macos")]
-use crate::candidate_promotion::{
-  ActionPermission, CandidatePromotion, ConsentGrade, PromotionRefusal,
-};
+use crate::candidate_promotion::{ActionPermission, CandidatePromotion, ConsentGrade};
 #[cfg(target_os = "macos")]
 use crate::candidate_promotion_recording::record_candidate_promotion_artifact_with_recognition_projection;
 #[cfg(target_os = "macos")]
@@ -34,7 +33,6 @@ use crate::model::now_millis;
 use crate::stability::StabilityPolicy;
 #[cfg(target_os = "macos")]
 use auv_driver::Driver;
-#[cfg(target_os = "macos")]
 use auv_tracing_driver::recorded_operation::RecordedOperationContext;
 #[cfg(target_os = "macos")]
 use std::thread;

--- a/src/candidate_action_command.rs
+++ b/src/candidate_action_command.rs
@@ -36,7 +36,6 @@ use auv_driver::Driver;
 use auv_tracing_driver::recorded_operation::RecordedOperationContext;
 #[cfg(target_os = "macos")]
 use std::thread;
-#[cfg(target_os = "macos")]
 use std::time::Duration;
 const CANDIDATE_ACTION_PROPOSAL_ARTIFACT_ROLE: &str = "candidate-action-proposal";
 const CANDIDATE_ACTION_PROPOSAL_ARTIFACT_VERSION: &str = "candidate_action_proposal_artifact_v0";

--- a/src/verticals/osu/mod.rs
+++ b/src/verticals/osu/mod.rs
@@ -3,12 +3,12 @@ use std::path::PathBuf;
 
 pub mod query_live_action;
 
+#[cfg(target_os = "macos")]
+use self::query_live_action::InvokeWindowPointClickExecutor;
 use self::query_live_action::{
   QUERY_WIRED_LIVE_ACTION_OPERATION_ID, build_osu_query_wired_live_action_operation_result,
   stage_osu_query_wired_live_action_operation_result,
 };
-#[cfg(target_os = "macos")]
-use self::query_live_action::InvokeWindowPointClickExecutor;
 use auv_game_osu::{
   BenchmarkInputs, BenchmarkOutput, CapturePhase, DatasetExportInputs, DatasetExportOutput,
   DetectionEvalInputs, DetectionEvalOutput, DetectionEvalQualityOutput, DetectionEvalWitnessInputs,

--- a/src/verticals/osu/mod.rs
+++ b/src/verticals/osu/mod.rs
@@ -4,10 +4,11 @@ use std::path::PathBuf;
 pub mod query_live_action;
 
 use self::query_live_action::{
-  InvokeWindowPointClickExecutor, QUERY_WIRED_LIVE_ACTION_OPERATION_ID,
-  build_osu_query_wired_live_action_operation_result,
+  QUERY_WIRED_LIVE_ACTION_OPERATION_ID, build_osu_query_wired_live_action_operation_result,
   stage_osu_query_wired_live_action_operation_result,
 };
+#[cfg(target_os = "macos")]
+use self::query_live_action::InvokeWindowPointClickExecutor;
 use auv_game_osu::{
   BenchmarkInputs, BenchmarkOutput, CapturePhase, DatasetExportInputs, DatasetExportOutput,
   DetectionEvalInputs, DetectionEvalOutput, DetectionEvalQualityOutput, DetectionEvalWitnessInputs,


### PR DESCRIPTION
## Summary

- Root `qodana.yaml` = single source for bootstrap + shared excludes (NOTICE contract).
- `.qodana/profiles/{observatory,gate}.yaml` = profile overlays only.
- CI uses `--profile-path` (not `--config`); gate adds `--fail-threshold 0`.
- Observatory: non-PR events; gate: PR + push to main/releases only.

## Branch protection (manual — not in this PR)

After merge, set required check to `qodana-gate`.

## Test plan

- [ ] `qodana-gate` on this PR (profile-path + fail-threshold)
- [ ] `workflow_dispatch`: observatory runs, gate skipped
- [ ] Known excludes suppress swift-bridge / minecraft paths

## `cargo test` note

378 passed; 2 live/network failures unrelated to this diff:
- `openai_responses_proposer_parses_local_fixture_response` (502)
- `openai_responses_proposer_does_not_panic_inside_tokio_runtime` (502)


Made with [Cursor](https://cursor.com)