### PR TITLE
feat(auv-cli-invoke): render invoke list outputs as tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,6 +415,7 @@ dependencies = [
  "auv-scan",
  "auv-tracing-driver",
  "clap",
+ "comfy-table",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/auv-cli-invoke/Cargo.toml
+++ b/crates/auv-cli-invoke/Cargo.toml
@@ -21,6 +21,7 @@ tempfile = "3"
 anstream = "1"
 anstyle = "1"
 clap = { version = "4.5", features = ["derive"] }
+comfy-table = { version = "7", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/auv-cli-invoke/src/commands/app.rs
+++ b/crates/auv-cli-invoke/src/commands/app.rs
@@ -66,9 +66,9 @@ fn probe_permissions_impl() -> InvokeCommandResult {
 }
 
 fn permission_report(permissions: &auv_driver::PermissionProbe) -> InvokeReport {
-  InvokeReport {
-    fields: vec![report_field("Result", "permissions probed")],
-    sections: vec![InvokeReportSection {
+  InvokeReport::new(
+    vec![report_field("Result", "permissions probed")],
+    vec![InvokeReportSection {
       title: "Permissions".to_string(),
       fields: vec![
         report_field("Screen Recording", permissions.screen_recording.as_str()),
@@ -77,7 +77,7 @@ fn permission_report(permissions: &auv_driver::PermissionProbe) -> InvokeReport 
         report_field("Automation to System Events", permissions.automation_to_system_events.as_str()),
       ],
     }],
-  }
+  )
 }
 
 fn report_field(label: &str, value: impl Into<String>) -> InvokeReportField {

--- a/crates/auv-cli-invoke/src/commands/display.rs
+++ b/crates/auv-cli-invoke/src/commands/display.rs
@@ -3,7 +3,7 @@ use crate::{
   arg::{NO_ARGS, TARGET_ARGS},
   invoke_command,
 };
-use crate::{InvokeReport, InvokeReportField, InvokeReportSection};
+use crate::{InvokeReport, InvokeReportField, InvokeReportTable, InvokeReportTableRow};
 #[cfg(target_os = "macos")]
 use auv_tracing_driver::{ProducedArtifact, now_millis};
 
@@ -173,26 +173,59 @@ fn display_list_report(displays: &[auv_driver::Display]) -> InvokeReport {
       "Result",
       format!("{} display(s)", displays.len()),
     )],
-    sections: displays
-      .iter()
-      .map(|display| InvokeReportSection {
-        title: display.id.clone(),
-        fields: vec![
-          report_field(
-            "Role",
-            if display.is_primary {
-              "primary"
-            } else {
-              "secondary"
-            },
-          ),
-          report_field("Kind", display_kind(display)),
-          report_field("Size", format!("{:.0}x{:.0} logical", display.frame.size.width, display.frame.size.height)),
-          report_field("Scale", format!("{:.3}", display.scale_factor)),
-          report_field("Frame", format_report_rect(display.frame)),
-        ],
-      })
-      .collect(),
+    tables: vec![InvokeReportTable::new(
+      vec![
+        "REF".to_string(),
+        "ROLE".to_string(),
+        "NAME".to_string(),
+        "FRAME".to_string(),
+        "SCALE".to_string(),
+      ],
+      displays
+        .iter()
+        .map(|display| InvokeReportTableRow {
+          cells: vec![
+            display.id.clone(),
+            display_role(display).to_string(),
+            display_label(display),
+            format_table_rect(display.frame),
+            format!("{:.3}", display.scale_factor),
+          ],
+        })
+        .collect(),
+    )],
+    wide_tables: vec![InvokeReportTable::new(
+      vec![
+        "REF".to_string(),
+        "ROLE".to_string(),
+        "NAME".to_string(),
+        "FRAME".to_string(),
+        "SCALE".to_string(),
+        "KIND".to_string(),
+      ],
+      displays
+        .iter()
+        .map(|display| InvokeReportTableRow {
+          cells: vec![
+            display.id.clone(),
+            display_role(display).to_string(),
+            display_label(display),
+            format_table_rect(display.frame),
+            format!("{:.3}", display.scale_factor),
+            display_kind(display).to_string(),
+          ],
+        })
+        .collect(),
+    )],
+    sections: Vec::new(),
+  }
+}
+
+fn display_role(display: &auv_driver::Display) -> &'static str {
+  if display.is_primary {
+    "primary"
+  } else {
+    "secondary"
   }
 }
 
@@ -208,8 +241,8 @@ fn format_rect(rect: auv_driver::Rect) -> String {
   format!("x={:.0},y={:.0},width={:.0},height={:.0}", rect.origin.x, rect.origin.y, rect.size.width, rect.size.height)
 }
 
-fn format_report_rect(rect: auv_driver::Rect) -> String {
-  format!("x={:.0},y={:.0},w={:.0},h={:.0}", rect.origin.x, rect.origin.y, rect.size.width, rect.size.height)
+fn format_table_rect(rect: auv_driver::Rect) -> String {
+  format!("{:.0},{:.0} {:.0}x{:.0}", rect.origin.x, rect.origin.y, rect.size.width, rect.size.height)
 }
 
 fn report_field(label: &str, value: impl Into<String>) -> InvokeReportField {
@@ -245,7 +278,7 @@ mod tests {
   }
 
   #[test]
-  fn display_list_report_includes_ids_and_preserves_role_kind_scale_and_frame() {
+  fn display_list_report_uses_human_first_table_and_wide_kind_column() {
     let displays = vec![
       Display {
         id: "display_0".to_string(),
@@ -281,16 +314,31 @@ mod tests {
     let report = output.report.as_ref().expect("report should be set");
 
     assert_eq!(report.fields[0].value, "2 display(s)");
-    assert_eq!(report.sections[0].title, "display_0");
-    assert_eq!(report.sections[1].title, "display_1");
-    assert_eq!(field_value(&report.sections[0], "Role"), "primary");
-    assert_eq!(field_value(&report.sections[0], "Kind"), "built-in");
-    assert_eq!(field_value(&report.sections[0], "Scale"), "2.000");
-    assert_eq!(field_value(&report.sections[0], "Frame"), "x=0,y=0,w=3008,h=1692");
-    assert_eq!(field_value(&report.sections[1], "Role"), "secondary");
-    assert_eq!(field_value(&report.sections[1], "Kind"), "external");
-    assert_eq!(field_value(&report.sections[1], "Scale"), "1.000");
-    assert_eq!(field_value(&report.sections[1], "Frame"), "x=3008,y=0,w=1920,h=1080");
+    assert!(report.sections.is_empty());
+    assert_eq!(report.tables[0].columns, ["REF", "ROLE", "NAME", "FRAME", "SCALE"]);
+    assert_eq!(
+      report.tables[0].rows[0].cells,
+      [
+        "display_0",
+        "primary",
+        "Built-in Retina Display",
+        "0,0 3008x1692",
+        "2.000"
+      ]
+    );
+    assert_eq!(
+      report.tables[0].rows[1].cells,
+      [
+        "display_1",
+        "secondary",
+        "display display_1",
+        "3008,0 1920x1080",
+        "1.000"
+      ]
+    );
+    assert_eq!(report.wide_tables[0].columns, ["REF", "ROLE", "NAME", "FRAME", "SCALE", "KIND"]);
+    assert_eq!(report.wide_tables[0].rows[0].cells[5], "built-in");
+    assert_eq!(report.wide_tables[0].rows[1].cells[5], "external");
   }
 
   #[test]
@@ -305,9 +353,5 @@ mod tests {
 
       assert!(error.contains("typed display API"), "{command_id} returned unclear error: {error}");
     }
-  }
-
-  fn field_value<'a>(section: &'a InvokeReportSection, label: &str) -> &'a str {
-    section.fields.iter().find(|field| field.label == label).map(|field| field.value.as_str()).expect("field should exist")
   }
 }

--- a/crates/auv-cli-invoke/src/commands/input.rs
+++ b/crates/auv-cli-invoke/src/commands/input.rs
@@ -445,10 +445,7 @@ fn input_key_report(key: &str, target: Option<&str>, backend: Option<&str>, resu
   if let Some(backend) = backend {
     fields.push(report_field("Backend", backend));
   }
-  InvokeReport {
-    fields,
-    sections: Vec::new(),
-  }
+  InvokeReport::new(fields, Vec::new())
 }
 
 fn attach_input_key_report(output: &mut InvokeCommandOutput, key: &str, target: Option<&str>, result: &auv_driver::InputActionResult) {

--- a/crates/auv-cli-invoke/src/commands/mod.rs
+++ b/crates/auv-cli-invoke/src/commands/mod.rs
@@ -3,6 +3,8 @@ pub mod display;
 pub mod fixture;
 pub mod input;
 pub mod media_control;
+#[cfg(target_os = "macos")]
+mod ocr;
 pub mod overlay;
 pub mod scan;
 pub mod screen;

--- a/crates/auv-cli-invoke/src/commands/ocr.rs
+++ b/crates/auv-cli-invoke/src/commands/ocr.rs
@@ -1,0 +1,145 @@
+use crate::{InvokeReport, InvokeReportField, InvokeReportTable, InvokeReportTableRow};
+
+pub(super) fn match_report(matches: &[auv_driver_macos::OcrMatch], selected_index: Option<usize>) -> InvokeReport {
+  let has_selection = selected_index.is_some();
+  InvokeReport {
+    fields: vec![report_field(
+      "Result",
+      format!("{} text match(es)", matches.len()),
+    )],
+    tables: vec![
+      InvokeReportTable::new(columns(has_selection, false), rows(matches, selected_index, false))
+        .with_display_max_chars(display_max_chars(has_selection, false)),
+    ],
+    wide_tables: vec![
+      InvokeReportTable::new(columns(has_selection, true), rows(matches, selected_index, true))
+        .with_display_max_chars(display_max_chars(has_selection, true)),
+    ],
+    sections: Vec::new(),
+  }
+}
+
+fn columns(has_selection: bool, wide: bool) -> Vec<String> {
+  let mut columns = Vec::new();
+  if has_selection {
+    columns.push("SEL".to_string());
+  }
+  columns.extend(["IDX", "TEXT", "POINT", "BOUNDS"].map(str::to_string));
+  if wide {
+    columns.push("CONF".to_string());
+  }
+  columns
+}
+
+fn display_max_chars(has_selection: bool, wide: bool) -> Vec<Option<usize>> {
+  let mut max_chars = Vec::new();
+  if has_selection {
+    max_chars.push(None);
+  }
+  max_chars.extend([None, Some(48), None, None]);
+  if wide {
+    max_chars.push(None);
+  }
+  max_chars
+}
+
+fn rows(matches: &[auv_driver_macos::OcrMatch], selected_index: Option<usize>, wide: bool) -> Vec<InvokeReportTableRow> {
+  matches
+    .iter()
+    .enumerate()
+    .map(|(index, matched)| {
+      let mut cells = Vec::new();
+      if let Some(selected_index) = selected_index {
+        cells.push(if index == selected_index { "*" } else { "" }.to_string());
+      }
+      cells.extend([
+        index.to_string(),
+        matched.text.clone(),
+        format_point(matched.action_point()),
+        format_rect(matched.bounds),
+      ]);
+      if wide {
+        cells.push(format!("{:.3}", matched.confidence));
+      }
+      InvokeReportTableRow { cells }
+    })
+    .collect()
+}
+
+fn report_field(label: &str, value: impl Into<String>) -> InvokeReportField {
+  InvokeReportField {
+    label: label.to_string(),
+    value: value.into(),
+  }
+}
+
+fn format_point(point: auv_driver::Point) -> String {
+  format!("{:.0},{:.0}", point.x, point.y)
+}
+
+fn format_rect(rect: auv_driver::Rect) -> String {
+  format!("{:.0},{:.0} {:.0}x{:.0}", rect.origin.x, rect.origin.y, rect.size.width, rect.size.height)
+}
+
+#[cfg(test)]
+mod tests {
+  use auv_driver::Rect;
+  use auv_driver_macos::OcrMatch;
+
+  use super::*;
+
+  #[test]
+  fn match_report_uses_default_table_and_wide_confidence_column() {
+    let matches = vec![
+      OcrMatch {
+        text: "Play".to_string(),
+        confidence: 0.92,
+        bounds: Rect::new(10.0, 20.0, 30.0, 40.0),
+      },
+      OcrMatch {
+        text: "Pause".to_string(),
+        confidence: 0.81,
+        bounds: Rect::new(50.0, 60.0, 70.0, 80.0),
+      },
+    ];
+
+    let report = match_report(&matches, None);
+
+    assert_eq!(report.fields[0].value, "2 text match(es)");
+    assert_eq!(report.tables[0].columns, ["IDX", "TEXT", "POINT", "BOUNDS"]);
+    assert_eq!(report.tables[0].display_max_chars, [None, Some(48), None, None]);
+    assert_eq!(report.tables[0].rows[0].cells, ["0", "Play", "25,40", "10,20 30x40"]);
+    assert_eq!(report.wide_tables[0].columns, ["IDX", "TEXT", "POINT", "BOUNDS", "CONF"]);
+    assert_eq!(report.wide_tables[0].display_max_chars, [None, Some(48), None, None, None]);
+    assert_eq!(report.wide_tables[0].rows[0].cells[4], "0.920");
+  }
+
+  #[test]
+  fn match_report_marks_selected_match_for_click_results() {
+    let matches = vec![OcrMatch {
+      text: "Play".to_string(),
+      confidence: 0.92,
+      bounds: Rect::new(10.0, 20.0, 30.0, 40.0),
+    }];
+
+    let report = match_report(&matches, Some(0));
+
+    assert_eq!(report.tables[0].columns, ["SEL", "IDX", "TEXT", "POINT", "BOUNDS"]);
+    assert_eq!(report.tables[0].rows[0].cells[0], "*");
+    assert_eq!(report.tables[0].display_max_chars, [None, None, Some(48), None, None]);
+  }
+
+  #[test]
+  fn match_report_preserves_full_text_for_machine_output() {
+    let text = "A very long OCR match that should remain complete in the report data before rendering".to_string();
+    let matches = vec![OcrMatch {
+      text: text.clone(),
+      confidence: 0.92,
+      bounds: Rect::new(10.0, 20.0, 30.0, 40.0),
+    }];
+
+    let report = match_report(&matches, None);
+
+    assert_eq!(report.tables[0].rows[0].cells[1], text);
+  }
+}

--- a/crates/auv-cli-invoke/src/commands/screen.rs
+++ b/crates/auv-cli-invoke/src/commands/screen.rs
@@ -190,12 +190,7 @@ fn find_screen_text_impl(input: InvokeCommandInput<'_>, wait: bool) -> InvokeCom
       if wait && matches.matches.is_empty() {
         return Err(format!("screen.waitForText did not find text {query:?} before timeout"));
       }
-      let mut output = text_matches_output(
-        input.command_id,
-        "auv-driver-macos.vision",
-        matches.matches.len(),
-        matches.best_match().map(|matched| matched.text.as_str()),
-      );
+      let mut output = text_matches_output(input.command_id, "auv-driver-macos.vision", &matches.matches, None);
       // TODO(invoke-recognition-result-artifacts): this records the OCR source
       // screenshot and scalar match signals, but not a structured
       // recognition-result artifact with query/bounds/confidence. Add that
@@ -242,7 +237,7 @@ fn click_screen_text_impl(input: InvokeCommandInput<'_>) -> InvokeCommandResult 
   let point = matched.action_point();
   session.input().click_at(point, Click::Single).map_err(|error| error.to_string())?;
 
-  let mut output = text_matches_output(input.command_id, "auv-driver-macos.input", matches.matches.len(), Some(matched.text.as_str()));
+  let mut output = text_matches_output(input.command_id, "auv-driver-macos.input", &matches.matches, Some(0));
   // TODO(invoke-recognition-result-artifacts): clickText records the OCR
   // source screenshot used for target resolution, but not the structured
   // recognition-result artifact. Add it with screen.findText once the
@@ -308,12 +303,20 @@ fn invoke_artifact_path(command_id: &str, label: &str, extension: &str) -> std::
   ))
 }
 
-fn text_matches_output(command_id: &str, backend: &str, count: usize, best_text: Option<&str>) -> InvokeCommandOutput {
+#[cfg(target_os = "macos")]
+fn text_matches_output(
+  command_id: &str,
+  backend: &str,
+  matches: &[auv_driver_macos::OcrMatch],
+  selected_index: Option<usize>,
+) -> InvokeCommandOutput {
+  let count = matches.len();
   let mut output = InvokeCommandOutput::new(format!("{command_id} matched {count} text region(s)"));
   output.backend = Some(backend.to_string());
   output.signals.insert("match.count".to_string(), count.to_string());
-  if let Some(best_text) = best_text {
-    output.signals.insert("match.best_text".to_string(), best_text.to_string());
+  if let Some(best_text) = matches.first() {
+    output.signals.insert("match.best_text".to_string(), best_text.text.clone());
   }
+  output.report = Some(crate::commands::ocr::match_report(matches, selected_index));
   output
 }

--- a/crates/auv-cli-invoke/src/commands/window.rs
+++ b/crates/auv-cli-invoke/src/commands/window.rs
@@ -1,5 +1,6 @@
 use crate::{
-  CommandGroup, InvokeCommandInput, InvokeCommandOutput, InvokeCommandResult,
+  CommandGroup, InvokeCommandInput, InvokeCommandOutput, InvokeCommandResult, InvokeReport, InvokeReportField, InvokeReportTable,
+  InvokeReportTableRow,
   arg::{NO_ARGS, WINDOW_ARGS, WINDOW_TEXT_ARGS, WINDOW_VERIFY_TEXT_ARGS},
   invoke_command,
 };
@@ -188,7 +189,7 @@ fn list_windows_impl(input: InvokeCommandInput<'_>) -> InvokeCommandResult {
   let driver = auv_driver_macos::MacosDriver::new();
   let session = driver.open_local().map_err(|error| error.to_string())?;
   let windows = session.window().list().map_err(|error| error.to_string())?;
-  let mut output = InvokeCommandOutput::new(format!("listed {} window(s)", windows.len()));
+  let mut output = window_list_output(&windows);
   output.backend = Some("auv-driver-macos.window".to_string());
   output.signals.insert("window.count".to_string(), windows.len().to_string());
   if let Some(front) = windows.first() {
@@ -278,12 +279,7 @@ fn find_window_text_impl(input: InvokeCommandInput<'_>, wait: bool) -> InvokeCom
         return Err(format!("window.waitForText did not find text {query:?} before timeout"));
       }
 
-      let mut output = text_matches_output(
-        input.command_id,
-        "auv-driver-macos.window.vision",
-        matches.matches.len(),
-        matches.best_match().map(|matched| matched.text.as_str()),
-      );
+      let mut output = text_matches_output(input.command_id, "auv-driver-macos.window.vision", &matches.matches, None);
       add_window_signals(&mut output, &window);
       // TODO(invoke-recognition-result-artifacts): this records the window OCR
       // source screenshot and scalar match signals, but not a structured
@@ -332,8 +328,7 @@ fn click_window_text_impl(input: InvokeCommandInput<'_>) -> InvokeCommandResult 
   let window_point = session.window().to_window_point(&window, screen_point).map_err(|error| error.to_string())?;
   let action = session.window().click(&window, window_point, ClickOptions::default()).map_err(|error| error.to_string())?;
 
-  let mut output =
-    text_matches_output(input.command_id, "auv-driver-macos.window.input", matches.matches.len(), Some(matched.text.as_str()));
+  let mut output = text_matches_output(input.command_id, "auv-driver-macos.window.input", &matches.matches, Some(0));
   add_window_signals(&mut output, &window);
   // TODO(invoke-recognition-result-artifacts): clickText records the OCR source
   // screenshot used for target resolution, but not the structured
@@ -421,12 +416,196 @@ fn add_window_signals(output: &mut InvokeCommandOutput, window: &auv_driver::Win
   }
 }
 
-fn text_matches_output(command_id: &str, backend: &str, count: usize, best_text: Option<&str>) -> InvokeCommandOutput {
+fn window_list_output(windows: &[auv_driver::Window]) -> InvokeCommandOutput {
+  let mut output = InvokeCommandOutput::new(format!("listed {} window(s)", windows.len()));
+  output.report = Some(window_list_report(windows));
+  output
+}
+
+fn window_list_report(windows: &[auv_driver::Window]) -> InvokeReport {
+  InvokeReport {
+    fields: vec![report_field(
+      "Result",
+      format!("{} window(s)", windows.len()),
+    )],
+    tables: vec![
+      InvokeReportTable::new(
+        vec![
+          "REF".to_string(),
+          "APP".to_string(),
+          "TITLE".to_string(),
+          "FRAME".to_string(),
+        ],
+        windows
+          .iter()
+          .map(|window| InvokeReportTableRow {
+            cells: vec![
+              window.reference.id.clone(),
+              optional_field(window.app_name.as_deref(), "unknown").to_string(),
+              optional_field(window.title.as_deref(), "untitled").to_string(),
+              format_table_rect(window.frame),
+            ],
+          })
+          .collect(),
+      )
+      .with_display_max_chars(vec![None, Some(18), Some(40), None]),
+    ],
+    wide_tables: vec![
+      InvokeReportTable::new(
+        vec![
+          "REF".to_string(),
+          "APP".to_string(),
+          "TITLE".to_string(),
+          "FRAME".to_string(),
+          "BUNDLE".to_string(),
+          "PID".to_string(),
+          "FLAGS".to_string(),
+        ],
+        windows
+          .iter()
+          .map(|window| InvokeReportTableRow {
+            cells: vec![
+              window.reference.id.clone(),
+              optional_field(window.app_name.as_deref(), "unknown").to_string(),
+              optional_field(window.title.as_deref(), "untitled").to_string(),
+              format_table_rect(window.frame),
+              optional_field(window.app_bundle_id.as_deref(), "unknown").to_string(),
+              window.process_id.map(|pid| pid.to_string()).unwrap_or_else(|| "unknown".to_string()),
+              window_flags(window),
+            ],
+          })
+          .collect(),
+      )
+      .with_display_max_chars(vec![None, Some(18), Some(40), None, Some(32), None, None]),
+    ],
+    sections: Vec::new(),
+  }
+}
+
+fn optional_field<'a>(value: Option<&'a str>, fallback: &'a str) -> &'a str {
+  value.filter(|value| !value.trim().is_empty()).unwrap_or(fallback)
+}
+
+fn report_field(label: &str, value: impl Into<String>) -> InvokeReportField {
+  InvokeReportField {
+    label: label.to_string(),
+    value: value.into(),
+  }
+}
+
+fn format_table_rect(rect: auv_driver::Rect) -> String {
+  format!("{:.0},{:.0} {:.0}x{:.0}", rect.origin.x, rect.origin.y, rect.size.width, rect.size.height)
+}
+
+fn window_flags(window: &auv_driver::Window) -> String {
+  let mut flags = Vec::new();
+  if window.is_main {
+    flags.push("main");
+  }
+  if window.is_visible {
+    flags.push("visible");
+  } else {
+    flags.push("hidden");
+  }
+  flags.join(",")
+}
+
+#[cfg(target_os = "macos")]
+fn text_matches_output(
+  command_id: &str,
+  backend: &str,
+  matches: &[auv_driver_macos::OcrMatch],
+  selected_index: Option<usize>,
+) -> InvokeCommandOutput {
+  let count = matches.len();
   let mut output = InvokeCommandOutput::new(format!("{command_id} matched {count} text region(s)"));
   output.backend = Some(backend.to_string());
   output.signals.insert("match.count".to_string(), count.to_string());
-  if let Some(best_text) = best_text {
-    output.signals.insert("match.best_text".to_string(), best_text.to_string());
+  if let Some(best_text) = matches.first() {
+    output.signals.insert("match.best_text".to_string(), best_text.text.clone());
   }
+  output.report = Some(crate::commands::ocr::match_report(matches, selected_index));
   output
+}
+
+#[cfg(test)]
+mod tests {
+  use auv_driver::{CoordinateSpace, Rect, Window, WindowRef};
+
+  use super::*;
+
+  #[test]
+  fn window_list_report_uses_human_first_table_and_wide_diagnostic_columns() {
+    let windows = vec![
+      Window {
+        reference: WindowRef {
+          id: "window_10".to_string(),
+        },
+        title: Some("Project Notes".to_string()),
+        app_name: Some("TextEdit".to_string()),
+        app_bundle_id: Some("com.apple.TextEdit".to_string()),
+        process_id: Some(1234),
+        frame: Rect::new(12.0, 34.0, 640.0, 480.0),
+        coordinate_space: CoordinateSpace::Screen,
+        is_main: true,
+        is_visible: true,
+      },
+      Window {
+        reference: WindowRef {
+          id: "window_11".to_string(),
+        },
+        title: None,
+        app_name: None,
+        app_bundle_id: None,
+        process_id: None,
+        frame: Rect::new(-100.0, 20.0, 300.0, 200.0),
+        coordinate_space: CoordinateSpace::Screen,
+        is_main: false,
+        is_visible: false,
+      },
+    ];
+
+    let output = window_list_output(&windows);
+    let report = output.report.as_ref().expect("window.list should expose a human-readable report");
+
+    assert_eq!(report.fields[0].value, "2 window(s)");
+    assert!(report.sections.is_empty());
+    assert_eq!(report.tables[0].columns, ["REF", "APP", "TITLE", "FRAME"]);
+    assert_eq!(report.tables[0].display_max_chars, [None, Some(18), Some(40), None]);
+    assert_eq!(report.tables[0].rows[0].cells, ["window_10", "TextEdit", "Project Notes", "12,34 640x480"]);
+    assert_eq!(report.tables[0].rows[1].cells, ["window_11", "unknown", "untitled", "-100,20 300x200"]);
+    assert_eq!(report.wide_tables[0].columns, ["REF", "APP", "TITLE", "FRAME", "BUNDLE", "PID", "FLAGS"]);
+    assert_eq!(report.wide_tables[0].display_max_chars, [None, Some(18), Some(40), None, Some(32), None, None]);
+    assert_eq!(report.wide_tables[0].rows[0].cells[4], "com.apple.TextEdit");
+    assert_eq!(report.wide_tables[0].rows[0].cells[5], "1234");
+    assert_eq!(report.wide_tables[0].rows[0].cells[6], "main,visible");
+    assert_eq!(report.wide_tables[0].rows[1].cells[6], "hidden");
+  }
+
+  #[test]
+  fn window_list_report_preserves_full_cell_values_for_machine_output() {
+    let long_title = "Fixture Window Title With Enough Words To Exceed The Human Display Limit".to_string();
+    let long_app_name = "Fixture Application Name Beyond Human Display Limit".to_string();
+    let long_bundle_id = "com.example.fixture.application.identifier.with.extra.segments".to_string();
+    let windows = vec![Window {
+      reference: WindowRef {
+        id: "window_long".to_string(),
+      },
+      title: Some(long_title.clone()),
+      app_name: Some(long_app_name.clone()),
+      app_bundle_id: Some(long_bundle_id.clone()),
+      process_id: Some(4321),
+      frame: Rect::new(1.0, 2.0, 3.0, 4.0),
+      coordinate_space: CoordinateSpace::Screen,
+      is_main: false,
+      is_visible: true,
+    }];
+
+    let output = window_list_output(&windows);
+    let report = output.report.as_ref().expect("window.list should expose a report");
+
+    assert_eq!(report.tables[0].rows[0].cells[1], long_app_name);
+    assert_eq!(report.tables[0].rows[0].cells[2], long_title);
+    assert_eq!(report.wide_tables[0].rows[0].cells[4], long_bundle_id);
+  }
 }

--- a/crates/auv-cli-invoke/src/help.rs
+++ b/crates/auv-cli-invoke/src/help.rs
@@ -2,7 +2,7 @@ use crate::{ArgSpec, CommandGroup, CommandNode, InvokeCommand, InvokeRegistry};
 
 pub fn render_help_index(registry: &InvokeRegistry) -> String {
   let mut help = String::from(
-    "USAGE\n  auv invoke <command> [options]\n\nOPTIONS\n  --json    Render machine-readable JSON output\n  --detail  Include diagnostic detail in human output\n\nUse auv invoke <command> --help for command-specific options.\n",
+    "USAGE\n  auv invoke <command> [options]\n\nOPTIONS\n  --json    Render machine-readable JSON output\n  --detail  Include diagnostic detail in human output\n  --wide    Include extra columns in human table output\n\nUse auv invoke <command> --help for command-specific options.\n",
   );
 
   for group in registry.groups() {
@@ -61,23 +61,22 @@ pub fn render_command_help(command: &InvokeCommand) -> String {
   );
 
   help.push_str("\nOPTIONS\n");
-  if command.args.is_empty() {
-    help.push_str("  none\n");
-  } else {
-    for arg in command.args {
-      help.push_str("  ");
-      help.push_str(arg.flag);
-      help.push(' ');
-      help.push_str(arg.value_name);
-      if arg.required {
-        help.push_str("  required  ");
-      } else {
-        help.push_str("  optional  ");
-      }
-      help.push_str(arg.help);
-      help.push('\n');
+  for arg in command.args {
+    help.push_str("  ");
+    help.push_str(arg.flag);
+    help.push(' ');
+    help.push_str(arg.value_name);
+    if arg.required {
+      help.push_str("  required  ");
+    } else {
+      help.push_str("  optional  ");
     }
+    help.push_str(arg.help);
+    help.push('\n');
   }
+  help.push_str("  --json    Render machine-readable JSON output\n");
+  help.push_str("  --detail  Include diagnostic detail in human output\n");
+  help.push_str("  --wide    Include extra columns in human table output\n");
 
   help
 }

--- a/crates/auv-cli-invoke/src/lib.rs
+++ b/crates/auv-cli-invoke/src/lib.rs
@@ -24,7 +24,8 @@ pub use auv_cli_invoke_macros::invoke_command;
 pub use command::{CommandGroup, CommandNode, InvokeCommand, InvokeCommandInput, InvokeCommandOutput, InvokeCommandResult, InvokeNamespace};
 pub use help::{render_command_help, render_help_index};
 pub use model::{
-  ExecutionTarget, InvokeOutputOptions, InvokeReport, InvokeReportField, InvokeReportSection, InvokeRequest, InvokeResult, RunStatus,
+  ExecutionTarget, InvokeOutputOptions, InvokeReport, InvokeReportField, InvokeReportSection, InvokeReportTable, InvokeReportTableRow,
+  InvokeRequest, InvokeResult, RunStatus,
 };
 pub use recorded::{invoke_recorded, invoke_recorded_in_span, invoke_recorded_with_session, invoke_resolved_recorded_in_span};
 pub use registry::{InvokeRegistry, default_registry};
@@ -75,13 +76,14 @@ pub fn parse_invoke_args(arguments: &[String]) -> Result<InvokeCliParse, String>
     output: InvokeOutputOptions {
       json: matches.get_flag("json") || matches.get_flag("format"),
       detail: matches.get_flag("detail"),
+      wide: matches.get_flag("wide"),
     },
   })
 }
 
 pub fn invoke_argument_consumes_value(argument: &str) -> bool {
   match argument {
-    "--dry-run" | "--detail" | "--json" | "--format" | "--help" | "-h" => false,
+    "--dry-run" | "--detail" | "--wide" | "--json" | "--format" | "--help" | "-h" => false,
     other => other.starts_with("--"),
   }
 }
@@ -107,6 +109,7 @@ fn invoke_cli_command() -> Command {
     .arg(Arg::new("target").long("target").value_name("bundle-id").num_args(1))
     .arg(Arg::new("label").long("label").value_name("value").num_args(1))
     .arg(Arg::new("detail").long("detail").action(ArgAction::SetTrue))
+    .arg(Arg::new("wide").long("wide").action(ArgAction::SetTrue))
     .arg(Arg::new("json").long("json").action(ArgAction::SetTrue))
     .arg(Arg::new("format").long("format").action(ArgAction::SetTrue).hide(true))
 }
@@ -127,7 +130,7 @@ fn normalize_for_clap(tokens: &[String]) -> Result<NormalizedInvokeArguments, St
           help: Some(InvokeCliParse::Help { command_id }),
         });
       }
-      "--dry-run" | "--detail" | "--json" | "--format" => {
+      "--dry-run" | "--detail" | "--wide" | "--json" | "--format" => {
         clap_arguments.push(token.clone());
         index += 1;
       }
@@ -182,6 +185,7 @@ mod tests {
     assert!(help.contains("DISPLAY\n"));
     assert!(help.contains("--json"));
     assert!(help.contains("--detail"));
+    assert!(help.contains("--wide"));
     assert!(!help.contains("--format"));
     assert!(help.contains("  display.list"));
     assert!(help.contains("WINDOW\n"));
@@ -300,6 +304,26 @@ mod tests {
       crate::InvokeCliParse::Invoke { output, .. } => {
         assert!(output.detail);
         assert!(!output.json);
+      }
+      other => panic!("unexpected parse result: {other:?}"),
+    }
+  }
+
+  #[test]
+  fn parse_invoke_wide_keeps_human_output_mode_and_does_not_become_command_input() {
+    let parsed = crate::parse_invoke_args(&[
+      "invoke".to_string(),
+      "window.list".to_string(),
+      "--wide".to_string(),
+    ])
+    .expect("wide should parse");
+
+    match parsed {
+      crate::InvokeCliParse::Invoke { inputs, output, .. } => {
+        assert!(output.wide);
+        assert!(!output.json);
+        assert!(!output.detail);
+        assert!(!inputs.contains_key("wide"));
       }
       other => panic!("unexpected parse result: {other:?}"),
     }
@@ -431,7 +455,10 @@ mod tests {
     assert!(help.contains("COMMAND\n  fixture.observe"));
     assert!(help.contains("USAGE\n  auv invoke fixture.observe"));
     assert!(help.contains("SUMMARY\n  Emit a deterministic observation result"));
-    assert!(help.contains("OPTIONS\n  none"));
+    assert!(help.contains("OPTIONS\n  --json"));
+    assert!(help.contains("--detail"));
+    assert!(help.contains("--wide"));
+    assert!(!help.contains("OPTIONS\n  none"));
     assert!(!help.contains("DRIVER\n"));
     assert!(!help.contains("DISTURBANCE\n"));
     assert!(!help.contains("ARTIFACTS\n"));

--- a/crates/auv-cli-invoke/src/model.rs
+++ b/crates/auv-cli-invoke/src/model.rs
@@ -21,6 +21,7 @@ pub struct InvokeRequest {
 pub struct InvokeOutputOptions {
   pub json: bool,
   pub detail: bool,
+  pub wide: bool,
 }
 
 impl Default for InvokeOutputOptions {
@@ -28,6 +29,7 @@ impl Default for InvokeOutputOptions {
     Self {
       json: false,
       detail: false,
+      wide: false,
     }
   }
 }
@@ -35,7 +37,22 @@ impl Default for InvokeOutputOptions {
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct InvokeReport {
   pub fields: Vec<InvokeReportField>,
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  pub tables: Vec<InvokeReportTable>,
+  #[serde(default, skip)]
+  pub wide_tables: Vec<InvokeReportTable>,
   pub sections: Vec<InvokeReportSection>,
+}
+
+impl InvokeReport {
+  pub fn new(fields: Vec<InvokeReportField>, sections: Vec<InvokeReportSection>) -> Self {
+    Self {
+      fields,
+      tables: Vec::new(),
+      wide_tables: Vec::new(),
+      sections,
+    }
+  }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -48,6 +65,34 @@ pub struct InvokeReportField {
 pub struct InvokeReportSection {
   pub title: String,
   pub fields: Vec<InvokeReportField>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct InvokeReportTable {
+  pub columns: Vec<String>,
+  pub rows: Vec<InvokeReportTableRow>,
+  #[serde(default, skip)]
+  pub display_max_chars: Vec<Option<usize>>,
+}
+
+impl InvokeReportTable {
+  pub fn new(columns: Vec<String>, rows: Vec<InvokeReportTableRow>) -> Self {
+    Self {
+      columns,
+      rows,
+      display_max_chars: Vec::new(),
+    }
+  }
+
+  pub fn with_display_max_chars(mut self, display_max_chars: Vec<Option<usize>>) -> Self {
+    self.display_max_chars = display_max_chars;
+    self
+  }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct InvokeReportTableRow {
+  pub cells: Vec<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]

--- a/crates/auv-cli-invoke/src/recorded.rs
+++ b/crates/auv-cli-invoke/src/recorded.rs
@@ -267,19 +267,19 @@ mod tests {
     output.notes.push("fixture note".to_string());
     output.known_limits.push("fixture limit".to_string());
     output.verification = Some("read-only; no semantic success claim".to_string());
-    output.report = Some(InvokeReport {
-      fields: vec![InvokeReportField {
+    output.report = Some(InvokeReport::new(
+      vec![InvokeReportField {
         label: "Result".to_string(),
         value: "Observed".to_string(),
       }],
-      sections: vec![InvokeReportSection {
+      vec![InvokeReportSection {
         title: "Fixture".to_string(),
         fields: vec![InvokeReportField {
           label: "Signal".to_string(),
           value: "observed".to_string(),
         }],
       }],
-    });
+    ));
     output.signals.insert("fixture".to_string(), "observed".to_string());
     Ok(output)
   }
@@ -294,19 +294,19 @@ mod tests {
     output.notes.push("artifact failure fixture note".to_string());
     output.known_limits.push("artifact failure fixture limit".to_string());
     output.verification = Some("capture-only; no semantic success claim".to_string());
-    output.report = Some(InvokeReport {
-      fields: vec![InvokeReportField {
+    output.report = Some(InvokeReport::new(
+      vec![InvokeReportField {
         label: "Result".to_string(),
         value: "Artifact pending".to_string(),
       }],
-      sections: vec![InvokeReportSection {
+      vec![InvokeReportSection {
         title: "Artifact Failure Fixture".to_string(),
         fields: vec![InvokeReportField {
           label: "Backend".to_string(),
           value: "fixture.artifact.backend".to_string(),
         }],
       }],
-    });
+    ));
     output.artifacts.push(ProducedArtifact {
       kind: "missing-fixture-artifact".to_string(),
       source_path: temp_dir("missing-artifact-source").join("missing.txt"),
@@ -408,19 +408,19 @@ mod tests {
     assert_eq!(result.verification.as_deref(), Some("read-only; no semantic success claim"));
     assert_eq!(
       result.report,
-      Some(InvokeReport {
-        fields: vec![InvokeReportField {
+      Some(InvokeReport::new(
+        vec![InvokeReportField {
           label: "Result".to_string(),
           value: "Observed".to_string(),
         }],
-        sections: vec![InvokeReportSection {
+        vec![InvokeReportSection {
           title: "Fixture".to_string(),
           fields: vec![InvokeReportField {
             label: "Signal".to_string(),
             value: "observed".to_string(),
           }],
         }],
-      })
+      ))
     );
 
     let _ = fs::remove_dir_all(store_root);
@@ -588,19 +588,19 @@ mod tests {
     assert_eq!(result.verification.as_deref(), Some("capture-only; no semantic success claim"));
     assert_eq!(
       result.report,
-      Some(InvokeReport {
-        fields: vec![InvokeReportField {
+      Some(InvokeReport::new(
+        vec![InvokeReportField {
           label: "Result".to_string(),
           value: "Artifact pending".to_string(),
         }],
-        sections: vec![InvokeReportSection {
+        vec![InvokeReportSection {
           title: "Artifact Failure Fixture".to_string(),
           fields: vec![InvokeReportField {
             label: "Backend".to_string(),
             value: "fixture.artifact.backend".to_string(),
           }],
         }],
-      })
+      ))
     );
     assert!(result.failure_message.as_deref().is_some_and(|message| message.contains("artifact recording failed")));
     assert!(result.artifacts.is_empty());

--- a/crates/auv-cli-invoke/src/render.rs
+++ b/crates/auv-cli-invoke/src/render.rs
@@ -3,9 +3,10 @@ use std::io::{self, Write};
 
 use anstream::{AutoStream, ColorChoice};
 use anstyle::{AnsiColor, Style};
+use comfy_table::{Cell, Table, presets::NOTHING};
 use serde::Serialize;
 
-use crate::{InvokeOutputOptions, InvokeReport, InvokeReportField, InvokeResult, RunStatus};
+use crate::{InvokeOutputOptions, InvokeReport, InvokeReportField, InvokeReportTable, InvokeResult, RunStatus};
 
 pub fn render_invoke_result(result: &InvokeResult, options: InvokeOutputOptions) -> Result<(), String> {
   if options.json {
@@ -48,7 +49,7 @@ fn write_human<W: Write>(writer: &mut W, result: &InvokeResult, options: InvokeO
   }
 
   match result.report.as_ref() {
-    Some(report) => write_report(writer, report, color)?,
+    Some(report) => write_report(writer, report, options, color)?,
     None => write_field_rows(writer, &[field("Output", &result.output_summary)], color)?,
   }
 
@@ -64,8 +65,18 @@ fn write_human<W: Write>(writer: &mut W, result: &InvokeResult, options: InvokeO
   Ok(())
 }
 
-fn write_report<W: Write>(writer: &mut W, report: &InvokeReport, color: bool) -> Result<(), String> {
+fn write_report<W: Write>(writer: &mut W, report: &InvokeReport, options: InvokeOutputOptions, color: bool) -> Result<(), String> {
   write_field_rows(writer, &report.fields, color)?;
+
+  let tables = if options.wide && !report.wide_tables.is_empty() {
+    &report.wide_tables
+  } else {
+    &report.tables
+  };
+  for table in tables {
+    writeln!(writer).map_err(write_error)?;
+    write_table(writer, table)?;
+  }
 
   for section in &report.sections {
     writeln!(writer).map_err(write_error)?;
@@ -74,6 +85,38 @@ fn write_report<W: Write>(writer: &mut W, report: &InvokeReport, color: bool) ->
   }
 
   Ok(())
+}
+
+fn write_table<W: Write>(writer: &mut W, table: &InvokeReportTable) -> Result<(), String> {
+  let mut rendered = Table::new();
+  rendered.load_preset(NOTHING);
+  rendered.set_header(table.columns.iter().map(Cell::new));
+  for row in &table.rows {
+    rendered.add_row(row.cells.iter().enumerate().map(|(index, cell)| Cell::new(display_cell(table, index, cell))));
+  }
+  for line in rendered.to_string().lines() {
+    writeln!(writer, "  {}", line.trim()).map_err(write_error)?;
+  }
+  Ok(())
+}
+
+fn display_cell(table: &InvokeReportTable, column_index: usize, value: &str) -> String {
+  match table.display_max_chars.get(column_index).copied().flatten() {
+    Some(max_chars) => truncate(value, max_chars),
+    None => value.to_string(),
+  }
+}
+
+fn truncate(value: &str, max_chars: usize) -> String {
+  if value.chars().count() <= max_chars {
+    return value.to_string();
+  }
+  if max_chars <= 3 {
+    return ".".repeat(max_chars);
+  }
+  let mut truncated = value.chars().take(max_chars - 3).collect::<String>();
+  truncated.push_str("...");
+  truncated
 }
 
 fn write_detail<W: Write>(writer: &mut W, result: &InvokeResult, color: bool) -> Result<(), String> {
@@ -222,7 +265,10 @@ mod tests {
   use auv_tracing_driver::trace::{ARTIFACT_API_VERSION, ArtifactId, ArtifactRecordV1Alpha1, EventId, SpanId};
   use serde_json::Value;
 
-  use crate::{InvokeOutputOptions, InvokeReport, InvokeReportField, InvokeReportSection, InvokeResult, RunStatus};
+  use crate::{
+    InvokeOutputOptions, InvokeReport, InvokeReportField, InvokeReportSection, InvokeReportTable, InvokeReportTableRow, InvokeResult,
+    RunStatus,
+  };
 
   fn fixture_result(status: RunStatus) -> InvokeResult {
     let mut signals = BTreeMap::new();
@@ -247,6 +293,28 @@ mod tests {
           label: "Result".to_string(),
           value: "observed".to_string(),
         }],
+        tables: vec![
+          InvokeReportTable::new(
+            vec!["REF".to_string(), "APP".to_string()],
+            vec![InvokeReportTableRow {
+              cells: vec![
+                "fixture_0".to_string(),
+                "Fixture Application With A Long Display Name".to_string(),
+              ],
+            }],
+          )
+          .with_display_max_chars(vec![None, Some(16)]),
+        ],
+        wide_tables: vec![InvokeReportTable::new(
+          vec!["REF".to_string(), "APP".to_string(), "PID".to_string()],
+          vec![InvokeReportTableRow {
+            cells: vec![
+              "fixture_0".to_string(),
+              "Fixture Application With A Long Display Name".to_string(),
+              "1234".to_string(),
+            ],
+          }],
+        )],
         sections: vec![InvokeReportSection {
           title: "fixture_0".to_string(),
           fields: vec![InvokeReportField {
@@ -279,7 +347,13 @@ mod tests {
     assert!(output.contains("OK. Run: run_fixture"));
     assert!(output.contains("fixture.observe - Observe fixture"));
     assert!(output.contains("Result: observed"));
+    assert!(output.contains("REF"));
     assert!(output.contains("fixture_0"));
+    assert!(output.contains("Fixture Appli..."));
+    assert!(!output.contains("Fixture Application With A Long Display Name"));
+    assert!(output.contains("fixture_0"));
+    assert!(!output.contains("PID"));
+    assert!(!output.contains("1234"));
     assert!(!output.contains("operatorSummary"));
     assert!(!output.contains("raw operator text"));
     assert!(!output.contains("Signals"));
@@ -307,6 +381,7 @@ mod tests {
       InvokeOutputOptions {
         json: false,
         detail: true,
+        wide: false,
       },
     )
     .expect("render should succeed");
@@ -324,12 +399,29 @@ mod tests {
   }
 
   #[test]
+  fn wide_output_renders_wide_report_table() {
+    let output = super::render_to_string(
+      &fixture_result(RunStatus::Completed),
+      InvokeOutputOptions {
+        json: false,
+        detail: false,
+        wide: true,
+      },
+    )
+    .expect("render should succeed");
+
+    assert!(output.contains("PID"));
+    assert!(output.contains("1234"));
+  }
+
+  #[test]
   fn json_output_parses_and_contains_no_ansi() {
     let output = super::render_to_string(
       &fixture_result(RunStatus::Completed),
       InvokeOutputOptions {
         json: true,
         detail: false,
+        wide: false,
       },
     )
     .expect("render should succeed");
@@ -341,6 +433,9 @@ mod tests {
     assert_eq!(value["command_id"], "fixture.observe");
     assert_eq!(value["summary"], "fixture observed");
     assert!(value.get("report").is_some());
+    assert_eq!(value["report"]["tables"][0]["rows"][0]["cells"][1], "Fixture Application With A Long Display Name");
+    assert!(value["report"].get("wide_tables").is_none());
+    assert!(value["report"]["tables"][0].get("display_max_chars").is_none());
     assert!(value.get("artifacts").is_some());
     assert!(value.get("signals").is_none());
   }


### PR DESCRIPTION
## Summary

- add `comfy-table` rendering for invoke reports with table sections and `--wide` human output
- migrate `window.list`, `display.list`, and OCR text match outputs to compact table reports
- keep table display truncation presentation-only so JSON preserves full report cell values
- include global `--json`, `--detail`, and `--wide` options in command-specific help
- add regression coverage for table rendering, JSON shape, wide output, and untruncated machine report data

## Validation

- `cargo test -p auv-cli-invoke`
- `cargo fmt --check`
- `cargo check`
- `cargo test`
- `git diff --check`
- `cargo run --quiet -- invoke window.list --help`
- `cargo run --quiet -- invoke fixture.observe --json`
- `cargo run --quiet -- invoke window.list --json`

## Notes

`cargo fmt --check` still prints the existing rustfmt config warnings for `fn_call_width` and `chain_width`, but exits 0. `cargo test` still prints existing dead-code warnings unrelated to this PR.