### PR TITLE
feat(inspect): unified netease proof run-detail hint (ACP-2c)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,10 +617,13 @@ dependencies = [
 name = "auv-qqmusic"
 version = "0.0.1"
 dependencies = [
+ "auv-cli-invoke",
  "auv-driver",
  "auv-driver-macos",
+ "auv-tracing-driver",
  "clap",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/auv-qqmusic/Cargo.toml
+++ b/crates/auv-qqmusic/Cargo.toml
@@ -12,7 +12,10 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
+auv-cli-invoke = { path = "../auv-cli-invoke" }
 auv-driver = { path = "../auv-driver" }
 auv-driver-macos = { path = "../auv-driver-macos" }
+auv-tracing-driver = { path = "../auv-tracing-driver" }
 clap = { version = "4", features = ["derive"] }
 serde.workspace = true
+serde_json.workspace = true

--- a/crates/auv-qqmusic/src/cli.rs
+++ b/crates/auv-qqmusic/src/cli.rs
@@ -23,6 +23,15 @@ struct CliArgs {
 enum CliCommand {
   /// Search QQMusic and operate on search results.
   Search(SearchArgs),
+  /// App-local invoke commands (hermetic proofs; not in root default_registry).
+  Invoke(InvokeArgs),
+}
+
+#[derive(Clone, Debug, Args)]
+pub(crate) struct InvokeArgs {
+  /// Arguments passed to the app-local invoke dispatcher (`<command> [options]`).
+  #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+  args: Vec<String>,
 }
 
 #[derive(Clone, Debug, Args)]
@@ -92,39 +101,47 @@ where
   T: Into<std::ffi::OsString> + Clone,
 {
   let args = CliArgs::try_parse_from(args)?;
-  Ok(match args.command {
-    CliCommand::Search(search) => match search.results {
-      None => SearchCommand::Search(SearchSubmit::defaults_with_query(search.query.ok_or_else(
-        || {
-          clap::Error::raw(
-            ErrorKind::MissingRequiredArgument,
-            "auv-qqmusic search requires <query>",
-          )
-        },
-      )?)),
-      Some(SearchSubcommand::Results(results)) => match results.command {
-        SearchResultsSubcommand::Select(args) => {
-          SearchCommand::Results(SearchResultsAction::Select(SearchResultsSelect {
-            app_id: args.app_id,
-            query: args.query,
-            anchor: args.anchor,
-            settle_ms: args.settle_ms,
-            anchor_timeout_ms: args.anchor_timeout_ms,
-          }))
-        }
-        SearchResultsSubcommand::Click(args) => {
-          validate_click_args(&args)?;
-          SearchCommand::Results(SearchResultsAction::Click(SearchResultsClick {
-            app_id: args.app_id,
-            query: args.query,
-            anchor: args.anchor,
-            row: args.row,
-            candidate_ref_json: args.candidate_ref,
-            settle_ms: args.settle_ms,
-            anchor_timeout_ms: args.anchor_timeout_ms,
-          }))
-        }
+  match args.command {
+    CliCommand::Invoke(_) => Err(clap::Error::raw(
+      ErrorKind::InvalidSubcommand,
+      "parse_from does not support invoke; use auv-qqmusic invoke",
+    )),
+    CliCommand::Search(search) => search_command_from_search_args(search),
+  }
+}
+
+fn search_command_from_search_args(search: SearchArgs) -> Result<SearchCommand, clap::Error> {
+  Ok(match search.results {
+    None => SearchCommand::Search(SearchSubmit::defaults_with_query(search.query.ok_or_else(
+      || {
+        clap::Error::raw(
+          ErrorKind::MissingRequiredArgument,
+          "auv-qqmusic search requires <query>",
+        )
       },
+    )?)),
+    Some(SearchSubcommand::Results(results)) => match results.command {
+      SearchResultsSubcommand::Select(args) => {
+        SearchCommand::Results(SearchResultsAction::Select(SearchResultsSelect {
+          app_id: args.app_id,
+          query: args.query,
+          anchor: args.anchor,
+          settle_ms: args.settle_ms,
+          anchor_timeout_ms: args.anchor_timeout_ms,
+        }))
+      }
+      SearchResultsSubcommand::Click(args) => {
+        validate_click_args(&args)?;
+        SearchCommand::Results(SearchResultsAction::Click(SearchResultsClick {
+          app_id: args.app_id,
+          query: args.query,
+          anchor: args.anchor,
+          row: args.row,
+          candidate_ref_json: args.candidate_ref,
+          settle_ms: args.settle_ms,
+          anchor_timeout_ms: args.anchor_timeout_ms,
+        }))
+      }
     },
   })
 }
@@ -158,13 +175,30 @@ fn validate_click_args(args: &SearchResultsClickArgs) -> Result<(), clap::Error>
 }
 
 pub fn run() -> ExitCode {
-  let command = match parse_from(std::env::args_os()) {
+  let cli = match CliArgs::try_parse_from(std::env::args_os()) {
+    Ok(cli) => cli,
+    Err(error) => {
+      let _ = error.print();
+      return ExitCode::from(2);
+    }
+  };
+
+  if let CliCommand::Invoke(args) = cli.command {
+    return crate::invoke::run(&args.args);
+  }
+
+  let CliCommand::Search(search) = cli.command else {
+    unreachable!("invoke handled above");
+  };
+
+  let command = match search_command_from_search_args(search) {
     Ok(command) => command,
     Err(error) => {
       let _ = error.print();
       return ExitCode::from(2);
     }
   };
+
   let mut driver = match MacosQqMusicDriver::open_local() {
     Ok(driver) => driver,
     Err(error) => {

--- a/crates/auv-qqmusic/src/invoke/help.rs
+++ b/crates/auv-qqmusic/src/invoke/help.rs
@@ -1,0 +1,85 @@
+use auv_cli_invoke::{CommandGroup, InvokeCommand, InvokeRegistry};
+
+const BINARY_USAGE: &str = "auv-qqmusic invoke";
+
+pub fn render_help_index(registry: &InvokeRegistry) -> String {
+  let mut help = String::from(
+    "USAGE\n  auv-qqmusic invoke <command> [options]\n\nOPTIONS\n  --dry-run  Validate inputs without writing a store proof\n\nUse auv-qqmusic invoke <command> --help for command-specific options.\n",
+  );
+
+  for group in registry.groups() {
+    if !has_commands(group) {
+      continue;
+    }
+    render_group_index(&mut help, group, 0);
+  }
+
+  help
+}
+
+fn render_group_index(help: &mut String, group: &CommandGroup, depth: usize) {
+  if !has_commands(group) {
+    return;
+  }
+
+  help.push('\n');
+  if depth == 0 {
+    help.push_str(group.heading);
+  } else {
+    help.push_str(&"  ".repeat(depth));
+    help.push_str(group.heading);
+  }
+  help.push('\n');
+
+  for child in &group.children {
+    match child {
+      auv_cli_invoke::CommandNode::Command(command) => {
+        help.push_str(&"  ".repeat(depth + 1));
+        help.push_str(command.id);
+        help.push_str("  ");
+        help.push_str(command.summary);
+        help.push('\n');
+      }
+      auv_cli_invoke::CommandNode::Group(group) => render_group_index(help, group, depth + 1),
+    }
+  }
+}
+
+fn has_commands(group: &CommandGroup) -> bool {
+  group.children.iter().any(|child| match child {
+    auv_cli_invoke::CommandNode::Command(_) => true,
+    auv_cli_invoke::CommandNode::Group(group) => has_commands(group),
+  })
+}
+
+pub fn render_command_help(command: &InvokeCommand) -> String {
+  let mut help = format!("USAGE\n  {BINARY_USAGE} {}", command.id);
+  for arg in command.args {
+    if arg.required {
+      help.push_str(&format!(
+        " --{} <{}>",
+        arg.flag.trim_start_matches("--"),
+        arg.value_name
+      ));
+    } else {
+      help.push_str(&format!(
+        " [--{} <{}>]",
+        arg.flag.trim_start_matches("--"),
+        arg.value_name
+      ));
+    }
+  }
+  help.push_str("\n\n");
+  help.push_str(command.summary);
+  help.push_str("\n\nOPTIONS\n");
+  for arg in command.args {
+    help.push_str(&format!(
+      "  {} <{}>{}\n    {}\n",
+      arg.flag,
+      arg.value_name,
+      if arg.required { "" } else { "  (optional)" },
+      arg.help
+    ));
+  }
+  help
+}

--- a/crates/auv-qqmusic/src/invoke/mod.rs
+++ b/crates/auv-qqmusic/src/invoke/mod.rs
@@ -1,0 +1,168 @@
+mod help;
+mod results_select_proof;
+
+use std::collections::BTreeMap;
+use std::process::ExitCode;
+
+use auv_cli_invoke::{CommandGroup, InvokeCommandInput, InvokeNamespace, InvokeRegistry, command};
+
+pub use help::{render_command_help, render_help_index};
+#[cfg(test)]
+pub(crate) use results_select_proof::hermetic_results_select_proof_fixture_dir;
+
+pub fn qqmusic_registry() -> InvokeRegistry {
+  InvokeRegistry::from_groups(vec![CommandGroup::new("qqmusic", "QQMUSIC").group(
+    CommandGroup::new("search", "Search").command(command::spec(
+      results_select_proof::RESULTS_SELECT_PROOF_COMMAND_ID,
+      InvokeNamespace::Fixture,
+      "Hermetic search results select proof from fixture dir",
+      results_select_proof::RESULTS_SELECT_PROOF_ARGS,
+      results_select_proof::results_select_proof_handler,
+    )),
+  )])
+}
+
+/// Dispatch `auv-qqmusic invoke …` without touching root `default_registry()`.
+pub fn run(tokens: &[String]) -> ExitCode {
+  let registry = qqmusic_registry();
+
+  if tokens.is_empty() || tokens == ["--help"] || tokens == ["-h"] {
+    print!("{}", render_help_index(&registry));
+    return ExitCode::SUCCESS;
+  }
+
+  let mut index = 0usize;
+  let mut dry_run = false;
+  while index < tokens.len() {
+    match tokens[index].as_str() {
+      "--dry-run" => {
+        dry_run = true;
+        index += 1;
+      }
+      "--help" | "-h" if index == 0 => {
+        print!("{}", render_help_index(&registry));
+        return ExitCode::SUCCESS;
+      }
+      _ => break,
+    }
+  }
+
+  let Some(command_id) = tokens.get(index) else {
+    eprintln!("error: invoke requires a command id");
+    print!("{}", render_help_index(&registry));
+    return ExitCode::from(2);
+  };
+
+  if tokens
+    .get(index + 1)
+    .is_some_and(|token| token == "--help" || token == "-h")
+  {
+    let Some(command) = registry.resolve(command_id) else {
+      eprintln!("error: unknown command {command_id}");
+      print!("{}", render_help_index(&registry));
+      return ExitCode::from(2);
+    };
+    print!("{}", render_command_help(command));
+    return ExitCode::SUCCESS;
+  }
+
+  let Some(command) = registry.resolve(command_id) else {
+    eprintln!("error: unknown command {command_id}");
+    print!("{}", render_help_index(&registry));
+    return ExitCode::from(2);
+  };
+
+  let mut inputs = BTreeMap::new();
+  let mut cursor = index + 1;
+  while cursor < tokens.len() {
+    let flag = tokens[cursor].as_str();
+    if flag == "--help" || flag == "-h" {
+      print!("{}", render_command_help(command));
+      return ExitCode::SUCCESS;
+    }
+    if !flag.starts_with("--") {
+      eprintln!("error: unexpected argument {flag}");
+      return ExitCode::from(2);
+    }
+    let key = flag.trim_start_matches("--");
+    let Some(value) = tokens.get(cursor + 1) else {
+      eprintln!("error: flag {flag} requires a value");
+      return ExitCode::from(2);
+    };
+    inputs.insert(key.to_string(), value.clone());
+    cursor += 2;
+  }
+
+  match command.invoke(InvokeCommandInput {
+    command_id: command.id,
+    target_application_id: None,
+    inputs: &inputs,
+    dry_run,
+  }) {
+    Ok(output) => {
+      println!("{}", output.summary);
+      if let Some(run_id) = output.signals.get("run_id") {
+        println!("run_id={run_id}");
+      }
+      if let Some(store_root) = output.signals.get("store_root") {
+        println!("store_root={store_root}");
+      }
+      for limit in &output.known_limits {
+        println!("known_limit: {limit}");
+      }
+      ExitCode::SUCCESS
+    }
+    Err(error) => {
+      eprintln!("error: {error}");
+      ExitCode::from(1)
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{qqmusic_registry, render_command_help, render_help_index, run};
+  use crate::invoke::results_select_proof::RESULTS_SELECT_PROOF_COMMAND_ID;
+
+  #[test]
+  fn invoke_help_uses_app_binary_prefix() {
+    let registry = qqmusic_registry();
+    let help = render_help_index(&registry);
+    assert!(help.contains("auv-qqmusic invoke"));
+    assert!(!help.contains("USAGE\n  auv invoke <command>"));
+
+    let command = registry
+      .resolve(RESULTS_SELECT_PROOF_COMMAND_ID)
+      .expect("command");
+    let command_help = render_command_help(command);
+    assert!(command_help.contains("auv-qqmusic invoke qqmusic.search.resultsSelectProof"));
+    assert!(!command_help.contains("USAGE\n  auv invoke qqmusic.search.resultsSelectProof"));
+  }
+
+  #[test]
+  fn invoke_run_requires_store_root() {
+    use std::process::ExitCode;
+
+    let fixture_dir = crate::invoke::hermetic_results_select_proof_fixture_dir();
+    let exit = run(&[
+      RESULTS_SELECT_PROOF_COMMAND_ID.to_string(),
+      "--fixture-dir".to_string(),
+      fixture_dir.display().to_string(),
+    ]);
+    assert_eq!(exit, ExitCode::from(1));
+  }
+
+  #[test]
+  fn invoke_run_allows_command_help_after_command_flags() {
+    use std::process::ExitCode;
+
+    let fixture_dir = crate::invoke::hermetic_results_select_proof_fixture_dir();
+    let exit = run(&[
+      RESULTS_SELECT_PROOF_COMMAND_ID.to_string(),
+      "--fixture-dir".to_string(),
+      fixture_dir.display().to_string(),
+      "--help".to_string(),
+    ]);
+    assert_eq!(exit, ExitCode::SUCCESS);
+  }
+}

--- a/crates/auv-qqmusic/src/invoke/results_select_proof.rs
+++ b/crates/auv-qqmusic/src/invoke/results_select_proof.rs
@@ -1,0 +1,356 @@
+use std::fs;
+use std::path::Path;
+#[cfg(test)]
+use std::path::PathBuf;
+
+use auv_cli_invoke::{
+  ArgSpec, InvokeCommandInput, InvokeCommandOutput, InvokeCommandResult, arg::FIXTURE_DIR,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::recording::{QQ_MUSIC_SEARCH_SELECT_RESULT_ROLE, persist_search_select_proof};
+use crate::search::SearchAnchorMatch;
+
+pub const RESULTS_SELECT_PROOF_COMMAND_ID: &str = "qqmusic.search.resultsSelectProof";
+pub const SELECT_RESULT_FILE: &str = "select-result.json";
+const EXPECTED_COMMAND: &str = "search.results.select";
+
+pub const RESULTS_SELECT_PROOF_ARGS: &[ArgSpec] = &[
+  FIXTURE_DIR,
+  ArgSpec {
+    flag: "--store-root",
+    value_name: "PATH",
+    required: true,
+    help: "Local store root where the select-proof run is persisted.",
+  },
+];
+
+/// Wire document aligned with [`crate::search::SearchCommandReport`] for hermetic fixtures.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SearchSelectProofDocument {
+  pub command: String,
+  pub steps: Vec<SearchSelectProofStep>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub anchor: Option<SearchAnchorMatch>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub unsupported: Option<String>,
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  pub known_limits: Vec<String>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub run_id: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SearchSelectProofStep {
+  pub step_id: String,
+  pub summary: String,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub input_action_result: Option<auv_driver::InputActionResult>,
+}
+
+pub fn build_select_document_from_fixture_dir(
+  fixture_dir: &Path,
+) -> Result<SearchSelectProofDocument, String> {
+  if !fixture_dir.is_dir() {
+    return Err(format!(
+      "fixture directory does not exist: {}",
+      fixture_dir.display()
+    ));
+  }
+
+  let fixture_path = fixture_dir.join(SELECT_RESULT_FILE);
+  if !fixture_path.is_file() {
+    return Err(format!(
+      "fixture file missing at {}",
+      fixture_path.display()
+    ));
+  }
+
+  let bytes = fs::read(&fixture_path)
+    .map_err(|error| format!("failed to read {}: {error}", fixture_path.display()))?;
+  let mut document: SearchSelectProofDocument =
+    serde_json::from_slice(&bytes).map_err(|error| {
+      format!(
+        "failed to parse {} as search select proof document: {error}",
+        fixture_path.display()
+      )
+    })?;
+
+  if document.command != EXPECTED_COMMAND {
+    return Err(format!(
+      "fixture command must be {EXPECTED_COMMAND}; got {}",
+      document.command
+    ));
+  }
+
+  if let Some(query) = read_optional_query_fixture(fixture_dir)? {
+    document.known_limits.push(format!("fixture_query:{query}"));
+  }
+
+  Ok(document)
+}
+
+fn read_optional_query_fixture(fixture_dir: &Path) -> Result<Option<String>, String> {
+  let query_path = fixture_dir.join("query.txt");
+  if !query_path.is_file() {
+    return Ok(None);
+  }
+  let query = fs::read_to_string(&query_path)
+    .map_err(|error| format!("failed to read {}: {error}", query_path.display()))?
+    .trim()
+    .to_string();
+  if query.is_empty() {
+    return Err(format!("{} must not be empty", query_path.display()));
+  }
+  Ok(Some(query))
+}
+
+pub fn results_select_proof_handler(input: InvokeCommandInput<'_>) -> InvokeCommandResult {
+  let fixture_dir = required_input(&input, "fixture-dir")?;
+  let store_root = required_input(&input, "store-root")?;
+  let fixture_path = Path::new(fixture_dir);
+
+  let preview = build_select_document_from_fixture_dir(fixture_path)?;
+
+  if input.dry_run {
+    let mut output = InvokeCommandOutput::new(format!(
+      "validated hermetic search select proof fixture at {}",
+      fixture_dir
+    ));
+    output.verification = Some("dry-run; no store proof written".to_string());
+    output
+      .known_limits
+      .push("hermetic_fixture_only".to_string());
+    output
+      .signals
+      .insert("fixture_dir".to_string(), fixture_dir.to_string());
+    output
+      .signals
+      .insert("command".to_string(), preview.command.clone());
+    if let Some(anchor) = &preview.anchor {
+      output
+        .signals
+        .insert("anchor_text".to_string(), anchor.text.clone());
+    }
+    return Ok(output);
+  }
+
+  let run_id = persist_search_select_proof(Path::new(store_root), |persisted_run_id| {
+    let mut document = preview.clone();
+    document.run_id = Some(persisted_run_id.to_string());
+    serde_json::to_vec_pretty(&document)
+      .map_err(|error| format!("failed to serialize search select proof document: {error}"))
+  })?;
+
+  let mut output = InvokeCommandOutput::new(format!(
+    "persisted hermetic search select proof run {run_id} under {}",
+    store_root
+  ));
+  output.verification =
+    Some("hermetic fixture proof only; no live search or semantic success claim".to_string());
+  output
+    .known_limits
+    .push("hermetic_fixture_only".to_string());
+  output.signals.insert("run_id".to_string(), run_id.clone());
+  output
+    .signals
+    .insert("store_root".to_string(), store_root.to_string());
+  output.signals.insert(
+    "artifact_role".to_string(),
+    QQ_MUSIC_SEARCH_SELECT_RESULT_ROLE.to_string(),
+  );
+  Ok(output)
+}
+
+fn required_input<'a>(input: &InvokeCommandInput<'a>, key: &str) -> Result<&'a str, String> {
+  input
+    .inputs
+    .get(key)
+    .map(String::as_str)
+    .filter(|value| !value.is_empty())
+    .ok_or_else(|| format!("{RESULTS_SELECT_PROOF_COMMAND_ID} requires --{key}"))
+}
+
+#[cfg(test)]
+pub fn hermetic_results_select_proof_fixture_dir() -> PathBuf {
+  PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/select-proof/hermetic_v0")
+}
+
+#[cfg(test)]
+mod tests {
+  use std::collections::BTreeMap;
+  use std::fs;
+
+  use auv_cli_invoke::default_registry;
+  use auv_tracing_driver::LocalStore;
+
+  use super::*;
+  use crate::invoke::qqmusic_registry;
+
+  #[test]
+  fn build_select_document_from_fixture_dir_reads_hermetic_fixture() {
+    let fixture_dir = hermetic_results_select_proof_fixture_dir();
+    let document =
+      build_select_document_from_fixture_dir(&fixture_dir).expect("fixture should parse");
+    assert_eq!(document.command, EXPECTED_COMMAND);
+    assert!(document.anchor.is_some());
+    assert!(
+      document
+        .known_limits
+        .iter()
+        .any(|limit| limit.contains("hermetic") || limit.contains("fixture_query"))
+    );
+  }
+
+  #[test]
+  fn qqmusic_search_results_select_proof_is_registered_in_qqmusic_registry() {
+    let registry = qqmusic_registry();
+    let command = registry
+      .resolve(RESULTS_SELECT_PROOF_COMMAND_ID)
+      .expect("resultsSelectProof should resolve");
+    assert_eq!(command.id, RESULTS_SELECT_PROOF_COMMAND_ID);
+  }
+
+  #[test]
+  fn qqmusic_search_results_select_proof_not_in_default_registry() {
+    assert!(
+      default_registry()
+        .resolve(RESULTS_SELECT_PROOF_COMMAND_ID)
+        .is_none()
+    );
+  }
+
+  #[test]
+  fn results_select_proof_fixture_writes_run_and_artifact() {
+    let root = std::env::temp_dir().join(format!("auv-acp-b-select-proof-{}", std::process::id()));
+    let store_root = root.join("store");
+    let _ = fs::remove_dir_all(&root);
+
+    let mut inputs = BTreeMap::new();
+    inputs.insert(
+      "fixture-dir".to_string(),
+      hermetic_results_select_proof_fixture_dir()
+        .display()
+        .to_string(),
+    );
+    inputs.insert("store-root".to_string(), store_root.display().to_string());
+
+    let registry = qqmusic_registry();
+    let command = registry
+      .resolve(RESULTS_SELECT_PROOF_COMMAND_ID)
+      .expect("command");
+    let output = command
+      .invoke(InvokeCommandInput {
+        command_id: command.id,
+        target_application_id: None,
+        inputs: &inputs,
+        dry_run: false,
+      })
+      .expect("handler");
+
+    let run_id = output.signals.get("run_id").expect("run_id signal");
+    let store = LocalStore::new(store_root.clone()).expect("store");
+    let run = store.read_run(run_id).expect("run");
+    assert!(
+      run
+        .artifacts
+        .iter()
+        .any(|artifact| artifact.role == QQ_MUSIC_SEARCH_SELECT_RESULT_ROLE)
+    );
+
+    let _ = fs::remove_dir_all(&root);
+  }
+
+  #[test]
+  fn results_select_proof_run_uses_qqmusic_runspec() {
+    let root = std::env::temp_dir().join(format!("auv-acp-b-runspec-{}", std::process::id()));
+    let store_root = root.join("store");
+    let _ = fs::remove_dir_all(&root);
+
+    let mut inputs = BTreeMap::new();
+    inputs.insert(
+      "fixture-dir".to_string(),
+      hermetic_results_select_proof_fixture_dir()
+        .display()
+        .to_string(),
+    );
+    inputs.insert("store-root".to_string(), store_root.display().to_string());
+
+    let registry = qqmusic_registry();
+    let command = registry
+      .resolve(RESULTS_SELECT_PROOF_COMMAND_ID)
+      .expect("command");
+    command
+      .invoke(InvokeCommandInput {
+        command_id: command.id,
+        target_application_id: None,
+        inputs: &inputs,
+        dry_run: false,
+      })
+      .expect("handler");
+
+    let store = LocalStore::new(store_root.clone()).expect("store");
+    let runs = store.list_runs().expect("runs");
+    assert_eq!(runs.len(), 1);
+    let run = store.read_run(runs[0].run_id.as_str()).expect("run");
+    let root_span = run
+      .spans
+      .iter()
+      .find(|span| span.parent_span_id.is_none())
+      .expect("root span");
+    assert_eq!(root_span.name, "auv.qqmusic.search.select");
+
+    let _ = fs::remove_dir_all(&root);
+  }
+
+  #[test]
+  fn results_select_proof_requires_store_root() {
+    let mut inputs = BTreeMap::new();
+    inputs.insert(
+      "fixture-dir".to_string(),
+      hermetic_results_select_proof_fixture_dir()
+        .display()
+        .to_string(),
+    );
+
+    let registry = qqmusic_registry();
+    let command = registry
+      .resolve(RESULTS_SELECT_PROOF_COMMAND_ID)
+      .expect("command");
+    let error = command
+      .invoke(InvokeCommandInput {
+        command_id: command.id,
+        target_application_id: None,
+        inputs: &inputs,
+        dry_run: false,
+      })
+      .expect_err("missing store-root should fail");
+
+    assert!(error.contains("store-root"));
+  }
+
+  #[test]
+  fn search_select_proof_document_round_trips_anchor_point() {
+    use auv_driver::Point;
+
+    let document = SearchSelectProofDocument {
+      command: EXPECTED_COMMAND.to_string(),
+      steps: vec![SearchSelectProofStep {
+        step_id: "select-result".to_string(),
+        summary: "fixture".to_string(),
+        input_action_result: None,
+      }],
+      anchor: Some(SearchAnchorMatch {
+        text: "Cure For Me".to_string(),
+        confidence: 0.9,
+        point: Point { x: 10.0, y: 20.0 },
+      }),
+      unsupported: None,
+      known_limits: vec!["hermetic_fixture_only".to_string()],
+      run_id: None,
+    };
+    let json = serde_json::to_vec(&document).expect("serialize");
+    let decoded: SearchSelectProofDocument = serde_json::from_slice(&json).expect("deserialize");
+    assert_eq!(decoded, document);
+  }
+}

--- a/crates/auv-qqmusic/src/lib.rs
+++ b/crates/auv-qqmusic/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod cli;
 pub mod driver;
+mod invoke;
+mod recording;
 pub mod search;
 
 pub use driver::{MacosQqMusicDriver, OperationResult, QqMusicDriver};

--- a/crates/auv-qqmusic/src/recording.rs
+++ b/crates/auv-qqmusic/src/recording.rs
@@ -1,0 +1,46 @@
+//! Hermetic run storage for qqmusic search select proof (ACP-B).
+
+use std::path::Path;
+
+use auv_tracing_driver::recorded_operation::RecordedOperationContext;
+use auv_tracing_driver::{LocalStore, RunRecordingBackend, RunSpec, RunType};
+
+pub const QQ_MUSIC_SEARCH_SELECT_RESULT_ROLE: &str = "qqmusic-search-select-result";
+
+pub fn persist_search_select_proof(
+  store_root: &Path,
+  build_result_json: impl FnOnce(&str) -> Result<Vec<u8>, String>,
+) -> Result<String, String> {
+  let store = LocalStore::new(store_root.to_path_buf()).map_err(|error| error.to_string())?;
+  let recording = RunRecordingBackend::local_only(store).handle();
+
+  let output = recording
+    .run_recorded_operation(
+      RunSpec::new(RunType::Command, "auv.qqmusic.search.select"),
+      "qqmusic search select store proof",
+      |ctx| persist_select_proof_in_recorded_context(ctx, build_result_json),
+    )
+    .map_err(|error| error.to_string())?;
+
+  Ok(output.run_id.as_str().to_string())
+}
+
+fn persist_select_proof_in_recorded_context<F>(
+  ctx: &mut RecordedOperationContext<'_>,
+  build_result_json: F,
+) -> Result<String, String>
+where
+  F: FnOnce(&str) -> Result<Vec<u8>, String>,
+{
+  let run_id = ctx.run_id().as_str().to_string();
+  let result_json = build_result_json(&run_id)?;
+  ctx
+    .stage_artifact_bytes_with_ref(
+      QQ_MUSIC_SEARCH_SELECT_RESULT_ROLE,
+      result_json,
+      "qqmusic-search-select-result.json",
+      Some("qqmusic search select proof".to_string()),
+    )
+    .map_err(|error| error.to_string())?;
+  Ok(run_id)
+}

--- a/crates/auv-qqmusic/tests/fixtures/select-proof/hermetic_v0/query.txt
+++ b/crates/auv-qqmusic/tests/fixtures/select-proof/hermetic_v0/query.txt
@@ -1,0 +1,1 @@
+hermetic-fixture

--- a/crates/auv-qqmusic/tests/fixtures/select-proof/hermetic_v0/select-result.json
+++ b/crates/auv-qqmusic/tests/fixtures/select-proof/hermetic_v0/select-result.json
@@ -1,0 +1,23 @@
+{
+  "command": "search.results.select",
+  "steps": [
+    {
+      "step_id": "select-result",
+      "summary": "hermetic fixture single-click on anchored search result",
+      "input_action_result": null
+    }
+  ],
+  "anchor": {
+    "text": "Cure For Me",
+    "confidence": 0.92,
+    "point": {
+      "x": 412.0,
+      "y": 318.0
+    }
+  },
+  "unsupported": null,
+  "known_limits": [
+    "hermetic_fixture_only",
+    "proof_class:hermetic"
+  ]
+}

--- a/docs/ai/references/2026-07-05-auv-core-app-command-pack-gate.md
+++ b/docs/ai/references/2026-07-05-auv-core-app-command-pack-gate.md
@@ -5,9 +5,13 @@
 
 ## Gate conditions (all required)
 
-1. [L8 closeout](2026-07-05-auv-core-l8-closeout-review.md) verdict ∈ `{ close, close_for_core_seam_surface_gap_only }`
+1. [L8 closeout](2026-07-05-auv-core-l8-closeout-review.md) verdict ∈ `{ close, close_for_core_seam_surface_gap_only }` (or [L8-R2](2026-07-06-auv-core-l8-r2-post-acp-closeout-review.md) `close_with_documented_gaps` for continued packaging)
 2. [L9 inspect surface](2026-07-05-auv-core-l9-inspect-surface-handoff.md) viewer hard acceptance green
 3. Owner names target app + command pack slice
+
+## Orthogonality callout (mandatory in every ACP handoff)
+
+> **Pack pass ≠ seam re-proof.** Completing an App Command Pack (hermetic invoke + persist + inspect JSON) does **not** upgrade the [L8](2026-07-05-auv-core-l8-closeout-review.md) / [L8-R2](2026-07-06-auv-core-l8-r2-post-acp-closeout-review.md) core action seam verdict. ACP lanes do not write `candidate-action-execution`, `action_resolver_decision`, or `ActionTransitionLineage` producer facts unless a separate owner-approved L8b slice says so.
 
 ## Reuse (do not reinvent)
 

--- a/docs/ai/references/2026-07-05-auv-netease-music-acp-1-handoff.md
+++ b/docs/ai/references/2026-07-05-auv-netease-music-acp-1-handoff.md
@@ -3,6 +3,8 @@
 **Date:** 2026-07-05  
 **Prerequisite:** [ACP gate](2026-07-05-auv-core-app-command-pack-gate.md), [L8 closeout](2026-07-05-auv-core-l8-closeout-review.md), [L9 inspect surface](2026-07-05-auv-core-l9-inspect-surface-handoff.md)
 
+> **Orthogonality:** ACP-1 packaging success does not re-validate or close the L8b candidate-action seam. See [ACP gate orthogonality callout](2026-07-05-auv-core-app-command-pack-gate.md#orthogonality-callout-mandatory-in-every-acp-handoff).
+
 ## Pack identity
 
 | Field | Value |

--- a/docs/ai/references/2026-07-05-auv-netease-music-acp-1-handoff.md
+++ b/docs/ai/references/2026-07-05-auv-netease-music-acp-1-handoff.md
@@ -74,8 +74,10 @@ git diff --check
 
 ## ACP-1c landed (viewer)
 
-- Run-detail panel `#netease-select-proof-hint` when root span is `auv.netease.playlist.select` and artifacts include `netease-playlist-select-result`.
-- Generic label only: **NetEase playlist select proof** (no `selectProof` wording).
+Superseded by ACP-2c unified panel — see [ACP-2 handoff](2026-07-05-auv-netease-music-acp-2-handoff.md#acp-2c-landed-viewer).
+
+- Run-detail panel `#netease-proof-hint` (unified) shows **NetEase playlist select proof** when root span is `auv.netease.playlist.select` and artifacts include `netease-playlist-select-result`.
+- Generic labels only (no `selectProof` wording).
 
 ## Next slices (not ACP-1)
 

--- a/docs/ai/references/2026-07-05-auv-netease-music-acp-2-handoff.md
+++ b/docs/ai/references/2026-07-05-auv-netease-music-acp-2-handoff.md
@@ -56,7 +56,29 @@ Same as ACP-1: `InvokeNamespace::Fixture` is an internal placeholder when buildi
 - View-memory / reacquire / lineage manifest to artifact-dir
 - L8b, S-line expansion, transport/playback commands
 - `GET /runs` list schema changes
-- **ACP-2c viewer hint** (defer to unified proof-pack inspect design)
+- Invoke vs product run distinction in viewer (see ACP-2c limits)
+
+## ACP-2c landed (viewer)
+
+Unified run-detail panel `#netease-proof-hint` in [`inspect_server_viewer.html`](../../../src/inspect_server_viewer.html):
+
+| Match | Label |
+|-------|-------|
+| Root span `auv.netease.playlist.select` + artifact `netease-playlist-select-result` | NetEase playlist select proof |
+| Root span `auv.netease.playlist.ls` + artifact `netease-playlist-sidebar-scan` | NetEase playlist sidebar scan proof |
+
+**Limits:** viewer does not distinguish invoke `sidebarScanProof` from product `playlist ls --store-root` (shared RunSpec + artifact). Labels are generic; no invoke command ids in copy.
+
+This is **viewer polish only** — not new inspect read surface or product-ready pack graduation.
+
+## ACP-2 hermetic packaging complete
+
+Documents the minimum hermetic observe + act packaging slice for NetEase Music (not product-ready or full ACP product closure):
+
+| Slice | Invoke | RunSpec | Artifact | Viewer |
+|-------|--------|---------|----------|--------|
+| ACP-1 act | `selectProof` | `auv.netease.playlist.select` | `netease-playlist-select-result` | unified hint row |
+| ACP-2 observe | `sidebarScanProof` | `auv.netease.playlist.ls` | `netease-playlist-sidebar-scan` | unified hint row |
 
 ## Persist-only `Inputs`
 
@@ -66,6 +88,7 @@ ACP-2 invoke constructs **minimal** [`Inputs`](../../../crates/auv-netease-music
 
 ```sh
 cargo fmt --check && cargo check
+cargo test -p auv-cli inspect_server::tests::viewer_renders_netease_proof_hint_hooks
 cargo test -p auv-netease-music sidebar_scan_proof
 cargo test -p auv-netease-music select_proof
 cargo test -p auv-netease-music recording::
@@ -75,9 +98,7 @@ git diff --check
 
 `invoke --help` must list **both** `netease.playlist.selectProof` and `netease.playlist.sidebarScanProof`.
 
-## Pack graduation (ACP-1 + ACP-2)
-
-Minimum observe + act hermetic pack:
+## Hermetic packaging reference (ACP-1 + ACP-2)
 
 | Slice | Invoke id | RunSpec | Artifact role |
 |-------|-----------|---------|---------------|
@@ -88,7 +109,8 @@ Minimum observe + act hermetic pack:
 
 | Slice | Gate |
 |-------|------|
-| ACP-2c | Unified proof-pack viewer / inspect panel (defer) |
+| Invoke vs product viewer distinction | Owner-approved; span/event or artifact `proof_class` signal |
+| Unified proof-pack deep-read panel | Owner-approved |
 | Live `netease.playlist.ls` invoke | Owner-approved |
 | Scan→select chained invoke | Owner-approved |
 | L8b reconnect | Failing evidence required |

--- a/docs/ai/references/2026-07-05-auv-netease-music-acp-2-handoff.md
+++ b/docs/ai/references/2026-07-05-auv-netease-music-acp-2-handoff.md
@@ -3,6 +3,8 @@
 **Date:** 2026-07-05  
 **Prerequisite:** [ACP-1 handoff](2026-07-05-auv-netease-music-acp-1-handoff.md), [ACP gate](2026-07-05-auv-core-app-command-pack-gate.md)
 
+> **Orthogonality:** ACP-2 observe packaging does not re-validate the L8b seam. Pack pass ≠ seam re-proof — see [ACP gate](2026-07-05-auv-core-app-command-pack-gate.md#orthogonality-callout-mandatory-in-every-acp-handoff).
+
 ## Pack identity
 
 | Field | Value |

--- a/docs/ai/references/2026-07-06-auv-core-l8-r2-post-acp-closeout-review.md
+++ b/docs/ai/references/2026-07-06-auv-core-l8-r2-post-acp-closeout-review.md
@@ -192,4 +192,6 @@ rg 'action_resolver_decision\.clone\(\)' src/candidate_action_decision.rs
 
 ## 9. Next gate
 
-Proceed on **app packaging** or **product** slices only with explicit owner naming. Before any future “seam graduation” claim, cite **this R2 doc** plus R1 — not ACP handoffs alone.
+Proceed on **app packaging** slices only with explicit owner naming and cite **this R2 doc** plus [L8 R1](2026-07-05-auv-core-l8-closeout-review.md) for seam claims — **not** ACP handoffs alone.
+
+**ACP-B (second app):** see [qqmusic ACP-B1 gate/handoff](2026-07-06-auv-qqmusic-acp-b1-gate-handoff.md). Second-app pack pass remains orthogonal to seam re-proof per [ACP gate](2026-07-05-auv-core-app-command-pack-gate.md#orthogonality-callout-mandatory-in-every-acp-handoff).

--- a/docs/ai/references/2026-07-06-auv-core-l8-r2-post-acp-closeout-review.md
+++ b/docs/ai/references/2026-07-06-auv-core-l8-r2-post-acp-closeout-review.md
@@ -1,0 +1,195 @@
+# AUV Core L8-R2 Post-ACP Closeout Review
+
+**Date:** 2026-07-06  
+**Lane:** docs-only hard audit (no default code changes)  
+**Status:** closeout complete — **verdict below**
+
+**Prerequisites:** [L8 closeout (R1)](2026-07-05-auv-core-l8-closeout-review.md), [L9 inspect surface](2026-07-05-auv-core-l9-inspect-surface-handoff.md), [ACP gate](2026-07-05-auv-core-app-command-pack-gate.md), [ACP-1](2026-07-05-auv-netease-music-acp-1-handoff.md) / [ACP-2](2026-07-05-auv-netease-music-acp-2-handoff.md) handoffs
+
+**Compat baseline (pinned):** forced-answer table and status/issue mapping in [2026-07-05-auv-core-l8-closeout-review.md](2026-07-05-auv-core-l8-closeout-review.md). R2 judges drift **only** against that document.
+
+---
+
+## 1. Audit baseline
+
+| Item | Value |
+|------|-------|
+| R2 audit HEAD | `80874bbf` — `feat(inspect): unified netease proof run-detail hint (ACP-2c)` |
+| Branch | `cursor/acp-2c-unified-netease-proof-hint` (1 commit ahead of `main`) |
+| `main` at audit time | `95af4d62` — `feat(auv-netease-music): add sidebar scan proof invoke` (ACP-2b) |
+| L8 R1 evidence commits | `3745c419` docs → `ac4e4e0b` L8b → `9483f2d6` read-side |
+| Delta since L8 R1 | L9 viewer ATL panel landed; ACP-1/2 hermetic packs; ACP-2c unified `#netease-proof-hint` |
+
+**Scope:** Re-validate **L8b candidate-action seam** (`decision → driver_result → verification → artifact → inspect`). ACP pack is **orthogonal evidence only**.
+
+---
+
+## 2. Forced-answer matrix
+
+### 2.1 Producer (L8b only)
+
+| Check | Result | Evidence |
+|-------|--------|----------|
+| Canonical execution artifact coexists `action_resolver_decision` + `input_action_result` | **Pass** | `build_candidate_action_execution_artifact` (`src/candidate_action_decision.rs:500+`) still calls `reconcile_effective_decision` before persist |
+| `plan_delivery_mismatch` in `known_limits`, not silent pass | **Pass** | `cargo test -p auv-cli --lib plan_delivery_mismatch` — 3 passed |
+| `activation_only` vs semantic verification boundary | **Pass** | No third schema introduced; producer path unchanged since R1 |
+| **ACP boundary — `*.rs` code references** | **Pass** | `rg 'action_resolver\|candidate.action' crates/auv-netease-music --glob '*.rs'` → **0 matches** |
+| **ACP boundary — non-code** | **Pass (informational)** | `rg ... --glob '!*.rs'` → **0 matches** in crate tree |
+
+### 2.2 Read-model (projection only)
+
+| Check | Result | Evidence |
+|-------|--------|----------|
+| ATL fields from artifacts, no synthesis | **Pass** | `action_transition_lineage_entry` (`run_read.rs:6185+`); no `InputActionResult::default` / fake success in read path |
+| `planned_decision` comparator-only | **Pass** | Join via `read_candidate_action_decision_artifact`; unchanged from [ATL read handoff](2026-07-05-auv-core-action-transition-lineage-read-handoff.md) |
+| `GET /runs/{id}` builds ATL via `extract_action_transition_lineage` only | **Pass** | `inspect_server/mod.rs:383-385` |
+| inspect_server `*.rs` does not `persist_` run facts on read path | **Pass** | `rg 'persist_' src/inspect_server/ --glob '*.rs'` → 0 on read assembly; `write_updates` is **live ingestion**, not ATL fabrication |
+| L9 ATL viewer renders API JSON only | **Pass** | `viewer_renders_action_transition_lineage_hooks` — 1 passed |
+| ACP-2c `#netease-proof-hint` | **Pass (non-seam)** | Heuristic on root span + artifact role; does not write run facts or populate ATL; `viewer_renders_netease_proof_hint_hooks` — 1 passed |
+
+### 2.3 Compatibility (vs R1 baseline doc)
+
+| Scenario | Expected (R1) | Result | Evidence |
+|----------|---------------|--------|----------|
+| Canonical L8b + plan/delivery mismatch | `partial` + `plan_delivery_mismatch` | **Pass** | `action_transition_lineage_surfaces_plan_delivery_mismatch_from_l8b` |
+| Legacy missing `action_resolver_decision` | `partial` + `missing_action_resolver_decision` | **Pass** | `action_transition_lineage_marks_legacy_missing_decision_as_partial` |
+| Legacy missing `input_action_result` only | `partial` + `missing_input_action_result` | **Pass (code)** / **Gap (test)** | `classify_action_transition_lineage` + `legacy_action_transition_lineage_entry` (`run_read.rs:6175-6179`, `6294`); **no isolated unit test** — see drift register |
+| Malformed JSON / non-JSON mime | `malformed` + issue | **Pass** | `malformed_action_transition_lineage` path unchanged |
+
+### 2.4 Post-ACP boundary (fourth dimension)
+
+| Question | Result | Notes |
+|----------|--------|-------|
+| ACP gate misused as L8 re-validation? | **Pass** | Gate requires prior L8 **verdict exists**; ACP completion does not upgrade seam verdict |
+| NetEase proof runs imply full action seam closure? | **Documented risk** | Shared RunSpec/artifact roles; viewer hint is UX-only — **not** ATL |
+| ACP-2c hint causes seam hallucination? | **Pass (non-seam)** | Labels from span name + artifact role; no decision/driver injection |
+| ACP orthogonal green (narrow filter) | **Pass** | `select_proof` 8 passed; `sidebar_scan_proof` 8 passed — **does not count toward seam pass** |
+
+---
+
+## 3. Drift register (relative to L8 R1)
+
+| ID | Kind | Finding | Seam impact |
+|----|------|---------|-------------|
+| D1 | test coverage | No dedicated regression for legacy **missing `input_action_result` only** (R1 doc names it; only combined legacy fixture tested) | None observed — code path unchanged |
+| D2 | docs/viewer | ACP handoffs list L8 closeout as prerequisite; easy to misread pack graduation as seam re-proof | Misread risk only |
+| D3 | viewer | `#netease-proof-hint` cannot distinguish invoke proof vs product `playlist ls --store-root` | Known non-seam limit (ACP-2 handoff) |
+| D4 | surface | L9 closed R1 viewer gap; ATL panel now renders mismatch/partial/malformed | Positive — no seam regression |
+
+**No producer/read/compat behavior regression** detected at `80874bbf`.
+
+---
+
+## 4. Validation commands (recorded)
+
+Audit HEAD: `80874bbf` on `cursor/acp-2c-unified-netease-proof-hint`.
+
+```sh
+git rev-parse HEAD
+# 80874bbf6019432a83332e41f977e272cdedb5cb
+
+cargo test -p auv-cli --lib action_transition_lineage -- --nocapture
+# 3 passed (includes ATL viewer hook + 2 run_read ATL tests)
+
+cargo test -p auv-cli --lib viewer_renders_action_transition -- --nocapture
+# 1 passed
+
+cargo test -p auv-cli --lib viewer_renders_netease_proof_hint_hooks -- --nocapture
+# 1 passed
+
+cargo test -p auv-cli --lib inspect -- --nocapture
+# 101 passed
+
+cargo test -p auv-cli --lib plan_delivery_mismatch -- --nocapture
+# 3 passed
+
+cargo test -p auv-netease-music select_proof -- --nocapture
+# 8 passed (orthogonal)
+
+cargo test -p auv-netease-music sidebar_scan_proof -- --nocapture
+# 8 passed (orthogonal)
+
+rg -n "action_resolver|candidate.action" crates/auv-netease-music --glob '*.rs'
+# 0 matches
+
+rg -n "action_resolver|candidate-action" crates/auv-netease-music --glob '!*.rs'
+# 0 matches
+
+rg -n "LocalStore::write|persist_" src/inspect_server/ --glob '*.rs'
+# 0 matches on read projection path
+
+rg 'action_resolver_decision\.clone\(\)' src/candidate_action_decision.rs
+# 0 matches (auxiliary, same as R1)
+```
+
+**Note:** Full-workspace `cargo test` may flake on network-coupled `candidate_action` OpenAI fixture tests (502). R2 seam verdict uses **narrow hermetic filters above** only.
+
+---
+
+## 5. Forced answers (R2)
+
+1. **L8b artifact 主路径是否仍真实共存 `decision + driver_result`?**  
+   **Yes.** Producer code and `plan_delivery_mismatch` tests unchanged in substance.
+
+2. **read-side 是否仍只读投影、未偷生产 seam 事实?**  
+   **Yes.** ATL assembly is `extract_*` only on `GET /runs`; viewer renders JSON.
+
+3. **old artifact 缺字段是否仍稳定 `partial` / `malformed`（core 层）?**  
+   **Yes** for tested paths; `missing_input_action_result`-only lacks isolated test (D1).
+
+4. **ACP-1/2 成功是否证明 core seam 毕业?**  
+   **No.** Orthogonal pack lane; zero seam references in NetEase `*.rs`.
+
+5. **相对 L8 R1，seam 是否漂移?**  
+   **No behavior drift.** L9 + ACP-2c are surface/pack layers outside L8b producer.
+
+---
+
+## 6. Verdict
+
+### Selected: `close_with_documented_gaps`
+
+**Rationale:** Producer, read-model, and compatibility **core** layers pass at `80874bbf`. No `reopen_*` trigger. Post-ACP **misread risk** remains (D2, D3): a reader can still equate ACP pack success with seam closure despite orthogonal design.
+
+**Not selected:**
+
+| Verdict | Why not |
+|---------|---------|
+| `close_confirmed` | D2 misread risk is material enough to require named follow-up docs hygiene |
+| `reopen_l8b_producer` | No failing producer evidence |
+| `reopen_read_projection` | No synthesis or read-path store mutation on seam fields |
+| `reopen_compat` | Tested compat paths match R1; D1 is coverage gap not behavior drift |
+
+### Relationship to L8 R1
+
+| R1 verdict | R2 outcome |
+|------------|------------|
+| `close_for_core_seam_surface_gap_only` | **Superseded for operations** by L9 viewer closure (D4) |
+| Core seam producer/read/compat | **Re-confirmed** — still tight post-ACP |
+| Operational next step | Address **documented gaps** below; do not reopen L8b without new failing evidence |
+
+---
+
+## 7. Follow-up slices (named only — not implemented in R2)
+
+| Slice | Kind | Trigger |
+|-------|------|---------|
+| `docs-acp-orthogonality-callout` | docs-only | Owner wants ACP handoffs + gate to carry an explicit “pack pass ≠ seam re-proof” callout block |
+| `test-only: action_transition_lineage_legacy_missing_driver` | test-only | Owner wants D1 closed with isolated `missing_input_action_result` fixture |
+| `L9-R1 netease-proof-hint-disambiguation` | owner-approved feature | Owner wants viewer to distinguish invoke proof vs product `playlist ls` (needs schema or metadata — out of R2) |
+
+---
+
+## 8. Explicit non-goals
+
+- S / Surface Memory lane
+- ACP-3 or second-app packaging
+- L8b producer changes without new failing evidence
+- Runtime execution semantics changes
+- Full `cargo test -p auv-netease-music` as R2 seam evidence (forbidden per audit plan)
+
+---
+
+## 9. Next gate
+
+Proceed on **app packaging** or **product** slices only with explicit owner naming. Before any future “seam graduation” claim, cite **this R2 doc** plus R1 — not ACP handoffs alone.

--- a/docs/ai/references/2026-07-06-auv-qqmusic-acp-b1-gate-handoff.md
+++ b/docs/ai/references/2026-07-06-auv-qqmusic-acp-b1-gate-handoff.md
@@ -1,0 +1,127 @@
+# QQ Music ACP-B1 — Gate + Forced Decisions Handoff
+
+**Date:** 2026-07-06  
+**Prerequisite:** [ACP gate](2026-07-05-auv-core-app-command-pack-gate.md), [L8-R2](2026-07-06-auv-core-l8-r2-post-acp-closeout-review.md), NetEase [ACP-1](2026-07-05-auv-netease-music-acp-1-handoff.md) + [ACP-2](2026-07-05-auv-netease-music-acp-2-handoff.md) on `main`
+
+> **Orthogonality:** Pack pass ≠ seam re-proof — see [ACP gate callout](2026-07-05-auv-core-app-command-pack-gate.md#orthogonality-callout-mandatory-in-every-acp-handoff).
+
+## Pack identity
+
+| Field | Value |
+|-------|-------|
+| App | `com.tencent.QQMusicMac` / crate `auv-qqmusic` |
+| Lane | ACP-B — second app **bootstrap** hermetic pack |
+| B1 role | Gate + forced decisions only (no product code) |
+
+## Why qqmusic (not a NetEase copy)
+
+- Second **active** app-local Rust crate with typed search/select commands.
+- Historical evidence under `docs/ai/references/evidence/*qqmusic*` informs fixture shape; it is **not** a finished scan+select+recording seam like NetEase.
+- ACP-B proves **packaging migration** (invoke registry, `--store-root`, `persist_*`, inspect-readable artifact) across apps.
+
+## Gap register (pre-B2)
+
+| Capability | NetEase ACP | qqmusic pre-B2 |
+|------------|-------------|----------------|
+| `invoke/` + app registry | yes | **no** |
+| `recording.rs` + `persist_*` | yes | **no** |
+| Hermetic fixture + tests | yes | **no** |
+| Live scan artifact + view-memory | yes | **no** (out of scope) |
+| `run_search` observe anchor | N/A (playlist scan) | `anchor: None` always |
+
+## ACP pattern contract (B2 must follow)
+
+- App-local `qqmusic_registry()` — **not** `default_registry()`.
+- Hermetic proofs use `--fixture-dir` + `--store-root`; no `invoke_recorded` shortcut.
+- Docs and code land in **separate commits**.
+- Merge gate = `GET /runs` JSON shows artifact role; **viewer hint is not in B2 scope** (B2c defer).
+- **Non-goals:** L8b/ATL producer work, view-memory, live CI, `action_resolver` / `candidate-action` in `auv-qqmusic`.
+
+---
+
+## Forced decision 1 — Verification goal
+
+| Option | Meaning | B2 merge gate |
+|--------|---------|---------------|
+| **A — packaging migration** (default) | One hermetic **act** proof + inspect-readable artifact | **Required** |
+| B — symmetric observe+act | Paired observe pack like NetEase | Requires decision 2 Observe-A + extra contract |
+
+### Default (no owner override)
+
+**Goal A — packaging migration.** One hermetic act proof is sufficient for ACP-B success.
+
+### Override register
+
+| Item | Default | Owner override |
+|------|---------|----------------|
+| Verification goal | A | Record here if owner selects B |
+
+---
+
+## Forced decision 2 — Observe contract
+
+**Code fact:** [`run_search`](../../../crates/auv-qqmusic/src/search.rs) returns `SearchCommandReport { anchor: None }`. `SearchAnchorMatch` appears only on `run_select` / `run_click`. There is **no** observe-only product path that reuses `SearchCommandReport` with a populated anchor.
+
+| Branch | Condition | B2 observe |
+|--------|-----------|------------|
+| **Observe-A** | Owner approves first proof-only observe schema | New role + wire JSON; not pseudo `command: "search"` with anchor |
+| **Observe-defer** (default) | Packaging migration first | **Skip B2 observe**; record named defer `ACP-B2-observe` |
+
+### Default (no owner override)
+
+**Observe-defer.** B2 ships **act-only**; observe is a follow-up slice.
+
+### Override register
+
+| Item | Default | Owner override |
+|------|---------|----------------|
+| Observe | defer | Observe-A only with explicit proof-only schema approval |
+
+---
+
+## Forced decision 3 — Act path (select vs click)
+
+| Option | Code path | `command` field | Click semantics |
+|--------|-----------|-----------------|-----------------|
+| **`resultsSelectProof`** (default) | Proof-only schema aligned to `run_select` command identity | `search.results.select` | Single click identity; fixture-only packaging proof |
+| `resultsClickProof` | `run_click` + `--anchor` | `search.results.click` | Double click / play-visible-anchor class |
+
+**Forbidden:** `resultsSelectProof` name with double-click fixture semantics.
+
+### Default (no owner override)
+
+| Field | Value |
+|-------|-------|
+| Invoke ID | `qqmusic.search.resultsSelectProof` |
+| RunSpec root span | `auv.qqmusic.search.select` |
+| Artifact role | `qqmusic-search-select-result` |
+| Fixture | `tests/fixtures/select-proof/hermetic_v0/select-result.json` |
+| Test filter | `cargo test -p auv-qqmusic results_select_proof` |
+
+### Override register
+
+| Item | Default | Owner override |
+|------|---------|----------------|
+| Act path | `resultsSelectProof` | `resultsClickProof` only for play-visible-anchor / double-click alignment |
+
+---
+
+## B2 entry checklist
+
+- [x] B1 forced decisions recorded (this doc)
+- [ ] `recording.rs` + `invoke/results_select_proof.rs` + fixture
+- [ ] `cargo test -p auv-qqmusic results_select_proof` green
+- [ ] `auv-qqmusic invoke` lists `qqmusic.search.resultsSelectProof`
+- [ ] B2 handoff with NetEase diff + orthogonality
+
+## Named defers (B1)
+
+| ID | Defer |
+|----|-------|
+| `ACP-B2-observe` | Observe proof until Observe-A approved |
+| `ACP-B2c-viewer` | qqmusic proof viewer hint until both apps act-green + owner re-evaluates |
+
+## References
+
+- Plan: ACP-B second app pack (qqmusic)
+- [L8-R2 drift D1](2026-07-06-auv-core-l8-r2-post-acp-closeout-review.md) — legacy `missing_input_action_result` test (R2a)

--- a/docs/ai/references/2026-07-06-auv-qqmusic-acp-b2-handoff.md
+++ b/docs/ai/references/2026-07-06-auv-qqmusic-acp-b2-handoff.md
@@ -1,0 +1,76 @@
+# QQ Music ACP-B2 — Bootstrap Act Pack Handoff
+
+**Date:** 2026-07-06  
+**Prerequisite:** [ACP-B1 gate/handoff](2026-07-06-auv-qqmusic-acp-b1-gate-handoff.md), [ACP gate](2026-07-05-auv-core-app-command-pack-gate.md)
+
+> **Orthogonality:** This pack does not change L8b seam verdict. Pack pass ≠ seam re-proof.
+
+## Landed (B2 act-first)
+
+| Item | Value |
+|------|-------|
+| Invoke ID | `qqmusic.search.resultsSelectProof` |
+| Registry | `crates/auv-qqmusic/src/invoke/mod.rs` → `qqmusic_registry()` |
+| Handler | `invoke/results_select_proof.rs` |
+| Recording | `recording.rs` → `persist_search_select_proof` |
+| Artifact role | `qqmusic-search-select-result` |
+| RunSpec | `auv.qqmusic.search.select` |
+| Fixture | `tests/fixtures/select-proof/hermetic_v0/` |
+| CLI | `auv-qqmusic invoke …` (sibling to `search`) |
+
+## Verification (owner-approved defaults from B1)
+
+```sh
+cargo fmt --check && cargo check
+cargo test -p auv-qqmusic results_select_proof
+cargo run -p auv-qqmusic -- invoke
+git diff --check
+```
+
+**Success:** Hermetic **packaging proof** persists a run with `qqmusic-search-select-result` artifact; inspect `GET /runs` JSON readable.
+
+## Bootstrap vs NetEase (not a copy)
+
+| Dimension | NetEase ACP-1/2 | qqmusic ACP-B2 |
+|-----------|-----------------|----------------|
+| Domain schema | `PlaylistSelectResult`, sidebar scan IR | `SearchSelectProofDocument` (wire aligned with `SearchCommandReport`, not full `run_select` replay fidelity) |
+| Observe half | `sidebarScanProof` landed | **Deferred** (`ACP-B2-observe`) |
+| View-memory / reacquire spans | ACP-1 select uses controlled reacquire subset | **None** — minimal `persist_*` only |
+| Act command | `playlist.select` | `search.results.select` command identity (fixture-only single-click packaging proof) |
+| Maturity | Scan artifact + select seam existed | **Bootstrap** — first invoke/recording in crate |
+
+Mechanism reused: app-local registry, `--fixture-dir` + `--store-root`, `RunRecordingBackend::run_recorded_operation`, hermetic fixture tests, exclusion from `default_registry()`.
+
+## Evidence boundary
+
+- This pack proves **app-local invoke + store persistence + inspect-readable artifact**.
+- It does **not** prove full-fidelity `run_select` execution replay.
+- Current fixture is intentionally minimal and does not mirror every live `SearchCommandReport` step or driver result field.
+
+## Observe defer (`ACP-B2-observe`)
+
+**Not implemented** per B1 Observe-defer default.
+
+- `run_search` never produces anchor; no product observe-only path.
+- Follow-up requires B1 Observe-A (proof-only schema) before any `*ObserveProof` invoke.
+
+## Viewer defer (`ACP-B2c-viewer`)
+
+**Not implemented** per plan default.
+
+Re-evaluate when NetEase + qqmusic act proofs are both green in inspect JSON and owner requests unified proof-pack viewer polish.
+
+## Non-goals (confirmed)
+
+- `resultsClickProof` / double-click path (unless B1 override)
+- L8b producer / `run_read` classify changes (except R2a isolated legacy test)
+- `action_resolver` / `candidate-action` in `auv-qqmusic`
+- Root `default_registry()` registration
+
+## Next slices (not approved here)
+
+| Slice | Trigger |
+|-------|---------|
+| ACP-B2-observe | Owner approves Observe-A schema |
+| ACP-B2c viewer | Two-app act green + owner request |
+| ACP-C third app | Owner names app |

--- a/docs/ai/references/INDEX.md
+++ b/docs/ai/references/INDEX.md
@@ -526,6 +526,8 @@ osu benchmark；G-series 需单独 owner 批准
 
 - [`2026-07-05-auv-netease-music-acp-1-handoff.md`](2026-07-05-auv-netease-music-acp-1-handoff.md)
 - [`2026-07-05-auv-netease-music-acp-2-handoff.md`](2026-07-05-auv-netease-music-acp-2-handoff.md)
+- [`2026-07-06-auv-qqmusic-acp-b1-gate-handoff.md`](2026-07-06-auv-qqmusic-acp-b1-gate-handoff.md) — ACP-B forced decisions (qqmusic second app)
+- [`2026-07-06-auv-qqmusic-acp-b2-handoff.md`](2026-07-06-auv-qqmusic-acp-b2-handoff.md) — ACP-B2 act bootstrap landed
 
 #### implementation-plan (3)
 

--- a/docs/ai/references/INDEX.md
+++ b/docs/ai/references/INDEX.md
@@ -110,6 +110,7 @@ AUV core runtime、contract、graduation、query-readiness
 - [`2026-07-05-auv-core-action-seam-l8b-reconnect-handoff.md`](2026-07-05-auv-core-action-seam-l8b-reconnect-handoff.md) — L8b reconciled effective decision + `plan_delivery_mismatch` hard acceptance
 - [`2026-07-05-auv-core-action-transition-lineage-read-handoff.md`](2026-07-05-auv-core-action-transition-lineage-read-handoff.md) — `ActionTransitionLineage` read-side projection (L8b effective, L8a comparator)
 - [`2026-07-05-auv-core-l8-closeout-review.md`](2026-07-05-auv-core-l8-closeout-review.md) — L8 closeout: producer/read-model/compatibility/drift verdict (`close_for_core_seam_surface_gap_only`)
+- [`2026-07-06-auv-core-l8-r2-post-acp-closeout-review.md`](2026-07-06-auv-core-l8-r2-post-acp-closeout-review.md) — L8-R2 post-ACP hard audit: seam re-validation + ACP orthogonality (`close_with_documented_gaps`)
 - [`2026-07-05-auv-core-l9-inspect-surface-handoff.md`](2026-07-05-auv-core-l9-inspect-surface-handoff.md) — L9 viewer surface for `action_transition_lineage` (mismatch, partial, verification)
 - [`2026-07-05-auv-core-app-command-pack-gate.md`](2026-07-05-auv-core-app-command-pack-gate.md) — App Command Pack entry gate (post L8+L9)
 - [`2026-07-05-auv-core-surface-memory-lane-discipline.md`](2026-07-05-auv-core-surface-memory-lane-discipline.md) — S/Surface Memory independent lane discipline

--- a/src/inspect_server/mod.rs
+++ b/src/inspect_server/mod.rs
@@ -2423,7 +2423,7 @@ function registerElement(document, tagName, id) {
 
 const document = new Document();
 registerElement(document, "div", "action-transition-lineage").hidden = true;
-registerElement(document, "div", "netease-select-proof-hint").hidden = true;
+registerElement(document, "div", "netease-proof-hint").hidden = true;
 registerElement(document, "div", "view-parser-proof").hidden = true;
 registerElement(document, "div", "conn").className = "conn-pill bad";
 registerElement(document, "div", "conn-label");
@@ -2827,30 +2827,48 @@ eval(scriptBody);
   }
 
   #[test]
-  fn viewer_renders_netease_select_proof_hint_hooks() {
+  fn viewer_renders_netease_proof_hint_hooks() {
     assert!(
-      super::VIEWER_HTML.contains("netease-select-proof-hint"),
-      "viewer payload should mount the netease select proof hint panel"
+      super::VIEWER_HTML.contains("netease-proof-hint"),
+      "viewer payload should mount the unified netease proof hint panel"
     );
     assert!(
-      super::VIEWER_HTML.contains("renderNeteaseSelectProofHint"),
-      "viewer payload should render netease select proof hint"
+      !super::VIEWER_HTML.contains("netease-select-proof-hint"),
+      "viewer payload should not retain the old select-only hint id"
+    );
+    assert!(
+      super::VIEWER_HTML.contains("renderNeteaseProofHint"),
+      "viewer payload should render unified netease proof hint"
     );
     assert!(
       super::VIEWER_HTML.contains("auv.netease.playlist.select"),
       "viewer payload should match netease select proof run root span"
     );
     assert!(
+      super::VIEWER_HTML.contains("auv.netease.playlist.ls"),
+      "viewer payload should match netease sidebar scan proof run root span"
+    );
+    assert!(
       super::VIEWER_HTML.contains("NetEase playlist select proof"),
       "viewer payload should use generic netease select proof label"
     );
     assert!(
-      super::VIEWER_HTML.contains("selfTestNeteaseSelectProofHint"),
-      "viewer payload should self-test netease select proof hint"
+      super::VIEWER_HTML.contains("NetEase playlist sidebar scan proof"),
+      "viewer payload should use generic netease sidebar scan proof label"
+    );
+    assert!(
+      super::VIEWER_HTML.contains("selfTestNeteaseProofHint"),
+      "viewer payload should self-test unified netease proof hint"
     );
     assert!(
       !super::VIEWER_HTML.contains("ACP-1 (selectProof)"),
       "viewer payload must not use selectProof-specific hint wording"
+    );
+    assert!(
+      !super::VIEWER_HTML
+        .to_lowercase()
+        .contains("sidebarscanproof"),
+      "viewer payload must not use sidebar scan invoke command id in hint copy"
     );
   }
 

--- a/src/inspect_server_viewer.html
+++ b/src/inspect_server_viewer.html
@@ -811,7 +811,7 @@
     background: var(--shell);
   }
   #action-transition-lineage[hidden] { display: none; }
-  #netease-select-proof-hint {
+  #netease-proof-hint {
     margin: 0.75rem 1rem 0;
     padding: 0.5rem 0.75rem;
     border-radius: 0.5rem;
@@ -820,9 +820,12 @@
     color: var(--fg-2);
     font-size: 0.8125rem;
     letter-spacing: 0.01em;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
   }
-  #netease-select-proof-hint[hidden] { display: none; }
-  #netease-select-proof-hint .netease-select-proof-hint-label {
+  #netease-proof-hint[hidden] { display: none; }
+  #netease-proof-hint .netease-proof-hint-label {
     color: var(--fg);
     font-weight: 500;
   }
@@ -921,7 +924,7 @@
         <span class="right" id="main-crumb"></span>
         <span id="main-status"></span>
       </div>
-      <div id="netease-select-proof-hint" hidden></div>
+      <div id="netease-proof-hint" hidden></div>
       <div id="view-parser-proof" hidden></div>
       <div id="action-transition-lineage" hidden></div>
       <div id="run-list-filter-banner" class="run-list-filter-banner" hidden></div>
@@ -1133,6 +1136,7 @@
 
   const VIEW_MEMORY_ARTIFACT_ROLE = "view-memory";
   const PLAYLIST_SELECT_RESULT_ARTIFACT_ROLE = "netease-playlist-select-result";
+  const PLAYLIST_SIDEBAR_SCAN_ARTIFACT_ROLE = "netease-playlist-sidebar-scan";
 
   function clearViewParserProof() {
     const panel = document.getElementById("view-parser-proof");
@@ -1141,37 +1145,55 @@
     panel.hidden = true;
   }
 
-  function clearNeteaseSelectProofHint() {
-    const panel = document.getElementById("netease-select-proof-hint");
+  function clearNeteaseProofHint() {
+    const panel = document.getElementById("netease-proof-hint");
     if (!panel) return;
     panel.innerHTML = "";
     panel.hidden = true;
   }
 
-  function neteasePlaylistSelectProofVisible(run, spans, artifacts) {
-    if (!run || !Array.isArray(artifacts) || !Array.isArray(spans)) return false;
-    const hasArtifact = artifacts.some(function (artifact) {
-      return artifact && artifact.role === PLAYLIST_SELECT_RESULT_ARTIFACT_ROLE;
-    });
-    if (!hasArtifact) return false;
+  function neteaseProofRootSpanName(spans) {
+    if (!Array.isArray(spans)) return null;
     const rootSpan = spans.find(function (span) {
       return span && (span.parent_span_id == null || span.parent_span_id === "");
     });
-    return !!(rootSpan && rootSpan.name === "auv.netease.playlist.select");
+    return rootSpan ? rootSpan.name : null;
   }
 
-  function renderNeteaseSelectProofHint(run, spans, artifacts) {
-    const panel = document.getElementById("netease-select-proof-hint");
+  function neteaseProofHintLabels(run, spans, artifacts) {
+    if (!run || !Array.isArray(artifacts) || !Array.isArray(spans)) return [];
+    const labels = [];
+    const rootName = neteaseProofRootSpanName(spans);
+    const hasSelectArtifact = artifacts.some(function (artifact) {
+      return artifact && artifact.role === PLAYLIST_SELECT_RESULT_ARTIFACT_ROLE;
+    });
+    const hasScanArtifact = artifacts.some(function (artifact) {
+      return artifact && artifact.role === PLAYLIST_SIDEBAR_SCAN_ARTIFACT_ROLE;
+    });
+    if (rootName === "auv.netease.playlist.select" && hasSelectArtifact) {
+      labels.push("NetEase playlist select proof");
+    }
+    if (rootName === "auv.netease.playlist.ls" && hasScanArtifact) {
+      labels.push("NetEase playlist sidebar scan proof");
+    }
+    return labels;
+  }
+
+  function renderNeteaseProofHint(run, spans, artifacts) {
+    const panel = document.getElementById("netease-proof-hint");
     if (!panel) return;
-    if (!neteasePlaylistSelectProofVisible(run, spans, artifacts)) {
-      clearNeteaseSelectProofHint();
+    const labels = neteaseProofHintLabels(run, spans, artifacts);
+    if (labels.length === 0) {
+      clearNeteaseProofHint();
       return;
     }
     panel.innerHTML = "";
     panel.hidden = false;
-    panel.appendChild(el("span", { className: "netease-select-proof-hint-label" }, [
-      "NetEase playlist select proof",
-    ]));
+    for (let index = 0; index < labels.length; index += 1) {
+      panel.appendChild(el("span", { className: "netease-proof-hint-label" }, [
+        labels[index],
+      ]));
+    }
   }
 
   function hasViewParserProof(run) {
@@ -1735,13 +1757,13 @@
       setMainHeader(state.activeRun, false);
       renderViewParserProof(state.activeRun);
       renderActionTransitionLineage(state.activeRun);
-      renderNeteaseSelectProofHint(state.activeRun, state.spans, state.artifacts);
+      renderNeteaseProofHint(state.activeRun, state.spans, state.artifacts);
       renderRunList();
     } catch (err) {
       if (state.activeRunId !== runId) return;
       clearViewParserProof();
       clearActionTransitionLineage();
-      clearNeteaseSelectProofHint();
+      clearNeteaseProofHint();
     }
   }
 
@@ -2002,7 +2024,7 @@
     closeStream();
     clearViewParserProof();
     clearActionTransitionLineage();
-    clearNeteaseSelectProofHint();
+    clearNeteaseProofHint();
     state.activeRunId = runId;
     state.activeRun = state.runs.find(function (r) { return r.run_id === runId; }) || null;
     state.spans = [];
@@ -2067,12 +2089,12 @@
       renderArtifactPreview(findArtifact(state.activeArtifactKey), state.artifacts);
       renderViewParserProof(state.activeRun);
       renderActionTransitionLineage(state.activeRun);
-      renderNeteaseSelectProofHint(state.activeRun, state.spans, state.artifacts);
+      renderNeteaseProofHint(state.activeRun, state.spans, state.artifacts);
     } catch (err) {
       if (state.activeRunId !== runId) return;
       clearViewParserProof();
       clearActionTransitionLineage();
-      clearNeteaseSelectProofHint();
+      clearNeteaseProofHint();
       setConnection(false, "/runs/:id (" + err.message + ")");
       renderPlaceholder([
         "failed to load run detail.",
@@ -4671,9 +4693,9 @@
   }
   selfTestActionTransitionLineage();
 
-  function selfTestNeteaseSelectProofHint() {
-    const hintPanel = document.getElementById("netease-select-proof-hint");
-    console.assert(!!hintPanel, "netease-select-proof-hint panel should exist in DOM");
+  function selfTestNeteaseProofHint() {
+    const hintPanel = document.getElementById("netease-proof-hint");
+    console.assert(!!hintPanel, "netease-proof-hint panel should exist in DOM");
 
     const run = { run_id: "run_netease_hint" };
     const spans = [{
@@ -4683,21 +4705,43 @@
     }];
     const artifacts = [{ role: PLAYLIST_SELECT_RESULT_ARTIFACT_ROLE, artifact_id: "art_1" }];
 
-    renderNeteaseSelectProofHint(run, spans, artifacts);
+    renderNeteaseProofHint(run, spans, artifacts);
     console.assert(!hintPanel.hidden, "hint should show for netease select proof run");
     console.assert(
       hintPanel.textContent.indexOf("NetEase playlist select proof") >= 0,
-      "generic hint label should render"
+      "generic select hint label should render"
     );
     console.assert(
       hintPanel.textContent.toLowerCase().indexOf("selectproof") < 0,
       "hint must not include invoke-specific wording"
     );
 
-    clearNeteaseSelectProofHint();
+    const lsRun = { run_id: "run_netease_ls_hint" };
+    const lsSpans = [{
+      span_id: "span_root_ls",
+      parent_span_id: null,
+      name: "auv.netease.playlist.ls",
+    }];
+    const lsArtifacts = [{
+      role: PLAYLIST_SIDEBAR_SCAN_ARTIFACT_ROLE,
+      artifact_id: "art_scan_1",
+    }];
+
+    renderNeteaseProofHint(lsRun, lsSpans, lsArtifacts);
+    console.assert(!hintPanel.hidden, "hint should show for netease sidebar scan proof run");
+    console.assert(
+      hintPanel.textContent.indexOf("NetEase playlist sidebar scan proof") >= 0,
+      "generic sidebar scan hint label should render"
+    );
+    console.assert(
+      hintPanel.textContent.toLowerCase().indexOf("sidebarscan") < 0,
+      "hint must not include invoke-specific sidebar scan wording"
+    );
+
+    clearNeteaseProofHint();
     console.assert(hintPanel.hidden, "hint should hide after clear");
   }
-  selfTestNeteaseSelectProofHint();
+  selfTestNeteaseProofHint();
 
   loadRuns();
 })();

--- a/src/run_read.rs
+++ b/src/run_read.rs
@@ -11555,6 +11555,7 @@ mod tests {
       source_promotion_id: "promotion_ready".to_string(),
       source_decision_id: "decision_ready".to_string(),
       candidate_local_id: "promoted-item_end_turn".to_string(),
+      action_resolver_decision: None,
       operation_result: full_execution.operation_result.clone(),
       verification_result: full_execution.verification_result.clone(),
       detail: json!({
@@ -11605,6 +11606,99 @@ mod tests {
       transitions[0].verification.verification_outcome,
       "activation_only"
     );
+
+    let _ = fs::remove_dir_all(root);
+  }
+
+  #[test]
+  fn action_transition_lineage_marks_legacy_missing_driver_as_partial() {
+    let root = temp_dir("run-read-action-transition-legacy-missing-driver");
+    let store = LocalStore::new(root.clone()).expect("store should initialize");
+    let run = dummy_run("run_read_action_transition_legacy_missing_driver");
+    let span = dummy_span(&run.root_span_id);
+    let source_decision_artifact = stage_json_artifact(
+      &store,
+      &root,
+      &run.run_id,
+      &span.span_id,
+      0,
+      CANDIDATE_ACTION_DECISION_ARTIFACT_ROLE,
+      "candidate-action-decision-source.json",
+      &json!({"fixture": "candidate-action-decision"}),
+    );
+    let full_execution = candidate_action_execution_artifact(
+      ArtifactRef {
+        run_id: run.run_id.clone(),
+        artifact_id: source_decision_artifact.artifact_id.clone(),
+        span_id: span.span_id.clone(),
+        captured_event_id: source_decision_artifact.event_id.clone(),
+      },
+      None,
+      "execution_legacy_missing_driver",
+    );
+    let legacy = LegacyExecutionFixture {
+      artifact_version: "candidate_action_execution_artifact_v0".to_string(),
+      execution_id: "execution_legacy_missing_driver".to_string(),
+      source_candidate_action_decision_artifact: ArtifactRef {
+        run_id: run.run_id.clone(),
+        artifact_id: source_decision_artifact.artifact_id.clone(),
+        span_id: span.span_id.clone(),
+        captured_event_id: source_decision_artifact.event_id.clone(),
+      },
+      source_candidate_promotion_artifact: None,
+      operation_result_artifact: None,
+      source_promotion_id: "promotion_ready".to_string(),
+      source_decision_id: "decision_ready".to_string(),
+      candidate_local_id: "promoted-item_end_turn".to_string(),
+      action_resolver_decision: Some(full_execution.action_resolver_decision.clone()),
+      operation_result: full_execution.operation_result.clone(),
+      verification_result: full_execution.verification_result.clone(),
+      detail: json!({
+        "input_delivery": "attempted",
+        "operation_status": "completed",
+      }),
+      known_limits: vec!["legacy fixture missing input_action_result".to_string()],
+    };
+
+    let artifacts = vec![
+      source_decision_artifact,
+      stage_json_artifact(
+        &store,
+        &root,
+        &run.run_id,
+        &span.span_id,
+        1,
+        CANDIDATE_ACTION_EXECUTION_ARTIFACT_ROLE,
+        "candidate-action-execution-legacy-missing-driver.json",
+        &legacy,
+      ),
+    ];
+
+    store
+      .write_run_snapshot(&CanonicalRun {
+        run,
+        spans: vec![span],
+        events: Vec::new(),
+        artifacts,
+      })
+      .expect("run snapshot should persist");
+
+    let canonical = store
+      .read_run("run_read_action_transition_legacy_missing_driver")
+      .expect("run should read back");
+    let transitions = extract_action_transition_lineage(&store, &canonical)
+      .expect("action transition lineage should extract");
+    assert_eq!(transitions.len(), 1);
+    assert_eq!(
+      transitions[0].status,
+      ActionTransitionLineageStatus::Partial
+    );
+    assert_eq!(
+      transitions[0].issue.as_deref(),
+      Some("missing_input_action_result")
+    );
+    assert!(transitions[0].effective_decision.is_some());
+    assert!(transitions[0].driver_result.is_none());
 
     let _ = fs::remove_dir_all(root);
   }
@@ -11899,6 +11993,8 @@ mod tests {
     source_promotion_id: String,
     source_decision_id: String,
     candidate_local_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    action_resolver_decision: Option<ActionResolverDecision>,
     operation_result: OperationResult,
     verification_result: VerificationResult,
     detail: serde_json::Value,


### PR DESCRIPTION
Replace select-only #netease-select-proof-hint with #netease-proof-hint covering select and sidebar scan proof runs; update ACP handoff docs.

Co-authored-by: Cursor <cursoragent@cursor.com>

Co-authored-by: GPT-5.6-sol

effort: max