### PR TITLE
refactor(session): separate grpc adapter and server

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,11 +1,10 @@
 //! External API service seams over AUV's runtime.
 //!
-//! API-P4 calls for a dedicated session API server boundary, separate from the
-//! tool-facing `mcp` surface and the inspect viewer/server API. This module is
-//! that owned subtree.
+//! The session API server is separate from the tool-facing `mcp` surface and
+//! the inspect viewer/server API.
 //!
 //! Current contents:
-//! - `session_service`: the execute-facing `SessionService` seam (summary read
-//!   path + join policy today; transport handlers are a later slice).
+//! - `session_service`: execute-facing application, gRPC, server, and summary
+//!   read/write boundaries.
 
 pub mod session_service;

--- a/src/api/session_service/grpc.rs
+++ b/src/api/session_service/grpc.rs
@@ -1,0 +1,158 @@
+//! Tonic adapter for the session API.
+//!
+//! This module owns protobuf RPC dispatch, handler-error mapping, and the
+//! blocking/cancellation bridge. Server configuration, listen policy, and
+//! lifecycle live in [`super::server`].
+//!
+//! `StreamSessionEvents` remains unimplemented because the application layer
+//! has no event projector to provide a real stream. The adapter returns
+//! `UNIMPLEMENTED` rather than fabricating an empty stream.
+//!
+//! NOTICE: Dropping an RPC cancels its join handle, but `spawn_blocking` work
+//! already in flight cannot be forcibly interrupted. An invoke may therefore
+//! finish recording after the caller receives `CANCELLED` until cooperative
+//! cancellation reaches the invoke runtime.
+
+use std::sync::Arc;
+
+use auv_api_proto::v1::session as proto;
+use auv_api_proto::v1::session::session_service_server::SessionService;
+use tokio_util::sync::CancellationToken;
+use tonic::{Request, Response, Status};
+
+use super::SessionApiError;
+use super::handler::SessionApiHandler;
+
+fn map_session_error(error: SessionApiError) -> Status {
+  match error {
+    SessionApiError::MissingField(_) | SessionApiError::PayloadDecode(_) => Status::invalid_argument(error.to_string()),
+    SessionApiError::UnknownSession(_) | SessionApiError::RunNotFound(_) => Status::not_found(error.to_string()),
+    SessionApiError::PersistedOperationRequired(_) => Status::failed_precondition(error.to_string()),
+    SessionApiError::OperationIdMismatch { .. } => Status::invalid_argument(error.to_string()),
+    SessionApiError::Storage(_) | SessionApiError::InvokeExecution(_) => Status::internal(error.to_string()),
+  }
+}
+
+/// Cancels the paired RPC token when the tonic handler future is dropped.
+struct RpcCancelGuard(CancellationToken);
+
+impl Drop for RpcCancelGuard {
+  fn drop(&mut self) {
+    self.0.cancel();
+  }
+}
+
+async fn run_blocking_rpc<T>(
+  cancel: CancellationToken,
+  work: impl FnOnce() -> Result<T, SessionApiError> + Send + 'static,
+) -> Result<T, Status>
+where
+  T: Send + 'static,
+{
+  let preflight = cancel.child_token();
+  let mut join = tokio::task::spawn_blocking(move || {
+    if preflight.is_cancelled() {
+      return None;
+    }
+    Some(work())
+  });
+
+  tokio::select! {
+    _ = cancel.cancelled() => {
+      join.abort();
+      Err(Status::cancelled("session API request cancelled"))
+    }
+    result = &mut join => {
+      let Some(result) = result
+        .map_err(|error| Status::internal(format!("handler task join failed: {error}")))?
+      else {
+        return Err(Status::cancelled("session API request cancelled"));
+      };
+      result.map_err(map_session_error)
+    }
+  }
+}
+
+/// Tonic `SessionService` adapter over the protobuf-aware application handler.
+#[derive(Clone)]
+pub(crate) struct SessionServiceGrpc {
+  handler: Arc<SessionApiHandler>,
+}
+
+impl SessionServiceGrpc {
+  pub(crate) fn new(handler: Arc<SessionApiHandler>) -> Self {
+    Self { handler }
+  }
+}
+
+#[tonic::async_trait]
+impl SessionService for SessionServiceGrpc {
+  async fn create_session(&self, request: Request<proto::CreateSessionRequest>) -> Result<Response<proto::CreateSessionResponse>, Status> {
+    let cancel = CancellationToken::new();
+    let _guard = RpcCancelGuard(cancel.clone());
+    let handler = Arc::clone(&self.handler);
+    let inner = request.into_inner();
+    run_blocking_rpc(cancel, move || handler.create_session(inner)).await.map(Response::new)
+  }
+
+  async fn invoke(&self, request: Request<proto::InvokeRequest>) -> Result<Response<proto::InvokeResponse>, Status> {
+    let cancel = CancellationToken::new();
+    let _guard = RpcCancelGuard(cancel.clone());
+    let handler = Arc::clone(&self.handler);
+    let inner = request.into_inner();
+    run_blocking_rpc(cancel, move || handler.invoke(inner)).await.map(Response::new)
+  }
+
+  async fn get_operation(&self, request: Request<proto::GetOperationRequest>) -> Result<Response<proto::GetOperationResponse>, Status> {
+    let cancel = CancellationToken::new();
+    let _guard = RpcCancelGuard(cancel.clone());
+    let handler = Arc::clone(&self.handler);
+    let inner = request.into_inner();
+    run_blocking_rpc(cancel, move || handler.get_operation(inner)).await.map(Response::new)
+  }
+
+  type StreamSessionEventsStream = std::pin::Pin<Box<dyn tokio_stream::Stream<Item = Result<proto::SessionEvent, Status>> + Send>>;
+
+  async fn stream_session_events(
+    &self,
+    _request: Request<proto::StreamSessionEventsRequest>,
+  ) -> Result<Response<Self::StreamSessionEventsStream>, Status> {
+    Err(Status::unimplemented("session API seam not wired: stream_session_events"))
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use auv_api_proto::v1::session::session_service_server::SessionService;
+  use tonic::Code;
+
+  use super::*;
+  use crate::api::session_service::test_fixtures::session_api_temp_store_root;
+
+  #[test]
+  fn map_session_error_maps_representative_variants() {
+    assert_eq!(map_session_error(SessionApiError::MissingField("session")).code(), Code::InvalidArgument);
+    assert_eq!(map_session_error(SessionApiError::UnknownSession("ghost".to_string())).code(), Code::NotFound);
+    assert_eq!(map_session_error(SessionApiError::PersistedOperationRequired("run-1".to_string())).code(), Code::FailedPrecondition);
+    assert_eq!(map_session_error(SessionApiError::Storage("disk".to_string())).code(), Code::Internal);
+  }
+
+  #[tokio::test]
+  async fn stream_session_events_remains_unimplemented() {
+    let handler = Arc::new(SessionApiHandler::new(session_api_temp_store_root("grpc-stream-events")));
+    let service = SessionServiceGrpc::new(handler);
+    let status = match service.stream_session_events(Request::new(proto::StreamSessionEventsRequest { session: None })).await {
+      Ok(_) => panic!("streaming should remain unimplemented"),
+      Err(status) => status,
+    };
+    assert_eq!(status.code(), Code::Unimplemented);
+  }
+
+  #[tokio::test]
+  async fn run_blocking_rpc_returns_cancelled_when_token_fires() {
+    let cancel = CancellationToken::new();
+    cancel.cancel();
+    let status = run_blocking_rpc(cancel, || Ok(42_u32)).await.expect_err("cancelled before work starts");
+    assert_eq!(status.code(), Code::Cancelled);
+  }
+}

--- a/src/api/session_service/handler.rs
+++ b/src/api/session_service/handler.rs
@@ -1,18 +1,14 @@
-//! Session API handler skeleton (API-P8).
+//! Session API application orchestration.
 //!
-//! Transport-agnostic: this is NOT a gRPC server and implements no tonic
-//! service trait. API-P4 defers the tonic/axum transport decision; this skeleton
-//! only wires the proto request/response shapes to the internal seams:
-//! session-aware invoke (API-P5), the operation summary cache (API-P6), the
-//! persisted operation-summary artifact (API-P11), synthetic operation-result
-//! artifact (API-R2), and the two-source `GetOperation` join (API-P7). Binding a
-//! transport is a later owner-named slice (see the `mod.rs` TODO).
+//! This module implements no tonic service trait, but it accepts generated
+//! protobuf request and response types, so it is tonic-independent rather than
+//! transport-agnostic. It wires session validation, recorded invoke, operation
+//! persistence, and the two-source `GetOperation` join.
 //!
-//! NOTICE(api-r2-invoke-persist): `Invoke` records a run, caches the runtime
-//! summary (API-P6), persists the runtime summary artifact (API-P11), and writes
-//! a synthetic `operation-result` skeleton (API-R2) so fresh `GetOperation` joins
-//! succeed on the happy path. Typed producers may still record richer domain
-//! `operation_id` labels outside this session invoke write path.
+//! Invoke records a run, caches the runtime summary only after both durability
+//! writes succeed, persists the runtime summary artifact, and writes a synthetic
+//! `operation-result` so fresh `GetOperation` joins succeed. Typed producers may
+//! still record richer domain operation identifiers outside this path.
 
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -34,12 +30,12 @@ use crate::api::session_service::summary_store::record_invoke_summary;
 /// **Not** a long-lived `Runtime`, `RunRecordingBackend`, or shared invoke executor.
 /// **Is** a process-local façade over:
 /// - `store_root` — durable runs and artifacts live here
-/// - `SessionRegistry` — lightweight session id registry (API-P4)
-/// - `OperationSummaryCache` — InvokeResult-sourced summary cache (API-P6)
+/// - `SessionRegistry` — lightweight session id registry
+/// - `OperationSummaryCache` — invoke-result-sourced summary cache
 ///
 /// Each `invoke` opens a fresh `LocalStore` + `RunRecordingBackend` (see
-/// `NOTICE(api-p8-ephemeral-recording)`); recording is discarded when the call
-/// returns. Durability is store-backed artifacts, not handler fields.
+/// [`SessionApiHandler::invoke`]); recording is discarded when the call returns.
+/// Durability is store-backed artifacts, not handler fields.
 pub struct SessionApiHandler {
   store_root: PathBuf,
   registry: Mutex<SessionRegistry>,
@@ -62,9 +58,8 @@ impl SessionApiHandler {
   /// `CreateSession`: allocate + register lightweight session metadata, return a
   /// `SessionRef`.
   pub fn create_session(&self, _request: proto::CreateSessionRequest) -> Result<proto::CreateSessionResponse, SessionApiError> {
-    // TODO(api-p8-event): emit a `session_created` SessionEvent once the event
-    // projector (API-P4 responsibility D) has a source. No event bus is wired in
-    // this skeleton, so creation is silent.
+    // TODO: Emit `session_created` after an application event source and event
+    // projector are approved. No event bus exists, so creation is silent.
     let session_id = self.registry.lock().expect("session registry mutex poisoned").create();
     Ok(proto::CreateSessionResponse {
       session: Some(proto::SessionRef {
@@ -74,11 +69,11 @@ impl SessionApiHandler {
   }
 
   /// `Invoke`: validate the session, decode the payload, run the session-aware
-  /// recorded invoke (API-P5), record the summary (API-P6), and map the result.
+  /// recorded invoke, record the summary, and map the result.
   ///
-  /// NOTICE(api-p8-ephemeral-recording): each call opens a new `LocalStore` and
-  /// `RunRecordingBackend`; nothing session-scoped survives the return. This
-  /// mirrors the MCP invoke surface and is not a session-bound runtime.
+  /// Each call opens a new `LocalStore` and `RunRecordingBackend`; nothing
+  /// session-scoped survives the return. This mirrors the MCP invoke surface
+  /// and is not a session-bound runtime.
   pub fn invoke(&self, request: proto::InvokeRequest) -> Result<proto::InvokeResponse, SessionApiError> {
     let session = request.session.ok_or(SessionApiError::MissingField("session"))?;
     let session_id = session.session_id;
@@ -105,9 +100,9 @@ impl SessionApiHandler {
     recording: &RunRecordingBackend,
   ) -> proto::InvokeResponse {
     let summary = OperationSummary::capture(result);
-    // NOTICE(api-p11-invoke-partial-success): invoke already finished; summary
-    // persistence failure must not surface as an invoke error (clients must not
-    // blind-retry non-idempotent commands). Durability gaps go to known_limits.
+    // Invoke already finished, so persistence failure must not surface as an
+    // invoke error that invites blind retry of a non-idempotent command.
+    // Durability gaps are reported through known_limits.
     let mut durability_limits = record_invoke_summary(recording.store(), result, &summary);
     durability_limits.extend(record_invoke_operation_result(recording.store(), command_id, result));
     // Process-local cache is populated only when both summary and operation-result persist succeed.
@@ -119,11 +114,11 @@ impl SessionApiHandler {
   }
 
   /// `GetOperation`: read the persisted record + runtime summary and return the
-  /// explicit two-source join (API-P7).
+  /// explicit two-source join.
   ///
   /// On this handler instance, a process-local cache hit becomes
   /// `process_local_runtime_override` for the join. A new handler or cache miss
-  /// falls back to the persisted `operation-summary` artifact (API-P11). A
+  /// falls back to the persisted `operation-summary` artifact. A
   /// persisted `OperationResult` skeleton is still required.
   pub fn get_operation(&self, request: proto::GetOperationRequest) -> Result<proto::GetOperationResponse, SessionApiError> {
     let operation = request.operation.ok_or(SessionApiError::MissingField("operation"))?;
@@ -163,21 +158,6 @@ impl SessionApiHandler {
       JoinedOperationSummaryLoad::RunNotFound => Err(SessionApiError::RunNotFound(run_id)),
       JoinedOperationSummaryLoad::NoPersistedOperationResult => Err(SessionApiError::PersistedOperationRequired(run_id)),
     }
-  }
-
-  /// `StreamSessionEvents`: validates the session, then refuses.
-  ///
-  /// API-P4 responsibility D (event projector) has no internal event source yet
-  /// (gate 4). Rather than emit a fabricated/empty stream, the skeleton returns
-  /// `NotWired` so callers see the gap explicitly.
-  pub fn stream_session_events(&self, request: proto::StreamSessionEventsRequest) -> Result<Vec<proto::SessionEvent>, SessionApiError> {
-    let session = request.session.ok_or(SessionApiError::MissingField("session"))?;
-    if !self.registry.lock().expect("session registry mutex poisoned").contains(&session.session_id) {
-      return Err(SessionApiError::UnknownSession(session.session_id));
-    }
-    Err(SessionApiError::NotWired {
-      gate: "event projector (API-P4 responsibility D)",
-    })
   }
 }
 
@@ -462,10 +442,9 @@ mod tests {
   fn invoke_durability_failure_keeps_cache_empty_and_get_operation_preconditions() {
     use std::os::unix::fs::PermissionsExt;
 
-    // NOTICE(api-r2-test-gap): without a store fault-injection seam, this test can
-    // only exercise the current "both write-through persists fail" path. That is
-    // enough to lock the cache gate and precondition behavior without widening
-    // API-R2 into injectable storage abstractions.
+    // TODO: A store fault-injection seam is needed to reproduce only the second
+    // durability write failing after the first succeeds. Add that case when
+    // durability writes gain an injectable storage boundary.
     let root = unique_temp_dir("session-api-op-result-persist-fail");
     let handler = SessionApiHandler::new(root.clone());
     let session = handler
@@ -519,7 +498,7 @@ mod tests {
   #[test]
   fn get_operation_rejects_operation_id_mismatch() {
     let run_id = "run-p12-mismatch";
-    let (handler, root) = handler_with_music_search_cached("session-api-p12-mismatch", run_id);
+    let (handler, root) = handler_with_music_search_cached("session-operation-id-mismatch", run_id);
 
     let error = handler
       .get_operation(proto::GetOperationRequest {
@@ -533,23 +512,5 @@ mod tests {
     assert!(matches!(error, SessionApiError::OperationIdMismatch { .. }));
 
     let _ = std::fs::remove_dir_all(root);
-  }
-
-  #[test]
-  fn stream_session_events_is_not_wired() {
-    let handler = handler();
-    let session = handler
-      .create_session(proto::CreateSessionRequest {
-        client_label: String::new(),
-      })
-      .expect("create_session")
-      .session
-      .expect("session ref");
-    let error = handler
-      .stream_session_events(proto::StreamSessionEventsRequest {
-        session: Some(session),
-      })
-      .expect_err("stream should be not wired");
-    assert!(matches!(error, SessionApiError::NotWired { .. }));
   }
 }

--- a/src/api/session_service/mapper.rs
+++ b/src/api/session_service/mapper.rs
@@ -1,6 +1,7 @@
-//! Proto <-> host mapping for the session API, isolated from handler and
-//! transport code (API-P4 handoff checklist: "isolate proto/host mapping from
-//! transport handler code").
+//! Protobuf and host-model mapping for the session API.
+//!
+//! Mapping stays separate from both application orchestration and tonic RPC
+//! dispatch.
 
 use std::collections::{BTreeMap, HashMap};
 
@@ -26,11 +27,9 @@ pub fn operation_status_str(status: OperationStatus) -> String {
   }
 }
 
-// NOTICE(api-p3-od5): the json_payload envelope schema is UNRESOLVED. This
-// provisional decoder follows the API-P3 sketch
-// ({target:{application_id,target_label}, inputs:{...}, dry_run}); an empty
-// payload maps to host defaults. A real slice must version this envelope and
-// define malformed-payload behavior. Trigger: an owner-named envelope decision.
+// TODO: The json_payload envelope remains provisional and unversioned. Keep the
+// current target/inputs/dry_run shape until an approved wire-version decision
+// defines compatibility and malformed-payload behavior.
 #[derive(serde::Deserialize, Default)]
 struct InvokePayloadEnvelope {
   #[serde(default)]
@@ -49,8 +48,10 @@ struct InvokeTargetEnvelope {
   target_label: Option<String>,
 }
 
-/// Decode a proto `json_payload` into a host `InvokeRequest` (provisional, see
-/// the od5 NOTICE above). An empty payload yields host defaults.
+/// Decode a protobuf `json_payload` into a host `InvokeRequest`.
+///
+/// An empty payload yields host defaults. The non-empty envelope is
+/// provisional as documented above.
 pub fn decode_invoke_payload(command_id: String, json_payload: &[u8]) -> Result<HostInvokeRequest, SessionApiError> {
   let envelope = if json_payload.is_empty() {
     InvokePayloadEnvelope::default()
@@ -68,8 +69,8 @@ pub fn decode_invoke_payload(command_id: String, json_payload: &[u8]) -> Result<
   })
 }
 
-// NOTICE(api-p3-od4): resolved in API-P12 — invoke path uses ArtifactRecordV1Alpha1;
-// GetOperation joins contract refs against the run artifact catalog.
+// Invoke returns recorder artifact records directly. GetOperation instead
+// joins slim contract references against the durable run artifact catalog.
 fn artifact_ref_from_record(run_id: &str, record: &ArtifactRecordV1Alpha1) -> proto::ArtifactRef {
   proto::ArtifactRef {
     run_id: run_id.to_string(),
@@ -78,8 +79,8 @@ fn artifact_ref_from_record(run_id: &str, record: &ArtifactRecordV1Alpha1) -> pr
   }
 }
 
-// API-P12: role on GetOperation comes from the run artifact catalog keyed by
-// artifact_id; contract::ArtifactRef stays slim (reference-only).
+// The durable run catalog supplies GetOperation roles by artifact id;
+// contract::ArtifactRef intentionally remains a slim reference.
 fn artifact_ref_from_contract(
   artifact: &ContractArtifactRef,
   artifact_roles: &BTreeMap<String, String>,
@@ -99,9 +100,10 @@ fn artifact_ref_from_contract(
 
 /// Map an `InvokeResult` (plus the request `command_id`) to a proto
 /// `InvokeResponse`. `extra_known_limits` surfaces invoke-path durability gaps
-/// without changing execution status (see API-P11 partial-success policy).
+/// without changing execution status.
 pub fn invoke_result_to_response(command_id: &str, result: &InvokeResult, extra_known_limits: &[&str]) -> proto::InvokeResponse {
-  // API-P12: wire operation_id is invoke command_id on both Invoke and GetOperation.
+  // The wire operation id is the invoke command id on both Invoke and
+  // GetOperation.
   let artifacts = result.artifacts.iter().map(|record| artifact_ref_from_record(&result.run_id, record)).collect();
   proto::InvokeResponse {
     operation: Some(proto::OperationRef {
@@ -110,16 +112,15 @@ pub fn invoke_result_to_response(command_id: &str, result: &InvokeResult, extra_
     }),
     status: run_status_str(&result.status),
     artifacts,
-    // NOTICE(api-p3-od1): known_limits is OperationResult-sourced and is not on
-    // the InvokeResult return value; empty on the invoke path until the summary
-    // source is joined with the persisted record. API-P11 may append durability
-    // limits when summary persistence fails after a successful command.
+    // InvokeResult has no domain known_limits field. This response therefore
+    // reports only durability limits discovered after command execution; the
+    // full OperationResult limits become available through GetOperation.
     known_limits: extra_known_limits.iter().map(|limit| (*limit).to_string()).collect(),
     failure_message: result.failure_message.clone().unwrap_or_default(),
   }
 }
 
-/// Map a joined two-source summary (API-P7) to a proto `GetOperationResponse`.
+/// Map a joined two-source summary to a protobuf `GetOperationResponse`.
 pub fn joined_to_get_operation_response(joined: &JoinedOperationSummary) -> proto::GetOperationResponse {
   let mut known_limits = joined.known_limits.clone();
   let (output_summary, signals, failure_message): (String, HashMap<String, String>, String) = match &joined.runtime {
@@ -127,10 +128,8 @@ pub fn joined_to_get_operation_response(joined: &JoinedOperationSummary) -> prot
       (runtime.output_summary.clone(), runtime.signals.clone().into_iter().collect(), runtime.failure_message.clone().unwrap_or_default())
     }
     None => {
-      // NOTICE(api-p4-two-source): the runtime summary is absent. API-P4 says we
-      // must not fabricate empty strings as authoritative data, so we surface
-      // the gap as an explicit known_limit rather than silently returning empty
-      // output_summary/signals.
+      // Do not present protobuf defaults as authoritative runtime data. The
+      // known limit makes the missing half of the projection explicit.
       known_limits.push("auv.api.session.runtime_summary_unavailable".to_string());
       (String::new(), HashMap::new(), String::new())
     }

--- a/src/api/session_service/mod.rs
+++ b/src/api/session_service/mod.rs
@@ -1,39 +1,40 @@
-//! Session API service seam (API-P4 boundary).
+//! Execute-facing session API boundary.
 //!
 //! Owns the execute-facing `SessionService` surface separately from the
 //! inspect viewer/server API and the tool-facing `mcp`.
 //!
 //! Modules:
-//! - `registry`: lightweight in-memory session registry (API-P4 responsibility A).
-//! - `mapper`: proto <-> host mapping, isolated from handler code (API-P4 checklist).
-//! - `summary`: two-source `GetOperation` read path + join policy (API-P7/P12).
-//! - `summary_store`: persisted `operation-summary` write path (API-P11).
-//! - `operation_result_store`: persisted `operation-result` write path (API-R2).
-//! - `handler`: transport-agnostic handler skeleton wiring proto RPCs to the
-//!   internal seams (API-P8).
-//! - `transport`: loopback-only tonic gRPC adapter (API-P9).
+//! - `handler`: protobuf-aware application orchestration.
+//! - `grpc`: tonic request adaptation and cancellation.
+//! - `server`: loopback listen policy and server lifecycle.
+//! - `registry`: lightweight in-memory session registry.
+//! - `mapper`: protobuf and host-model mapping.
+//! - `summary`: two-source `GetOperation` read path and join policy.
+//! - `summary_store`: persisted `operation-summary` write path.
+//! - `operation_result_store`: persisted `operation-result` write path.
 //! - `test_fixtures` (tests only): shared run/artifact staging helpers.
 //!
-//! TODO(api-p4-stream-events): `StreamSessionEvents` remains deferred to the
-//! event projector (API-P4 responsibility D); the transport returns
-//! `UNIMPLEMENTED` until that seam is wired.
+//! TODO: `StreamSessionEvents` remains deferred because no event projector
+//! exists. Implement it only after an application event source is approved;
+//! until then the gRPC adapter returns `UNIMPLEMENTED`.
 
-pub mod handler;
-pub mod mapper;
+pub(crate) mod grpc;
+pub(crate) mod handler;
+pub(crate) mod mapper;
 pub(crate) mod operation_result_store;
-pub mod registry;
-pub mod summary;
-pub mod summary_store;
-pub mod transport;
+pub(crate) mod registry;
+pub mod server;
+pub(crate) mod summary;
+pub(crate) mod summary_store;
 
 #[cfg(test)]
 pub(crate) mod test_fixtures;
 
 use std::fmt;
 
-/// Errors surfaced by the session API handler skeleton (API-P8).
+/// Errors surfaced by session application orchestration.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum SessionApiError {
+pub(crate) enum SessionApiError {
   /// A required proto field was absent.
   MissingField(&'static str),
   /// `Invoke` / `StreamSessionEvents` referenced a session that was never created.
@@ -54,8 +55,6 @@ pub enum SessionApiError {
     requested: String,
     resolved: String,
   },
-  /// A seam this RPC depends on is not wired in the current skeleton.
-  NotWired { gate: &'static str },
 }
 
 impl fmt::Display for SessionApiError {
@@ -75,7 +74,6 @@ impl fmt::Display for SessionApiError {
         requested,
         resolved,
       } => write!(f, "operation_id mismatch for run {run_id}: requested {requested}, resolved {resolved}"),
-      Self::NotWired { gate } => write!(f, "session API seam not wired: {gate}"),
     }
   }
 }

--- a/src/api/session_service/operation_result_store.rs
+++ b/src/api/session_service/operation_result_store.rs
@@ -1,4 +1,4 @@
-//! Persisted operation-result artifact write path (API-R2).
+//! Persisted operation-result artifact write path.
 //!
 //! Write-through companion after invoke: the persisted skeleton required by
 //! `GetOperation` is staged as an `operation-result` JSON artifact on the
@@ -17,8 +17,8 @@ use crate::contract::{ArtifactRef, OPERATION_RESULT_API_VERSION, OperationOutput
 pub const INVOKE_SYNTHETIC_OPERATION_RESULT_KNOWN_LIMIT: &str = "auv.api.session.invoke_synthetic_operation_result";
 
 /// Known limit when invoke succeeded but the operation-result artifact could not
-/// be persisted (API-R2). The command already executed; callers must not treat
-/// this as a failed invoke suitable for blind retry.
+/// be persisted. The command already executed; callers must not treat this as a
+/// failed invoke suitable for blind retry.
 pub const OPERATION_RESULT_PERSIST_FAILED_KNOWN_LIMIT: &str = "auv.api.session.operation_result_persist_failed";
 
 const OPERATION_RESULT_ARTIFACT_ROLE: &str = "operation-result";
@@ -60,9 +60,10 @@ fn synthetic_operation_result_from_invoke(command_id: &str, result: &InvokeResul
 /// `operation-result`, and replaces the run snapshot with the new artifact
 /// list. Uses [`InvokeResult::producer_span_id`] as the artifact span.
 ///
-/// NOTICE(api-r2-duplicate-artifacts): invoke retries may append multiple
-/// `operation-result` artifacts; the read path takes the **first** match,
-/// mirroring [`crate::run_read::read_operation_result`].
+/// NOTICE: Invoke retries may append multiple `operation-result` artifacts.
+/// The read path takes the first match, mirroring
+/// [`crate::run_read::read_operation_result`]. Remove this behavior only with an
+/// explicit idempotency and artifact-replacement policy.
 pub fn persist_operation_result(store: &LocalStore, result: &InvokeResult, operation: &OperationResult) -> Result<(), SessionApiError> {
   let run_id = result.run_id.as_str();
   let mut canonical = store.read_run(run_id).map_err(SessionApiError::Storage)?;

--- a/src/api/session_service/registry.rs
+++ b/src/api/session_service/registry.rs
@@ -1,9 +1,9 @@
-//! Lightweight in-memory session registry (API-P4 responsibility A).
+//! Lightweight in-memory session registry.
 //!
 //! Creates and looks up session handles and lets the handler reject unknown
 //! sessions on `Invoke` / `StreamSessionEvents`. Deliberately metadata-only: it
-//! does NOT materialize a `SessionRuntime` (API-P4: lazy provider/observation
-//! state is a later RPC's concern, not the invoke-only first slice).
+//! does not materialize a `SessionRuntime`; provider and observation state stay
+//! lazy until an approved session-runtime design owns them.
 
 use std::collections::HashMap;
 
@@ -30,9 +30,8 @@ impl SessionRegistry {
 
   /// Allocate a fresh session id, register lightweight metadata, and return it.
   ///
-  /// API-P4 `CreateSession`: allocate/normalize then register. This skeleton
-  /// always allocates a new id (the proto `CreateSessionRequest` carries only a
-  /// `client_label` hint, no caller-supplied id).
+  /// Always allocates a new id because `CreateSessionRequest` carries only a
+  /// client label, not a caller-supplied id.
   pub fn create(&mut self) -> SessionId {
     self.counter += 1;
     let session_id = SessionId::new(format!("session_{}_{}", now_millis(), self.counter));
@@ -51,17 +50,9 @@ impl SessionRegistry {
     self.entries.contains_key(session_id)
   }
 
-  /// Look up a registered session entry.
-  pub fn get(&self, session_id: &str) -> Option<&SessionEntry> {
-    self.entries.get(session_id)
-  }
-
+  #[cfg(test)]
   pub fn len(&self) -> usize {
     self.entries.len()
-  }
-
-  pub fn is_empty(&self) -> bool {
-    self.entries.is_empty()
   }
 }
 

--- a/src/api/session_service/server.rs
+++ b/src/api/session_service/server.rs
@@ -1,28 +1,21 @@
-//! Loopback-only tonic gRPC transport for the session API (API-P9).
+//! Loopback-only server lifecycle for the session API.
 //!
-//! NOTICE(api-p9-non-goals):
-//! - No TLS and no non-loopback bind; remote access is out of scope.
-//! - `StreamSessionEvents` is not wired (event projector, API-P4 responsibility D).
-//! - `Invoke` persists synthetic `operation-result` on the happy path (API-R2).
-//!   `GetOperation` still requires a persisted skeleton when that write fails.
-//! - `spawn_blocking` work is not forcibly interrupted mid-flight; RPC cancellation
-//!   returns `CANCELLED` to the server and aborts the join handle, but an in-flight
-//!   `Invoke` may still complete recorded command execution until cooperative
-//!   cancellation is wired through the invoke seam.
+//! This module owns configuration, listen policy, binding, readiness output,
+//! and tonic server lifecycle. RPC adaptation lives in [`super::grpc`].
+//!
+//! NOTICE: The server intentionally has no TLS or non-loopback mode. Remote
+//! access requires a separately approved authentication and transport design.
 
 use std::io::Write;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 
-use auv_api_proto::v1::session as proto;
-use auv_api_proto::v1::session::session_service_server::{SessionService, SessionServiceServer};
+use auv_api_proto::v1::session::session_service_server::SessionServiceServer;
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
-use tokio_util::sync::CancellationToken;
-use tonic::{Request, Response, Status};
 
-use crate::api::session_service::SessionApiError;
-use crate::api::session_service::handler::SessionApiHandler;
+use super::grpc::SessionServiceGrpc;
+use super::handler::SessionApiHandler;
 
 pub const DEFAULT_SESSION_API_HOST: &str = "127.0.0.1";
 pub const DEFAULT_SESSION_API_PORT: u16 = 9847;
@@ -45,8 +38,7 @@ impl Default for SessionApiServeConfig {
   }
 }
 
-/// Rejects host strings that are not allowed loopback listen targets.
-pub fn assert_loopback_host(host: &str) -> Result<(), String> {
+fn assert_loopback_host(host: &str) -> Result<(), String> {
   if host.eq_ignore_ascii_case("localhost") {
     return Ok(());
   }
@@ -57,16 +49,14 @@ pub fn assert_loopback_host(host: &str) -> Result<(), String> {
   }
 }
 
-/// Verifies a bound socket address is loopback-only.
-pub fn assert_socket_addr_is_loopback(addr: SocketAddr) -> Result<(), String> {
+fn assert_socket_addr_is_loopback(addr: SocketAddr) -> Result<(), String> {
   if addr.ip().is_loopback() {
     return Ok(());
   }
   Err(format!("session API server refused non-loopback bind address: {addr}"))
 }
 
-/// Resolves a loopback-only bind address for the configured host and port.
-pub async fn resolve_loopback_bind_addr(host: &str, port: u16) -> Result<SocketAddr, String> {
+async fn resolve_loopback_bind_addr(host: &str, port: u16) -> Result<SocketAddr, String> {
   assert_loopback_host(host)?;
   if host.eq_ignore_ascii_case("localhost") {
     let mut addresses =
@@ -79,108 +69,7 @@ pub async fn resolve_loopback_bind_addr(host: &str, port: u16) -> Result<SocketA
   Ok(SocketAddr::new(ip, port))
 }
 
-/// Maps handler errors to gRPC status codes for the session API transport.
-pub fn map_session_error(error: SessionApiError) -> Status {
-  match error {
-    SessionApiError::MissingField(_) | SessionApiError::PayloadDecode(_) => Status::invalid_argument(error.to_string()),
-    SessionApiError::UnknownSession(_) | SessionApiError::RunNotFound(_) => Status::not_found(error.to_string()),
-    SessionApiError::PersistedOperationRequired(_) => Status::failed_precondition(error.to_string()),
-    SessionApiError::OperationIdMismatch { .. } => Status::invalid_argument(error.to_string()),
-    SessionApiError::Storage(_) | SessionApiError::InvokeExecution(_) => Status::internal(error.to_string()),
-    SessionApiError::NotWired { .. } => Status::unimplemented(error.to_string()),
-  }
-}
-
-/// Cancels the paired RPC token when the tonic handler future is dropped.
-struct RpcCancelGuard(CancellationToken);
-
-impl Drop for RpcCancelGuard {
-  fn drop(&mut self) {
-    self.0.cancel();
-  }
-}
-
-async fn run_blocking_rpc<T>(
-  cancel: CancellationToken,
-  work: impl FnOnce() -> Result<T, SessionApiError> + Send + 'static,
-) -> Result<T, Status>
-where
-  T: Send + 'static,
-{
-  let preflight = cancel.child_token();
-  let mut join = tokio::task::spawn_blocking(move || {
-    if preflight.is_cancelled() {
-      return None;
-    }
-    Some(work())
-  });
-
-  tokio::select! {
-    _ = cancel.cancelled() => {
-      join.abort();
-      Err(Status::cancelled("session API request cancelled"))
-    }
-    result = &mut join => {
-      let Some(result) = result
-        .map_err(|error| Status::internal(format!("handler task join failed: {error}")))?
-      else {
-        return Err(Status::cancelled("session API request cancelled"));
-      };
-      result.map_err(map_session_error)
-    }
-  }
-}
-
-/// Tonic `SessionService` adapter over the transport-agnostic handler.
-#[derive(Clone)]
-pub struct SessionServiceGrpc {
-  handler: Arc<SessionApiHandler>,
-}
-
-impl SessionServiceGrpc {
-  pub fn new(handler: Arc<SessionApiHandler>) -> Self {
-    Self { handler }
-  }
-}
-
-#[tonic::async_trait]
-impl SessionService for SessionServiceGrpc {
-  async fn create_session(&self, request: Request<proto::CreateSessionRequest>) -> Result<Response<proto::CreateSessionResponse>, Status> {
-    let cancel = CancellationToken::new();
-    let _guard = RpcCancelGuard(cancel.clone());
-    let handler = Arc::clone(&self.handler);
-    let inner = request.into_inner();
-    run_blocking_rpc(cancel, move || handler.create_session(inner)).await.map(Response::new)
-  }
-
-  async fn invoke(&self, request: Request<proto::InvokeRequest>) -> Result<Response<proto::InvokeResponse>, Status> {
-    let cancel = CancellationToken::new();
-    let _guard = RpcCancelGuard(cancel.clone());
-    let handler = Arc::clone(&self.handler);
-    let inner = request.into_inner();
-    run_blocking_rpc(cancel, move || handler.invoke(inner)).await.map(Response::new)
-  }
-
-  async fn get_operation(&self, request: Request<proto::GetOperationRequest>) -> Result<Response<proto::GetOperationResponse>, Status> {
-    let cancel = CancellationToken::new();
-    let _guard = RpcCancelGuard(cancel.clone());
-    let handler = Arc::clone(&self.handler);
-    let inner = request.into_inner();
-    run_blocking_rpc(cancel, move || handler.get_operation(inner)).await.map(Response::new)
-  }
-
-  type StreamSessionEventsStream = std::pin::Pin<Box<dyn tokio_stream::Stream<Item = Result<proto::SessionEvent, Status>> + Send>>;
-
-  async fn stream_session_events(
-    &self,
-    _request: Request<proto::StreamSessionEventsRequest>,
-  ) -> Result<Response<Self::StreamSessionEventsStream>, Status> {
-    Err(Status::unimplemented("session API seam not wired: stream_session_events"))
-  }
-}
-
-/// Binds a loopback listener and returns the resolved local address.
-pub async fn bind_session_api(config: &SessionApiServeConfig) -> Result<(TcpListener, SocketAddr), String> {
+async fn bind_session_api(config: &SessionApiServeConfig) -> Result<(TcpListener, SocketAddr), String> {
   let bind_addr = resolve_loopback_bind_addr(&config.host, config.port).await?;
   let display_address = format!("{bind_addr}");
   let listener =
@@ -196,8 +85,8 @@ pub(crate) async fn serve_on_listener(
   store_root: std::path::PathBuf,
 ) -> Result<(), String> {
   println!("session API: grpc://{local_address}");
-  // NOTICE(api-s1-readiness): flush so subprocess integration tests reading piped
-  // stdout see the bind address without block-buffer delay.
+  // Flush so subprocess clients reading piped stdout see readiness without a
+  // block-buffer delay.
   std::io::stdout().flush().map_err(|error| format!("failed to flush session API readiness line: {error}"))?;
   let handler = Arc::new(SessionApiHandler::new(store_root));
   let service = SessionServiceGrpc::new(handler);
@@ -218,13 +107,12 @@ pub async fn serve(config: SessionApiServeConfig) -> Result<SocketAddr, String> 
 
 #[cfg(test)]
 mod tests {
+  use auv_api_proto::v1::session as proto;
   use auv_api_proto::v1::session::session_service_client::SessionServiceClient;
-  use tonic::Code;
-
-  use crate::api::session_service::operation_result_store::INVOKE_SYNTHETIC_OPERATION_RESULT_KNOWN_LIMIT;
-  use crate::api::session_service::test_fixtures::session_api_temp_store_root;
 
   use super::*;
+  use crate::api::session_service::operation_result_store::INVOKE_SYNTHETIC_OPERATION_RESULT_KNOWN_LIMIT;
+  use crate::api::session_service::test_fixtures::session_api_temp_store_root;
 
   #[test]
   fn assert_loopback_host_accepts_loopback_literals() {
@@ -253,18 +141,9 @@ mod tests {
     assert!(address.ip().is_loopback());
   }
 
-  #[test]
-  fn map_session_error_maps_representative_variants() {
-    assert_eq!(map_session_error(SessionApiError::MissingField("session")).code(), Code::InvalidArgument);
-    assert_eq!(map_session_error(SessionApiError::UnknownSession("ghost".to_string())).code(), Code::NotFound);
-    assert_eq!(map_session_error(SessionApiError::PersistedOperationRequired("run-1".to_string())).code(), Code::FailedPrecondition);
-    assert_eq!(map_session_error(SessionApiError::Storage("disk".to_string())).code(), Code::Internal);
-    assert_eq!(map_session_error(SessionApiError::NotWired { gate: "events" }).code(), Code::Unimplemented);
-  }
-
   #[tokio::test]
   async fn grpc_create_session_round_trip() {
-    let store_root = session_api_temp_store_root("transport");
+    let store_root = session_api_temp_store_root("server");
     let config = SessionApiServeConfig {
       host: DEFAULT_SESSION_API_HOST.to_string(),
       port: 0,
@@ -279,7 +158,7 @@ mod tests {
 
     let response = client
       .create_session(proto::CreateSessionRequest {
-        client_label: "transport-test".to_string(),
+        client_label: "server-test".to_string(),
       })
       .await
       .expect("create_session")
@@ -293,7 +172,7 @@ mod tests {
 
   #[tokio::test]
   async fn grpc_invoke_and_get_operation_round_trips() {
-    let store_root = session_api_temp_store_root("transport");
+    let store_root = session_api_temp_store_root("server");
     let config = SessionApiServeConfig {
       host: DEFAULT_SESSION_API_HOST.to_string(),
       port: 0,
@@ -341,13 +220,5 @@ mod tests {
 
     server.abort();
     let _ = server.await;
-  }
-
-  #[tokio::test]
-  async fn run_blocking_rpc_returns_cancelled_when_token_fires() {
-    let cancel = CancellationToken::new();
-    cancel.cancel();
-    let status = run_blocking_rpc(cancel, || Ok(42_u32)).await.expect_err("cancelled before work starts");
-    assert_eq!(status.code(), Code::Cancelled);
   }
 }

--- a/src/api/session_service/summary.rs
+++ b/src/api/session_service/summary.rs
@@ -1,26 +1,23 @@
-//! Two-source operation summary read path and join policy (API-P7/P12).
+//! Two-source operation summary read path and join policy.
 //!
-//! API-P3 showed `GetOperation` is a two-source projection:
+//! `GetOperation` is a two-source projection:
 //! - `OperationResult` (persisted) owns `operation_id`, `status`,
 //!   `known_limits`, and evidence artifact refs.
 //! - the `InvokeResult`-sourced summary (via `OperationSummarySource`) owns
 //!   `output_summary`, `signals`, and `failure_message`.
 //!
-//! This module joins them explicitly. Per API-P4 (`GetOperation` flow), the
-//! persisted record is the required skeleton and the runtime summary is layered
-//! on when available. When the runtime summary is absent, the join records it as
-//! `None` rather than fabricating empty strings as authoritative data (API-P4:
-//! "It must not silently fabricate empty strings").
+//! The persisted record is the required skeleton and the runtime summary is
+//! layered on when available. When the runtime summary is absent, the join
+//! records `None` rather than treating protobuf defaults as authoritative data.
 //!
 //! ## Runtime summary resolution
 //!
-//! [`load_joined_operation_summary`] picks the InvokeResult-sourced half in this
-//! order (see also API-P11 handoff in
-//! `docs/ai/references/2026-06-30-auv-api-p11-summary-durability-handoff.md`):
+//! [`load_joined_operation_summary`] picks the invoke-result-sourced half in
+//! this order:
 //!
 //! 1. `process_local_runtime_override` — same-process cache hit from
-//!    [`SessionApiHandler`](super::handler::SessionApiHandler) (API-P6).
-//! 2. Persisted `operation-summary` artifact on the run (API-P11, store read).
+//!    [`SessionApiHandler`](super::handler::SessionApiHandler).
+//! 2. Persisted `operation-summary` artifact on the run.
 //! 3. `None` — join leaves `runtime` absent; callers must not treat that as empty output.
 
 use std::collections::BTreeMap;
@@ -32,10 +29,10 @@ use crate::contract::{ArtifactRef, OperationResult, OperationStatus};
 use crate::model::AuvResult;
 use crate::run_read;
 
-/// Known limit when wire `command_id` cannot be resolved (API-P12).
+/// Known limit when the wire `command_id` cannot be resolved.
 pub const COMMAND_ID_UNAVAILABLE_KNOWN_LIMIT: &str = "auv.api.session.command_id_unavailable";
 
-/// Known limit when an evidence artifact has no catalog role entry (API-P12).
+/// Known limit when an evidence artifact has no catalog role entry.
 pub const ARTIFACT_ROLE_UNAVAILABLE_KNOWN_LIMIT: &str = "auv.api.session.artifact_role_unavailable";
 
 /// Outcome of loading and joining a `GetOperation` summary for one run.
@@ -80,12 +77,12 @@ pub struct JoinedOperationSummary {
   pub run_id: String,
   /// Internal domain label from `OperationResult.operation_id` (not API wire).
   pub domain_operation_id: String,
-  /// Invoke `command_id` for proto `OperationRef.operation_id` (API-P12).
+  /// Invoke `command_id` for protobuf `OperationRef.operation_id`.
   pub command_id: Option<String>,
   pub status: OperationStatus,
   pub known_limits: Vec<String>,
   pub artifacts: Vec<ArtifactRef>,
-  /// Run artifact catalog `artifact_id` → `role` (API-P12).
+  /// Run artifact catalog from `artifact_id` to `role`.
   pub artifact_roles: BTreeMap<String, String>,
   // InvokeResult-sourced (runtime return value, may be absent).
   pub runtime: Option<RuntimeOperationSummary>,
@@ -176,7 +173,7 @@ fn artifact_role_catalog(store: &LocalStore, run_id: &str) -> AuvResult<BTreeMap
 /// Reads the persisted `OperationResult` (storage-side read path via
 /// [`run_read::read_operation_result`]) and joins it with the runtime summary
 /// source. When `process_local_runtime_override` is absent, falls back to the
-/// persisted `operation-summary` artifact (API-P11). Distinguishes a missing run
+/// persisted `operation-summary` artifact. Distinguishes a missing run
 /// from a run that exists but recorded no `OperationResult`.
 pub fn load_joined_operation_summary(
   store: &LocalStore,

--- a/src/api/session_service/summary_store.rs
+++ b/src/api/session_service/summary_store.rs
@@ -1,4 +1,4 @@
-//! Persisted operation-summary artifact write path (API-P11).
+//! Persisted operation-summary artifact write path.
 //!
 //! Write-through companion to the in-memory [`OperationSummaryCache`]: after
 //! invoke, the runtime half of the `GetOperation` projection is staged as an
@@ -13,8 +13,8 @@ use crate::api::session_service::SessionApiError;
 use crate::contract::{OPERATION_SUMMARY_API_VERSION, OPERATION_SUMMARY_ARTIFACT_ROLE};
 
 /// Known limit surfaced when invoke succeeded but the operation-summary artifact
-/// could not be persisted (API-P11). The command already executed; callers must
-/// not treat this as a failed invoke suitable for blind retry.
+/// could not be persisted. The command already executed; callers must not treat
+/// this as a failed invoke suitable for blind retry.
 pub const OPERATION_SUMMARY_PERSIST_FAILED_KNOWN_LIMIT: &str = "auv.api.session.operation_summary_persist_failed";
 
 /// Stage and append an `operation-summary` artifact onto an existing run.
@@ -24,9 +24,10 @@ pub const OPERATION_SUMMARY_PERSIST_FAILED_KNOWN_LIMIT: &str = "auv.api.session.
 /// new artifact list. Uses [`InvokeResult::producer_span_id`] as the artifact
 /// span.
 ///
-/// NOTICE(api-p11-duplicate-artifacts): invoke retries may append multiple
-/// `operation-summary` artifacts; the read path takes the **first** match,
-/// mirroring [`crate::run_read::read_operation_result`].
+/// NOTICE: Invoke retries may append multiple `operation-summary` artifacts.
+/// The read path takes the first match, mirroring
+/// [`crate::run_read::read_operation_result`]. Remove this behavior only with an
+/// explicit idempotency and artifact-replacement policy.
 pub fn persist_operation_summary(store: &LocalStore, result: &InvokeResult, summary: &OperationSummary) -> Result<(), SessionApiError> {
   let run_id = result.run_id.as_str();
   let mut canonical = store.read_run(run_id).map_err(SessionApiError::Storage)?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1977,8 +1977,8 @@ fn parse_session(arguments: &[String]) -> AuvResult<CliCommand> {
 }
 
 fn parse_session_serve(arguments: &[String]) -> AuvResult<CliCommand> {
-  let mut host = auv_cli::api::session_service::transport::DEFAULT_SESSION_API_HOST.to_string();
-  let mut port = auv_cli::api::session_service::transport::DEFAULT_SESSION_API_PORT;
+  let mut host = auv_cli::api::session_service::server::DEFAULT_SESSION_API_HOST.to_string();
+  let mut port = auv_cli::api::session_service::server::DEFAULT_SESSION_API_PORT;
   let mut store_root = None;
   let mut index = 2;
   while index < arguments.len() {
@@ -3706,8 +3706,8 @@ mod tests {
         port,
         store_root,
       } => {
-        assert_eq!(host, auv_cli::api::session_service::transport::DEFAULT_SESSION_API_HOST);
-        assert_eq!(port, auv_cli::api::session_service::transport::DEFAULT_SESSION_API_PORT);
+        assert_eq!(host, auv_cli::api::session_service::server::DEFAULT_SESSION_API_HOST);
+        assert_eq!(port, auv_cli::api::session_service::server::DEFAULT_SESSION_API_PORT);
         assert_eq!(store_root.as_deref(), Some("/tmp/auv-session-store"));
       }
       other => panic!("unexpected command: {other:?}"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,12 +80,12 @@ async fn run() -> Result<(), String> {
   } = &command
   {
     let store_root = resolve_store_root(&project_root, store_root.as_ref());
-    let config = auv_cli::api::session_service::transport::SessionApiServeConfig {
+    let config = auv_cli::api::session_service::server::SessionApiServeConfig {
       host: host.clone(),
       port: *port,
       store_root,
     };
-    auv_cli::api::session_service::transport::serve(config).await?;
+    auv_cli::api::session_service::server::serve(config).await?;
     return Ok(());
   }
 


### PR DESCRIPTION
## Summary

- split the session tonic adapter from loopback server configuration and lifecycle
- replace task-id comments with current behavior, invariants, and explicit deferral triggers
- make StreamSessionEvents UNIMPLEMENTED behavior owned and regression-tested in the gRPC adapter
- narrow internal session modules while keeping the server bootstrap public

## Verification

- `cargo fmt --check`
- `git diff --check`
- `cargo check`
- `cargo test`
- `cargo test --test session_api_subprocess_smoke`
- `cargo test cli::tests::parse_session_serve --bin auv`
- `cargo run --quiet -- invoke --help`
- RustRover project build and changed-file error lint

## Scope

Behavior-preserving structure and comment cleanup only. Session durability aggregation and partial-success policy changes are intentionally deferred to a separate PR.