### PR TITLE
fix(textedit): activate app without resolving a window

### DIFF
--- a/crates/auv-apple-textedit/src/driver.rs
+++ b/crates/auv-apple-textedit/src/driver.rs
@@ -48,11 +48,8 @@ mod macos {
   use std::time::Duration;
 
   use auv_driver::LocalDriverSession;
-  use auv_driver::{
-    ActivationPolicy, App, InputActionResult, InputDeliveryPath, PasteTextOptions, PrepareForInputOptions, TextSubmit, Window,
-    WindowSelector,
-  };
-  use auv_driver_macos::MacosDriverSession;
+  use auv_driver::{InputActionResult, InputDeliveryPath, PasteTextOptions, TextSubmit};
+  use auv_driver_macos::{ApplicationControl, MacosDriverSession};
 
   use super::{OperationResult, StepOutcome, TextEditDriver, VerificationOutcome};
 
@@ -71,31 +68,17 @@ mod macos {
         session: LocalDriverSession::Macos(session),
       }
     }
-
-    fn main_window(&self, app_id: &str) -> OperationResult<Window> {
-      self.session.window().resolve(main_window_selector(app_id)).map_err(|error| error.to_string())
-    }
   }
 
   impl TextEditDriver for MacosTextEditDriver {
     fn activate_app(&mut self, app_id: &str, settle: Duration) -> OperationResult<StepOutcome> {
-      let window = self.main_window(app_id)?;
       self
         .session
-        .window()
-        .prepare_for_input(
-          &window,
-          PrepareForInputOptions {
-            activation: ActivationPolicy::Foreground { settle },
-            preserve_frontmost: false,
-            install_focus_guard: false,
-            settle: Duration::ZERO,
-          },
-        )
-        .map_err(|error| error.to_string())?;
+        .activate_bundle_id(app_id, settle)
+        .map_err(|error| format!("TextEdit activation failed: {error}"))?;
       Ok(StepOutcome {
         step_id: "activate-target-app",
-        summary: format!("activated foreground TextEdit window for {app_id}"),
+        summary: format!("activated foreground TextEdit application for {app_id} without requiring WindowServer discovery"),
         input_action_result: None,
       })
     }
@@ -153,14 +136,6 @@ mod macos {
         observation_path: Some(observation.path),
         observation_pid: Some(observation.pid),
       })
-    }
-  }
-
-  fn main_window_selector(app_id: &str) -> WindowSelector {
-    WindowSelector {
-      app: Some(App::bundle_id(app_id)),
-      title: None,
-      main_visible: true,
     }
   }
 }

