### PR TITLE
refactor: name non-storage modules by content

### DIFF
--- a/crates/auv-cli-invoke/src/commands/scan.rs
+++ b/crates/auv-cli-invoke/src/commands/scan.rs
@@ -7,7 +7,7 @@ use crate::{
   invoke_command,
 };
 use auv_scan::{
-  SCAN_COVERAGE_ARTIFACT_FILE_NAME, SCAN_COVERAGE_ARTIFACT_ROLE, artifact::frame_artifact_file_name, produce_coverage_from_fixture_dir,
+  SCAN_COVERAGE_ARTIFACT_FILE_NAME, SCAN_COVERAGE_ARTIFACT_ROLE, frame_artifact_file_name, produce_coverage_from_fixture_dir,
   produce_frame_from_fixture_dir,
 };
 use auv_tracing_driver::{ProducedArtifact, now_millis};

--- a/crates/auv-driver-macos/src/capture.rs
+++ b/crates/auv-driver-macos/src/capture.rs
@@ -1,5 +1,5 @@
 #[doc(hidden)]
-pub mod artifact;
+pub mod contract_render;
 #[doc(hidden)]
 pub mod geometry;
 #[doc(hidden)]

--- a/crates/auv-driver-macos/src/capture/contract_render.rs
+++ b/crates/auv-driver-macos/src/capture/contract_render.rs
@@ -1,4 +1,5 @@
-// File: src/driver/macos/capture/artifact.rs
+//! Capture contract renderers for JSON artifacts and human-readable output.
+
 use super::types::{CaptureContract, CaptureSource, CoordinateSpace};
 use crate::types::AuvResult;
 

--- a/crates/auv-game-minecraft/src/evidence.rs
+++ b/crates/auv-game-minecraft/src/evidence.rs
@@ -1,9 +1,9 @@
 use image::RgbImage;
 
-use crate::artifact::MinecraftProjectionArtifact;
 use crate::bind::bind_capture_to_frame;
 use crate::overlay::render_projection_overlay;
 use crate::projection::MinecraftProjector;
+use crate::projection_record::MinecraftProjectionArtifact;
 use crate::types::{MinecraftBlockTarget, MinecraftSpatialFrame, RaycastHit};
 use crate::verify::{MismatchRefusal, evaluate_mismatch_refusal};
 

--- a/crates/auv-game-minecraft/src/lib.rs
+++ b/crates/auv-game-minecraft/src/lib.rs
@@ -1,4 +1,3 @@
-pub mod artifact;
 pub mod bind;
 pub mod closed_scene_toy_fixture;
 pub mod dataset;
@@ -9,6 +8,7 @@ pub mod measurement;
 pub mod overlay;
 pub mod prep;
 pub mod projection;
+mod projection_record;
 pub mod sample_builder;
 pub mod scene_packet;
 pub mod session_observation;
@@ -27,7 +27,6 @@ pub mod training_result_spatial_query_provider;
 pub mod types;
 pub mod verify;
 
