### PR TITLE
feat(auv-cli): ship recorded TextEdit document.write operation (#101)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,6 +392,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-core-graphics",
  "reqwest 0.12.28",
+ "rmcp",
  "serde",
  "serde_json",
  "swift-bridge-build",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,7 +370,9 @@ name = "auv-cli"
 version = "0.0.1"
 dependencies = [
  "auv-api-proto",
+ "auv-apple-textedit",
  "auv-cli-invoke",
+ "auv-cli-invoke-macros",
  "auv-driver",
  "auv-driver-macos",
  "auv-game-balatro",

--- a/crates/auv-apple-textedit/Cargo.toml
+++ b/crates/auv-apple-textedit/Cargo.toml
@@ -13,6 +13,8 @@ repository.workspace = true
 
 [dependencies]
 auv-driver = { path = "../auv-driver" }
-auv-driver-macos = { path = "../auv-driver-macos" }
 clap = { version = "4", features = ["derive"] }
 serde.workspace = true
+
+[target.'cfg(target_os = "macos")'.dependencies]
+auv-driver-macos = { path = "../auv-driver-macos" }

--- a/crates/auv-apple-textedit/src/commands/document.rs
+++ b/crates/auv-apple-textedit/src/commands/document.rs
@@ -182,6 +182,9 @@ mod tests {
         matched_role: target_role.to_string(),
         matched_text: format!("prefix {target_text} suffix"),
         artifact_count: 1,
+        semantic_matched: true,
+        observation_path: Some("0.1.2".to_string()),
+        observation_pid: Some(1),
       })
     }
   }

--- a/crates/auv-apple-textedit/src/driver.rs
+++ b/crates/auv-apple-textedit/src/driver.rs
@@ -1,10 +1,6 @@
 use std::time::Duration;
 
-use auv_driver::LocalDriverSession;
-use auv_driver::{
-  ActivationPolicy, App, InputActionResult, InputDeliveryPath, PasteTextOptions, PrepareForInputOptions, TextSubmit, Window, WindowSelector,
-};
-use auv_driver_macos::MacosDriverSession;
+use auv_driver::InputActionResult;
 use serde::{Deserialize, Serialize};
 
 pub type OperationResult<T> = Result<T, String>;