--- a/crates/auv-apple-textedit/src/driver.rs
+++ b/crates/auv-apple-textedit/src/driver.rs
@@ -72,10 +72,7 @@ mod macos {
 
   impl TextEditDriver for MacosTextEditDriver {
     fn activate_app(&mut self, app_id: &str, settle: Duration) -> OperationResult<StepOutcome> {
-      self
-        .session
-        .activate_bundle_id(app_id, settle)
-        .map_err(|error| format!("TextEdit activation failed: {error}"))?;
+      self.session.activate_bundle_id(app_id, settle).map_err(|error| format!("TextEdit activation failed: {error}"))?;
       Ok(StepOutcome {
         step_id: "activate-target-app",
         summary: format!("activated foreground TextEdit application for {app_id} without requiring WindowServer discovery"),

--- a/crates/auv-driver-macos/src/application.rs
+++ b/crates/auv-driver-macos/src/application.rs
@@ -1,0 +1,110 @@
+//! Application-scoped control for macOS workflows that do not require a
+//! WindowServer capture target.
+
+use std::time::Duration;
+
+#[cfg(target_os = "macos")]
+use std::process::Command;
+
+use auv_driver_common::error::{DriverError, DriverResult};
+
+use crate::MacosDriverSession;
+
+/// Typed application control that is independent of `CGWindowID` discovery.
+///
+/// Use this for foreground AX/keyboard workflows that target an application by
+/// bundle id. Screenshot, coordinate, and window-targeted input paths should
+/// continue to resolve a concrete window through `WindowApi`.
+pub trait ApplicationControl {
+  fn activate_bundle_id(&self, bundle_id: &str, settle: Duration) -> DriverResult<()>;
+}
+
+impl ApplicationControl for MacosDriverSession {
+  fn activate_bundle_id(&self, bundle_id: &str, settle: Duration) -> DriverResult<()> {
+    let _ = self;
+    let script = activation_script(bundle_id)?;
+    run_activation_script(&script)?;
+
+    let _ = settle;
+    #[cfg(target_os = "macos")]
+    if !settle.is_zero() {
+      std::thread::sleep(settle);
+    }
+
+    Ok(())
+  }
+}
+
+fn activation_script(bundle_id: &str) -> DriverResult<String> {
+  let bundle_id = bundle_id.trim();
+  if bundle_id.is_empty() {
+    return Err(DriverError::InvalidInput {
+      message: "application activation requires a non-empty bundle id".to_string(),
+    });
+  }
+
+  Ok(format!(
+    "tell application id \"{}\" to activate",
+    escape_applescript(bundle_id)
+  ))
+}
+
+fn escape_applescript(value: &str) -> String {
+  value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+#[cfg(target_os = "macos")]
+fn run_activation_script(script: &str) -> DriverResult<()> {
+  let output = Command::new("osascript")
+    .arg("-e")
+    .arg(script)
+    .output()
+    .map_err(|error| DriverError::Backend {
+      message: format!("failed to launch osascript for application activation: {error}"),
+    })?;
+
+  if output.status.success() {
+    return Ok(());
+  }
+
+  let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+  Err(DriverError::Backend {
+    message: if stderr.is_empty() {
+      format!("osascript application activation exited with {}", output.status)
+    } else {
+      format!("osascript application activation failed: {stderr}")
+    },
+  })
+}
+
+#[cfg(not(target_os = "macos"))]
+fn run_activation_script(_script: &str) -> DriverResult<()> {
+  Err(DriverError::unsupported("application.activate_bundle_id"))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn activation_script_is_scoped_to_exact_bundle_id() {
+    assert_eq!(
+      activation_script("com.apple.TextEdit").expect("script"),
+      "tell application id \"com.apple.TextEdit\" to activate"
+    );
+  }
+
+  #[test]
+  fn activation_script_rejects_blank_bundle_id() {
+    let error = activation_script("   ").expect_err("blank bundle id should fail");
+    assert!(error.to_string().contains("non-empty bundle id"));
+  }
+
+  #[test]
+  fn activation_script_escapes_applescript_string_content() {
+    assert_eq!(
+      activation_script("com.example.\\\"quoted").expect("script"),
+      "tell application id \"com.example.\\\\\\\"quoted\" to activate"
+    );
+  }
+}

--- a/crates/auv-driver-macos/src/application.rs
+++ b/crates/auv-driver-macos/src/application.rs
@@ -43,10 +43,7 @@ fn activation_script(bundle_id: &str) -> DriverResult<String> {
     });
   }
 
-  Ok(format!(
-    "tell application id \"{}\" to activate",
-    escape_applescript(bundle_id)
-  ))
+  Ok(format!("tell application id \"{}\" to activate", escape_applescript(bundle_id)))
 }
 
 fn escape_applescript(value: &str) -> String {
@@ -55,13 +52,9 @@ fn escape_applescript(value: &str) -> String {
 
 #[cfg(target_os = "macos")]
 fn run_activation_script(script: &str) -> DriverResult<()> {
-  let output = Command::new("osascript")
-    .arg("-e")
-    .arg(script)
-    .output()
-    .map_err(|error| DriverError::Backend {
-      message: format!("failed to launch osascript for application activation: {error}"),
-    })?;
+  let output = Command::new("osascript").arg("-e").arg(script).output().map_err(|error| DriverError::Backend {
+    message: format!("failed to launch osascript for application activation: {error}"),
+  })?;
 
   if output.status.success() {
     return Ok(());
@@ -88,10 +81,7 @@ mod tests {
 
   #[test]
   fn activation_script_is_scoped_to_exact_bundle_id() {
-    assert_eq!(
-      activation_script("com.apple.TextEdit").expect("script"),
-      "tell application id \"com.apple.TextEdit\" to activate"
-    );
+    assert_eq!(activation_script("com.apple.TextEdit").expect("script"), "tell application id \"com.apple.TextEdit\" to activate");
   }
 
   #[test]

--- a/crates/auv-driver-macos/src/lib.rs
+++ b/crates/auv-driver-macos/src/lib.rs
@@ -1,4 +1,5 @@
 mod accessibility;
+mod application;
 mod descriptor;
 mod driver;
 mod readiness;
@@ -24,6 +25,7 @@ pub mod types;
 pub mod native;
 
 pub use accessibility::{AxFocusObservation, AxTextObservation, DEFAULT_AX_MAX_CHILDREN, DEFAULT_AX_MAX_DEPTH};
+pub use application::ApplicationControl;
 pub use auv_driver_common::vision::{OcrMatch, OcrMatches};
 pub use descriptor::{MacosDriverDescriptor, macos_driver_descriptor};
 #[doc(hidden)]

--- a/crates/auv-driver-macos/src/native/clipboard.rs
+++ b/crates/auv-driver-macos/src/native/clipboard.rs
@@ -51,7 +51,7 @@ mod tests {
   #[cfg(target_os = "macos")]
   use super::decode_clipboard_snapshot;
   #[cfg(target_os = "macos")]
-  use crate::native::types::NativeClipboardSnapshotResponse;
+  use crate::native::binding::ffi::NativeClipboardSnapshotResponse;
 
   #[cfg(target_os = "macos")]
   #[test]

--- a/crates/auv-driver-macos/src/native/input.rs
+++ b/crates/auv-driver-macos/src/native/input.rs
@@ -139,7 +139,7 @@ mod tests {
   #[cfg(target_os = "macos")]
   use super::action_result;
   #[cfg(target_os = "macos")]
-  use crate::native::types::NativeActionResponse;
+  use crate::native::binding::ffi::NativeActionResponse;
 
   #[cfg(target_os = "macos")]
   #[test]

--- a/crates/auv-driver-macos/src/native/pointer.rs
+++ b/crates/auv-driver-macos/src/native/pointer.rs
@@ -100,7 +100,7 @@ mod tests {
   #[cfg(target_os = "macos")]
   use super::action_result;
   #[cfg(target_os = "macos")]
-  use crate::native::types::NativeActionResponse;
+  use crate::native::binding::ffi::NativeActionResponse;
 
   #[cfg(target_os = "macos")]
   #[test]


### PR DESCRIPTION
## Summary

- Add typed macOS `ApplicationControl::activate_bundle_id` support for application-scoped foreground activation.
- Use that capability in `MacosTextEditDriver::activate_app` instead of resolving and preparing a concrete window first.
- Keep capture, coordinates, mutation, and window-targeted input on the existing `WindowApi` + `CGWindowID` boundary.

## Why

The TextEdit live closure reached this native state:

```text
TextEdit process exists
AX application/tree exists
WindowServer .optionOnScreenOnly snapshot omits the TextEdit window
WindowApi::resolve(main_visible) fails before AX focus
```

`app.textedit.document.write` only needs to activate TextEdit, focus its AX text target, paste through the clipboard, and observe the resulting AX text. Requiring a WindowServer capture target before those app-scoped control operations made an unrelated window-enumeration limitation fatal.

## Design boundary

This change does not fabricate a `Window` or weaken APIs that genuinely require a native window id:

```text
application activation / AX control
  -> bundle-id scoped ApplicationControl

capture / coordinates / window-targeted input / mutation
  -> concrete WindowApi + CGWindowID
```

The new path therefore removes an unnecessary dependency for TextEdit while preserving fail-closed behavior for window-scoped operations.

## Regression coverage

`auv-driver-macos` now covers:

- exact bundle-id activation scripts;
- blank bundle-id rejection;
- AppleScript string escaping.

The branch also corrects native test imports exposed by the macOS test build in `clipboard`, `input`, and `pointer`.

## Validation

GitHub validation is green on head `6da0e121`:

- `cargo fmt --check` on Ubuntu 24.04 and macOS 14;
- full workspace `cargo check` on both platforms;
- full workspace `cargo test` on both platforms;
- `auv invoke --help` on both platforms;
- public-claims checks on both platforms;
- installed-binary smoke on both platforms;
- `git diff --check` on both platforms;
- Qodana Gate and Qodana for Rust.

## Live evidence boundary

This remains a candidate fix for the blocker recorded in:

```text
docs/ai/references/apps/textedit/2026-07-13-textedit-document-write-live-closure.md
```

The real opt-in TextEdit closure has not yet been recorded as rerun on this PR, so this change does not update `docs/SUPPORT_MATRIX.md` or claim `live-validated` / `supported`.

Run before moving the PR out of Draft and merging:

```sh
AUV_TEXTEDIT_LIVE=1 \
cargo test -p auv-cli \
  --test textedit_document_write_parity \
  textedit_document_write_live_macos_closure \
  -- --ignored --nocapture
```

## Collaboration

Implementation, review, and PR preparation were completed collaboratively with ChatGPT (GPT-5.6 Thinking). The branch commits include explicit co-author attribution.