### PR TITLE
fix: resolve qodana cloud unresolved-path regressions

### DIFF
--- a/crates/auv-driver-linux/src/atspi_stub.rs
+++ b/crates/auv-driver-linux/src/atspi_stub.rs
@@ -1,0 +1,30 @@
+use auv_driver::error::{DriverError, DriverResult};
+use auv_driver::geometry::Rect;
+use auv_driver::window::Window;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Node {
+  pub depth: usize,
+  pub path: String,
+  pub role: String,
+  pub name: String,
+  pub description: String,
+  pub accessible_id: String,
+  pub value: Option<String>,
+  pub focused: bool,
+  pub bounds: Rect,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct TreeSnapshot {
+  pub window_ref: String,
+  pub nodes: Vec<Node>,
+}
+
+pub fn snapshot_window(_window: &Window) -> DriverResult<TreeSnapshot> {
+  Err(DriverError::unsupported("window.capture_ax_tree"))
+}
+
+pub fn focus_window(_window: &Window) -> DriverResult<()> {
+  Err(DriverError::unsupported("accessibility.focus_node"))
+}

--- a/crates/auv-driver-linux/src/capture/display.rs
+++ b/crates/auv-driver-linux/src/capture/display.rs
@@ -1,6 +1,8 @@
 use auv_driver::display::Display;
 use auv_driver::error::DriverResult;
-use auv_driver::geometry::{CoordinateSpace, Rect};
+#[cfg(any(target_os = "linux", test))]
+use auv_driver::geometry::CoordinateSpace;
+use auv_driver::geometry::Rect;
 
 use crate::error::{backend, not_found};
 
@@ -29,8 +31,14 @@ pub struct DisplayTarget {
   pub display: Display,
 }
 
+#[cfg(target_os = "linux")]
 pub fn list_targets() -> DriverResult<Vec<DisplayTarget>> {
   wayland_display_targets()
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn list_targets() -> DriverResult<Vec<DisplayTarget>> {
+  Err(auv_driver::error::DriverError::unsupported("display.list"))
 }
 
 pub fn resolve_target(
@@ -281,6 +289,7 @@ fn wayland_display_targets() -> DriverResult<Vec<DisplayTarget>> {
     .collect()
 }
 
+#[cfg(target_os = "linux")]
 fn output_target((index, output): (usize, WaylandOutputState)) -> DriverResult<DisplayTarget> {
   let (x, y) = output
     .logical_position

--- a/crates/auv-driver-linux/src/lib.rs
+++ b/crates/auv-driver-linux/src/lib.rs
@@ -8,7 +8,10 @@
 //! lifecycle is wired end to end.
 
 mod accessibility;
+#[cfg(target_os = "linux")]
 mod atspi;
+#[cfg(not(target_os = "linux"))]
+mod atspi_stub;
 mod capture;
 mod clipboard;
 mod descriptor;
@@ -21,6 +24,8 @@ mod permission;
 mod session;
 pub mod vision;
 mod window;
+#[cfg(not(target_os = "linux"))]
+pub(crate) use atspi_stub as atspi;
 
 pub use descriptor::{LINUX_DESKTOP_CAPABILITIES, LinuxDriverDescriptor, linux_driver_descriptor};
 pub use driver::{LinuxDriver, LinuxDriverSession};

--- a/crates/auv-driver-linux/src/native.rs
+++ b/crates/auv-driver-linux/src/native.rs
@@ -1,1 +1,66 @@
+#[cfg(target_os = "linux")]
 pub mod portal;
+
+#[cfg(not(target_os = "linux"))]
+pub mod portal {
+  use auv_driver::error::{DriverError, DriverResult};
+  use auv_driver::geometry::Point;
+  use auv_driver::input::{Click, Scroll};
+
+  // NOTICE(linux-portal-nonlinux-stub): the real portal sessions depend on Linux-only
+  // crates (`zbus`, `pipewire`) wired under target-specific Cargo dependencies. Keep a
+  // narrow unsupported stub on non-Linux targets so cross-target analysis can compile
+  // the crate without pretending those capabilities exist.
+
+  #[derive(Debug, Default)]
+  pub struct PortalClipboard;
+
+  impl PortalClipboard {
+    pub fn open() -> DriverResult<ClipboardSession> {
+      Err(DriverError::unsupported("linux.portal.clipboard"))
+    }
+  }
+
+  #[derive(Debug, Default)]
+  pub struct ClipboardSession;
+
+  impl ClipboardSession {
+    pub fn snapshot(&mut self) -> DriverResult<String> {
+      Err(DriverError::unsupported("linux.portal.clipboard"))
+    }
+
+    pub fn set_text(&mut self, _text: &str) -> DriverResult<()> {
+      Err(DriverError::unsupported("linux.portal.clipboard"))
+    }
+  }
+
+  #[derive(Debug, Default)]
+  pub struct PortalInput;
+
+  impl PortalInput {
+    pub fn open() -> DriverResult<InputSession> {
+      Err(DriverError::unsupported("linux.portal.input"))
+    }
+  }
+
+  #[derive(Debug, Default)]
+  pub struct InputSession;
+
+  impl InputSession {
+    pub fn click_at(&mut self, _point: Point, _click: Click) -> DriverResult<Option<String>> {
+      Err(DriverError::unsupported("linux.portal.input"))
+    }
+
+    pub fn scroll(&mut self, _scroll: Scroll) -> DriverResult<()> {
+      Err(DriverError::unsupported("linux.portal.input"))
+    }
+
+    pub fn key_press(&mut self, _keysym: i32) -> DriverResult<()> {
+      Err(DriverError::unsupported("linux.portal.input"))
+    }
+
+    pub fn key_chord(&mut self, _modifiers: &[i32], _key: i32) -> DriverResult<()> {
+      Err(DriverError::unsupported("linux.portal.input"))
+    }
+  }
+}

--- a/crates/auv-game-balatro/src/cli.rs
+++ b/crates/auv-game-balatro/src/cli.rs
@@ -4160,7 +4160,7 @@ fn load_deck_atlas() -> Option<RgbaImage> {
   None
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(test, target_os = "macos"))]
 fn load_deck_atlas_from_setup_cache(cache_dir: &Path) -> Option<RgbaImage> {
   let deck_atlas_path = cache_dir.join(DECK_ATLAS_CACHE_FILE);
   if !deck_atlas_path.exists() {

--- a/crates/auv-game-minecraft/src/ingest.rs
+++ b/crates/auv-game-minecraft/src/ingest.rs
@@ -438,7 +438,7 @@ mod tests {
         .expect("unix epoch")
         .as_nanos()
     ));
-    std::fs::create_dir_all(&temp).expect("temp dir should create");
+    fs::create_dir_all(&temp).expect("temp dir should create");
     let path = temp.join("telemetry.jsonl");
     fs::write(&path, format!("{}\n", frame_line("frame-1", 1, 1000)))
       .expect("telemetry should write");
@@ -477,9 +477,9 @@ mod tests {
         .expect("unix epoch")
         .as_nanos()
     ));
-    std::fs::create_dir_all(&temp).expect("temp dir should create");
+    fs::create_dir_all(&temp).expect("temp dir should create");
     let path = temp.join("telemetry.jsonl");
-    std::fs::write(&path, format!("{}\n", frame_line("frame-1", 1, 1000)))
+    fs::write(&path, format!("{}\n", frame_line("frame-1", 1, 1000)))
       .expect("telemetry should write");
 
     let frame = read_latest_spatial_frame_newer_than(&path, 1000, TailFrameWaitConfig::new(20, 5))
@@ -488,6 +488,6 @@ mod tests {
 
     assert_eq!(frame.spatial_frame_id, "frame-1");
     assert_eq!(frame.monotonic_timestamp_ms, 1000);
-    let _ = std::fs::remove_dir_all(temp);
+    let _ = fs::remove_dir_all(temp);
   }
 }

--- a/crates/auv-game-minecraft/src/ingest.rs
+++ b/crates/auv-game-minecraft/src/ingest.rs
@@ -208,6 +208,7 @@ fn parse_frame_line(bytes: &[u8]) -> Result<Option<MinecraftSpatialFrame>, Strin
 
 #[cfg(test)]
 mod tests {
+  use std::fs;
   use std::io::Cursor;
   use std::thread;
   use std::time::Duration;


### PR DESCRIPTION
## Summary
- fix Minecraft ingest test imports for cloud analysis
- relax Balatro deck-atlas cache helper cfg for tests
- add non-Linux stubs in auv-driver-linux so cloud cross-target analysis compiles cleanly

## Validation
- cargo check -p auv-driver-linux --target aarch64-apple-darwin
- cargo check -p auv-driver-linux --tests --target aarch64-apple-darwin
- cargo check -p auv-game-minecraft --tests
- cargo check -p auv-game-balatro --tests
- cargo fmt --check --all
- git diff --check