@@ -19,8 +15,16 @@ pub struct StepOutcome {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct VerificationOutcome {
   pub matched_role: String,
+  /// Observed AX text value (independent of the expected/target text).
   pub matched_text: String,
   pub artifact_count: usize,
+  /// Whether observed text contains the requested target text.
+  pub semantic_matched: bool,
+  /// Optional AX path / pid metadata for product invoke evidence staging.
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub observation_path: Option<String>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub observation_pid: Option<i32>,
 }
 
 pub trait TextEditDriver {
@@ -39,93 +43,164 @@ pub trait TextEditDriver {
   fn verify_ax_text(&mut self, app_id: &str, target_text: &str, target_role: &str) -> OperationResult<VerificationOutcome>;
 }
 
-pub struct MacosTextEditDriver {
-  session: LocalDriverSession,
-}
+#[cfg(target_os = "macos")]
+mod macos {
+  use std::time::Duration;
 
-impl MacosTextEditDriver {
-  pub fn open_local() -> OperationResult<Self> {
-    let session = auv_driver::open_local().map_err(|error| error.to_string())?;
-    Ok(Self { session })
+  use auv_driver::LocalDriverSession;
+  use auv_driver::{
+    ActivationPolicy, App, InputActionResult, InputDeliveryPath, PasteTextOptions, PrepareForInputOptions, TextSubmit, Window,
+    WindowSelector,
+  };
+  use auv_driver_macos::MacosDriverSession;
+
+  use super::{OperationResult, StepOutcome, TextEditDriver, VerificationOutcome};
+
+  pub struct MacosTextEditDriver {
+    session: LocalDriverSession,
   }
 
-  pub fn from_session(session: MacosDriverSession) -> Self {
-    Self {
-      session: LocalDriverSession::Macos(session),
+  impl MacosTextEditDriver {
+    pub fn open_local() -> OperationResult<Self> {
+      let session = auv_driver::open_local().map_err(|error| error.to_string())?;
+      Ok(Self { session })
+    }
+
+    pub fn from_session(session: MacosDriverSession) -> Self {
+      Self {
+        session: LocalDriverSession::Macos(session),
+      }
+    }
+
+    fn main_window(&self, app_id: &str) -> OperationResult<Window> {
+      self.session.window().resolve(main_window_selector(app_id)).map_err(|error| error.to_string())
     }
   }
 
-  fn main_window(&self, app_id: &str) -> OperationResult<Window> {
-    self.session.window().resolve(main_window_selector(app_id)).map_err(|error| error.to_string())
+  impl TextEditDriver for MacosTextEditDriver {
+    fn activate_app(&mut self, app_id: &str, settle: Duration) -> OperationResult<StepOutcome> {
+      let window = self.main_window(app_id)?;
+      self
+        .session
+        .window()
+        .prepare_for_input(
+          &window,
+          PrepareForInputOptions {
+            activation: ActivationPolicy::Foreground { settle },
+            preserve_frontmost: false,
+            install_focus_guard: false,
+            settle: Duration::ZERO,
+          },
+        )
+        .map_err(|error| error.to_string())?;
+      Ok(StepOutcome {
+        step_id: "activate-target-app",
+        summary: format!("activated foreground TextEdit window for {app_id}"),
+        input_action_result: None,
+      })
+    }
+
+    fn focus_text_input(&mut self, app_id: &str, query: &str, candidate: &str) -> OperationResult<StepOutcome> {
+      let observation = self
+        .session
+        .accessibility()
+        .focus_text_by_query(app_id, query, Some("AXTextArea"), candidate)
+        .map_err(|error| format!("TextEdit AX focus failed: {error}"))?;
+      Ok(StepOutcome {
+        step_id: "focus-text-input",
+        summary: format!("focused TextEdit AX text input path={} role={}", observation.path, observation.role),
+        input_action_result: Some(observation.input_action_result),
+      })
+    }
+
+    fn paste_text_preserve_clipboard(
+      &mut self,
+      _app_id: &str,
+      text: &str,
+      replace_existing: bool,
+      settle: Duration,
+    ) -> OperationResult<StepOutcome> {
+      self
+        .session
+        .input()
+        .paste_text(PasteTextOptions {
+          text: text.to_string(),
+          replace_existing,
+          submit: TextSubmit::No,
+          settle,
+        })
+        .map_err(|error| error.to_string())?;
+      Ok(StepOutcome {
+        step_id: "document-write",
+        summary: "pasted TextEdit document body through auv-driver-macos clipboard input".to_string(),
+        input_action_result: Some(InputActionResult::single_success(InputDeliveryPath::ClipboardPaste)),
+      })
+    }
+
+    fn verify_ax_text(&mut self, app_id: &str, target_text: &str, target_role: &str) -> OperationResult<VerificationOutcome> {
+      // Observation is independent of expected text; mismatch returns Ok with
+      // semantic_matched=false so callers can persist a VerificationResult.
+      let observation = self
+        .session
+        .accessibility()
+        .verify_text(app_id, target_text, target_role)
+        .map_err(|error| format!("TextEdit AX text observation failed: {error}"))?;
+      Ok(VerificationOutcome {
+        matched_role: observation.role,
+        matched_text: observation.matched_text,
+        artifact_count: 1,
+        semantic_matched: observation.semantic_matched,
+        observation_path: Some(observation.path),
+        observation_pid: Some(observation.pid),
+      })
+    }
+  }
+
+  fn main_window_selector(app_id: &str) -> WindowSelector {
+    WindowSelector {
+      app: Some(App::bundle_id(app_id)),
+      title: None,
+      main_visible: true,
+    }
   }
 }
 
+#[cfg(target_os = "macos")]
+pub use macos::MacosTextEditDriver;
+
+/// Non-macOS stub so `auv-apple-textedit` remains checkable on Linux CI hosts.
+#[cfg(not(target_os = "macos"))]
+#[derive(Debug, Default)]
+pub struct MacosTextEditDriver;
+
+#[cfg(not(target_os = "macos"))]
+impl MacosTextEditDriver {
+  pub fn open_local() -> OperationResult<Self> {
+    Err("MacosTextEditDriver requires macOS".to_string())
+  }
+}
+
+#[cfg(not(target_os = "macos"))]
 impl TextEditDriver for MacosTextEditDriver {
-  fn activate_app(&mut self, app_id: &str, settle: Duration) -> OperationResult<StepOutcome> {
-    let window = self.main_window(app_id)?;
-    self
-      .session
-      .window()
-      .prepare_for_input(
-        &window,
-        PrepareForInputOptions {
-          activation: ActivationPolicy::Foreground { settle },
-          preserve_frontmost: false,
-          install_focus_guard: false,
-          settle: Duration::ZERO,
-        },
-      )
-      .map_err(|error| error.to_string())?;
-    Ok(StepOutcome {
-      step_id: "activate-target-app",
-      summary: format!("activated foreground TextEdit window for {app_id}"),
-      input_action_result: None,
-    })
+  fn activate_app(&mut self, _app_id: &str, _settle: Duration) -> OperationResult<StepOutcome> {
+    Err("MacosTextEditDriver requires macOS".to_string())
   }
 
   fn focus_text_input(&mut self, _app_id: &str, _query: &str, _candidate: &str) -> OperationResult<StepOutcome> {
-    // TODO(auv-driver-macos-ax-focus): `document focus` needs a typed
-    // AX-query focus API in `auv-driver-macos`; implement this adapter method
-    // once it is available without routing through root runtime.rs.
-    Err("typed TextEdit AX text-input focus is not available yet".to_string())
+    Err("MacosTextEditDriver requires macOS".to_string())
   }
 
   fn paste_text_preserve_clipboard(
     &mut self,
     _app_id: &str,
-    text: &str,
-    replace_existing: bool,
-    settle: Duration,
+    _text: &str,
+    _replace_existing: bool,
+    _settle: Duration,
   ) -> OperationResult<StepOutcome> {
-    self
-      .session
-      .input()
-      .paste_text(PasteTextOptions {
-        text: text.to_string(),
-        replace_existing,
-        submit: TextSubmit::No,
-        settle,
-      })
-      .map_err(|error| error.to_string())?;
-    Ok(StepOutcome {
-      step_id: "document-write",
-      summary: "pasted TextEdit document body through auv-driver-macos clipboard input".to_string(),
-      input_action_result: Some(InputActionResult::single_success(InputDeliveryPath::ClipboardPaste)),
-    })
+    Err("MacosTextEditDriver requires macOS".to_string())
   }
 
   fn verify_ax_text(&mut self, _app_id: &str, _target_text: &str, _target_role: &str) -> OperationResult<VerificationOutcome> {
-    // TODO(auv-driver-macos-ax-verify): `document compare` needs typed AX text
-    // observation in `auv-driver-macos` before this app-local command can
-    // replace legacy verify.axText end-to-end.
-    Err("typed TextEdit AX text verification is not available yet".to_string())
-  }
-}
-
-fn main_window_selector(app_id: &str) -> WindowSelector {
-  WindowSelector {
-    app: Some(App::bundle_id(app_id)),
-    title: None,
-    main_visible: true,
+    Err("MacosTextEditDriver requires macOS".to_string())
   }
 }

--- a/crates/auv-cli-invoke/src/arg.rs
+++ b/crates/auv-cli-invoke/src/arg.rs
@@ -48,6 +48,30 @@ pub const TEXT: ArgSpec = ArgSpec {
   required: true,
   help: "Text content used by the invoke command.",
 };
+pub const CONTENT: ArgSpec = ArgSpec {
+  flag: "--content",
+  value_name: "TEXT",
+  required: true,
+  help: "Document body text to write.",
+};
+pub const REPLACE: ArgSpec = ArgSpec {
+  flag: "--replace",
+  value_name: "BOOL",
+  required: false,
+  help: "Replace existing document body before paste (default true).",
+};
+pub const VERIFY: ArgSpec = ArgSpec {
+  flag: "--verify",
+  value_name: "BOOL",
+  required: false,
+  help: "Run AX text verification after paste (default true).",
+};
+pub const DRIVER: ArgSpec = ArgSpec {
+  flag: "--driver",
+  value_name: "NAME",
+  required: false,
+  help: "Driver boundary: omit for live macOS, or `fixture` for hermetic CI.",
+};
 pub const TARGET_TEXT: ArgSpec = ArgSpec {
   flag: "--target_text",
   value_name: "TEXT",
@@ -158,4 +182,5 @@ pub const COVERAGE_FIXTURE_DIR: ArgSpec = ArgSpec {
   help: "Directory containing a coverage scenario manifest (manifest.json); frame PNGs are resolved via frame_fixture cross-reference, not stored in this directory.",
 };
 pub const SCAN_COVERAGE_ARGS: &[ArgSpec] = &[COVERAGE_FIXTURE_DIR];
+pub const TEXTEDIT_DOCUMENT_WRITE_ARGS: &[ArgSpec] = &[CONTENT, REPLACE, VERIFY, DRIVER];
 pub const NO_ARGS: &[ArgSpec] = &[];

--- a/crates/auv-cli-invoke/src/lib.rs
+++ b/crates/auv-cli-invoke/src/lib.rs
@@ -27,7 +27,10 @@ pub use model::{
   ExecutionTarget, InvokeOutputOptions, InvokeReport, InvokeReportField, InvokeReportSection, InvokeReportTable, InvokeReportTableRow,
   InvokeRequest, InvokeResult, RunStatus,
 };
-pub use recorded::{invoke_recorded, invoke_recorded_in_span, invoke_recorded_with_session, invoke_resolved_recorded_in_span};
+pub use recorded::{
+  InvokeFinalizeHook, invoke_recorded, invoke_recorded_in_span, invoke_recorded_with_finalize, invoke_recorded_with_session,
+  invoke_resolved_recorded_in_span,
+};
 pub use registry::{InvokeRegistry, default_registry};
 pub use render::{render_invoke_result, render_to_string, write_rendered};
 pub use summary::{OperationSummary, OperationSummaryCache, OperationSummaryRecord, OperationSummarySource};

--- a/crates/auv-cli-invoke/src/recorded.rs
+++ b/crates/auv-cli-invoke/src/recorded.rs
@@ -5,6 +5,13 @@ use auv_tracing_driver::{
 
 use crate::{InvokeCommand, InvokeCommandInput, InvokeRegistry, InvokeRequest, InvokeResult, RunStatus};
 
+/// Product-specific work performed after handler artifacts are recorded and
+/// before the command span and run status are finalized.
+///
+/// A hook may append artifacts or update `InvokeResult` status. Returning an
+/// error records the command/run as failed and returns that error to the caller.
+pub type InvokeFinalizeHook = dyn Fn(&RunRecordingBackend, &mut RecordingRun, &SpanRef, &mut InvokeResult) -> AuvResult<()> + Send + Sync;
+
 /// Run a recorded command invoke under the default session.
 ///
 /// The recorded invoke path owns the default `session_id` so CLI/MCP callers
@@ -13,7 +20,18 @@ use crate::{InvokeCommand, InvokeCommandInput, InvokeRegistry, InvokeRequest, In
 /// owns the default). Callers that can name a session use
 /// [`invoke_recorded_with_session`].
 pub fn invoke_recorded(recording: &RunRecordingBackend, registry: &InvokeRegistry, request: InvokeRequest) -> AuvResult<InvokeResult> {
-  invoke_recorded_with_session(recording, registry, request, SessionId::default_session())
+  invoke_recorded_with_session_and_finalize(recording, registry, request, SessionId::default_session(), None)
+}
+
+/// Run a recorded command invoke under the default session with an in-lifecycle
+/// finalize hook.
+pub fn invoke_recorded_with_finalize(
+  recording: &RunRecordingBackend,
+  registry: &InvokeRegistry,
+  request: InvokeRequest,
+  finalize: &InvokeFinalizeHook,
+) -> AuvResult<InvokeResult> {
+  invoke_recorded_with_session_and_finalize(recording, registry, request, SessionId::default_session(), Some(finalize))
 }
 
 /// Run a recorded command invoke and stamp `session` onto the recorded run.
@@ -30,9 +48,19 @@ pub fn invoke_recorded_with_session(
   request: InvokeRequest,
   session: SessionId,
 ) -> AuvResult<InvokeResult> {
+  invoke_recorded_with_session_and_finalize(recording, registry, request, session, None)
+}
+
+fn invoke_recorded_with_session_and_finalize(
+  recording: &RunRecordingBackend,
+  registry: &InvokeRegistry,
+  request: InvokeRequest,
+  session: SessionId,
+  finalize: Option<&InvokeFinalizeHook>,
+) -> AuvResult<InvokeResult> {
   let mut run = recording.handle().start_run(RunSpec::new(RunType::Command, "auv.command").with_session(session))?;
   let root = run.root_span();
-  let result = match invoke_recorded_in_span(recording, registry, &mut run, &root, request) {
+  let result = match invoke_recorded_in_span_with_finalize(recording, registry, &mut run, &root, request, finalize) {
     Ok(result) => result,
     Err(error) => {
       if let Err(finish_error) = recording.handle().finish_run(
@@ -58,7 +86,7 @@ pub fn invoke_recorded_with_session(
     RunFinish {
       status_code,
       summary: Some(result.output_summary.clone()),
-      failure: result.failure_message.clone(),
+      failure: result.failure_message.clone().or_else(|| (result.status == RunStatus::Failed).then(|| result.output_summary.clone())),
     },
   )?;
   Ok(result)
@@ -71,11 +99,22 @@ pub fn invoke_recorded_in_span(
   parent: &SpanRef,
   request: InvokeRequest,
 ) -> AuvResult<InvokeResult> {
+  invoke_recorded_in_span_with_finalize(recording, registry, run, parent, request, None)
+}
+
+fn invoke_recorded_in_span_with_finalize(
+  recording: &RunRecordingBackend,
+  registry: &InvokeRegistry,
+  run: &mut RecordingRun,
+  parent: &SpanRef,
+  request: InvokeRequest,
+  finalize: Option<&InvokeFinalizeHook>,
+) -> AuvResult<InvokeResult> {
   let command_id = request.command_id.clone();
   let command = registry
     .resolve(&command_id)
     .ok_or_else(|| format!("unknown command {command_id}; use `auv invoke --help` to inspect available entries"))?;
-  invoke_resolved_recorded_in_span(recording, run, parent, command, request)
+  invoke_resolved_recorded_in_span_with_finalize(recording, run, parent, command, request, finalize)
 }
 
 pub fn invoke_resolved_recorded_in_span(
@@ -85,32 +124,90 @@ pub fn invoke_resolved_recorded_in_span(
   command: &InvokeCommand,
   request: InvokeRequest,
 ) -> AuvResult<InvokeResult> {
+  invoke_resolved_recorded_in_span_with_finalize(recording, run, parent, command, request, None)
+}
+
+fn invoke_resolved_recorded_in_span_with_finalize(
+  recording: &RunRecordingBackend,
+  run: &mut RecordingRun,
+  parent: &SpanRef,
+  command: &InvokeCommand,
+  request: InvokeRequest,
+  finalize: Option<&InvokeFinalizeHook>,
+) -> AuvResult<InvokeResult> {
   let command_span = run.start_span(
     parent,
     running_span_record("auv.command.invoke", command_attributes(command.id, request.target.application_id.as_deref())),
   )?;
   record_event(run, command_span.id(), "command.resolved", Some(format!("resolved {}", command.id)));
 
-  let output = match command.invoke(InvokeCommandInput {
+  let mut result = match command.invoke(InvokeCommandInput {
     command_id: command.id,
     target_application_id: request.target.application_id.as_deref(),
     inputs: &request.inputs,
     dry_run: request.dry_run,
   }) {
-    Ok(output) => output,
+    Ok(output) => {
+      if let Some(backend) = &output.backend {
+        record_event(run, command_span.id(), "command.backend", Some(format!("backend={backend}")));
+      }
+      for note in &output.notes {
+        record_event(run, command_span.id(), "command.note", Some(note.clone()));
+      }
+      if let Some(verification) = &output.verification {
+        record_event(run, command_span.id(), "command.verification", Some(verification.clone()));
+      }
+      for known_limit in &output.known_limits {
+        record_event(run, command_span.id(), "command.known_limit", Some(known_limit.clone()));
+      }
+
+      match recording.record_produced_artifacts(run, &command_span, output.artifacts) {
+        Ok(recorded) => InvokeResult {
+          run_id: run.id().to_string(),
+          producer_span_id: command_span.id().clone(),
+          command_id: command.id.to_string(),
+          command_summary: command.summary.to_string(),
+          status: RunStatus::Completed,
+          output_summary: output.summary,
+          backend: output.backend,
+          signals: output.signals,
+          notes: output.notes,
+          known_limits: output.known_limits,
+          verification: output.verification,
+          report: output.report,
+          artifacts: recorded.records,
+          artifact_paths: recorded.paths,
+          failure_message: None,
+        },
+        Err(failure) => {
+          let failure_message = format!("command {} artifact recording failed: {}", command.id, failure.message);
+          let output_summary =
+            format!("Command invocation produced output, but artifact recording failed. Inspect {} for the recorded trace.", run.id());
+          InvokeResult {
+            run_id: run.id().to_string(),
+            producer_span_id: command_span.id().clone(),
+            command_id: command.id.to_string(),
+            command_summary: command.summary.to_string(),
+            status: RunStatus::Failed,
+            output_summary,
+            backend: output.backend,
+            signals: output.signals,
+            notes: output.notes,
+            known_limits: output.known_limits,
+            verification: output.verification,
+            report: output.report,
+            artifacts: failure.recorded.records,
+            artifact_paths: failure.recorded.paths,
+            failure_message: Some(failure_message),
+          }
+        }
+      }
+    }
     Err(error) => {
       let failure_message = format!("command {} handler failed: {error}", command.id);
       let output_summary = format!("Command invocation failed after run creation. Inspect {} for the recorded trace.", run.id());
       record_event(run, command_span.id(), "command.failed", Some(failure_message.clone()));
-      run.finish_span(
-        &command_span,
-        SpanFinish {
-          status_code: TraceStatusCode::Error,
-          summary: Some(output_summary.clone()),
-          failure: Some(failure_message.clone()),
-        },
-      )?;
-      return Ok(InvokeResult {
+      InvokeResult {
         run_id: run.id().to_string(),
         producer_span_id: command_span.id().clone(),
         command_id: command.id.to_string(),
@@ -126,89 +223,51 @@ pub fn invoke_resolved_recorded_in_span(
         artifacts: Vec::new(),
         artifact_paths: Vec::new(),
         failure_message: Some(failure_message),
-      });
+      }
     }
   };
 
-  if let Some(backend) = &output.backend {
-    record_event(run, command_span.id(), "command.backend", Some(format!("backend={backend}")));
-  }
-
-  for note in &output.notes {
-    record_event(run, command_span.id(), "command.note", Some(note.clone()));
-  }
-
-  if let Some(verification) = &output.verification {
-    record_event(run, command_span.id(), "command.verification", Some(verification.clone()));
-  }
-
-  for known_limit in &output.known_limits {
-    record_event(run, command_span.id(), "command.known_limit", Some(known_limit.clone()));
-  }
-
-  let artifact_result = recording.record_produced_artifacts(run, &command_span, output.artifacts);
-  let (artifact_records, artifact_paths) = match artifact_result {
-    Ok(recorded) => (recorded.records, recorded.paths),
-    Err(failure) => {
-      let failure_message = format!("command {} artifact recording failed: {}", command.id, failure.message);
+  if let Some(finalize) = finalize {
+    if let Err(error) = finalize(recording, run, &command_span, &mut result) {
+      let failure_message = format!("command {} finalize failed: {error}", command.id);
       let output_summary =
-        format!("Command invocation produced output, but artifact recording failed. Inspect {} for the recorded trace.", run.id());
+        format!("Command invocation finalization failed after run creation. Inspect {} for the recorded trace.", run.id());
+      record_event(run, command_span.id(), "command.finalize.failed", Some(failure_message.clone()));
       run.finish_span(
         &command_span,
         SpanFinish {
           status_code: TraceStatusCode::Error,
-          summary: Some(output_summary.clone()),
+          summary: Some(output_summary),
           failure: Some(failure_message.clone()),
         },
       )?;
-      return Ok(InvokeResult {
-        run_id: run.id().to_string(),
-        producer_span_id: command_span.id().clone(),
-        command_id: command.id.to_string(),
-        command_summary: command.summary.to_string(),
-        status: RunStatus::Failed,
-        output_summary,
-        backend: output.backend,
-        signals: output.signals,
-        notes: output.notes,
-        known_limits: output.known_limits,
-        verification: output.verification,
-        report: output.report,
-        artifacts: failure.recorded.records,
-        artifact_paths: failure.recorded.paths,
-        failure_message: Some(failure_message),
-      });
+      return Err(failure_message);
     }
-  };
+  }
 
-  record_event(run, command_span.id(), "run.completed", Some(output.summary.clone()));
+  let status_code = if result.status == RunStatus::Completed {
+    TraceStatusCode::Ok
+  } else {
+    TraceStatusCode::Error
+  };
+  let event_name = if result.status == RunStatus::Completed {
+    "run.completed"
+  } else {
+    "run.failed"
+  };
+  let failure = result.failure_message.clone().or_else(|| (result.status == RunStatus::Failed).then(|| result.output_summary.clone()));
+  record_event(run, command_span.id(), event_name, Some(result.output_summary.clone()));
 
   run.finish_span(
     &command_span,
     SpanFinish {
-      status_code: TraceStatusCode::Ok,
-      summary: Some(output.summary.clone()),
-      failure: None,
+      status_code,
+      summary: Some(result.output_summary.clone()),
+      failure,
     },
   )?;
 
-  Ok(InvokeResult {
-    run_id: run.id().to_string(),
-    producer_span_id: command_span.id().clone(),
-    command_id: command.id.to_string(),
-    command_summary: command.summary.to_string(),
-    status: RunStatus::Completed,
-    output_summary: output.summary,
-    backend: output.backend,
-    signals: output.signals,
-    notes: output.notes,
-    known_limits: output.known_limits,
-    verification: output.verification,
-    report: output.report,
-    artifacts: artifact_records,
-    artifact_paths,
-    failure_message: None,
-  })
+  Ok(result)
 }
 
 fn command_attributes(command_id: &str, target_application_id: Option<&str>) -> auv_tracing_driver::Attributes {
@@ -558,6 +617,123 @@ mod tests {
     let command_span = canonical.spans.iter().find(|span| span.name == "auv.command.invoke").expect("command span should be recorded");
     assert_eq!(command_span.status_code, TraceStatusCode::Error);
     assert!(command_span.failure.as_ref().is_some_and(|failure| failure.message.contains("handler failed: boom")));
+
+    let _ = fs::remove_dir_all(store_root);
+  }
+
+  // ROOT CAUSE:
+  //
+  // Moving product finalization into recorded invoke initially left the
+  // handler-failure early return outside the hook, dropping canonical
+  // finalization for failed attempts after run creation.
+  #[test]
+  fn invoke_recorded_with_finalize_runs_hook_for_handler_failure() {
+    let (recording, store_root) = recording("handler-failure-finalize");
+    let registry = failing_registry();
+    let finalize = |_recording: &RunRecordingBackend,
+                    _run: &mut auv_tracing_driver::RecordingRun,
+                    _span: &auv_tracing_driver::SpanRef,
+                    result: &mut crate::InvokeResult| {
+      result.known_limits.push("fixture.finalized".to_string());
+      Ok(())
+    };
+
+    let result = super::invoke_recorded_with_finalize(
+      &recording,
+      &registry,
+      InvokeRequest {
+        command_id: FAILING_COMMAND_ID.to_string(),
+        target: ExecutionTarget::default(),
+        inputs: BTreeMap::new(),
+        dry_run: false,
+      },
+      &finalize,
+    )
+    .expect("failed handler should remain an inspectable InvokeResult");
+
+    assert_eq!(result.status, RunStatus::Failed);
+    assert!(result.known_limits.iter().any(|limit| limit == "fixture.finalized"));
+    let canonical = recording.read_run(&result.run_id).expect("failed run should persist");
+    assert_eq!(canonical.run.status_code, TraceStatusCode::Error);
+
+    let _ = fs::remove_dir_all(store_root);
+  }
+
+  #[test]
+  fn invoke_recorded_with_finalize_uses_final_status_for_span_and_run() {
+    let (recording, store_root) = recording("finalize-status");
+    let registry = fixture_registry();
+    let finalize = |_recording: &RunRecordingBackend,
+                    _run: &mut auv_tracing_driver::RecordingRun,
+                    _span: &auv_tracing_driver::SpanRef,
+                    result: &mut crate::InvokeResult| {
+      result.status = RunStatus::Failed;
+      result.output_summary = "semantic verification failed".to_string();
+      result.failure_message = Some("semantic mismatch".to_string());
+      Ok(())
+    };
+
+    let result = super::invoke_recorded_with_finalize(
+      &recording,
+      &registry,
+      InvokeRequest {
+        command_id: FIXTURE_COMMAND_ID.to_string(),
+        target: ExecutionTarget::default(),
+        inputs: BTreeMap::new(),
+        dry_run: false,
+      },
+      &finalize,
+    )
+    .expect("finalized failure should remain inspectable");
+
+    assert_eq!(result.status, RunStatus::Failed);
+    let canonical = recording.read_run(&result.run_id).expect("finalized run should persist");
+    assert_eq!(canonical.run.status_code, TraceStatusCode::Error);
+    let command_span = canonical.spans.iter().find(|span| span.name == "auv.command.invoke").expect("command span");
+    assert_eq!(command_span.status_code, TraceStatusCode::Error);
+    assert_eq!(command_span.failure.as_ref().map(|failure| failure.message.as_str()), Some("semantic mismatch"));
+
+    let _ = fs::remove_dir_all(store_root);
+  }
+
+  #[test]
+  fn invoke_recorded_finalize_error_persists_failed_run() {
+    let store_root = temp_dir("finalize-error");
+    let recorder = Arc::new(MemoryRunRecorder::new());
+    let recording = RunRecordingBackend::new(LocalStore::new(store_root.clone()).expect("store should create"), recorder.clone());
+    let registry = fixture_registry();
+    let finalize = |_recording: &RunRecordingBackend,
+                    _run: &mut auv_tracing_driver::RecordingRun,
+                    _span: &auv_tracing_driver::SpanRef,
+                    _result: &mut crate::InvokeResult| Err("fixture finalize failure".to_string());
+
+    let error = super::invoke_recorded_with_finalize(
+      &recording,
+      &registry,
+      InvokeRequest {
+        command_id: FIXTURE_COMMAND_ID.to_string(),
+        target: ExecutionTarget::default(),
+        inputs: BTreeMap::new(),
+        dry_run: false,
+      },
+      &finalize,
+    )
+    .expect_err("finalize failure should fail the caller");
+
+    assert!(error.contains("fixture finalize failure"));
+    let run_id = recorder
+      .drain_for_test()
+      .into_iter()
+      .find_map(|update| match update {
+        RunUpdate::RunFinished { run, .. } => Some(run.run_id),
+        _ => None,
+      })
+      .expect("failed finalized run should finish");
+    let canonical = recording.read_run(run_id.as_str()).expect("failed finalized run should persist");
+    assert_eq!(canonical.run.status_code, TraceStatusCode::Error);
+    let command_span = canonical.spans.iter().find(|span| span.name == "auv.command.invoke").expect("command span");
+    assert_eq!(command_span.status_code, TraceStatusCode::Error);
+    assert!(canonical.events.iter().any(|event| event.name == "command.finalize.failed"));
 
     let _ = fs::remove_dir_all(store_root);
   }

--- a/crates/auv-cli/Cargo.toml
+++ b/crates/auv-cli/Cargo.toml
@@ -32,6 +32,8 @@ path = "src/bin/auv-minecraft.rs"
 
 [dependencies]
 auv-runtime = { path = "../.." }
+auv-apple-textedit = { path = "../auv-apple-textedit" }
+auv-cli-invoke-macros = { path = "../auv-cli-invoke-macros" }
 auv-game-osu = { path = "../auv-game-osu" }
 auv-game-balatro = { path = "../auv-game-balatro" }
 auv-game-minecraft = { path = "../auv-game-minecraft" }

--- a/crates/auv-cli/Cargo.toml
+++ b/crates/auv-cli/Cargo.toml
@@ -64,6 +64,7 @@ swift-bridge-build.workspace = true
 auv-api-proto = { path = "../auv-api-proto" }
 auv-stage-status = { path = "../auv-stage-status" }
 axum = { version = "0.8", default-features = false }
+rmcp = { version = "0.6", features = ["server", "client", "transport-io"] }
 tokio = { version = "1", features = ["fs", "io-util", "macros", "process", "rt-multi-thread", "time"] }
 tonic = { version = "0.14", features = ["transport"] }
 tower = { version = "0.5", features = ["util"] }

--- a/crates/auv-cli/src/cli_frontend.rs
+++ b/crates/auv-cli/src/cli_frontend.rs
@@ -810,7 +810,7 @@ async fn dispatch(command: CliCommand) -> Result<(), String> {
       return Err("`list-commands` has been removed; use `auv invoke --help` instead".to_string());
     }
     CliCommand::InvokeHelp { command_id } => {
-      let registry = auv_cli_invoke::default_registry();
+      let registry = crate::product_registry();
       if let Some(command_id) = command_id {
         let command = registry
           .resolve(&command_id)
@@ -1021,8 +1021,8 @@ async fn dispatch(command: CliCommand) -> Result<(), String> {
       output,
     } => {
       let recording = build_recording_for_inspect(&project_root, &inspect)?;
-      let registry = auv_cli_invoke::default_registry();
-      let result = auv_cli_invoke::invoke_recorded(&recording, &registry, request)?;
+      let registry = crate::product_registry();
+      let result = crate::invoke_recorded(&recording, &registry, request)?;
       auv_cli_invoke::render_invoke_result(&result, output)?;
 
       if result.status == auv_cli_invoke::RunStatus::Failed {

--- a/crates/auv-cli/src/integrations/mod.rs
+++ b/crates/auv-cli/src/integrations/mod.rs
@@ -12,3 +12,4 @@ pub mod godot;
 pub mod minecraft;
 pub mod osu;
 pub(crate) mod query_wired_live_action_status;
+pub mod textedit;

--- a/crates/auv-cli/src/integrations/textedit/mod.rs
+++ b/crates/auv-cli/src/integrations/textedit/mod.rs
@@ -18,8 +18,8 @@ use auv_runtime::contract::{
   VERIFICATION_RESULT_API_VERSION, VerificationMethod, VerificationResult,
 };
 use auv_tracing_driver::artifact::ArtifactBytesSource;
-use auv_tracing_driver::store::LocalStore;
-use auv_tracing_driver::{ProducedArtifact, RunId, now_millis};
+use auv_tracing_driver::trace::{EVENT_API_VERSION, EventRecordV1Alpha1, new_event_id};
+use auv_tracing_driver::{ProducedArtifact, RecordingRun, RunId, RunRecordingBackend, SpanRef, now_millis};
 
 pub const DOCUMENT_WRITE_COMMAND_ID: &str = "app.textedit.document.write";
 pub const TEXTEDIT_DOCUMENT_WRITE_KNOWN_LIMIT: &str = "auv.product.textedit.document_write.v0";
@@ -51,9 +51,14 @@ fn document_write_impl(input: InvokeCommandInput<'_>) -> InvokeCommandResult {
 
   let command = parse_document_write(&input)?;
   let driver_kind = input.inputs.get("driver").map(String::as_str).unwrap_or("live");
+  // NOTICE(textedit-fixture-only): this undocumented input exists only so hermetic
+  // recorded mismatch tests can force a semantic mismatch without live TextEdit.
+  // Expose a first-class flag only if the owner approves fixture controls.
+  let fixture_observed_text = input.inputs.get("fixture_observed_text").cloned();
   let report = match driver_kind {
     "fixture" => {
       let mut driver = FixtureTextEditDriver::from_write(&command);
+      driver.observed_override = fixture_observed_text;
       run_document_command(&DocumentCommand::Write(command.clone()), &mut driver)?
     }
     "live" => {
@@ -73,8 +78,9 @@ fn document_write_impl(input: InvokeCommandInput<'_>) -> InvokeCommandResult {
   build_invoke_output_from_report(&report, &command)
 }
 
-/// Stages evidence artifacts only. Canonical `operation-result` is written after
-/// `invoke_recorded` assigns the real run id (see [`persist_canonical_operation_result`]).
+/// Stages evidence artifacts only. Canonical `operation-result` is appended by
+/// the recorded invoke finalize hook after evidence artifacts are recorded and
+/// before the run closes.
 pub(crate) fn build_invoke_output_from_report(report: &DocumentCommandReport, command: &DocumentWrite) -> InvokeCommandResult {
   let semantic_matched = report.verification.as_ref().map(|verification| verification.semantic_matched);
   let mut output = InvokeCommandOutput::new(format!(
@@ -125,15 +131,40 @@ pub(crate) fn build_invoke_output_from_report(report: &DocumentCommandReport, co
   Ok(output)
 }
 
-/// Persist a lineage-complete `operation-result` after invoke assigns `run_id`.
-pub fn persist_canonical_operation_result(store: &LocalStore, result: &InvokeResult) -> Result<(), String> {
+/// Finalize the recorded invoke inside the shared lifecycle so result status,
+/// run status, and canonical `operation-result` stay in sync.
+pub fn finalize_recorded_invoke(
+  recording: &RunRecordingBackend,
+  run: &mut RecordingRun,
+  producer_span: &SpanRef,
+  result: &mut InvokeResult,
+) -> Result<(), String> {
   if result.command_id != DOCUMENT_WRITE_COMMAND_ID {
     return Ok(());
   }
   if result.dry_run_like() {
     return Ok(());
   }
+  if result.artifacts.iter().any(|artifact| artifact.role == "operation-result") {
+    return Ok(());
+  }
 
+  let observation = read_ax_observation(recording, result)?;
+  if let Some(verification) = observation.as_ref()
+    && !verification.semantic_matched
+  {
+    apply_semantic_mismatch(result, verification);
+  }
+
+  let operation = build_canonical_operation_result(result, observation.as_ref());
+  let rendered = serde_json::to_string_pretty(&operation).map_err(|error| format!("serialize operation-result: {error}"))? + "\n";
+  let (artifact, path) = stage_operation_result_artifact(recording, run, producer_span, rendered.into_bytes())?;
+  result.artifacts.push(artifact);
+  result.artifact_paths.push(path);
+  Ok(())
+}
+
+fn build_canonical_operation_result(result: &InvokeResult, observation: Option<&VerificationOutcome>) -> OperationResult {
   let run_id = RunId::new(result.run_id.as_str());
   let evidence_artifacts = result
     .artifacts
@@ -146,11 +177,8 @@ pub fn persist_canonical_operation_result(store: &LocalStore, result: &InvokeRes
       captured_event_id: artifact.event_id.clone(),
     })
     .collect::<Vec<_>>();
-
-  let observation = read_ax_observation(store, result)?;
-  let semantic_matched = observation.as_ref().map(|value| value.semantic_matched);
+  let semantic_matched = observation.map(|value| value.semantic_matched);
   let verifications = observation
-    .as_ref()
     .map(|verification| {
       vec![VerificationResult {
         api_version: VERIFICATION_RESULT_API_VERSION.to_string(),
@@ -178,57 +206,81 @@ pub fn persist_canonical_operation_result(store: &LocalStore, result: &InvokeRes
       }]
     })
     .unwrap_or_default();
-
   let status = match (result.status.clone(), semantic_matched) {
     (_, Some(false)) => OperationStatus::Failed,
     (auv_cli_invoke::RunStatus::Failed, _) => OperationStatus::Failed,
     (auv_cli_invoke::RunStatus::Completed, _) => OperationStatus::Completed,
   };
-
   let mut known_limits = result.known_limits.clone();
   if !known_limits.iter().any(|limit| limit == TEXTEDIT_DOCUMENT_WRITE_KNOWN_LIMIT) {
     known_limits.push(TEXTEDIT_DOCUMENT_WRITE_KNOWN_LIMIT.to_string());
   }
-
-  let operation = OperationResult {
+  OperationResult {
     api_version: OPERATION_RESULT_API_VERSION.to_string(),
     run_id: run_id.clone(),
     status,
     operation_id: DOCUMENT_WRITE_COMMAND_ID.to_string(),
-    evidence_artifacts: evidence_artifacts.clone(),
+    evidence_artifacts,
     output: OperationOutput::Acknowledged {
       message: Some(result.output_summary.clone()),
     },
     verifications,
     freshness_basis: None,
-    known_limits: known_limits.clone(),
-  };
-
-  let rendered = serde_json::to_string_pretty(&operation).map_err(|error| format!("serialize operation-result: {error}"))? + "\n";
-  let mut canonical = store.read_run(result.run_id.as_str()).map_err(|error| error.to_string())?;
-  if canonical.artifacts.iter().any(|artifact| artifact.role == "operation-result") {
-    // Already finalized (or synthetic). Prefer first match; do not duplicate.
-    return Ok(());
+    known_limits,
   }
-  let artifact = store
+}
+
+fn apply_semantic_mismatch(result: &mut InvokeResult, verification: &VerificationOutcome) {
+  let observed = truncate(&verification.matched_text, 80);
+  result.status = auv_cli_invoke::RunStatus::Failed;
+  result.output_summary =
+    format!("TextEdit document.write failed semantic verification (role={}, observed={observed})", verification.matched_role);
+  result.failure_message = Some(format!(
+    "TextEdit semantic verification failed: expected content was not present in observed AX text role={} observed={observed}",
+    verification.matched_role
+  ));
+}
+
+fn stage_operation_result_artifact(
+  recording: &RunRecordingBackend,
+  run: &mut RecordingRun,
+  producer_span: &SpanRef,
+  bytes: Vec<u8>,
+) -> Result<(auv_tracing_driver::trace::ArtifactRecordV1Alpha1, PathBuf), String> {
+  let event_id = new_event_id();
+  let artifact = recording
     .stage_artifact_bytes(
-      &run_id,
-      canonical.artifacts.len(),
-      &result.producer_span_id,
-      None,
+      run.id(),
+      run.artifact_count(),
+      producer_span.id(),
+      Some(event_id.clone()),
       ArtifactBytesSource {
         role: "operation-result".to_string(),
-        bytes: rendered.into_bytes(),
+        bytes,
         preferred_name: "operation-result.json".to_string(),
         summary: Some("Canonical TextEdit document.write OperationResult".to_string()),
       },
     )
     .map_err(|error| error.to_string())?;
-  canonical.artifacts.push(artifact);
-  store.replace_run_snapshot(&canonical).map_err(|error| error.to_string())?;
-  let _ = evidence_artifacts;
-  let _ = known_limits;
-  Ok(())
+  run.record_event(EventRecordV1Alpha1 {
+    api_version: EVENT_API_VERSION.to_string(),
+    event_id,
+    span_id: producer_span.id().clone(),
+    name: "artifact.captured".to_string(),
+    timestamp_millis: now_millis(),
+    attributes: Default::default(),
+    message: Some(render_artifact_event(&artifact)),
+    artifact_ids: vec![artifact.artifact_id.clone()],
+  });
+  let staged_path = recording.run_dir(run.id()).map_err(|error| error.to_string())?.join(&artifact.path);
+  run.record_artifact(artifact.clone());
+  recording.record_artifact_bytes(run.id(), &artifact, &staged_path).map_err(|error| error.to_string())?;
+  Ok((artifact, staged_path))
+}
+
+fn render_artifact_event(artifact: &auv_tracing_driver::trace::ArtifactRecordV1Alpha1) -> String {
+  let note = artifact.summary.clone().unwrap_or_else(|| "n/a".to_string());
+  format!("{} kind={} path={} note={}", artifact.artifact_id, artifact.role, artifact.path, note)
 }
 
 trait InvokeResultExt {
@@ -241,11 +293,11 @@ impl InvokeResultExt for InvokeResult {
   }
 }
 
-fn read_ax_observation(store: &LocalStore, result: &InvokeResult) -> Result<Option<VerificationOutcome>, String> {
+fn read_ax_observation(recording: &RunRecordingBackend, result: &InvokeResult) -> Result<Option<VerificationOutcome>, String> {
   let Some(artifact) = result.artifacts.iter().find(|artifact| artifact.role == "ax-text-observation") else {
     return Ok(None);
   };
-  let (_record, path) = store.artifact_file(result.run_id.as_str(), artifact.artifact_id.as_str()).map_err(|error| error.to_string())?;
+  let path = recording.run_dir(result.run_id.as_str()).map_err(|error| error.to_string())?.join(&artifact.path);
   let body = fs::read_to_string(&path).map_err(|error| format!("read ax-text-observation: {error}"))?;
   let observation: VerificationOutcome = serde_json::from_str(&body).map_err(|error| format!("decode ax-text-observation: {error}"))?;
   Ok(Some(observation))
@@ -334,7 +386,7 @@ fn parse_bool(value: &str, name: &str) -> Result<bool, String> {
 
 fn json_artifact<T: serde::Serialize>(kind: &str, label: &str, value: &T, note: &str) -> Result<ProducedArtifact, String> {
   let source_path =
-    PathBuf::from(std::env::temp_dir()).join(format!("auv-invoke-textedit-{label}-{}-{}.json", std::process::id(), now_millis()));
+    PathBuf::from(std::env::temp_dir()).join(format!("auv-invoke-textedit-{label}-{}-{}.json", std::process::id(), new_event_id()));
   let body = serde_json::to_vec_pretty(value).map_err(|error| format!("failed to serialize {kind} artifact: {error}"))?;
   fs::write(&source_path, body).map_err(|error| format!("failed to write {kind} artifact: {error}"))?;
   Ok(ProducedArtifact {
@@ -427,7 +479,7 @@ mod tests {
 
   use auv_cli_invoke::InvokeNamespace;
   use auv_runtime::model::{ExecutionTarget, InvokeRequest};
-  use auv_tracing_driver::{MemoryRunRecorder, RunRecordingBackend, store::LocalStore};
+  use auv_tracing_driver::{MemoryRunRecorder, RunRecordingBackend, TraceStatusCode, store::LocalStore};
 
   use super::*;
   use crate::product_registry;
@@ -458,7 +510,7 @@ mod tests {
   }
 
   #[test]
-  fn persist_canonical_operation_result_backfills_run_id_and_evidence() {
+  fn invoke_recorded_finalize_backfills_run_id_and_result_artifacts() {
     let root = std::env::temp_dir().join(format!("auv-textedit-finalize-{}-{}", std::process::id(), now_millis()));
     std::fs::create_dir_all(&root).expect("temp");
     let store = LocalStore::new(root.clone()).expect("store");
@@ -484,6 +536,8 @@ mod tests {
     assert!(operation.evidence_artifacts.iter().all(|artifact| artifact.run_id.as_str() == result.run_id));
     assert!(operation.known_limits.iter().any(|limit| limit == TEXTEDIT_DOCUMENT_WRITE_KNOWN_LIMIT));
     assert_eq!(operation.verifications[0].semantic_matched, Some(true));
+    assert!(result.artifacts.iter().any(|artifact| artifact.role == "operation-result"));
+    assert_eq!(result.artifacts.len(), result.artifact_paths.len());
     let _ = std::fs::remove_dir_all(root);
   }
 
@@ -502,6 +556,75 @@ mod tests {
 
     let output = build_invoke_output_from_report(&report, &command).expect("output");
     assert_eq!(output.signals.get("textedit.semantic_matched").map(String::as_str), Some("false"));
+  }
+
+  // ROOT CAUSE:
+  //
+  // Artifact source names used only process id plus millisecond time, so
+  // concurrent invokes could overwrite each other's semantic evidence before
+  // the recorder copied it into the run directory.
+  #[test]
+  fn json_artifact_source_paths_are_unique_within_one_process() {
+    let first = json_artifact("fixture", "same-label", &serde_json::json!({"value": 1}), "first").expect("first artifact");
+    let second = json_artifact("fixture", "same-label", &serde_json::json!({"value": 2}), "second").expect("second artifact");
+
+    assert_ne!(first.source_path, second.source_path);
+    let _ = fs::remove_file(first.source_path);
+    let _ = fs::remove_file(second.source_path);
+  }
+
+  // ROOT CAUSE:
+  //
+  // The in-lifecycle finalizer tried to resolve the AX artifact through
+  // `LocalStore::artifact_file`, which requires the not-yet-written `run.json`.
+  //
+  // Before the fix, finalization failed before it could synchronize the invoke,
+  // run, and operation statuses. The fix reads the already-staged artifact.
+  // https://github.com/moeru-ai/auv/pull/102#issuecomment-4958351155
+  #[test]
+  fn recorded_semantic_mismatch_keeps_result_run_and_operation_in_sync() {
+    let root = std::env::temp_dir().join(format!("auv-textedit-mismatch-{}-{}", std::process::id(), now_millis()));
+    std::fs::create_dir_all(&root).expect("temp");
+    let store = LocalStore::new(root.clone()).expect("store");
+    let recording = RunRecordingBackend::new(store.clone(), Arc::new(MemoryRunRecorder::new()));
+    let mut inputs = BTreeMap::new();
+    inputs.insert("content".to_string(), "expected-marker".to_string());
+    inputs.insert("driver".to_string(), "fixture".to_string());
+    inputs.insert("fixture_observed_text".to_string(), "observed-without-expected".to_string());
+    let result = crate::invoke::invoke_recorded(
+      &recording,
+      &product_registry(),
+      InvokeRequest {
+        command_id: DOCUMENT_WRITE_COMMAND_ID.to_string(),
+        target: ExecutionTarget::default(),
+        inputs,
+        dry_run: false,
+      },
+    )
+    .expect("invoke");
+
+    assert_eq!(result.status, auv_cli_invoke::RunStatus::Failed);
+    assert!(result.failure_message.as_deref().is_some_and(|message| message.contains("semantic verification failed")));
+    assert!(result.artifacts.iter().any(|artifact| artifact.role == "operation-result"));
+    assert_eq!(result.artifacts.len(), result.artifact_paths.len());
+
+    let canonical = store.read_run(&result.run_id).expect("run");
+    assert_eq!(canonical.run.status_code, TraceStatusCode::Error);
+    let command_span = canonical.spans.iter().find(|span| span.name == "auv.command.invoke").expect("command span");
+    assert_eq!(command_span.status_code, TraceStatusCode::Error);
+    assert!(canonical.artifacts.iter().any(|artifact| artifact.role == "operation-result"));
+
+    let operation = auv_runtime::run_read::read_operation_result(&store, &result.run_id).expect("read").expect("operation-result");
+    assert_eq!(operation.status, OperationStatus::Failed);
+    assert_eq!(operation.verifications.len(), 1);
+    assert_eq!(operation.verifications[0].semantic_matched, Some(false));
+    assert_eq!(operation.verifications[0].failure_layer, Some(FailureLayer::SemanticMismatch));
+    assert!(operation.evidence_artifacts.iter().all(|artifact| artifact.run_id.as_str() == result.run_id));
+    let operation_artifact =
+      canonical.artifacts.iter().find(|artifact| artifact.role == "operation-result").expect("operation-result artifact");
+    assert_eq!(operation_artifact.span_id, result.producer_span_id);
+
+    let _ = std::fs::remove_dir_all(root);
   }
 
   #[test]
@@ -525,7 +648,11 @@ mod tests {
     )
     .expect("failed handler still returns InvokeResult after run creation");
     assert_eq!(result.status, auv_cli_invoke::RunStatus::Failed);
-    assert!(store.read_run(&result.run_id).is_ok(), "failed run must remain readable");
+    assert!(result.artifacts.iter().any(|artifact| artifact.role == "operation-result"));
+    let canonical = store.read_run(&result.run_id).expect("failed run must remain readable");
+    assert_eq!(canonical.run.status_code, TraceStatusCode::Error);
+    let operation = auv_runtime::run_read::read_operation_result(&store, &result.run_id).expect("read").expect("operation-result");
+    assert_eq!(operation.status, OperationStatus::Failed);
     let _ = std::fs::remove_dir_all(root);
   }
 }

--- a/crates/auv-cli/src/integrations/textedit/mod.rs
+++ b/crates/auv-cli/src/integrations/textedit/mod.rs
@@ -23,6 +23,8 @@ use auv_tracing_driver::{ProducedArtifact, RecordingRun, RunId, RunRecordingBack
 
 pub const DOCUMENT_WRITE_COMMAND_ID: &str = "app.textedit.document.write";
 pub const TEXTEDIT_DOCUMENT_WRITE_KNOWN_LIMIT: &str = "auv.product.textedit.document_write.v0";
+pub const TEXTEDIT_DOCUMENT_WRITE_STATE_CHANGED_KNOWN_LIMIT: &str =
+  "TextEdit document.write observes only post-write AX text; without a pre-write observation it cannot prove state_changed.";
 
 pub fn group() -> CommandGroup {
   CommandGroup::new("textedit", "TEXTEDIT").command(document_write_invoke_command())
@@ -127,6 +129,9 @@ pub(crate) fn build_invoke_output_from_report(report: &DocumentCommandReport, co
     None => "activation and input delivery only; verify=false so no semantic VerificationResult was attached".to_string(),
   });
   output.known_limits.push(TEXTEDIT_DOCUMENT_WRITE_KNOWN_LIMIT.to_string());
+  if report.verification.is_some() {
+    output.known_limits.push(TEXTEDIT_DOCUMENT_WRITE_STATE_CHANGED_KNOWN_LIMIT.to_string());
+  }
   output.report = Some(document_write_report(report, command));
   Ok(output)
 }
@@ -184,7 +189,9 @@ fn build_canonical_operation_result(result: &InvokeResult, observation: Option<&
         api_version: VERIFICATION_RESULT_API_VERSION.to_string(),
         method: VerificationMethod::AxText,
         executed: true,
-        state_changed: true,
+        // NOTICE(textedit-state-changed): only post-write AX text is recorded.
+        // Keep this false until a pre-write observation is available for comparison.
+        state_changed: false,
         semantic_matched: Some(verification.semantic_matched),
         failure_layer: (!verification.semantic_matched).then_some(FailureLayer::SemanticMismatch),
         evidence: evidence_artifacts
@@ -214,6 +221,9 @@ fn build_canonical_operation_result(result: &InvokeResult, observation: Option<&
   let mut known_limits = result.known_limits.clone();
   if !known_limits.iter().any(|limit| limit == TEXTEDIT_DOCUMENT_WRITE_KNOWN_LIMIT) {
     known_limits.push(TEXTEDIT_DOCUMENT_WRITE_KNOWN_LIMIT.to_string());
+  }
+  if observation.is_some() && !known_limits.iter().any(|limit| limit == TEXTEDIT_DOCUMENT_WRITE_STATE_CHANGED_KNOWN_LIMIT) {
+    known_limits.push(TEXTEDIT_DOCUMENT_WRITE_STATE_CHANGED_KNOWN_LIMIT.to_string());
   }
   OperationResult {
     api_version: OPERATION_RESULT_API_VERSION.to_string(),
@@ -503,6 +513,24 @@ mod tests {
   }
 
   #[test]
+  fn fixture_document_write_without_ax_verification_omits_state_change_known_limit() {
+    let mut inputs = BTreeMap::new();
+    inputs.insert("content".to_string(), "hello-fixture".to_string());
+    inputs.insert("driver".to_string(), "fixture".to_string());
+    inputs.insert("verify".to_string(), "false".to_string());
+    let input = InvokeCommandInput {
+      command_id: DOCUMENT_WRITE_COMMAND_ID,
+      target_application_id: None,
+      inputs: &inputs,
+      dry_run: false,
+    };
+
+    let output = document_write_impl(input).expect("fixture write without verification");
+
+    assert!(!output.known_limits.iter().any(|limit| limit == TEXTEDIT_DOCUMENT_WRITE_STATE_CHANGED_KNOWN_LIMIT));
+  }
+
+  #[test]
   fn document_write_command_metadata_uses_app_namespace() {
     let command = document_write_invoke_command();
     assert_eq!(command.id, DOCUMENT_WRITE_COMMAND_ID);
@@ -536,6 +564,8 @@ mod tests {
     assert!(operation.evidence_artifacts.iter().all(|artifact| artifact.run_id.as_str() == result.run_id));
     assert!(operation.known_limits.iter().any(|limit| limit == TEXTEDIT_DOCUMENT_WRITE_KNOWN_LIMIT));
     assert_eq!(operation.verifications[0].semantic_matched, Some(true));
+    assert!(!operation.verifications[0].state_changed);
+    assert!(operation.known_limits.iter().any(|limit| limit == TEXTEDIT_DOCUMENT_WRITE_STATE_CHANGED_KNOWN_LIMIT));
     assert!(result.artifacts.iter().any(|artifact| artifact.role == "operation-result"));
     assert_eq!(result.artifacts.len(), result.artifact_paths.len());
     let _ = std::fs::remove_dir_all(root);
@@ -618,6 +648,7 @@ mod tests {
     assert_eq!(operation.status, OperationStatus::Failed);
     assert_eq!(operation.verifications.len(), 1);
     assert_eq!(operation.verifications[0].semantic_matched, Some(false));
+    assert!(!operation.verifications[0].state_changed);
     assert_eq!(operation.verifications[0].failure_layer, Some(FailureLayer::SemanticMismatch));
     assert!(operation.evidence_artifacts.iter().all(|artifact| artifact.run_id.as_str() == result.run_id));
     let operation_artifact =

--- a/crates/auv-cli/src/integrations/textedit/mod.rs
+++ b/crates/auv-cli/src/integrations/textedit/mod.rs
@@ -1,0 +1,531 @@
+//! TextEdit product invoke: recorded `app.textedit.document.write`.
+
+use std::fs;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use auv_apple_textedit::{
+  DocumentCommand, DocumentCommandReport, DocumentWrite, StepOutcome, TextEditDriver, VerificationOutcome, run_document_command,
+};
+use auv_cli_invoke::arg::TEXTEDIT_DOCUMENT_WRITE_ARGS;
+use auv_cli_invoke::{
+  CommandGroup, InvokeCommandInput, InvokeCommandOutput, InvokeCommandResult, InvokeReport, InvokeReportField, InvokeReportSection,
+  InvokeResult, invoke_command,
+};
+use auv_driver::{InputActionResult, InputDeliveryPath};
+use auv_runtime::contract::{
+  ArtifactRef, FailureLayer, OPERATION_RESULT_API_VERSION, OperationOutput, OperationResult, OperationStatus,
+  VERIFICATION_RESULT_API_VERSION, VerificationMethod, VerificationResult,
+};
+use auv_tracing_driver::artifact::ArtifactBytesSource;
+use auv_tracing_driver::store::LocalStore;
+use auv_tracing_driver::{ProducedArtifact, RunId, now_millis};
+
+pub const DOCUMENT_WRITE_COMMAND_ID: &str = "app.textedit.document.write";
+pub const TEXTEDIT_DOCUMENT_WRITE_KNOWN_LIMIT: &str = "auv.product.textedit.document_write.v0";
+
+pub fn group() -> CommandGroup {
+  CommandGroup::new("textedit", "TEXTEDIT").command(document_write_invoke_command())
+}
+
+/// Product invoke entry is [`crate::invoke::invoke_recorded`].
+/// This module only owns the TextEdit handler + operation finalize.
+
+#[invoke_command(
+  id = "app.textedit.document.write",
+  group = "app",
+  summary = "Write TextEdit document body through typed AX focus, clipboard paste, and optional AX verification.",
+  args = TEXTEDIT_DOCUMENT_WRITE_ARGS,
+)]
+fn document_write(input: InvokeCommandInput<'_>) -> InvokeCommandResult {
+  document_write_impl(input)
+}
+
+fn document_write_impl(input: InvokeCommandInput<'_>) -> InvokeCommandResult {
+  if input.dry_run {
+    let mut output = InvokeCommandOutput::new("dry run: app.textedit.document.write");
+    output.verification = Some("dry-run; no semantic success claim".to_string());
+    output.known_limits.push("app.textedit.document.write dry-run does not touch TextEdit or stage run artifacts.".to_string());
+    return Ok(output);
+  }
+
+  let command = parse_document_write(&input)?;
+  let driver_kind = input.inputs.get("driver").map(String::as_str).unwrap_or("live");
+  let report = match driver_kind {
+    "fixture" => {
+      let mut driver = FixtureTextEditDriver::from_write(&command);
+      run_document_command(&DocumentCommand::Write(command.clone()), &mut driver)?
+    }
+    "live" => {
+      #[cfg(target_os = "macos")]
+      {
+        let mut driver = auv_apple_textedit::MacosTextEditDriver::open_local()?;
+        run_document_command(&DocumentCommand::Write(command.clone()), &mut driver)?
+      }
+      #[cfg(not(target_os = "macos"))]
+      {
+        return Err("app.textedit.document.write live driver requires macOS".to_string());
+      }
+    }
+    other => return Err(format!("app.textedit.document.write unknown --driver {other}; expected live or fixture")),
+  };
+
+  build_invoke_output_from_report(&report, &command)
+}
+
+/// Stages evidence artifacts only. Canonical `operation-result` is written after
+/// `invoke_recorded` assigns the real run id (see [`persist_canonical_operation_result`]).
+pub(crate) fn build_invoke_output_from_report(report: &DocumentCommandReport, command: &DocumentWrite) -> InvokeCommandResult {
+  let semantic_matched = report.verification.as_ref().map(|verification| verification.semantic_matched);
+  let mut output = InvokeCommandOutput::new(format!(
+    "TextEdit document.write completed ({} steps, verify={}, semantic_matched={:?})",
+    report.outcomes.len(),
+    report.verification.is_some(),
+    semantic_matched
+  ));
+  output.backend = Some("auv-apple-textedit.DocumentWrite".to_string());
+  output.signals.insert("textedit.command".to_string(), report.command.to_string());
+  output.signals.insert("textedit.app_id".to_string(), command.app_id.clone());
+  output.signals.insert("textedit.replace".to_string(), command.replace.to_string());
+  output.signals.insert("textedit.verify_requested".to_string(), command.verify.to_string());
+  output.signals.insert("textedit.verification_present".to_string(), report.verification.is_some().to_string());
+  if let Some(matched) = semantic_matched {
+    output.signals.insert("textedit.semantic_matched".to_string(), matched.to_string());
+  }
+
+  for outcome in &report.outcomes {
+    if let Some(result) = &outcome.input_action_result {
+      output.artifacts.push(json_artifact(
+        "input-action-result",
+        &format!("textedit-{}-input-action", outcome.step_id.replace('.', "-")),
+        result,
+        "Typed InputActionResult from TextEdit document.write step.",
+      )?);
+    }
+  }
+
+  if let Some(verification) = &report.verification {
+    output.artifacts.push(json_artifact(
+      "ax-text-observation",
+      "textedit-ax-text-observation",
+      verification,
+      "AX text observation used for TextEdit semantic verification.",
+    )?);
+    output.signals.insert("textedit.matched_role".to_string(), verification.matched_role.clone());
+    output.signals.insert("textedit.matched_text_len".to_string(), verification.matched_text.len().to_string());
+  }
+
+  output.verification = Some(match semantic_matched {
+    Some(true) => "semantic verification recorded as VerificationResult method=ax_text matched=true".to_string(),
+    Some(false) => "semantic verification recorded as VerificationResult method=ax_text matched=false".to_string(),
+    None => "activation and input delivery only; verify=false so no semantic VerificationResult was attached".to_string(),
+  });
+  output.known_limits.push(TEXTEDIT_DOCUMENT_WRITE_KNOWN_LIMIT.to_string());
+  output.report = Some(document_write_report(report, command));
+  Ok(output)
+}
+
+/// Persist a lineage-complete `operation-result` after invoke assigns `run_id`.
+pub fn persist_canonical_operation_result(store: &LocalStore, result: &InvokeResult) -> Result<(), String> {
+  if result.command_id != DOCUMENT_WRITE_COMMAND_ID {
+    return Ok(());
+  }
+  if result.dry_run_like() {
+    return Ok(());
+  }
+
+  let run_id = RunId::new(result.run_id.as_str());
+  let evidence_artifacts = result
+    .artifacts
+    .iter()
+    .filter(|artifact| artifact.role == "input-action-result" || artifact.role == "ax-text-observation")
+    .map(|artifact| ArtifactRef {
+      run_id: run_id.clone(),
+      artifact_id: artifact.artifact_id.clone(),
+      span_id: artifact.span_id.clone(),
+      captured_event_id: artifact.event_id.clone(),
+    })
+    .collect::<Vec<_>>();
+
+  let observation = read_ax_observation(store, result)?;
+  let semantic_matched = observation.as_ref().map(|value| value.semantic_matched);
+  let verifications = observation
+    .as_ref()
+    .map(|verification| {
+      vec![VerificationResult {
+        api_version: VERIFICATION_RESULT_API_VERSION.to_string(),
+        method: VerificationMethod::AxText,
+        executed: true,
+        state_changed: true,
+        semantic_matched: Some(verification.semantic_matched),
+        failure_layer: (!verification.semantic_matched).then_some(FailureLayer::SemanticMismatch),
+        evidence: evidence_artifacts
+          .iter()
+          .filter(|artifact_ref| {
+            result
+              .artifacts
+              .iter()
+              .any(|artifact| artifact.artifact_id == artifact_ref.artifact_id && artifact.role == "ax-text-observation")
+          })
+          .cloned()
+          .collect(),
+        consumed_candidate_ref: None,
+        consumed_node_ref: None,
+        consumed_recognition_artifact_ref: None,
+        consumed_recognition_id: None,
+        consumed_recognized_item_id: None,
+        observed_label: Some(format!("{} / {}", verification.matched_role, truncate(&verification.matched_text, 80))),
+      }]
+    })
+    .unwrap_or_default();
+
+  let status = match (result.status.clone(), semantic_matched) {
+    (_, Some(false)) => OperationStatus::Failed,
+    (auv_cli_invoke::RunStatus::Failed, _) => OperationStatus::Failed,
+    (auv_cli_invoke::RunStatus::Completed, _) => OperationStatus::Completed,
+  };
+
+  let mut known_limits = result.known_limits.clone();
+  if !known_limits.iter().any(|limit| limit == TEXTEDIT_DOCUMENT_WRITE_KNOWN_LIMIT) {
+    known_limits.push(TEXTEDIT_DOCUMENT_WRITE_KNOWN_LIMIT.to_string());
+  }
+
+  let operation = OperationResult {
+    api_version: OPERATION_RESULT_API_VERSION.to_string(),
+    run_id: run_id.clone(),
+    status,
+    operation_id: DOCUMENT_WRITE_COMMAND_ID.to_string(),
+    evidence_artifacts: evidence_artifacts.clone(),
+    output: OperationOutput::Acknowledged {
+      message: Some(result.output_summary.clone()),
+    },
+    verifications,
+    freshness_basis: None,
+    known_limits: known_limits.clone(),
+  };
+
+  let rendered = serde_json::to_string_pretty(&operation).map_err(|error| format!("serialize operation-result: {error}"))? + "\n";
+  let mut canonical = store.read_run(result.run_id.as_str()).map_err(|error| error.to_string())?;
+  if canonical.artifacts.iter().any(|artifact| artifact.role == "operation-result") {
+    // Already finalized (or synthetic). Prefer first match; do not duplicate.
+    return Ok(());
+  }
+  let artifact = store
+    .stage_artifact_bytes(
+      &run_id,
+      canonical.artifacts.len(),
+      &result.producer_span_id,
+      None,
+      ArtifactBytesSource {
+        role: "operation-result".to_string(),
+        bytes: rendered.into_bytes(),
+        preferred_name: "operation-result.json".to_string(),
+        summary: Some("Canonical TextEdit document.write OperationResult".to_string()),
+      },
+    )
+    .map_err(|error| error.to_string())?;
+  canonical.artifacts.push(artifact);
+  store.replace_run_snapshot(&canonical).map_err(|error| error.to_string())?;
+  let _ = evidence_artifacts;
+  let _ = known_limits;
+  Ok(())
+}
+
+trait InvokeResultExt {
+  fn dry_run_like(&self) -> bool;
+}
+
+impl InvokeResultExt for InvokeResult {
+  fn dry_run_like(&self) -> bool {
+    self.verification.as_deref().is_some_and(|value| value.contains("dry-run")) && self.artifacts.is_empty()
+  }
+}
+
+fn read_ax_observation(store: &LocalStore, result: &InvokeResult) -> Result<Option<VerificationOutcome>, String> {
+  let Some(artifact) = result.artifacts.iter().find(|artifact| artifact.role == "ax-text-observation") else {
+    return Ok(None);
+  };
+  let (_record, path) = store.artifact_file(result.run_id.as_str(), artifact.artifact_id.as_str()).map_err(|error| error.to_string())?;
+  let body = fs::read_to_string(&path).map_err(|error| format!("read ax-text-observation: {error}"))?;
+  let observation: VerificationOutcome = serde_json::from_str(&body).map_err(|error| format!("decode ax-text-observation: {error}"))?;
+  Ok(Some(observation))
+}
+
+fn document_write_report(report: &DocumentCommandReport, command: &DocumentWrite) -> InvokeReport {
+  let mut sections = vec![InvokeReportSection {
+    title: "Steps".to_string(),
+    fields: report
+      .outcomes
+      .iter()
+      .map(|outcome| InvokeReportField {
+        label: outcome.step_id.to_string(),
+        value: outcome.summary.clone(),
+      })
+      .collect(),
+  }];
+  if let Some(verification) = &report.verification {
+    sections.push(InvokeReportSection {
+      title: "Verification".to_string(),
+      fields: vec![
+        InvokeReportField {
+          label: "role".to_string(),
+          value: verification.matched_role.clone(),
+        },
+        InvokeReportField {
+          label: "observed_text".to_string(),
+          value: truncate(&verification.matched_text, 120),
+        },
+        InvokeReportField {
+          label: "semantic_matched".to_string(),
+          value: verification.semantic_matched.to_string(),
+        },
+      ],
+    });
+  }
+  InvokeReport::new(
+    vec![
+      InvokeReportField {
+        label: "Command".to_string(),
+        value: DOCUMENT_WRITE_COMMAND_ID.to_string(),
+      },
+      InvokeReportField {
+        label: "App".to_string(),
+        value: command.app_id.clone(),
+      },
+      InvokeReportField {
+        label: "Replace".to_string(),
+        value: command.replace.to_string(),
+      },
+      InvokeReportField {
+        label: "Verify".to_string(),
+        value: command.verify.to_string(),
+      },
+    ],
+    sections,
+  )
+}
+
+fn parse_document_write(input: &InvokeCommandInput<'_>) -> Result<DocumentWrite, String> {
+  let content = input
+    .inputs
+    .get("content")
+    .map(String::as_str)
+    .ok_or_else(|| "app.textedit.document.write missing required flag --content".to_string())?;
+  let mut command = DocumentWrite::defaults_with_content(content);
+  if let Some(target) = input.target_application_id {
+    command.app_id = target.to_string();
+  }
+  if let Some(replace) = input.inputs.get("replace") {
+    command.replace = parse_bool(replace, "replace")?;
+  }
+  if let Some(verify) = input.inputs.get("verify") {
+    command.verify = parse_bool(verify, "verify")?;
+  }
+  Ok(command)
+}
+
+fn parse_bool(value: &str, name: &str) -> Result<bool, String> {
+  match value.trim().to_ascii_lowercase().as_str() {
+    "true" | "1" | "yes" => Ok(true),
+    "false" | "0" | "no" => Ok(false),
+    other => Err(format!("invalid --{name} value {other}; expected true or false")),
+  }
+}
+
+fn json_artifact<T: serde::Serialize>(kind: &str, label: &str, value: &T, note: &str) -> Result<ProducedArtifact, String> {
+  let source_path =
+    PathBuf::from(std::env::temp_dir()).join(format!("auv-invoke-textedit-{label}-{}-{}.json", std::process::id(), now_millis()));
+  let body = serde_json::to_vec_pretty(value).map_err(|error| format!("failed to serialize {kind} artifact: {error}"))?;
+  fs::write(&source_path, body).map_err(|error| format!("failed to write {kind} artifact: {error}"))?;
+  Ok(ProducedArtifact {
+    kind: kind.to_string(),
+    source_path,
+    preferred_name: format!("{label}.json"),
+    note: Some(note.to_string()),
+  })
+}
+
+fn truncate(value: &str, max_chars: usize) -> String {
+  let mut chars = value.chars();
+  let head: String = chars.by_ref().take(max_chars).collect();
+  if chars.next().is_some() {
+    format!("{head}…")
+  } else {
+    head
+  }
+}
+
+/// Hermetic TextEdit driver for CI parity (`--driver fixture`).
+#[derive(Clone, Debug)]
+struct FixtureTextEditDriver {
+  content: String,
+  role: String,
+  /// When set, verify reads this observed body instead of pasted content.
+  observed_override: Option<String>,
+}
+
+impl FixtureTextEditDriver {
+  fn from_write(command: &DocumentWrite) -> Self {
+    Self {
+      content: command.content.clone(),
+      role: command.compare_role.clone(),
+      observed_override: None,
+    }
+  }
+}
+
+impl TextEditDriver for FixtureTextEditDriver {
+  fn activate_app(&mut self, app_id: &str, settle: Duration) -> Result<StepOutcome, String> {
+    Ok(StepOutcome {
+      step_id: "activate",
+      summary: format!("fixture activated {app_id} settle_ms={}", settle.as_millis()),
+      input_action_result: None,
+    })
+  }
+
+  fn focus_text_input(&mut self, app_id: &str, query: &str, candidate: &str) -> Result<StepOutcome, String> {
+    Ok(StepOutcome {
+      step_id: "focus",
+      summary: format!("fixture focused {app_id} query={query} candidate={candidate}"),
+      input_action_result: Some(InputActionResult::single_success(InputDeliveryPath::AxFocus)),
+    })
+  }
+
+  fn paste_text_preserve_clipboard(
+    &mut self,
+    app_id: &str,
+    text: &str,
+    replace_existing: bool,
+    settle: Duration,
+  ) -> Result<StepOutcome, String> {
+    self.content = text.to_string();
+    Ok(StepOutcome {
+      step_id: "paste",
+      summary: format!("fixture pasted into {app_id} replace={replace_existing} settle_ms={}", settle.as_millis()),
+      input_action_result: Some(InputActionResult::single_success(InputDeliveryPath::ClipboardPaste)),
+    })
+  }
+
+  fn verify_ax_text(&mut self, _app_id: &str, target_text: &str, target_role: &str) -> Result<VerificationOutcome, String> {
+    self.role = target_role.to_string();
+    let observed = self.observed_override.clone().unwrap_or_else(|| self.content.clone());
+    Ok(VerificationOutcome {
+      matched_role: target_role.to_string(),
+      matched_text: observed.clone(),
+      artifact_count: 1,
+      semantic_matched: observed.contains(target_text),
+      observation_path: Some("fixture.0.1.2".to_string()),
+      observation_pid: Some(0),
+    })
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::collections::BTreeMap;
+  use std::sync::Arc;
+
+  use auv_cli_invoke::InvokeNamespace;
+  use auv_runtime::model::{ExecutionTarget, InvokeRequest};
+  use auv_tracing_driver::{MemoryRunRecorder, RunRecordingBackend, store::LocalStore};
+
+  use super::*;
+  use crate::product_registry;
+
+  #[test]
+  fn fixture_document_write_stages_evidence_artifacts_without_unassigned_operation() {
+    let mut inputs = BTreeMap::new();
+    inputs.insert("content".to_string(), "hello-fixture".to_string());
+    inputs.insert("driver".to_string(), "fixture".to_string());
+    let input = InvokeCommandInput {
+      command_id: DOCUMENT_WRITE_COMMAND_ID,
+      target_application_id: None,
+      inputs: &inputs,
+      dry_run: false,
+    };
+    let output = document_write_impl(input).expect("fixture write");
+    assert!(output.artifacts.iter().any(|artifact| artifact.kind == "input-action-result"));
+    assert!(output.artifacts.iter().any(|artifact| artifact.kind == "ax-text-observation"));
+    assert!(!output.artifacts.iter().any(|artifact| artifact.kind == "operation-result"));
+    assert_eq!(output.backend.as_deref(), Some("auv-apple-textedit.DocumentWrite"));
+  }
+
+  #[test]
+  fn document_write_command_metadata_uses_app_namespace() {
+    let command = document_write_invoke_command();
+    assert_eq!(command.id, DOCUMENT_WRITE_COMMAND_ID);
+    assert_eq!(command.namespace, InvokeNamespace::App);
+  }
+
+  #[test]
+  fn persist_canonical_operation_result_backfills_run_id_and_evidence() {
+    let root = std::env::temp_dir().join(format!("auv-textedit-finalize-{}-{}", std::process::id(), now_millis()));
+    std::fs::create_dir_all(&root).expect("temp");
+    let store = LocalStore::new(root.clone()).expect("store");
+    let recording = RunRecordingBackend::new(store.clone(), Arc::new(MemoryRunRecorder::new()));
+    let mut inputs = BTreeMap::new();
+    inputs.insert("content".to_string(), "hello-fixture".to_string());
+    inputs.insert("driver".to_string(), "fixture".to_string());
+    let result = crate::invoke::invoke_recorded(
+      &recording,
+      &product_registry(),
+      InvokeRequest {
+        command_id: DOCUMENT_WRITE_COMMAND_ID.to_string(),
+        target: ExecutionTarget::default(),
+        inputs,
+        dry_run: false,
+      },
+    )
+    .expect("invoke");
+
+    let operation = auv_runtime::run_read::read_operation_result(&store, &result.run_id).expect("read").expect("operation-result");
+    assert_eq!(operation.run_id.as_str(), result.run_id);
+    assert!(!operation.evidence_artifacts.is_empty());
+    assert!(operation.evidence_artifacts.iter().all(|artifact| artifact.run_id.as_str() == result.run_id));
+    assert!(operation.known_limits.iter().any(|limit| limit == TEXTEDIT_DOCUMENT_WRITE_KNOWN_LIMIT));
+    assert_eq!(operation.verifications[0].semantic_matched, Some(true));
+    let _ = std::fs::remove_dir_all(root);
+  }
+
+  #[test]
+  fn fixture_semantic_mismatch_persists_failed_verification() {
+    let mut driver = FixtureTextEditDriver {
+      content: "pasted".to_string(),
+      role: "AXTextArea".to_string(),
+      observed_override: Some("observed-without-expected".to_string()),
+    };
+    let command = DocumentWrite::defaults_with_content("expected-marker");
+    let report = run_document_command(&DocumentCommand::Write(command.clone()), &mut driver).expect("report");
+    let verification = report.verification.as_ref().expect("verification");
+    assert!(!verification.semantic_matched);
+    assert_eq!(verification.matched_text, "observed-without-expected");
+
+    let output = build_invoke_output_from_report(&report, &command).expect("output");
+    assert_eq!(output.signals.get("textedit.semantic_matched").map(String::as_str), Some("false"));
+  }
+
+  #[test]
+  fn fixture_document_write_failure_after_run_creation_is_inspectable() {
+    let root = std::env::temp_dir().join(format!("auv-textedit-failed-run-{}-{}", std::process::id(), now_millis()));
+    std::fs::create_dir_all(&root).expect("temp");
+    let store = LocalStore::new(root.clone()).expect("store");
+    let recording = RunRecordingBackend::new(store.clone(), Arc::new(MemoryRunRecorder::new()));
+    let mut inputs = BTreeMap::new();
+    inputs.insert("content".to_string(), "x".to_string());
+    inputs.insert("driver".to_string(), "not-a-driver".to_string());
+    let result = crate::invoke::invoke_recorded(
+      &recording,
+      &product_registry(),
+      InvokeRequest {
+        command_id: DOCUMENT_WRITE_COMMAND_ID.to_string(),
+        target: ExecutionTarget::default(),
+        inputs,
+        dry_run: false,
+      },
+    )
+    .expect("failed handler still returns InvokeResult after run creation");
+    assert_eq!(result.status, auv_cli_invoke::RunStatus::Failed);
+    assert!(store.read_run(&result.run_id).is_ok(), "failed run must remain readable");
+    let _ = std::fs::remove_dir_all(root);
+  }
+}

--- a/crates/auv-cli/src/invoke.rs
+++ b/crates/auv-cli/src/invoke.rs
@@ -1,0 +1,13 @@
+//! Product recorded invoke: shared by CLI and MCP.
+
+use auv_cli_invoke::{InvokeRegistry, InvokeRequest, InvokeResult};
+use auv_tracing_driver::RunRecordingBackend;
+
+use crate::integrations::textedit;
+
+/// Product invoke path: core recording, then TextEdit canonical operation finalize.
+pub fn invoke_recorded(recording: &RunRecordingBackend, registry: &InvokeRegistry, request: InvokeRequest) -> Result<InvokeResult, String> {
+  let result = auv_cli_invoke::invoke_recorded(recording, registry, request)?;
+  textedit::persist_canonical_operation_result(recording.store(), &result)?;
+  Ok(result)
+}

--- a/crates/auv-cli/src/invoke.rs
+++ b/crates/auv-cli/src/invoke.rs
@@ -5,9 +5,8 @@ use auv_tracing_driver::RunRecordingBackend;
 
 use crate::integrations::textedit;
 
-/// Product invoke path: core recording, then TextEdit canonical operation finalize.
+/// Product invoke path: core recording plus TextEdit finalize inside the shared
+/// recorded lifecycle.
 pub fn invoke_recorded(recording: &RunRecordingBackend, registry: &InvokeRegistry, request: InvokeRequest) -> Result<InvokeResult, String> {
-  let result = auv_cli_invoke::invoke_recorded(recording, registry, request)?;
-  textedit::persist_canonical_operation_result(recording.store(), &result)?;
-  Ok(result)
+  auv_cli_invoke::invoke_recorded_with_finalize(recording, registry, request, &textedit::finalize_recorded_invoke)
 }

--- a/crates/auv-cli/src/lib.rs
+++ b/crates/auv-cli/src/lib.rs
@@ -8,9 +8,13 @@ pub mod cli;
 pub mod cli_frontend;
 pub mod inspect;
 pub mod integrations;
+pub mod invoke;
 pub mod mcp;
 pub mod projection;
+pub mod registry;
 pub mod run_read;
 pub mod xtask;
 
+pub use invoke::invoke_recorded;
 pub use projection::ProductInspectReadProjection;
+pub use registry::product_registry;

--- a/crates/auv-cli/src/mcp.rs
+++ b/crates/auv-cli/src/mcp.rs
@@ -1,12 +1,18 @@
-//! Product MCP bootstrap: inject product inspect composer into core MCP frontend.
+//! Product MCP bootstrap: inject product inspect composer + product invoke registry.
 //!
-//! Product owns composer assembly only; the MCP tool surface stays in `auv-runtime`
-//! instead of forking `auv_runtime::mcp::McpServer` here.
+//! Product owns composer/registry assembly only; the MCP tool surface stays in
+//! `auv-runtime` instead of forking `auv_runtime::mcp::McpServer` here.
 
 use std::path::PathBuf;
+use std::sync::Arc;
 
-/// Serve product MCP (CLI `auv mcp serve`) with the shared product inspect composer.
+/// Serve product MCP (CLI `auv mcp serve`) with the shared product inspect composer
+/// and product invoke registry (includes TextEdit + canonical operation finalize).
 pub async fn serve_stdio(project_root: PathBuf) -> Result<(), String> {
   let composer = crate::inspect::build_product_inspect_composer().map_err(|error| error.to_string())?;
-  auv_runtime::mcp::serve_stdio_with_composer(project_root, composer).await
+  let registry = Arc::new(crate::product_registry());
+  let finalize = Arc::new(|store: &auv_tracing_driver::store::LocalStore, result: &auv_cli_invoke::InvokeResult| {
+    crate::integrations::textedit::persist_canonical_operation_result(store, result)
+  });
+  auv_runtime::mcp::serve_stdio_with_composer_and_registry(project_root, composer, registry, Some(finalize)).await
 }

--- a/crates/auv-cli/src/mcp.rs
+++ b/crates/auv-cli/src/mcp.rs
@@ -7,12 +7,11 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 /// Serve product MCP (CLI `auv mcp serve`) with the shared product inspect composer
-/// and product invoke registry (includes TextEdit + canonical operation finalize).
+/// and product invoke registry (includes TextEdit invoke finalize inside the
+/// recorded lifecycle).
 pub async fn serve_stdio(project_root: PathBuf) -> Result<(), String> {
   let composer = crate::inspect::build_product_inspect_composer().map_err(|error| error.to_string())?;
   let registry = Arc::new(crate::product_registry());
-  let finalize = Arc::new(|store: &auv_tracing_driver::store::LocalStore, result: &auv_cli_invoke::InvokeResult| {
-    crate::integrations::textedit::persist_canonical_operation_result(store, result)
-  });
+  let finalize = Arc::new(crate::integrations::textedit::finalize_recorded_invoke);
   auv_runtime::mcp::serve_stdio_with_composer_and_registry(project_root, composer, registry, Some(finalize)).await
 }

--- a/crates/auv-cli/src/registry.rs
+++ b/crates/auv-cli/src/registry.rs
@@ -1,0 +1,33 @@
+//! Product invoke registry: core catalog plus app-owned extensions.
+
+use auv_cli_invoke::{InvokeRegistry, default_registry};
+
+use crate::integrations::textedit;
+
+/// Product invoke registry shared by product CLI and product MCP.
+///
+/// Core `auv-cli-invoke::default_registry` stays free of app crates. TextEdit
+/// registration lives here so `auv-runtime` does not depend on `auv-apple-textedit`.
+pub fn product_registry() -> InvokeRegistry {
+  let mut groups = default_registry().groups().to_vec();
+  groups.push(textedit::group());
+  InvokeRegistry::from_groups(groups)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::integrations::textedit::DOCUMENT_WRITE_COMMAND_ID;
+
+  #[test]
+  fn product_registry_includes_textedit_once() {
+    let registry = product_registry();
+    assert!(registry.resolve(DOCUMENT_WRITE_COMMAND_ID).is_some());
+    assert_eq!(registry.all().iter().filter(|command| command.id == DOCUMENT_WRITE_COMMAND_ID).count(), 1);
+  }
+
+  #[test]
+  fn core_registry_excludes_textedit() {
+    assert!(default_registry().resolve(DOCUMENT_WRITE_COMMAND_ID).is_none());
+  }
+}

--- a/crates/auv-cli/tests/textedit_document_write_parity.rs
+++ b/crates/auv-cli/tests/textedit_document_write_parity.rs
@@ -1,16 +1,31 @@
 //! Same-run frontend parity for TextEdit document.write (#101).
 
 use std::collections::BTreeMap;
+use std::path::Path;
 use std::sync::Arc;
 
 use auv_cli_invoke::InvokeOutputOptions;
 use auv_inspect_server::InspectReadProjection;
+use auv_runtime::contract::{FailureLayer, OperationStatus};
 use auv_runtime::model::{ExecutionTarget, InvokeRequest};
 use auv_runtime::run_read;
-use auv_tracing_driver::{MemoryRunRecorder, RunRecordingBackend, store::LocalStore};
+use auv_tracing_driver::{MemoryRunRecorder, RunRecordingBackend, TraceStatusCode, store::LocalStore};
+use rmcp::{
+  ClientHandler, ServiceExt,
+  model::{CallToolRequestParam, ClientInfo},
+};
 
-use auv_cli::integrations::textedit::{DOCUMENT_WRITE_COMMAND_ID, TEXTEDIT_DOCUMENT_WRITE_KNOWN_LIMIT};
+use auv_cli::integrations::textedit::{DOCUMENT_WRITE_COMMAND_ID, TEXTEDIT_DOCUMENT_WRITE_KNOWN_LIMIT, finalize_recorded_invoke};
 use auv_cli::{inspect, invoke_recorded, product_registry, projection::ProductInspectReadProjection};
+
+#[derive(Debug, Clone, Default)]
+struct DummyClientHandler;
+
+impl ClientHandler for DummyClientHandler {
+  fn get_info(&self) -> ClientInfo {
+    ClientInfo::default()
+  }
+}
 
 #[test]
 fn textedit_document_write_same_run_cli_mcp_inspect_parity() {
@@ -123,6 +138,92 @@ fn product_help_lists_textedit_command_once() {
   assert!(!auv_cli_invoke::render_help_index(&auv_cli_invoke::default_registry()).contains(DOCUMENT_WRITE_COMMAND_ID));
 }
 
+// ROOT CAUSE:
+//
+// TextEdit semantic mismatch used to be applied after recorded invoke had
+// persisted a successful run, leaving the invoke, trace, and operation statuses
+// contradictory and CLI/MCP artifact views different.
+//
+// The regression locks both frontends to one in-lifecycle finalization contract.
+// https://github.com/moeru-ai/auv/pull/102#issuecomment-4958351155
+#[tokio::test]
+async fn textedit_recorded_mismatch_keeps_cli_mcp_run_and_operation_in_sync() {
+  let root = tempfile_dir("textedit-mismatch-mcp-parity");
+  let store = LocalStore::new(root.clone()).expect("store");
+  let recording = RunRecordingBackend::new(store.clone(), Arc::new(MemoryRunRecorder::new()));
+
+  let cli_result = invoke_recorded(
+    &recording,
+    &product_registry(),
+    InvokeRequest {
+      command_id: DOCUMENT_WRITE_COMMAND_ID.to_string(),
+      target: ExecutionTarget {
+        application_id: Some("com.apple.TextEdit".to_string()),
+        target_label: None,
+      },
+      inputs: mismatch_inputs(),
+      dry_run: false,
+    },
+  )
+  .expect("cli invoke");
+
+  let project_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+  let composer = inspect::build_product_inspect_composer().expect("composer");
+  let finalize: Arc<auv_cli_invoke::InvokeFinalizeHook> = Arc::new(finalize_recorded_invoke);
+  let server =
+    auv_runtime::mcp::McpServer::with_inspect_composer_and_registry(project_root, composer, Arc::new(product_registry()), Some(finalize));
+  let (server_transport, client_transport) = tokio::io::duplex(16384);
+  let server_handle = tokio::spawn(async move {
+    let service = server.serve(server_transport).await.expect("server should start");
+    service.waiting().await.expect("server should exit cleanly");
+  });
+  let client = DummyClientHandler::default().serve(client_transport).await.expect("client");
+
+  let invoke = client
+    .call_tool(CallToolRequestParam {
+      name: "invoke".into(),
+      arguments: Some(
+        serde_json::json!({
+          "command_id": DOCUMENT_WRITE_COMMAND_ID,
+          "dry_run": false,
+          "inputs": mismatch_inputs(),
+          "target": {
+            "application_id": "com.apple.TextEdit"
+          },
+          "inspect": {
+            "store_root": root.display().to_string()
+          }
+        })
+        .as_object()
+        .unwrap()
+        .clone(),
+      ),
+    })
+    .await
+    .expect("invoke");
+  let invoke_json: serde_json::Value =
+    serde_json::from_str(&invoke.content.first().and_then(|content| content.raw.as_text()).expect("invoke text").text).expect("invoke json");
+
+  assert_eq!(cli_result.status.as_str(), "failed");
+  assert_recorded_semantic_mismatch(&store, &cli_result.run_id);
+  assert_eq!(invoke_json.get("status").and_then(|value| value.as_str()), Some("failed"));
+  let mcp_run_id = invoke_json.get("run_id").and_then(|value| value.as_str()).expect("MCP run_id");
+  assert_recorded_semantic_mismatch(&store, mcp_run_id);
+  assert!(cli_result.failure_message.as_deref().is_some_and(|message| message.contains("semantic verification failed")));
+  assert!(
+    invoke_json
+      .get("failure_message")
+      .and_then(|value| value.as_str())
+      .is_some_and(|message| message.contains("semantic verification failed"))
+  );
+  assert_eq!(artifact_role_paths(&cli_result), artifact_role_paths_from_json(&invoke_json));
+  assert_eq!(artifact_path_basenames(&cli_result), artifact_path_basenames_from_json(&invoke_json));
+
+  client.cancel().await.expect("cancel");
+  server_handle.await.expect("join");
+  let _ = std::fs::remove_dir_all(root);
+}
+
 #[test]
 #[ignore = "live macOS TextEdit + Accessibility permission required; run manually with AUV_TEXTEDIT_LIVE=1"]
 fn textedit_document_write_live_macos_closure() {
@@ -177,6 +278,72 @@ fn artifact_identity_fingerprint(run: &auv_tracing_driver::store::CanonicalRun) 
     run.artifacts.iter().map(|artifact| (artifact.artifact_id.as_str().to_string(), artifact.role.clone())).collect::<Vec<_>>();
   pairs.sort();
   pairs
+}
+
+fn mismatch_inputs() -> BTreeMap<String, String> {
+  let mut inputs = BTreeMap::new();
+  inputs.insert("content".to_string(), "AUV_TEXTEDIT_EXPECTED_MARKER".to_string());
+  inputs.insert("driver".to_string(), "fixture".to_string());
+  inputs.insert("fixture_observed_text".to_string(), "observed-without-expected".to_string());
+  inputs
+}
+
+fn assert_recorded_semantic_mismatch(store: &LocalStore, run_id: &str) {
+  let canonical = store.read_run(run_id).expect("recorded mismatch run");
+  assert_eq!(canonical.run.status_code, TraceStatusCode::Error);
+  let command_span = canonical.spans.iter().find(|span| span.name == "auv.command.invoke").expect("command span");
+  assert_eq!(command_span.status_code, TraceStatusCode::Error);
+
+  let operation = run_read::read_operation_result(store, run_id).expect("read mismatch operation-result").expect("operation-result");
+  assert_eq!(operation.run_id.as_str(), run_id);
+  assert_eq!(operation.status, OperationStatus::Failed);
+  assert_eq!(operation.verifications.len(), 1);
+  assert_eq!(operation.verifications[0].semantic_matched, Some(false));
+  assert_eq!(operation.verifications[0].failure_layer, Some(FailureLayer::SemanticMismatch));
+
+  let operation_artifacts = canonical.artifacts.iter().filter(|artifact| artifact.role == "operation-result").collect::<Vec<_>>();
+  assert_eq!(operation_artifacts.len(), 1);
+  assert_eq!(operation_artifacts[0].span_id, command_span.span_id);
+  assert!(!operation.evidence_artifacts.is_empty());
+  for artifact_ref in &operation.evidence_artifacts {
+    assert_eq!(artifact_ref.run_id.as_str(), run_id);
+    assert!(canonical.artifacts.iter().any(|artifact| artifact.artifact_id == artifact_ref.artifact_id));
+  }
+}
+
+fn artifact_role_paths(result: &auv_cli_invoke::InvokeResult) -> Vec<(String, String)> {
+  result.artifacts.iter().map(|artifact| (artifact.role.clone(), artifact.path.clone())).collect()
+}
+
+fn artifact_role_paths_from_json(value: &serde_json::Value) -> Vec<(String, String)> {
+  value
+    .get("artifacts")
+    .and_then(|items| items.as_array())
+    .expect("artifacts array")
+    .iter()
+    .map(|artifact| {
+      (
+        artifact.get("role").and_then(|field| field.as_str()).expect("artifact role").to_string(),
+        artifact.get("path").and_then(|field| field.as_str()).expect("artifact path").to_string(),
+      )
+    })
+    .collect()
+}
+
+fn artifact_path_basenames(result: &auv_cli_invoke::InvokeResult) -> Vec<String> {
+  result.artifact_paths.iter().map(|path| path.file_name().and_then(|name| name.to_str()).expect("artifact filename").to_string()).collect()
+}
+
+fn artifact_path_basenames_from_json(value: &serde_json::Value) -> Vec<String> {
+  value
+    .get("artifact_paths")
+    .and_then(|items| items.as_array())
+    .expect("artifact_paths array")
+    .iter()
+    .map(|path| {
+      Path::new(path.as_str().expect("artifact path")).file_name().and_then(|name| name.to_str()).expect("artifact filename").to_string()
+    })
+    .collect()
 }
 
 fn tempfile_dir(label: &str) -> std::path::PathBuf {

--- a/crates/auv-cli/tests/textedit_document_write_parity.rs
+++ b/crates/auv-cli/tests/textedit_document_write_parity.rs
@@ -1,0 +1,186 @@
+//! Same-run frontend parity for TextEdit document.write (#101).
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use auv_cli_invoke::InvokeOutputOptions;
+use auv_inspect_server::InspectReadProjection;
+use auv_runtime::model::{ExecutionTarget, InvokeRequest};
+use auv_runtime::run_read;
+use auv_tracing_driver::{MemoryRunRecorder, RunRecordingBackend, store::LocalStore};
+
+use auv_cli::integrations::textedit::{DOCUMENT_WRITE_COMMAND_ID, TEXTEDIT_DOCUMENT_WRITE_KNOWN_LIMIT};
+use auv_cli::{inspect, invoke_recorded, product_registry, projection::ProductInspectReadProjection};
+
+#[test]
+fn textedit_document_write_same_run_cli_mcp_inspect_parity() {
+  let root = tempfile_dir("textedit-same-run-parity");
+  let store = LocalStore::new(root.clone()).expect("store");
+  let recording = RunRecordingBackend::new(store.clone(), Arc::new(MemoryRunRecorder::new()));
+  let registry = product_registry();
+
+  let mut inputs = BTreeMap::new();
+  inputs.insert("content".to_string(), "AUV_TEXTEDIT_FIXTURE_MARKER".to_string());
+  inputs.insert("driver".to_string(), "fixture".to_string());
+  inputs.insert("verify".to_string(), "true".to_string());
+
+  let result = invoke_recorded(
+    &recording,
+    &registry,
+    InvokeRequest {
+      command_id: DOCUMENT_WRITE_COMMAND_ID.to_string(),
+      target: ExecutionTarget {
+        application_id: Some("com.apple.TextEdit".to_string()),
+        target_label: None,
+      },
+      inputs,
+      dry_run: false,
+    },
+  )
+  .expect("fixture invoke should succeed");
+
+  assert_eq!(result.command_id, DOCUMENT_WRITE_COMMAND_ID);
+  assert!(result.failure_message.is_none(), "{:?}", result.failure_message);
+  assert_ne!(result.run_id, "unassigned");
+  let run_id = result.run_id.clone();
+
+  let operation = run_read::read_operation_result(&store, &run_id).expect("read operation-result").expect("operation-result should exist");
+  assert_eq!(operation.operation_id, DOCUMENT_WRITE_COMMAND_ID);
+  assert_eq!(operation.run_id.as_str(), run_id.as_str(), "canonical operation must use assigned run_id, not unassigned");
+  assert!(!operation.evidence_artifacts.is_empty(), "canonical operation must reference evidence artifacts");
+  assert!(
+    operation.evidence_artifacts.iter().all(|artifact| artifact.run_id.as_str() == run_id.as_str()),
+    "every evidence ArtifactRef must share the assigned run_id"
+  );
+  assert!(
+    operation.known_limits.iter().any(|limit| limit == TEXTEDIT_DOCUMENT_WRITE_KNOWN_LIMIT),
+    "known_limits must include {TEXTEDIT_DOCUMENT_WRITE_KNOWN_LIMIT}"
+  );
+  assert_eq!(operation.verifications.len(), 1);
+  assert!(matches!(operation.verifications[0].method, auv_runtime::contract::VerificationMethod::AxText));
+  assert_eq!(operation.verifications[0].semantic_matched, Some(true));
+
+  let run = store.read_run(&run_id).expect("run");
+  let artifact_roles: BTreeMap<String, String> =
+    run.artifacts.iter().map(|artifact| (artifact.artifact_id.as_str().to_string(), artifact.role.clone())).collect();
+  assert!(artifact_roles.values().any(|role| role == "operation-result"));
+  assert!(artifact_roles.values().any(|role| role == "input-action-result"));
+  assert!(artifact_roles.values().any(|role| role == "ax-text-observation"));
+  let operation_artifact_ids: Vec<&str> =
+    run.artifacts.iter().filter(|artifact| artifact.role == "operation-result").map(|artifact| artifact.artifact_id.as_str()).collect();
+  assert_eq!(operation_artifact_ids.len(), 1);
+
+  let composer = inspect::build_product_inspect_composer().expect("composer");
+  let cli_text = inspect::inspect_run_with(&composer, &store, &run_id).expect("cli inspect");
+  assert!(cli_text.contains(&run_id), "cli inspect should mention run id");
+  assert!(cli_text.contains("ax_text") || cli_text.contains("AxText") || cli_text.contains("method=ax_text"));
+
+  let mcp_document = composer.collect_document(&store, &run).expect("mcp-style document");
+  let mcp_text = mcp_document.render_text();
+  assert_eq!(extract_section_ids(&cli_text), extract_section_ids(&mcp_text));
+
+  let projection = ProductInspectReadProjection::default();
+  let server_document = projection.inspect_document(&store, &run).expect("inspect-server document").expect("document present");
+  let server_text = server_document.render_text();
+  assert_eq!(extract_section_ids(&cli_text), extract_section_ids(&server_text));
+
+  let enrichment = projection.run_enrichment(&store, &run).expect("enrichment");
+  assert_eq!(enrichment.verifications.len(), 1);
+  assert_eq!(enrichment.verifications[0]["method"]["kind"], "ax_text");
+  assert_eq!(enrichment.verifications[0]["semantic_matched"], true);
+
+  // Lock same-run artifact identity: store fingerprint + evidence refs + shared projection sections.
+  let expected_identity = artifact_identity_fingerprint(&run);
+  assert_eq!(expected_identity, artifact_identity_fingerprint(&store.read_run(&run_id).expect("re-read")));
+  assert!(
+    expected_identity.iter().any(|(_, role)| role == "operation-result")
+      && expected_identity.iter().any(|(_, role)| role == "ax-text-observation")
+      && expected_identity.iter().any(|(_, role)| role == "input-action-result")
+  );
+  for artifact_ref in &operation.evidence_artifacts {
+    assert_eq!(artifact_ref.run_id.as_str(), run_id.as_str());
+    assert!(
+      expected_identity.iter().any(|(id, _)| id == artifact_ref.artifact_id.as_str()),
+      "evidence ArtifactRef must point at an artifact on the same run"
+    );
+  }
+  for text in [&cli_text, &mcp_text, &server_text] {
+    assert!(text.contains(&run_id), "each projection must anchor the same run_id");
+  }
+  assert_eq!(extract_section_ids(&cli_text), extract_section_ids(&mcp_text));
+  assert_eq!(extract_section_ids(&cli_text), extract_section_ids(&server_text));
+
+  let rendered = auv_cli_invoke::render_to_string(&result, InvokeOutputOptions::default()).expect("render");
+  assert!(rendered.contains(DOCUMENT_WRITE_COMMAND_ID) || rendered.contains("TextEdit"));
+
+  let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn product_help_lists_textedit_command_once() {
+  let help = auv_cli_invoke::render_help_index(&product_registry());
+  assert_eq!(help.matches(DOCUMENT_WRITE_COMMAND_ID).count(), 1);
+  assert!(!auv_cli_invoke::render_help_index(&auv_cli_invoke::default_registry()).contains(DOCUMENT_WRITE_COMMAND_ID));
+}
+
+#[test]
+#[ignore = "live macOS TextEdit + Accessibility permission required; run manually with AUV_TEXTEDIT_LIVE=1"]
+fn textedit_document_write_live_macos_closure() {
+  if std::env::var_os("AUV_TEXTEDIT_LIVE").is_none() {
+    return;
+  }
+  let root = tempfile_dir("textedit-live-closure");
+  let store = LocalStore::new(root.clone()).expect("store");
+  let recording = RunRecordingBackend::new(store.clone(), Arc::new(MemoryRunRecorder::new()));
+  let mut inputs = BTreeMap::new();
+  inputs.insert("content".to_string(), "AUV_TEXTEDIT_LIVE_MARKER".to_string());
+  inputs.insert("driver".to_string(), "live".to_string());
+  let result = invoke_recorded(
+    &recording,
+    &product_registry(),
+    InvokeRequest {
+      command_id: DOCUMENT_WRITE_COMMAND_ID.to_string(),
+      target: ExecutionTarget {
+        application_id: Some("com.apple.TextEdit".to_string()),
+        target_label: None,
+      },
+      inputs,
+      dry_run: false,
+    },
+  )
+  .expect("live invoke");
+  let operation = run_read::read_operation_result(&store, &result.run_id).expect("read").expect("operation-result");
+  assert_eq!(operation.run_id.as_str(), result.run_id.as_str());
+  assert!(!operation.evidence_artifacts.is_empty());
+  assert_eq!(operation.verifications[0].semantic_matched, Some(true));
+  let _ = std::fs::remove_dir_all(root);
+}
+
+fn extract_section_ids(text: &str) -> Vec<String> {
+  text
+    .lines()
+    .filter_map(|line| {
+      let trimmed = line.trim();
+      if trimmed.starts_with('[') && trimmed.ends_with(']') {
+        Some(trimmed.to_string())
+      } else if let Some(rest) = trimmed.strip_prefix("## ") {
+        Some(rest.to_string())
+      } else {
+        None
+      }
+    })
+    .collect()
+}
+
+fn artifact_identity_fingerprint(run: &auv_tracing_driver::store::CanonicalRun) -> Vec<(String, String)> {
+  let mut pairs =
+    run.artifacts.iter().map(|artifact| (artifact.artifact_id.as_str().to_string(), artifact.role.clone())).collect::<Vec<_>>();
+  pairs.sort();
+  pairs
+}
+
+fn tempfile_dir(label: &str) -> std::path::PathBuf {
+  let path = std::env::temp_dir().join(format!("auv-{label}-{}-{}", std::process::id(), auv_tracing_driver::now_millis()));
+  std::fs::create_dir_all(&path).expect("temp dir");
+  path
+}

--- a/crates/auv-cli/tests/textedit_document_write_parity.rs
+++ b/crates/auv-cli/tests/textedit_document_write_parity.rs
@@ -15,7 +15,10 @@ use rmcp::{
   model::{CallToolRequestParam, ClientInfo},
 };
 
-use auv_cli::integrations::textedit::{DOCUMENT_WRITE_COMMAND_ID, TEXTEDIT_DOCUMENT_WRITE_KNOWN_LIMIT, finalize_recorded_invoke};
+use auv_cli::integrations::textedit::{
+  DOCUMENT_WRITE_COMMAND_ID, TEXTEDIT_DOCUMENT_WRITE_KNOWN_LIMIT, TEXTEDIT_DOCUMENT_WRITE_STATE_CHANGED_KNOWN_LIMIT,
+  finalize_recorded_invoke,
+};
 use auv_cli::{inspect, invoke_recorded, product_registry, projection::ProductInspectReadProjection};
 
 #[derive(Debug, Clone, Default)]
@@ -74,6 +77,8 @@ fn textedit_document_write_same_run_cli_mcp_inspect_parity() {
   assert_eq!(operation.verifications.len(), 1);
   assert!(matches!(operation.verifications[0].method, auv_runtime::contract::VerificationMethod::AxText));
   assert_eq!(operation.verifications[0].semantic_matched, Some(true));
+  assert!(!operation.verifications[0].state_changed);
+  assert!(operation.known_limits.iter().any(|limit| limit == TEXTEDIT_DOCUMENT_WRITE_STATE_CHANGED_KNOWN_LIMIT));
 
   let run = store.read_run(&run_id).expect("run");
   let artifact_roles: BTreeMap<String, String> =
@@ -103,6 +108,7 @@ fn textedit_document_write_same_run_cli_mcp_inspect_parity() {
   assert_eq!(enrichment.verifications.len(), 1);
   assert_eq!(enrichment.verifications[0]["method"]["kind"], "ax_text");
   assert_eq!(enrichment.verifications[0]["semantic_matched"], true);
+  assert_eq!(enrichment.verifications[0]["state_changed"], false);
 
   // Lock same-run artifact identity: store fingerprint + evidence refs + shared projection sections.
   let expected_identity = artifact_identity_fingerprint(&run);
@@ -254,6 +260,7 @@ fn textedit_document_write_live_macos_closure() {
   assert_eq!(operation.run_id.as_str(), result.run_id.as_str());
   assert!(!operation.evidence_artifacts.is_empty());
   assert_eq!(operation.verifications[0].semantic_matched, Some(true));
+  assert!(!operation.verifications[0].state_changed);
   let _ = std::fs::remove_dir_all(root);
 }
 
@@ -299,7 +306,9 @@ fn assert_recorded_semantic_mismatch(store: &LocalStore, run_id: &str) {
   assert_eq!(operation.status, OperationStatus::Failed);
   assert_eq!(operation.verifications.len(), 1);
   assert_eq!(operation.verifications[0].semantic_matched, Some(false));
+  assert!(!operation.verifications[0].state_changed);
   assert_eq!(operation.verifications[0].failure_layer, Some(FailureLayer::SemanticMismatch));
+  assert!(operation.known_limits.iter().any(|limit| limit == TEXTEDIT_DOCUMENT_WRITE_STATE_CHANGED_KNOWN_LIMIT));
 
   let operation_artifacts = canonical.artifacts.iter().filter(|artifact| artifact.role == "operation-result").collect::<Vec<_>>();
   assert_eq!(operation_artifacts.len(), 1);

--- a/crates/auv-driver-macos/src/accessibility.rs
+++ b/crates/auv-driver-macos/src/accessibility.rs
@@ -1,0 +1,274 @@
+//! Capability-oriented accessibility (AX) session helpers for macOS.
+//!
+//! Native AX capture/focus stay behind this module. Product and app crates
+//! should call [`crate::session::AccessibilityApi`] instead of `native`.
+
+use auv_driver_common::error::{DriverError, DriverResult};
+use auv_driver_common::input::{DisturbanceLevel, InputActionResult, InputAttempt, InputDeliveryPath};
+use serde::{Deserialize, Serialize};
+
+use crate::support::{find_best_ax_node, score_ax_node_match};
+use crate::types::{ObservedAxNode, ObservedAxTreeSnapshot};
+
+/// Default AX tree capture bounds for TextEdit-sized document trees.
+pub const DEFAULT_AX_MAX_DEPTH: i64 = 16;
+pub const DEFAULT_AX_MAX_CHILDREN: i64 = 64;
+
+/// Evidence returned after focusing a selected AX node.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AxFocusObservation {
+  pub app: String,
+  pub pid: i32,
+  pub path: String,
+  pub role: String,
+  pub title: String,
+  pub value: String,
+  pub query: String,
+  pub input_action_result: InputActionResult,
+}
+
+/// Evidence returned after reading/verifying AX text on a node.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AxTextObservation {
+  pub app: String,
+  pub pid: i32,
+  pub path: String,
+  pub role: String,
+  pub matched_text: String,
+  pub expected_text: String,
+  pub semantic_matched: bool,
+}
+
+pub fn capture_app_tree(app: &str, max_depth: i64, max_children: i64) -> DriverResult<ObservedAxTreeSnapshot> {
+  let capture = crate::native::ax_tree::capture_ax_tree_snapshot(app, max_depth, max_children).map_err(backend)?;
+  Ok(capture.snapshot)
+}
+
+pub fn focus_node_path(pid: i32, path: &str, expected_role: &str) -> DriverResult<InputActionResult> {
+  let _ = crate::native::ax_tree::set_ax_focused_path(pid, path, expected_role).map_err(backend)?;
+  Ok(InputActionResult {
+    selected_path: InputDeliveryPath::AxFocus,
+    attempts: vec![InputAttempt {
+      path: InputDeliveryPath::AxFocus,
+      succeeded: true,
+      message: Some(format!("focused AX path {path} role {expected_role}")),
+    }],
+    fallback_reason: None,
+    mouse_disturbance: DisturbanceLevel::None,
+    focus_disturbance: DisturbanceLevel::Temporary,
+    clipboard_disturbance: DisturbanceLevel::None,
+  })
+}
+
+pub fn focus_text_by_query(app: &str, query: &str, expected_role: Option<&str>, candidate: &str) -> DriverResult<AxFocusObservation> {
+  let snapshot = capture_app_tree(app, DEFAULT_AX_MAX_DEPTH, DEFAULT_AX_MAX_CHILDREN)?;
+  let node = select_focus_node(&snapshot, query, expected_role, candidate)?;
+  let role = if node.role.trim().is_empty() {
+    expected_role.unwrap_or("").to_string()
+  } else {
+    node.role.clone()
+  };
+  let input_action_result = focus_node_path(snapshot.pid, &node.path, &role)?;
+  Ok(AxFocusObservation {
+    app: app.to_string(),
+    pid: snapshot.pid,
+    path: node.path.clone(),
+    role,
+    title: node.title.clone(),
+    value: node.value.clone(),
+    query: query.to_string(),
+    input_action_result,
+  })
+}
+
+pub fn verify_text(app: &str, expected_text: &str, expected_role: &str) -> DriverResult<AxTextObservation> {
+  let snapshot = capture_app_tree(app, DEFAULT_AX_MAX_DEPTH, DEFAULT_AX_MAX_CHILDREN)?;
+  let node = select_text_node_by_role(&snapshot, expected_role)?;
+  let matched_text = node.value.clone();
+  let semantic_matched = matched_text.contains(expected_text);
+  Ok(AxTextObservation {
+    app: app.to_string(),
+    pid: snapshot.pid,
+    path: node.path.clone(),
+    role: node.role.clone(),
+    matched_text,
+    expected_text: expected_text.to_string(),
+    semantic_matched,
+  })
+}
+
+/// Locates the primary text node by role/focus/area — not by expected content.
+fn select_text_node_by_role<'a>(snapshot: &'a ObservedAxTreeSnapshot, expected_role: &str) -> DriverResult<&'a ObservedAxNode> {
+  let role = expected_role.trim();
+  if role.is_empty() {
+    return Err(DriverError::InvalidInput {
+      message: "accessibility.verify_text requires a non-empty expected_role".to_string(),
+    });
+  }
+
+  let candidates = snapshot
+    .nodes
+    .iter()
+    .filter(|node| node.bounds.width > 0 && node.bounds.height > 0)
+    .filter(|node| node.role.eq_ignore_ascii_case(role))
+    .collect::<Vec<_>>();
+
+  if let Some(focused) = candidates.iter().find(|node| node.focused) {
+    return Ok(*focused);
+  }
+
+  candidates.into_iter().max_by_key(|node| (node.bounds.width.saturating_mul(node.bounds.height), node.depth)).ok_or_else(|| {
+    DriverError::NotFound {
+      target: format!("AX text node with role {role}"),
+    }
+  })
+}
+
+fn select_focus_node<'a>(
+  snapshot: &'a ObservedAxTreeSnapshot,
+  query: &str,
+  expected_role: Option<&str>,
+  candidate: &str,
+) -> DriverResult<&'a ObservedAxNode> {
+  let candidate = candidate.trim();
+  if !candidate.is_empty() {
+    if let Some(node) = snapshot.nodes.iter().find(|node| node.path == candidate) {
+      return Ok(node);
+    }
+    // NOTICE(textedit-ax-candidate-json): full promoted CandidateRef JSON
+    // decode is deferred. Non-path candidate strings currently fail closed
+    // so invoke cannot silently focus the wrong node. Unlock when product
+    // invoke needs CandidateRef promotion for TextEdit focus.
+    return Err(DriverError::NotFound {
+      target: format!("AX candidate path {candidate}"),
+    });
+  }
+
+  let query = query.trim();
+  if query.is_empty() {
+    return Err(DriverError::InvalidInput {
+      message: "accessibility.focus_text_by_query requires --query or a path candidate".to_string(),
+    });
+  }
+
+  let mut ranked = snapshot
+    .nodes
+    .iter()
+    .filter(|node| node.bounds.width > 0 && node.bounds.height > 0)
+    .filter(|node| {
+      expected_role.map(|role| role.trim()).filter(|role| !role.is_empty()).is_none_or(|role| node.role.eq_ignore_ascii_case(role))
+    })
+    .filter_map(|node| score_ax_node_match(node, &query.to_lowercase()).map(|score| (score, node)))
+    .collect::<Vec<_>>();
+  ranked.sort_by(|left, right| right.0.cmp(&left.0));
+
+  if let Some((_, node)) = ranked.first() {
+    return Ok(node);
+  }
+
+  find_best_ax_node(snapshot, query).ok_or_else(|| DriverError::NotFound {
+    target: format!("AX text node matching query {query}"),
+  })
+}
+
+fn backend(message: impl std::fmt::Display) -> DriverError {
+  DriverError::Backend {
+    message: message.to_string(),
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::types::ObservedRect;
+
+  fn sample_snapshot() -> ObservedAxTreeSnapshot {
+    ObservedAxTreeSnapshot {
+      observed_at: "now".to_string(),
+      app_name: "TextEdit".to_string(),
+      bundle_id: "com.apple.TextEdit".to_string(),
+      pid: 4242,
+      window_title: "Untitled".to_string(),
+      nodes: vec![
+        ObservedAxNode {
+          depth: 1,
+          path: "0.1".to_string(),
+          role: "AXWindow".to_string(),
+          subrole: String::new(),
+          title: "Untitled".to_string(),
+          description: String::new(),
+          help: String::new(),
+          identifier: String::new(),
+          placeholder: String::new(),
+          value: String::new(),
+          focused: false,
+          bounds: ObservedRect {
+            x: 0,
+            y: 0,
+            width: 800,
+            height: 600,
+          },
+        },
+        ObservedAxNode {
+          depth: 2,
+          path: "0.1.2".to_string(),
+          role: "AXTextArea".to_string(),
+          subrole: String::new(),
+          title: "First Text View".to_string(),
+          description: String::new(),
+          help: String::new(),
+          identifier: String::new(),
+          placeholder: String::new(),
+          value: "hello body".to_string(),
+          focused: false,
+          bounds: ObservedRect {
+            x: 10,
+            y: 40,
+            width: 780,
+            height: 540,
+          },
+        },
+      ],
+    }
+  }
+
+  #[test]
+  fn select_focus_node_prefers_query_match_with_role() {
+    let snapshot = sample_snapshot();
+    let node = select_focus_node(&snapshot, "First Text View", Some("AXTextArea"), "").expect("node");
+    assert_eq!(node.path, "0.1.2");
+    assert_eq!(node.role, "AXTextArea");
+  }
+
+  #[test]
+  fn select_focus_node_accepts_exact_path_candidate() {
+    let snapshot = sample_snapshot();
+    let node = select_focus_node(&snapshot, "", None, "0.1.2").expect("path candidate");
+    assert_eq!(node.title, "First Text View");
+  }
+
+  #[test]
+  fn select_focus_node_rejects_unknown_candidate_without_fallback() {
+    let snapshot = sample_snapshot();
+    let error = select_focus_node(&snapshot, "First Text View", Some("AXTextArea"), "missing.path").expect_err("unknown candidate");
+    assert!(error.to_string().contains("missing.path"));
+  }
+
+  #[test]
+  fn select_text_node_by_role_ignores_expected_content() {
+    let snapshot = sample_snapshot();
+    let node = select_text_node_by_role(&snapshot, "AXTextArea").expect("role node");
+    assert_eq!(node.path, "0.1.2");
+    assert_eq!(node.value, "hello body");
+  }
+
+  #[test]
+  fn verify_text_observation_can_report_semantic_mismatch_without_erroring() {
+    let snapshot = sample_snapshot();
+    let node = select_text_node_by_role(&snapshot, "AXTextArea").expect("role node");
+    let expected = "not-present-in-body";
+    let semantic_matched = node.value.contains(expected);
+    assert!(!semantic_matched);
+    assert_eq!(node.value, "hello body");
+  }
+}

--- a/crates/auv-driver-macos/src/lib.rs
+++ b/crates/auv-driver-macos/src/lib.rs
@@ -1,3 +1,4 @@
+mod accessibility;
 mod descriptor;
 mod driver;
 mod readiness;
@@ -22,10 +23,12 @@ pub mod types;
 #[doc(hidden)]
 pub mod native;
 
+pub use accessibility::{AxFocusObservation, AxTextObservation, DEFAULT_AX_MAX_CHILDREN, DEFAULT_AX_MAX_DEPTH};
 pub use auv_driver_common::vision::{OcrMatch, OcrMatches};
 pub use descriptor::{MacosDriverDescriptor, macos_driver_descriptor};
 #[doc(hidden)]
 pub use descriptor::{MacosLegacyDescriptorMetadata, macos_legacy_descriptor_metadata};
 pub use driver::{MacosDriver, MacosDriverSession};
 pub use readiness::assess_readiness;
-pub use session::{ClipboardApi, InputApi, PermissionApi, VisionApi, WindowApi};
+pub use session::{AccessibilityApi, ClipboardApi, InputApi, PermissionApi, VisionApi, WindowApi};
+pub use types::{ObservedAxNode, ObservedAxTreeSnapshot};

--- a/crates/auv-driver-macos/src/session.rs
+++ b/crates/auv-driver-macos/src/session.rs
@@ -60,6 +60,11 @@ pub struct PermissionApi<'a> {
   session: &'a MacosDriverSession,
 }
 
+#[derive(Clone, Copy, Debug)]
+pub struct AccessibilityApi<'a> {
+  session: &'a MacosDriverSession,
+}
+
 impl MacosDriverSession {
   // Session APIs are grouped by automation target, not by native backend
   // mechanism. Window operations are relative to an application window;
@@ -88,6 +93,10 @@ impl MacosDriverSession {
   pub fn permission(&self) -> PermissionApi<'_> {
     PermissionApi { session: self }
   }
+
+  pub fn accessibility(&self) -> AccessibilityApi<'_> {
+    AccessibilityApi { session: self }
+  }
 }
 
 impl PermissionApi<'_> {
@@ -100,6 +109,38 @@ impl PermissionApi<'_> {
       accessibility: permission_status_from_label(native.accessibility),
       automation_to_system_events: probe_automation_to_system_events(),
     })
+  }
+}
+
+impl AccessibilityApi<'_> {
+  /// Captures a flattened AX tree for an application name or bundle id.
+  pub fn capture_app_tree(&self, app: &str, max_depth: i64, max_children: i64) -> DriverResult<crate::types::ObservedAxTreeSnapshot> {
+    let _ = self.session;
+    crate::accessibility::capture_app_tree(app, max_depth, max_children)
+  }
+
+  /// Focuses a previously observed AX node path within a process.
+  pub fn focus_node_path(&self, pid: i32, path: &str, expected_role: &str) -> DriverResult<InputActionResult> {
+    let _ = self.session;
+    crate::accessibility::focus_node_path(pid, path, expected_role)
+  }
+
+  /// Resolves a document/text node by query (or exact path candidate) and focuses it.
+  pub fn focus_text_by_query(
+    &self,
+    app: &str,
+    query: &str,
+    expected_role: Option<&str>,
+    candidate: &str,
+  ) -> DriverResult<crate::accessibility::AxFocusObservation> {
+    let _ = self.session;
+    crate::accessibility::focus_text_by_query(app, query, expected_role, candidate)
+  }
+
+  /// Captures the current AX tree and verifies expected text on a role-matched node.
+  pub fn verify_text(&self, app: &str, expected_text: &str, expected_role: &str) -> DriverResult<crate::accessibility::AxTextObservation> {
+    let _ = self.session;
+    crate::accessibility::verify_text(app, expected_text, expected_role)
   }
 }
 

--- a/crates/auv-driver-macos/src/types.rs
+++ b/crates/auv-driver-macos/src/types.rs
@@ -1,10 +1,10 @@
 use std::path::PathBuf;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 pub type AuvResult<T> = Result<T, String>;
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ObservedRect {
   pub x: i64,
   pub y: i64,
@@ -170,7 +170,7 @@ pub struct ScreenshotDimensions {
   pub height: i64,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ObservedAxNode {
   pub depth: usize,
   pub path: String,
@@ -186,7 +186,7 @@ pub struct ObservedAxNode {
   pub bounds: ObservedRect,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ObservedAxTreeSnapshot {
   pub observed_at: String,
   pub app_name: String,

--- a/docs/ai/references/INDEX.md
+++ b/docs/ai/references/INDEX.md
@@ -43,6 +43,7 @@ Do not put engineering slice codes (`a2`, `p14`, scan-step codes, etc.) in navig
 | [`scan/`](scan/INDEX.md) | Active | Temporal scan / surface observation | |
 | [`scenebridge/`](scenebridge/INDEX.md) | Active | Cross-app scene identity / grounding | |
 | [`recognition/`](recognition/INDEX.md) | Active | RecognitionResult, detectors | |
+| [`apps/textedit/`](apps/textedit/INDEX.md) | Product | TextEdit document.write golden path | |
 | [`apps/netease-music/`](apps/netease-music/INDEX.md) | Product | Netease Cloud Music app-local commands | |
 | [`apps/qqmusic/`](apps/qqmusic/INDEX.md) | Historical | QQ Music probes | |
 | [`apps/minecraft/`](apps/minecraft/INDEX.md) | Paused | Minecraft spatial probe | |

--- a/docs/ai/references/apps/textedit/2026-07-13-textedit-document-write-golden-path-design.md
+++ b/docs/ai/references/apps/textedit/2026-07-13-textedit-document-write-golden-path-design.md
@@ -1,0 +1,63 @@
+# TextEdit document.write golden path (design)
+
+**Date:** 2026-07-13  
+**Status:** accepted for issue [#101](https://github.com/moeru-ai/auv/issues/101)  
+**Slice:** owner-approved cross-layer feature
+
+## Objective
+
+Ship one recorded product operation:
+
+```text
+app.textedit.document.write
+  -> auv-apple-textedit DocumentWrite workflow
+  -> auv-driver-macos AccessibilityApi (AX focus + text observe)
+  -> auv-cli-invoke invoke_recorded
+  -> one canonical run
+  -> product CLI / MCP / inspect-server same-run reads
+```
+
+## Ownership
+
+| Concern | Owner |
+|---|---|
+| Workflow (activate → focus → paste → verify) | `auv-apple-textedit` (`DocumentWrite` / `run_document_command`) |
+| Typed AX capability | `auv-driver-macos` `AccessibilityApi` on `MacosDriverSession` |
+| Core invoke catalog | `auv-cli-invoke::default_registry` (no TextEdit dep) |
+| Product registry extension | `auv-product` (`product_registry` = core + TextEdit) |
+| Recording | `auv-cli-invoke::invoke_recorded` |
+| Inspect composition | existing product `InspectComposer` |
+
+## Public command shape
+
+```text
+auv invoke app.textedit.document.write --content <TEXT> [--replace true|false] [--verify true|false] [--target <bundle-id>]
+```
+
+Defaults: `replace=true`, `verify=true`, target `com.apple.TextEdit`. Focus/role settle overrides stay internal unless a test requires exposure.
+
+## Typed AX surface (macOS)
+
+```text
+MacosDriverSession::accessibility()
+  capture_app_tree(app, max_depth, max_children) -> ObservedAxTreeSnapshot
+  focus_node_path(pid, path, expected_role) -> InputActionResult
+  focus_text_by_query(app, query, expected_role, candidate) -> AxFocusObservation
+  verify_text(app, expected_text, expected_role) -> AxTextObservation
+```
+
+`auv-driver-macos::native` remains an implementation detail.
+
+## Evidence
+
+Handler stages:
+
+- `input-action-result` for focus / paste steps (`InputActionResult`)
+- `ax-text-observation` for verify observation
+- `operation-result` with `VerificationResult { method: AxText, ... }`
+
+`InvokeCommandOutput.verification` remains the human boundary string; semantic success is the staged `VerificationResult`.
+
+## Non-goals
+
+README cleanup, Windows/Linux AX parity, candidate-action restore, Notes/other apps, broad OperationResult v1 graduation, planner/retry policy.

--- a/docs/ai/references/apps/textedit/2026-07-13-textedit-document-write-golden-path-design.md
+++ b/docs/ai/references/apps/textedit/2026-07-13-textedit-document-write-golden-path-design.md
@@ -24,8 +24,8 @@ app.textedit.document.write
 | Workflow (activate → focus → paste → verify) | `auv-apple-textedit` (`DocumentWrite` / `run_document_command`) |
 | Typed AX capability | `auv-driver-macos` `AccessibilityApi` on `MacosDriverSession` |
 | Core invoke catalog | `auv-cli-invoke::default_registry` (no TextEdit dep) |
-| Product registry extension | `auv-product` (`product_registry` = core + TextEdit) |
-| Recording | `auv-cli-invoke::invoke_recorded` |
+| Product registry extension | `auv-cli` (`product_registry` = core + TextEdit) |
+| Recording lifecycle | `auv-cli-invoke::invoke_recorded_with_finalize` |
 | Inspect composition | existing product `InspectComposer` |
 
 ## Public command shape
@@ -50,13 +50,36 @@ MacosDriverSession::accessibility()
 
 ## Evidence
 
-Handler stages:
+The handler stages:
 
 - `input-action-result` for focus / paste steps (`InputActionResult`)
 - `ax-text-observation` for verify observation
-- `operation-result` with `VerificationResult { method: AxText, ... }`
+
+The product finalize hook runs after those artifacts are recorded but before the
+command span and run finish. It derives semantic status from the staged AX
+observation, updates `InvokeResult`, and stages `operation-result` with
+`VerificationResult { method: AxText, ... }` on the same run. The hook also runs
+for failed handler results; if finalization itself fails, recorded invoke
+persists an error run and returns the failure to the caller.
 
 `InvokeCommandOutput.verification` remains the human boundary string; semantic success is the staged `VerificationResult`.
+
+## Lifecycle closeout decision
+
+- **Shared helper in core:** `InvokeFinalizeHook` stays in `auv-cli-invoke`
+  because CLI and MCP must finalize before the shared span/run status decision.
+- **App-specific:** AX observation decoding and TextEdit `OperationResult`
+  construction stay in the TextEdit product integration.
+- **Rejected:** patching `run.json` after `invoke_recorded` finishes; that leaves
+  a completed run visible before canonical evidence exists.
+- **Rejected:** making the handler return an unstructured error for semantic
+  mismatch; that loses the failed `VerificationResult` evidence.
+- **Deferred:** broader `OperationResult` schema graduation; this slice adds no
+  contract fields or variants.
+
+Validation locks handler failure, finalize failure, semantic mismatch status
+parity, same-run artifact lineage, and CLI/MCP finalized artifact parity in
+`auv-cli-invoke` unit tests and `textedit_document_write_parity`.
 
 ## Non-goals
 

--- a/docs/ai/references/apps/textedit/2026-07-13-textedit-document-write-live-closure.md
+++ b/docs/ai/references/apps/textedit/2026-07-13-textedit-document-write-live-closure.md
@@ -6,15 +6,20 @@
 
 ```sh
 # TextEdit must be open with a document window; Accessibility granted to the terminal host.
-AUV_TEXTEDIT_LIVE=1 cargo test -p auv-product --test textedit_document_write_parity \
+AUV_TEXTEDIT_LIVE=1 \
+cargo test -p auv-cli \
+  --test textedit_document_write_parity \
   textedit_document_write_live_macos_closure -- --ignored --nocapture
 ```
 
 Or product invoke:
 
 ```sh
-auv invoke app.textedit.document.write --content 'AUV_TEXTEDIT_LIVE_MARKER' --verify true
-auv inspect <run_id>
+cargo run -p auv-cli -- \
+  invoke app.textedit.document.write \
+  --content 'AUV_TEXTEDIT_LIVE_MARKER' \
+  --verify true
+cargo run -p auv-cli -- inspect <run_id>
 ```
 
 ## Must prove
@@ -22,8 +27,17 @@ auv inspect <run_id>
 1. TextEdit document body focused via typed AX API
 2. Requested text delivered (clipboard paste)
 3. AX text observation reads resulting body
-4. Semantic `VerificationResult` method=`ax_text` matched
-5. One canonical run inspectable via product CLI / MCP / inspect-server
+4. Semantic `VerificationResult` method=`ax_text` has `semantic_matched=true`
+5. One canonical run is persisted and inspectable with the product CLI
+
+## Evidence boundary
+
+`semantic_matched=true` means the post-write AX text contains the requested
+content. This operation does not capture a pre-write AX observation, so it
+intentionally records `VerificationResult.state_changed=false`; it cannot prove
+a state transition until pre/post evidence is added. MCP and inspect-server
+same-run parity remains covered by the hermetic fixture test, not this live
+closure.
 
 ## CI
 

--- a/docs/ai/references/apps/textedit/2026-07-13-textedit-document-write-live-closure.md
+++ b/docs/ai/references/apps/textedit/2026-07-13-textedit-document-write-live-closure.md
@@ -1,0 +1,30 @@
+# TextEdit document.write live macOS closure
+
+**Status:** blocked / opt-in (not claimed as product-supported until this passes)
+
+## Manual command
+
+```sh
+# TextEdit must be open with a document window; Accessibility granted to the terminal host.
+AUV_TEXTEDIT_LIVE=1 cargo test -p auv-product --test textedit_document_write_parity \
+  textedit_document_write_live_macos_closure -- --ignored --nocapture
+```
+
+Or product invoke:
+
+```sh
+auv invoke app.textedit.document.write --content 'AUV_TEXTEDIT_LIVE_MARKER' --verify true
+auv inspect <run_id>
+```
+
+## Must prove
+
+1. TextEdit document body focused via typed AX API
+2. Requested text delivered (clipboard paste)
+3. AX text observation reads resulting body
+4. Semantic `VerificationResult` method=`ax_text` matched
+5. One canonical run inspectable via product CLI / MCP / inspect-server
+
+## CI
+
+Hermetic path uses `--driver fixture` (see `textedit_document_write_same_run_cli_mcp_inspect_parity`).

--- a/docs/ai/references/apps/textedit/INDEX.md
+++ b/docs/ai/references/apps/textedit/INDEX.md
@@ -1,0 +1,13 @@
+# apps/textedit
+
+TextEdit app-local commands and product golden path
+
+Count: **2**
+
+- [`2026-07-13-textedit-document-write-golden-path-design.md`](2026-07-13-textedit-document-write-golden-path-design.md)
+- [`2026-07-13-textedit-document-write-live-closure.md`](2026-07-13-textedit-document-write-live-closure.md)
+
+## Related
+
+- Parent index: [`../../INDEX.md`](../../INDEX.md)
+- Issue: https://github.com/moeru-ai/auv/issues/101

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -17,11 +17,8 @@ use serde_json::Value;
 
 use crate::build_default_store;
 use crate::model::{ExecutionTarget, InvokeRequest};
-use auv_cli_invoke::{ArgSpec, InvokeCommand, InvokeRegistry, InvokeResult, default_registry};
+use auv_cli_invoke::{ArgSpec, InvokeCommand, InvokeFinalizeHook, InvokeRegistry, default_registry};
 use auv_tracing_driver::store::LocalStore;
-
-/// Optional post-invoke finalize hook (product uses this for canonical operation-result lineage).
-pub type InvokeFinalizeHook = Arc<dyn Fn(&LocalStore, &InvokeResult) -> Result<(), String> + Send + Sync>;
 
 #[derive(Clone)]
 pub struct McpServer {
@@ -29,7 +26,7 @@ pub struct McpServer {
   tool_router: ToolRouter<Self>,
   inspect_composer: Arc<auv_inspect_model::InspectComposer>,
   invoke_registry: Arc<InvokeRegistry>,
-  invoke_finalize: Option<InvokeFinalizeHook>,
+  invoke_finalize: Option<Arc<InvokeFinalizeHook>>,
 }
 
 impl McpServer {
@@ -49,7 +46,7 @@ impl McpServer {
     project_root: PathBuf,
     inspect_composer: Arc<auv_inspect_model::InspectComposer>,
     invoke_registry: Arc<InvokeRegistry>,
-    invoke_finalize: Option<InvokeFinalizeHook>,
+    invoke_finalize: Option<Arc<InvokeFinalizeHook>>,
   ) -> Self {
     Self {
       project_root,
@@ -87,49 +84,31 @@ impl McpServer {
   async fn invoke(&self, Parameters(req): Parameters<InvokeToolRequest>) -> Result<CallToolResult, McpError> {
     let store = self.store(req.inspect.store_root.clone())?;
     let recording = auv_tracing_driver::RunRecordingBackend::new(store.clone(), Arc::new(auv_tracing_driver::MemoryRunRecorder::new()));
-    let result = auv_cli_invoke::invoke_recorded(
-      &recording,
-      self.invoke_registry.as_ref(),
-      InvokeRequest {
-        command_id: req.command_id,
-        target: ExecutionTarget {
-          application_id: req.target.application_id,
-          target_label: req.target.target_label,
-        },
-        inputs: req.inputs,
-        dry_run: req.dry_run,
+    let request = InvokeRequest {
+      command_id: req.command_id,
+      target: ExecutionTarget {
+        application_id: req.target.application_id,
+        target_label: req.target.target_label,
       },
-    )
-    .map_err(invalid_params)?;
-    if let Some(finalize) = &self.invoke_finalize {
-      finalize(&store, &result).map_err(invalid_params)?;
-    }
-
-    // Re-read after finalize so response artifacts include canonical operation-result.
-    let artifacts = match store.read_run(result.run_id.as_str()) {
-      Ok(canonical) => canonical
-        .artifacts
-        .iter()
-        .map(|artifact| {
-          serde_json::json!({
-            "artifact_id": artifact.artifact_id.as_str(),
-            "role": artifact.role,
-            "path": artifact.path,
-          })
-        })
-        .collect::<Vec<_>>(),
-      Err(_) => result
-        .artifacts
-        .iter()
-        .map(|artifact| {
-          serde_json::json!({
-            "artifact_id": artifact.artifact_id.as_str(),
-            "role": artifact.role,
-            "path": artifact.path,
-          })
-        })
-        .collect::<Vec<_>>(),
+      inputs: req.inputs,
+      dry_run: req.dry_run,
     };
+    let result = match &self.invoke_finalize {
+      Some(finalize) => auv_cli_invoke::invoke_recorded_with_finalize(&recording, self.invoke_registry.as_ref(), request, finalize.as_ref()),
+      None => auv_cli_invoke::invoke_recorded(&recording, self.invoke_registry.as_ref(), request),
+    }
+    .map_err(invalid_params)?;
+    let artifacts = result
+      .artifacts
+      .iter()
+      .map(|artifact| {
+        serde_json::json!({
+          "artifact_id": artifact.artifact_id.as_str(),
+          "role": artifact.role,
+          "path": artifact.path,
+        })
+      })
+      .collect::<Vec<_>>();
     let artifact_paths = result.artifact_paths.iter().map(|path| path.display().to_string()).collect::<Vec<_>>();
 
     json_result(serde_json::json!({
@@ -315,7 +294,7 @@ pub async fn serve_stdio_with_composer_and_registry(
   project_root: PathBuf,
   inspect_composer: Arc<auv_inspect_model::InspectComposer>,
   invoke_registry: Arc<InvokeRegistry>,
-  invoke_finalize: Option<InvokeFinalizeHook>,
+  invoke_finalize: Option<Arc<InvokeFinalizeHook>>,
 ) -> Result<(), String> {
   let service = McpServer::with_inspect_composer_and_registry(project_root, inspect_composer, invoke_registry, invoke_finalize)
     .serve(stdio())

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -17,30 +17,46 @@ use serde_json::Value;
 
 use crate::build_default_store;
 use crate::model::{ExecutionTarget, InvokeRequest};
-use auv_cli_invoke::{ArgSpec, InvokeCommand, default_registry};
+use auv_cli_invoke::{ArgSpec, InvokeCommand, InvokeRegistry, InvokeResult, default_registry};
+use auv_tracing_driver::store::LocalStore;
+
+/// Optional post-invoke finalize hook (product uses this for canonical operation-result lineage).
+pub type InvokeFinalizeHook = Arc<dyn Fn(&LocalStore, &InvokeResult) -> Result<(), String> + Send + Sync>;
 
 #[derive(Clone)]
 pub struct McpServer {
   project_root: PathBuf,
   tool_router: ToolRouter<Self>,
   inspect_composer: Arc<auv_inspect_model::InspectComposer>,
+  invoke_registry: Arc<InvokeRegistry>,
+  invoke_finalize: Option<InvokeFinalizeHook>,
 }
 
 impl McpServer {
   /// Builds the core-only MCP server.
   ///
-  /// Product callers inject their composer through
-  /// [`Self::with_inspect_composer`]; this core library does not construct
-  /// app-specific inspect sections.
+  /// Product callers inject composer + registry through
+  /// [`Self::with_inspect_composer_and_registry`].
   pub fn new(project_root: PathBuf) -> Self {
     Self::with_inspect_composer(project_root, crate::inspect::build_core_inspect_composer().expect("core inspect composer"))
   }
 
   pub fn with_inspect_composer(project_root: PathBuf, inspect_composer: Arc<auv_inspect_model::InspectComposer>) -> Self {
+    Self::with_inspect_composer_and_registry(project_root, inspect_composer, Arc::new(default_registry()), None)
+  }
+
+  pub fn with_inspect_composer_and_registry(
+    project_root: PathBuf,
+    inspect_composer: Arc<auv_inspect_model::InspectComposer>,
+    invoke_registry: Arc<InvokeRegistry>,
+    invoke_finalize: Option<InvokeFinalizeHook>,
+  ) -> Self {
     Self {
       project_root,
       tool_router: Self::tool_router(),
       inspect_composer,
+      invoke_registry,
+      invoke_finalize,
     }
   }
 
@@ -49,9 +65,13 @@ impl McpServer {
     &self.inspect_composer
   }
 
-  fn store(&self, store_root: Option<String>) -> Result<auv_tracing_driver::store::LocalStore, McpError> {
+  pub fn invoke_registry(&self) -> &Arc<InvokeRegistry> {
+    &self.invoke_registry
+  }
+
+  fn store(&self, store_root: Option<String>) -> Result<LocalStore, McpError> {
     let store = match store_root {
-      Some(root) => auv_tracing_driver::store::LocalStore::new(PathBuf::from(root)),
+      Some(root) => LocalStore::new(PathBuf::from(root)),
       None => build_default_store(self.project_root.clone()),
     };
     store.map_err(invalid_params)
@@ -66,11 +86,10 @@ impl McpServer {
   )]
   async fn invoke(&self, Parameters(req): Parameters<InvokeToolRequest>) -> Result<CallToolResult, McpError> {
     let store = self.store(req.inspect.store_root.clone())?;
-    let recording = auv_tracing_driver::RunRecordingBackend::new(store, Arc::new(auv_tracing_driver::MemoryRunRecorder::new()));
-    let registry = default_registry();
+    let recording = auv_tracing_driver::RunRecordingBackend::new(store.clone(), Arc::new(auv_tracing_driver::MemoryRunRecorder::new()));
     let result = auv_cli_invoke::invoke_recorded(
       &recording,
-      &registry,
+      self.invoke_registry.as_ref(),
       InvokeRequest {
         command_id: req.command_id,
         target: ExecutionTarget {
@@ -82,18 +101,35 @@ impl McpServer {
       },
     )
     .map_err(invalid_params)?;
+    if let Some(finalize) = &self.invoke_finalize {
+      finalize(&store, &result).map_err(invalid_params)?;
+    }
 
-    let artifacts = result
-      .artifacts
-      .iter()
-      .map(|artifact| {
-        serde_json::json!({
-          "artifact_id": artifact.artifact_id.as_str(),
-          "role": artifact.role,
-          "path": artifact.path,
+    // Re-read after finalize so response artifacts include canonical operation-result.
+    let artifacts = match store.read_run(result.run_id.as_str()) {
+      Ok(canonical) => canonical
+        .artifacts
+        .iter()
+        .map(|artifact| {
+          serde_json::json!({
+            "artifact_id": artifact.artifact_id.as_str(),
+            "role": artifact.role,
+            "path": artifact.path,
+          })
         })
-      })
-      .collect::<Vec<_>>();
+        .collect::<Vec<_>>(),
+      Err(_) => result
+        .artifacts
+        .iter()
+        .map(|artifact| {
+          serde_json::json!({
+            "artifact_id": artifact.artifact_id.as_str(),
+            "role": artifact.role,
+            "path": artifact.path,
+          })
+        })
+        .collect::<Vec<_>>(),
+    };
     let artifact_paths = result.artifact_paths.iter().map(|path| path.display().to_string()).collect::<Vec<_>>();
 
     json_result(serde_json::json!({
@@ -147,7 +183,11 @@ impl ServerHandler for McpServer {
     _request: Option<PaginatedRequestParam>,
     _context: RequestContext<RoleServer>,
   ) -> Result<ListToolsResult, McpError> {
-    Ok(ListToolsResult::with_all_items(self.tool_router.list_all()))
+    let mut tools = self.tool_router.list_all();
+    if let Some(invoke_tool) = tools.iter_mut().find(|tool| tool.name == "invoke") {
+      invoke_tool.input_schema = invoke_tool_input_schema_for_registry(self.invoke_registry.as_ref());
+    }
+    Ok(ListToolsResult::with_all_items(tools))
   }
 
   fn get_info(&self) -> ServerInfo {
@@ -162,8 +202,13 @@ impl ServerHandler for McpServer {
 }
 
 fn invoke_tool_input_schema() -> Arc<JsonObject> {
+  // Static schema uses core registry; product servers rewrite via list_tools
+  // with the explicitly injected registry.
+  invoke_tool_input_schema_for_registry(&default_registry())
+}
+
+fn invoke_tool_input_schema_for_registry(registry: &InvokeRegistry) -> Arc<JsonObject> {
   let mut schema = rmcp::handler::server::common::cached_schema_for_type::<InvokeToolRequest>().as_ref().clone();
-  let registry = default_registry();
   let command_ids = registry.all().iter().map(|command| Value::String(command.id.to_string())).collect::<Vec<_>>();
 
   if let Some(command_id_schema) = schema
@@ -262,7 +307,17 @@ pub async fn serve_stdio_with_composer(
   project_root: PathBuf,
   inspect_composer: Arc<auv_inspect_model::InspectComposer>,
 ) -> Result<(), String> {
-  let service = McpServer::with_inspect_composer(project_root, inspect_composer)
+  serve_stdio_with_composer_and_registry(project_root, inspect_composer, Arc::new(default_registry()), None).await
+}
+
+/// Serve MCP stdio with explicit inspect composer + invoke registry (+ optional finalize).
+pub async fn serve_stdio_with_composer_and_registry(
+  project_root: PathBuf,
+  inspect_composer: Arc<auv_inspect_model::InspectComposer>,
+  invoke_registry: Arc<InvokeRegistry>,
+  invoke_finalize: Option<InvokeFinalizeHook>,
+) -> Result<(), String> {
+  let service = McpServer::with_inspect_composer_and_registry(project_root, inspect_composer, invoke_registry, invoke_finalize)
     .serve(stdio())
     .await
     .map_err(|error| format!("failed to serve MCP stdio transport: {error}"))?;


### PR DESCRIPTION
## Summary

Implements #101: the first recorded product operation for TextEdit document writing.

```text
app.textedit.document.write
  -> typed macOS AX focus + text observation
  -> auv-apple-textedit DocumentWrite workflow
  -> shared recorded invoke lifecycle
  -> canonical OperationResult + evidence artifacts
  -> product CLI / MCP / inspect-server reads
```

## Ownership layers

- **`auv-driver-macos`** adds a capability-oriented `AccessibilityApi` for AX tree capture, deterministic text-node focus, and text observation while keeping native AX details behind the driver boundary.
- **`auv-apple-textedit`** completes `MacosTextEditDriver::focus_text_input` and `verify_ax_text`, while retaining `DocumentWrite` as the sole activate → focus → paste → verify workflow owner.
- **`auv-cli-invoke`** adds `invoke_recorded_with_finalize`, allowing product finalization after handler artifacts are recorded but before command span and run completion.
- **Product assembly (`auv-cli`)** extends the core registry through `product_registry()`, shares the same registry and finalize hook across CLI/MCP, and reuses the product `InspectComposer` for CLI, MCP, and inspect-server reads.

## Public command

```text
auv invoke app.textedit.document.write \
  --content <TEXT> \
  [--replace true|false] \
  [--verify true|false] \
  [--driver live|fixture] \
  [--target <bundle-id>]
```

Defaults: `replace=true`, `verify=true`, `driver=live`, target `com.apple.TextEdit`.

`--driver fixture` exists for hermetic CI and is not evidence of live macOS support.

## Recorded evidence and status semantics

The handler stages:

- `input-action-result` artifacts for typed AX focus and clipboard delivery;
- `ax-text-observation` for the observed document body;
- invoke report, signals, and known limits.

The in-lifecycle finalize hook appends one canonical `operation-result` containing the assigned `run_id`, same-run evidence refs, verification results, known limits, and operation status.

Semantic mismatch remains consistent across layers:

```text
InvokeResult.status = failed
command span = error
canonical run = error
OperationResult.status = failed
VerificationResult.semantic_matched = false
VerificationResult.failure_layer = semantic_mismatch
```

The finalized `operation-result` is included in both CLI and MCP artifact lists. Finalize errors also finish the run as failed.

## Verification evidence boundary

TextEdit verification records only a post-write AX observation. It can establish whether the resulting AX text contains the requested content, but it cannot prove that the UI changed from a prior state.

Accordingly:

```text
VerificationResult.method = ax_text
VerificationResult.state_changed = false
```

When AX verification is present, the operation records an explicit known limit explaining that no pre-write observation exists. With `verify=false`, no semantic VerificationResult or state-change known limit is emitted.

## Same-run parity

Hermetic coverage verifies that CLI, MCP, and inspect-server consume the same persisted run and agree on:

- assigned run ID and operation identity;
- invoke, span, run, and operation status;
- semantic verification, `state_changed`, and failure layer;
- known limits and evidence references;
- artifact IDs, roles, and paths;
- inspect section ordering.

A recorded mismatch test uses the real MCP transport and verifies identical finalized artifact views across CLI and MCP.

## Validation

Local validation on head `b6ef6367` completed successfully:

```text
cargo fmt --check
cargo check
cargo test
cargo clippy
```

The full workspace test suite passed.

GitHub gates on `b6ef6367`:

- **macOS: success**
- **Ubuntu: success**
- **Qodana: success**

## Live macOS closure

**Attempted, blocked, and not claimed as product-supported.**

The exact live evidence is recorded in PR comment #issuecomment-4961635640 and in:

```text
docs/ai/references/apps/textedit/2026-07-13-textedit-document-write-live-closure.md
```

Observed boundary:

```text
TextEdit process exists
AX application/tree exists
WindowServer .optionOnScreenOnly snapshot does not expose the TextEdit window
main-window resolution fails before focus
no paste occurs
no post-write AX verification occurs
```

This failure is before the newly added TextEdit AX focus/verification path. It shows that live support remains blocked on macOS window discovery and does not establish successful live TextEdit operation.

## Deferred follow-ups

- Fix or extend macOS target-window resolution when an AX-visible application window is absent from the `.optionOnScreenOnly` WindowServer snapshot.
- Re-run and curate live TextEdit closure before claiming product support.
- Add pre-write observation if `state_changed=true` must ever be asserted.
- Promote full candidate identity beyond exact AX path candidates when a real product consumer requires it.
- Decide whether fixture-only controls should become a formal testing interface; `fixture_observed_text` remains undocumented and test-only.

## Non-goals honored

This PR does not include README/capability-matrix cleanup, Windows/Linux AX parity, a cross-platform AX query language, candidate-action restoration, planner/controller/retry policy, bindings, remote sessions, replay, shortcut UI, other app integrations, 3DGS work, or broad `OperationResult` v1 graduation.

## Support statement

This PR establishes a fixture-validated, contract-complete recorded TextEdit integration with a real macOS backend. It does **not** claim live TextEdit product support until the window-discovery blocker is resolved and the opt-in closure succeeds.