### PR TITLE
test(auv-cli): restore training result parser coverage

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3442,6 +3442,7 @@ mod tests {
     assert!(error.contains("mutually exclusive"));
   }
 
+  #[test]
   fn parse_minecraft_validate_3dgs_training_result_command_requires_manifest() {
     let error = parse_cli(&[
       "minecraft".to_string(),


### PR DESCRIPTION
## Summary

- rebase the remaining valid fix onto current `main`
- restore the missing `#[test]` on the training-result manifest validation parser case
- intentionally omit obsolete warning-only edits that conflict with the archived candidate-action removal (#88) or are already covered on `main`

## Verification

- `cargo fmt --check`
- `git diff --check origin/main...HEAD`
- `cargo check -p auv-cli`
- `cargo test -p auv-cli cli::tests::parse_minecraft_validate_3dgs_training_result_command_requires_manifest -- --exact`
- `cargo test`
- `cargo run --quiet -- invoke --help`