-pub use artifact::{MinecraftProjectionArtifact, ProjectionViewportBounds};
 pub use bind::{BoundSpatialFrame, bind_capture_to_frame};
 pub use dataset::{
   SPATIAL_BUNDLE_SCHEMA_VERSION, SourceRunSummary, SpatialBundleArtifactRecord, SpatialBundleCounts, SpatialBundleDirectory,
@@ -50,6 +49,7 @@ pub use prep::{
   TextureSweepRunStep, prepare_texture_sweep_resource_packs,
 };
 pub use projection::MinecraftProjector;
+pub use projection_record::{MinecraftProjectionArtifact, ProjectionViewportBounds};
 pub use sample_builder::{
   TEXTURE_SWEEP_SAMPLE_BUILDER_GENERATOR, TextureSweepSampleBuildInputs, TextureSweepSampleBuildOutput,
   build_texture_sweep_samples_from_bundles,

--- a/crates/auv-game-minecraft/src/projection.rs
+++ b/crates/auv-game-minecraft/src/projection.rs
@@ -93,8 +93,8 @@ impl MinecraftProjector {
     &self,
     projected_point: Option<MinecraftProjectedPoint>,
     verification_reference: Option<String>,
-  ) -> crate::artifact::MinecraftProjectionArtifact {
-    crate::artifact::MinecraftProjectionArtifact::for_frame(&self.frame, projected_point, verification_reference)
+  ) -> crate::projection_record::MinecraftProjectionArtifact {
+    crate::projection_record::MinecraftProjectionArtifact::for_frame(&self.frame, projected_point, verification_reference)
   }
 
   fn non_visible_point(&self, visibility: ProjectionVisibility) -> MinecraftProjectedPoint {

--- a/crates/auv-game-minecraft/src/projection_record.rs
+++ b/crates/auv-game-minecraft/src/projection_record.rs
@@ -1,3 +1,5 @@
+//! Serialized Minecraft projection evidence and shared-contract conversions.
+
 use serde::{Deserialize, Serialize};
 
 use auv_driver::geometry::{CoordinateSpace, ProjectionBasis, ProjectionDerivationFamily, ProjectionSourceSpace, Rect};

--- a/crates/auv-game-minecraft/src/sample_builder.rs
+++ b/crates/auv-game-minecraft/src/sample_builder.rs
@@ -7,9 +7,9 @@ use auv_driver::geometry::Point;
 use serde::de::DeserializeOwned;
 
 use crate::MinecraftProjector;
-use crate::artifact::MinecraftProjectionArtifact;
 use crate::dataset::{SpatialBundleDirectory, SpatialBundleManifest};
 use crate::measurement::{TextureSweepSample, TextureSweepSampleSet, TextureSweepSampleSource};
+use crate::projection_record::MinecraftProjectionArtifact;
 use crate::types::{MinecraftSpatialFrame, MinecraftTargetSemantics, ProjectionVisibility};
 use crate::verify::MismatchRefusalReason;
 
@@ -333,8 +333,8 @@ fn read_json_file<T: DeserializeOwned>(path: &Path, label: &str) -> SampleBuildR
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::artifact::MinecraftProjectionArtifact;
   use crate::dataset::{SPATIAL_BUNDLE_SCHEMA_VERSION, SourceRunSummary, SpatialBundleArtifactRecord, SpatialBundleCounts};
+  use crate::projection_record::MinecraftProjectionArtifact;
   use crate::types::{BlockFace, BlockPosition, PlayerPose, RaycastHit, Vec3, Viewport};
   use crate::verify::MismatchRefusalReason;
 
@@ -389,7 +389,7 @@ mod tests {
       monotonic_timestamp_ms: frame.monotonic_timestamp_ms,
       screenshot_artifact_ref: frame.screenshot_artifact_ref.clone(),
       mc_capture_skew_ms: frame.mc_capture_skew_ms,
-      viewport_bounds: crate::artifact::ProjectionViewportBounds::from_rect(frame.viewport.bounds()),
+      viewport_bounds: crate::projection_record::ProjectionViewportBounds::from_rect(frame.viewport.bounds()),
       projected_point: None,
       visibility: ProjectionVisibility::OutsideWindow,
       raycast_block_id: frame.raycast_hit.as_ref().map(|hit| hit.block_id.clone()),

--- a/crates/auv-scan/src/coverage_wire.rs
+++ b/crates/auv-scan/src/coverage_wire.rs
@@ -1,7 +1,7 @@
-//! Bounded crate-local coverage ledger wire (`scan-coverage-v0`).
+//! Durable scan coverage wire format and directory-level IO.
 //!
-//! NOTICE(s8a-artifact-boundary): directory-level artifact beside scan-frame-*.json;
-//! not run-level; not runtime-staged by S8a; not scene_state durable product.
+//! The coverage file lives beside scan frame JSON in a scan output directory;
+//! it is not a run-store record and does not own scene-state persistence.
 
 use std::fs;
 use std::io::Write;

--- a/crates/auv-scan/src/fixture.rs
+++ b/crates/auv-scan/src/fixture.rs
@@ -5,8 +5,8 @@ use std::path::Path;
 
 use serde::Deserialize;
 
-use crate::artifact::ScanArtifactError;
 use crate::frame::{SCAN_FRAME_SCHEMA_VERSION, ScanBounds, ScanFrame, ScanImageRef};
+use crate::frame_io::ScanArtifactError;
 
 const MANIFEST_FILE: &str = "manifest.json";
 
@@ -51,8 +51,8 @@ mod tests {
   use std::path::PathBuf;
 
   use super::*;
-  use crate::artifact::{frame_artifact_file_name, read_frame_artifact, write_frame_artifact};
   use crate::frame::{SCAN_FRAME_SCHEMA_VERSION, ScanBounds, ScanImageRef};
+  use crate::frame_io::{frame_artifact_file_name, read_frame_artifact, write_frame_artifact};
 
   fn single_frame_fixture_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/scan/temporal/single_frame_v0")

--- a/crates/auv-scan/src/frame.rs
+++ b/crates/auv-scan/src/frame.rs
@@ -16,12 +16,12 @@ pub struct ScanBounds {
 }
 
 impl ScanBounds {
-  pub fn validate_positive(&self, field: &'static str) -> Result<(), crate::artifact::ScanArtifactError> {
+  pub fn validate_positive(&self, field: &'static str) -> Result<(), crate::frame_io::ScanArtifactError> {
     if self.width <= 0 {
-      return Err(crate::artifact::ScanArtifactError::InvalidBounds { field });
+      return Err(crate::frame_io::ScanArtifactError::InvalidBounds { field });
     }
     if self.height <= 0 {
-      return Err(crate::artifact::ScanArtifactError::InvalidBounds { field });
+      return Err(crate::frame_io::ScanArtifactError::InvalidBounds { field });
     }
     Ok(())
   }
@@ -48,9 +48,9 @@ pub struct ScanFrame {
 }
 
 impl ScanFrame {
-  pub fn validate_wire(&self) -> Result<(), crate::artifact::ScanArtifactError> {
+  pub fn validate_wire(&self) -> Result<(), crate::frame_io::ScanArtifactError> {
     if self.schema_version != SCAN_FRAME_SCHEMA_VERSION {
-      return Err(crate::artifact::ScanArtifactError::SchemaMismatch {
+      return Err(crate::frame_io::ScanArtifactError::SchemaMismatch {
         found: self.schema_version.clone(),
       });
     }

--- a/crates/auv-scan/src/frame_io.rs
+++ b/crates/auv-scan/src/frame_io.rs
@@ -1,4 +1,4 @@
-//! Frame artifact read/write for `scan-frame-v0`.
+//! Frame read/write for the durable `scan-frame-v0` wire format.
 
 use std::fs;
 use std::io::Write;

--- a/crates/auv-scan/src/lib.rs
+++ b/crates/auv-scan/src/lib.rs
@@ -1,4 +1,4 @@
-//! Temporal scan contracts, producers, artifact IO, and read-side projections.
+//! Temporal scan contracts, producers, frame and coverage IO, and read-side projections.
 //!
 //! The crate root is the only public import path. Implementation modules stay
 //! private so one concept cannot be imported through both `auv_scan::Type` and
@@ -17,11 +17,11 @@ mod fixture;
 #[cfg(test)]
 mod scene_fixture_support;
 
-mod artifact;
 mod association;
 mod coverage;
-mod coverage_artifact;
+mod coverage_wire;
 mod frame;
+mod frame_io;
 mod lifecycle;
 mod motion;
 mod producer;
@@ -31,15 +31,15 @@ mod scene_state_inspect;
 mod timeline;
 mod tracks;
 
-pub use artifact::{ScanArtifactError, frame_artifact_file_name, read_frame_artifact, write_frame_artifact};
 pub use association::{AssociationDiagnostic, AssociationResult, FrameObservation, associate_adjacent_frames};
 pub use coverage::{CompletenessClaim, CoverageEntry, CoverageView, NegativeEvidence, build_coverage_view};
-pub use coverage_artifact::{
+pub use coverage_wire::{
   CompletenessWire, CoverageArtifactError, CoverageEntryWire, NegativeEvidenceWire, SCAN_COVERAGE_ARTIFACT_FILE_NAME,
   SCAN_COVERAGE_ARTIFACT_ROLE, SCAN_COVERAGE_SCHEMA_VERSION, ScanCoverageWire, coverage_view_to_wire, read_coverage_artifact,
   write_coverage_artifact,
 };
 pub use frame::{SCAN_FRAME_SCHEMA_VERSION, ScanBounds, ScanFrame, ScanImageRef};
+pub use frame_io::{ScanArtifactError, frame_artifact_file_name, read_frame_artifact, write_frame_artifact};
 pub use lifecycle::{LifecycleError, LifecycleEvent, LifecycleVerdict, TransitionEvidence, evaluate_lifecycle};
 pub use motion::{MotionError, MotionEstimate, MotionResult, MotionUnknown, estimate_viewport_motion};
 #[cfg(feature = "live-capture")]

--- a/crates/auv-scan/src/lib.rs
+++ b/crates/auv-scan/src/lib.rs
@@ -1,30 +1,43 @@
-//! Temporal scan contracts — `scan-frame-v0` wire, artifact IO, producers, and read-side loader.
+//! Temporal scan contracts, producers, artifact IO, and read-side projections.
+//!
+//! The crate root is the only public import path. Implementation modules stay
+//! private so one concept cannot be imported through both `auv_scan::Type` and
+//! `auv_scan::module::Type`.
+//!
+//! ```
+//! use auv_scan::ScanFrame;
+//! ```
+//!
+//! ```compile_fail
+//! use auv_scan::frame::ScanFrame;
+//! ```
 
 #[cfg(test)]
 mod fixture;
 #[cfg(test)]
 mod scene_fixture_support;
 
-pub mod artifact;
-pub mod association;
-pub mod coverage;
-pub mod coverage_artifact;
-pub mod frame;
-pub mod lifecycle;
-pub mod motion;
-pub mod producer;
-pub mod reader;
-pub mod scene_state;
-pub mod scene_state_inspect;
-pub mod timeline;
-pub mod tracks;
+mod artifact;
+mod association;
+mod coverage;
+mod coverage_artifact;
+mod frame;
+mod lifecycle;
+mod motion;
+mod producer;
+mod reader;
+mod scene_state;
+mod scene_state_inspect;
+mod timeline;
+mod tracks;
 
 pub use artifact::{ScanArtifactError, frame_artifact_file_name, read_frame_artifact, write_frame_artifact};
 pub use association::{AssociationDiagnostic, AssociationResult, FrameObservation, associate_adjacent_frames};
 pub use coverage::{CompletenessClaim, CoverageEntry, CoverageView, NegativeEvidence, build_coverage_view};
 pub use coverage_artifact::{
-  CoverageArtifactError, SCAN_COVERAGE_ARTIFACT_FILE_NAME, SCAN_COVERAGE_ARTIFACT_ROLE, SCAN_COVERAGE_SCHEMA_VERSION, ScanCoverageWire,
-  coverage_view_to_wire, read_coverage_artifact, write_coverage_artifact,
+  CompletenessWire, CoverageArtifactError, CoverageEntryWire, NegativeEvidenceWire, SCAN_COVERAGE_ARTIFACT_FILE_NAME,
+  SCAN_COVERAGE_ARTIFACT_ROLE, SCAN_COVERAGE_SCHEMA_VERSION, ScanCoverageWire, coverage_view_to_wire, read_coverage_artifact,
+  write_coverage_artifact,
 };
 pub use frame::{SCAN_FRAME_SCHEMA_VERSION, ScanBounds, ScanFrame, ScanImageRef};
 pub use lifecycle::{LifecycleError, LifecycleEvent, LifecycleVerdict, TransitionEvidence, evaluate_lifecycle};

--- a/crates/auv-scan/src/producer/coverage.rs
+++ b/crates/auv-scan/src/producer/coverage.rs
@@ -26,7 +26,7 @@ use thiserror::Error;
 use super::{ScanProducerError, produce_frames_from_fixture_dir};
 use crate::association::{FrameObservation, associate_adjacent_frames};
 use crate::coverage::build_coverage_view;
-use crate::coverage_artifact::{CoverageArtifactError, ScanCoverageWire, coverage_view_to_wire, write_coverage_artifact};
+use crate::coverage_wire::{CoverageArtifactError, ScanCoverageWire, coverage_view_to_wire, write_coverage_artifact};
 use crate::reader::ScanFrameBundle;
 
 const MANIFEST_FILE: &str = "manifest.json";
@@ -160,7 +160,7 @@ pub fn produce_coverage_from_fixture_dir(coverage_fixture_dir: &Path, out_dir: &
 mod tests {
   use std::path::PathBuf;
 
-  use crate::coverage_artifact::{SCAN_COVERAGE_ARTIFACT_FILE_NAME, read_coverage_artifact};
+  use crate::coverage_wire::{SCAN_COVERAGE_ARTIFACT_FILE_NAME, read_coverage_artifact};
 
   use super::*;
 

--- a/crates/auv-scan/src/producer/error.rs
+++ b/crates/auv-scan/src/producer/error.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-use crate::artifact::ScanArtifactError;
+use crate::frame_io::ScanArtifactError;
 
 #[derive(Debug, Error)]
 pub enum ScanProducerError {

--- a/crates/auv-scan/src/producer/live.rs
+++ b/crates/auv-scan/src/producer/live.rs
@@ -29,8 +29,8 @@ mod tests {
   use image::RgbaImage;
 
   use super::*;
-  use crate::artifact::read_frame_artifact;
   use crate::frame::ScanBounds;
+  use crate::frame_io::read_frame_artifact;
 
   #[test]
   #[ignore = "live"]

--- a/crates/auv-scan/src/producer/mod.rs
+++ b/crates/auv-scan/src/producer/mod.rs
@@ -14,8 +14,8 @@ use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 
-use crate::artifact::write_frame_artifact;
 use crate::frame::{SCAN_FRAME_SCHEMA_VERSION, ScanBounds, ScanFrame, ScanImageRef};
+use crate::frame_io::write_frame_artifact;
 
 pub use coverage::{CoverageProducerError, ProducedCoverage, produce_coverage_from_fixture_dir};
 pub use error::ScanProducerError;
@@ -259,7 +259,7 @@ mod tests {
   use image::RgbaImage;
 
   use super::*;
-  use crate::artifact::{frame_artifact_file_name, read_frame_artifact};
+  use crate::frame_io::{frame_artifact_file_name, read_frame_artifact};
 
   fn single_frame_fixture_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/scan/temporal/single_frame_v0")
@@ -508,7 +508,7 @@ mod tests {
     fs::create_dir_all(out_dir.join(frame_artifact_file_name(1))).expect("poison path");
 
     let err = produce_frames_from_fixture_dir(&fixture_dir, &out_dir).expect_err("late failure");
-    assert!(matches!(err, ScanProducerError::Artifact(crate::artifact::ScanArtifactError::Io(_))));
+    assert!(matches!(err, ScanProducerError::Artifact(crate::frame_io::ScanArtifactError::Io(_))));
     assert!(!out_dir.join(frame_artifact_file_name(0)).exists());
     assert!(!out_dir.join("frame-0001.png").exists());
     assert!(!out_dir.join("frame-0002.png").exists());

--- a/crates/auv-scan/src/reader.rs
+++ b/crates/auv-scan/src/reader.rs
@@ -6,8 +6,8 @@ use std::path::{Path, PathBuf};
 
 use thiserror::Error;
 
-use crate::artifact::{ScanArtifactError, read_frame_artifact};
 use crate::frame::ScanFrame;
+use crate::frame_io::{ScanArtifactError, read_frame_artifact};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ScanFrameBundle {
@@ -179,9 +179,9 @@ mod tests {
 
   use super::test_support::{FrameFieldExpectation, assert_frame_matches_expectation};
   use super::*;
-  use crate::artifact::{frame_artifact_file_name, read_frame_artifact, write_frame_artifact};
   use crate::fixture::build_frame_from_fixture;
   use crate::frame::{SCAN_FRAME_SCHEMA_VERSION, ScanBounds, ScanFrame, ScanImageRef};
+  use crate::frame_io::{frame_artifact_file_name, read_frame_artifact, write_frame_artifact};
   use crate::producer::{produce_frame_from_fixture_dir, produce_frames_from_fixture_dir};
 
   fn single_frame_fixture_dir() -> PathBuf {

--- a/crates/auv-scan/src/scene_fixture_support.rs
+++ b/crates/auv-scan/src/scene_fixture_support.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use serde::Deserialize;
 
 use crate::association::FrameObservation;
-use crate::coverage_artifact::read_coverage_artifact_from_scan_dir;
+use crate::coverage_wire::read_coverage_artifact_from_scan_dir;
 use crate::lifecycle::{LifecycleEvent, TransitionEvidence};
 use crate::producer::produce_frames_from_fixture_dir;
 use crate::reader::{ScanFrameBundle, load_scan_frames_from_dir};
@@ -139,7 +139,7 @@ pub(crate) fn coverage_golden_scenario_for_scene(scene_scenario: &str) -> Option
   }
 }
 
-pub(crate) fn coverage_wire_from_scene_fixture(scenario_dir: &str) -> Option<crate::coverage_artifact::ScanCoverageWire> {
+pub(crate) fn coverage_wire_from_scene_fixture(scenario_dir: &str) -> Option<crate::coverage_wire::ScanCoverageWire> {
   let golden = coverage_golden_scenario_for_scene(scenario_dir)?;
   let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/scan/coverage").join(golden).join("golden");
   Some(read_coverage_artifact_from_scan_dir(&dir).expect("read coverage golden"))

--- a/crates/auv-scan/src/scene_state.rs
+++ b/crates/auv-scan/src/scene_state.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 
 use crate::association::{AssociationResult, FrameObservation, associate_adjacent_frames};
 use crate::coverage::{CoverageView, build_coverage_view};
-use crate::coverage_artifact::{ScanCoverageWire, coverage_wire_to_view};
+use crate::coverage_wire::{ScanCoverageWire, coverage_wire_to_view};
 use crate::lifecycle::{LifecycleError, LifecycleEvent, LifecycleVerdict, evaluate_lifecycle};
 use crate::motion::{MotionResult, MotionUnknown, estimate_viewport_motion};
 use crate::reader::ScanFrameBundle;

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -310,7 +310,7 @@ pub fn render_run_text(
   verifications: &[VerificationResult],
   observation_snapshots: &[ObservationSnapshot],
   detector_recognition_lineage: &[DetectorRecognitionLineage],
-  minecraft_projection_artifacts: &[auv_game_minecraft::artifact::MinecraftProjectionArtifact],
+  minecraft_projection_artifacts: &[auv_game_minecraft::MinecraftProjectionArtifact],
   minecraft_telemetry_sample_artifacts: &[MinecraftTelemetrySampleArtifactLineage],
   minecraft_spatial_bundle_manifests: &[MinecraftSpatialBundleManifestLineage],
   minecraft_training_package_manifests: &[MinecraftTrainingPackageManifestLineage],
@@ -902,11 +902,11 @@ mod tests {
       ],
       issue: None,
     }];
-    let minecraft_projection_artifacts = vec![auv_game_minecraft::artifact::MinecraftProjectionArtifact {
+    let minecraft_projection_artifacts = vec![auv_game_minecraft::MinecraftProjectionArtifact {
       spatial_frame_id: "frame-1".to_string(),
       world_tick: 42,
       monotonic_timestamp_ms: 1_000,
-      viewport_bounds: auv_game_minecraft::artifact::ProjectionViewportBounds {
+      viewport_bounds: auv_game_minecraft::ProjectionViewportBounds {
         x: 0.0,
         y: 0.0,
         width: 800.0,

--- a/src/inspect/minecraft.rs
+++ b/src/inspect/minecraft.rs
@@ -4,7 +4,7 @@ use super::*;
 
 pub(super) fn append_primary_sections(
   output: &mut String,
-  minecraft_projection_artifacts: &[auv_game_minecraft::artifact::MinecraftProjectionArtifact],
+  minecraft_projection_artifacts: &[auv_game_minecraft::MinecraftProjectionArtifact],
   minecraft_telemetry_sample_artifacts: &[MinecraftTelemetrySampleArtifactLineage],
   minecraft_spatial_bundle_manifests: &[MinecraftSpatialBundleManifestLineage],
   minecraft_training_package_manifests: &[MinecraftTrainingPackageManifestLineage],

--- a/src/run_read/minecraft.rs
+++ b/src/run_read/minecraft.rs
@@ -1,7 +1,7 @@
 //! Minecraft donor read-side helpers.
 
 use super::*;
-use auv_game_minecraft::artifact::MinecraftProjectionArtifact;
+use auv_game_minecraft::MinecraftProjectionArtifact;
 use auv_game_minecraft::dataset::{SourceRunSummary, SpatialBundleCounts};
 use auv_game_minecraft::{
   TrainingCompatibilityViewReport, TrainingLaunchInspectReport, TrainingLaunchJobInspectReport, TrainingLaunchJobManifest,


### PR DESCRIPTION
## Summary

- rename scan frame IO to `frame_io` and the coverage wire boundary to `coverage_wire`
- rename the macOS capture contract renderer to `contract_render`
- rename the Minecraft projection payload module to private `projection_record` while keeping the root type exports
- keep `auv-tracing-driver/src/artifact.rs` unchanged as the canonical artifact storage/model owner
- replace the task-ID coverage comment with a current persistence-boundary description

This PR is stacked on #98 because the scan module declarations were narrowed there.

## Verification

- RustRover project build and changed-file lint
- `cargo fmt --check`
- `git diff HEAD^ --check`
- `cargo check`
- `cargo test -p auv-scan -p auv-game-minecraft -p auv-cli-invoke`
- `cargo test`
- `cargo run --quiet -- invoke --help`

`cargo test -p auv-driver-macos` remains blocked by three pre-existing native test imports for `NativeClipboardSnapshotResponse` / `NativeActionResponse`; the affected native files are unchanged in this branch. Production `cargo check` and RustRover build both compile the renamed capture module.