### PR TITLE
feat(apple-music-macos): add bounded AX search surface probe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,6 +339,7 @@ name = "auv-apple-music"
 version = "0.0.1"
 dependencies = [
  "auv-driver",
+ "auv-driver-macos",
  "auv-driver-windows",
  "clap",
  "serde",

--- a/crates/auv-apple-music/Cargo.toml
+++ b/crates/auv-apple-music/Cargo.toml
@@ -23,3 +23,6 @@ serde_json.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]
 auv-driver-windows = { path = "../auv-driver-windows" }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+auv-driver-macos = { path = "../auv-driver-macos" }

--- a/crates/auv-apple-music/src/cli.rs
+++ b/crates/auv-apple-music/src/cli.rs
@@ -6,12 +6,13 @@ use clap::{Args, Parser, Subcommand};
 
 use crate::commands::launch::OpenWindowInputs;
 use crate::commands::playback::PlaybackStatusInputs;
+use crate::commands::probe_macos::{DEFAULT_ACTIVATE_SETTLE_MS, DEFAULT_MUSIC_APP_BUNDLE_ID, ProbeInputs};
 use crate::commands::search::{
   DEFAULT_RESULT_SELECTION_TIMEOUT_MS, DEFAULT_SEARCH_SETTLE_MS, DEFAULT_SEARCH_VERIFICATION_TIMEOUT_MS, SearchInputs,
   SearchResultSelectInputs,
 };
 use crate::commands::transport::{TransportAction, TransportInputs};
-use crate::{run_open_window, run_playback_status, run_search, run_search_result_select, run_transport_action};
+use crate::{run_open_window, run_playback_status, run_probe, run_search, run_search_result_select, run_transport_action};
 
 #[derive(Clone, Debug, Parser)]
 #[command(
@@ -34,6 +35,8 @@ enum CliCommand {
   Search(SearchArgs),
   /// Send a transport control action (play/pause, next, previous).
   Transport(TransportArgs),
+  /// Probe Music.app's AX surface for search field and result row candidates (macOS).
+  ProbeMacos(ProbeMacosArgs),
 }
 
 #[derive(Clone, Debug, Args)]
@@ -111,6 +114,25 @@ struct TransportArgs {
   json: bool,
 }
 
+#[derive(Clone, Debug, Args)]
+struct ProbeMacosArgs {
+  /// Bundle id to activate and probe.
+  #[arg(long = "bundle-id", default_value = DEFAULT_MUSIC_APP_BUNDLE_ID)]
+  bundle_id: String,
+
+  /// How long to wait after activation before capturing the AX tree (ms).
+  #[arg(long = "activate-settle-ms", default_value_t = DEFAULT_ACTIVATE_SETTLE_MS)]
+  activate_settle_ms: u64,
+
+  /// Persist the captured AX snapshot as JSON to this directory.
+  #[arg(long = "artifact-dir", value_name = "DIR")]
+  artifact_dir: Option<PathBuf>,
+
+  /// Output as JSON instead of human-readable text.
+  #[arg(long)]
+  json: bool,
+}
+
 #[derive(Clone, Debug, Subcommand)]
 enum TransportSubcommand {
   /// Toggle play/pause.
@@ -129,6 +151,7 @@ pub fn run() -> ExitCode {
     CliCommand::Playback(args) => run_playback_cmd(args),
     CliCommand::Search(args) => run_search_cmd(args),
     CliCommand::Transport(args) => run_transport_cmd(args),
+    CliCommand::ProbeMacos(args) => run_probe_macos_cmd(args),
   }
 }
 
@@ -295,6 +318,46 @@ fn run_search_cmd(args: SearchArgs) -> ExitCode {
       } else {
         ExitCode::FAILURE
       }
+    }
+  }
+}
+
+fn run_probe_macos_cmd(args: ProbeMacosArgs) -> ExitCode {
+  let inputs = ProbeInputs {
+    bundle_id: args.bundle_id,
+    activate_settle_ms: args.activate_settle_ms,
+    artifact_dir: args.artifact_dir,
+  };
+
+  match run_probe(&inputs) {
+    Err(error) => {
+      eprintln!("error: {error}");
+      ExitCode::FAILURE
+    }
+    Ok(result) => {
+      if args.json {
+        println!("{}", serde_json::to_string_pretty(&result).unwrap());
+      } else {
+        println!("bundle_id:        {}", result.bundle_id);
+        println!("activated:        {}", result.activated);
+        println!("ax_captured:      {}", result.ax_snapshot_captured);
+        println!("node_count:       {}", result.node_count);
+        println!("search_fields:    {}", result.search_field_candidates.len());
+        for node in &result.search_field_candidates {
+          println!("  path={} role={} subrole={} title={:?}", node.path, node.role, node.subrole, node.title);
+        }
+        println!("result_rows:      {}", result.result_row_candidates.len());
+        for node in &result.result_row_candidates {
+          println!("  path={} role={} title={:?} value={:?}", node.path, node.role, node.title, node.value);
+        }
+        if let Some(artifact) = &result.artifact {
+          println!("artifact:         {artifact}");
+        }
+        for note in &result.diagnostics {
+          println!("note:             {note}");
+        }
+      }
+      ExitCode::SUCCESS
     }
   }
 }

--- a/crates/auv-apple-music/src/cli.rs
+++ b/crates/auv-apple-music/src/cli.rs
@@ -35,7 +35,7 @@ enum CliCommand {
   Search(SearchArgs),
   /// Send a transport control action (play/pause, next, previous).
   Transport(TransportArgs),
-  /// Probe Music.app's AX surface for search field and result row candidates (macOS).
+  /// Probe Music.app's AX surface for search field candidates (macOS).
   ProbeMacos(ProbeMacosArgs),
 }
 
@@ -345,10 +345,6 @@ fn run_probe_macos_cmd(args: ProbeMacosArgs) -> ExitCode {
         println!("search_fields:    {}", result.search_field_candidates.len());
         for node in &result.search_field_candidates {
           println!("  path={} role={} subrole={} title={:?}", node.path, node.role, node.subrole, node.title);
-        }
-        println!("result_rows:      {}", result.result_row_candidates.len());
-        for node in &result.result_row_candidates {
-          println!("  path={} role={} title={:?} value={:?}", node.path, node.role, node.title, node.value);
         }
         if let Some(artifact) = &result.artifact {
           println!("artifact:         {artifact}");

--- a/crates/auv-apple-music/src/commands/mod.rs
+++ b/crates/auv-apple-music/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod launch;
 pub mod playback;
+pub mod probe_macos;
 pub mod search;
 pub mod transport;

--- a/crates/auv-apple-music/src/commands/probe_macos.rs
+++ b/crates/auv-apple-music/src/commands/probe_macos.rs
@@ -1,8 +1,9 @@
 //! macOS Music.app AX surface probe.
 //!
-//! Bounded discovery for search field and result list nodes — activation,
-//! capture, locate, persist. Does not click results, play tracks, or implement
-//! candidate selection algorithms.
+//! Bounded discovery for the search field only — activate, capture, locate,
+//! persist. Does not submit a search query, click results, play tracks, or
+//! implement candidate selection algorithms. Result-row classification is
+//! deferred; see [`ProbeResult`] doc for why.
 
 use std::path::PathBuf;
 use std::time::Duration;
@@ -50,6 +51,15 @@ pub struct DiscoveredNode {
 }
 
 /// Output produced by the probe.
+///
+/// NOTICE(apple-music-result-row-deferred): a `result_row_candidates` field
+/// was deliberately removed here. This probe never submits a search query, so
+/// it only ever observes Music.app's default/landing surface. Any static-text
+/// heuristic run against that surface would misclassify sidebar labels,
+/// buttons, and recommendation copy as "search results" — a taxonomy that
+/// cannot be validated without first observing a real post-search AX tree.
+/// Unlock once a query-submission slice captures a live post-search snapshot
+/// an owner can review.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ProbeResult {
   pub command: String,
@@ -58,7 +68,6 @@ pub struct ProbeResult {
   pub ax_snapshot_captured: bool,
   pub node_count: usize,
   pub search_field_candidates: Vec<DiscoveredNode>,
-  pub result_row_candidates: Vec<DiscoveredNode>,
   pub artifact: Option<String>,
   pub diagnostics: Vec<String>,
 }
@@ -81,13 +90,12 @@ fn run_probe_macos(inputs: &ProbeInputs) -> Result<ProbeResult, String> {
   let LocalDriverSession::Macos(session) = session;
 
   let mut result = ProbeResult {
-    command: "probe".to_string(),
+    command: "probe-macos".to_string(),
     bundle_id: inputs.bundle_id.clone(),
     activated: false,
     ax_snapshot_captured: false,
     node_count: 0,
     search_field_candidates: Vec::new(),
-    result_row_candidates: Vec::new(),
     artifact: None,
     diagnostics: Vec::new(),
   };
@@ -112,13 +120,7 @@ fn run_probe_macos(inputs: &ProbeInputs) -> Result<ProbeResult, String> {
     result.diagnostics.push("no search field candidates found".to_string());
   }
 
-  // Step 4: locate result row candidates
-  result.result_row_candidates = find_result_row_candidates(&snapshot);
-  if result.result_row_candidates.is_empty() {
-    result.diagnostics.push("no result row candidates found (search may need to be submitted first)".to_string());
-  }
-
-  // Step 5: persist artifact if requested
+  // Step 4: persist artifact if requested
   if let Some(dir) = &inputs.artifact_dir {
     result.artifact = Some(save_probe_artifact(dir, &snapshot)?);
   }
@@ -138,17 +140,6 @@ fn find_search_field_candidates(snapshot: &ObservedAxTreeSnapshot) -> Vec<Discov
 }
 
 #[cfg(target_os = "macos")]
-fn find_result_row_candidates(snapshot: &ObservedAxTreeSnapshot) -> Vec<DiscoveredNode> {
-  snapshot
-    .nodes
-    .iter()
-    .filter(|node| node.bounds.width > 0 && node.bounds.height > 0)
-    .filter(|node| is_result_row_candidate(node))
-    .map(node_to_discovered)
-    .collect()
-}
-
-#[cfg(target_os = "macos")]
 fn is_search_field_candidate(node: &ObservedAxNode) -> bool {
   let role_match = node.role.eq_ignore_ascii_case("AXTextField") || node.role.eq_ignore_ascii_case("AXSearchField");
   let subrole_match = node.subrole.eq_ignore_ascii_case("AXSearchField");
@@ -156,15 +147,6 @@ fn is_search_field_candidate(node: &ObservedAxNode) -> bool {
   let title_match = node.title.to_lowercase().contains("search");
 
   role_match || subrole_match || placeholder_match || title_match
-}
-
-#[cfg(target_os = "macos")]
-fn is_result_row_candidate(node: &ObservedAxNode) -> bool {
-  // Result rows in Music.app are typically AXRow or similar list items
-  let role_match = node.role.eq_ignore_ascii_case("AXRow") || node.role.eq_ignore_ascii_case("AXStaticText");
-  let has_content = !node.title.trim().is_empty() || !node.value.trim().is_empty();
-
-  role_match && has_content
 }
 
 #[cfg(target_os = "macos")]
@@ -248,32 +230,5 @@ mod tests {
     };
 
     assert!(is_search_field_candidate(&node));
-  }
-
-  #[cfg(target_os = "macos")]
-  #[test]
-  fn is_result_row_candidate_matches_row_with_content() {
-    use auv_driver_macos::ObservedAxNode;
-    let node = ObservedAxNode {
-      depth: 3,
-      path: "0.1.2.3".to_string(),
-      role: "AXRow".to_string(),
-      subrole: String::new(),
-      title: "Track Title - Artist Name".to_string(),
-      description: String::new(),
-      help: String::new(),
-      identifier: String::new(),
-      placeholder: String::new(),
-      value: String::new(),
-      focused: false,
-      bounds: auv_driver_macos::types::ObservedRect {
-        x: 10,
-        y: 100,
-        width: 400,
-        height: 40,
-      },
-    };
-
-    assert!(is_result_row_candidate(&node));
   }
 }

--- a/crates/auv-apple-music/src/commands/probe_macos.rs
+++ b/crates/auv-apple-music/src/commands/probe_macos.rs
@@ -36,7 +36,7 @@ impl Default for ProbeInputs {
   }
 }
 
-/// A discovered AX node candidate (search field or result row).
+/// A discovered search-field AX node candidate.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DiscoveredNode {
   pub path: String,

--- a/crates/auv-apple-music/src/commands/probe_macos.rs
+++ b/crates/auv-apple-music/src/commands/probe_macos.rs
@@ -181,7 +181,6 @@ mod tests {
   #[cfg(target_os = "macos")]
   #[test]
   fn is_search_field_candidate_matches_role() {
-    use auv_driver_macos::ObservedAxNode;
     let node = ObservedAxNode {
       depth: 2,
       path: "0.1.2".to_string(),
@@ -208,7 +207,6 @@ mod tests {
   #[cfg(target_os = "macos")]
   #[test]
   fn is_search_field_candidate_matches_placeholder() {
-    use auv_driver_macos::ObservedAxNode;
     let node = ObservedAxNode {
       depth: 2,
       path: "0.1.2".to_string(),

--- a/crates/auv-apple-music/src/commands/probe_macos.rs
+++ b/crates/auv-apple-music/src/commands/probe_macos.rs
@@ -1,0 +1,279 @@
+//! macOS Music.app AX surface probe.
+//!
+//! Bounded discovery for search field and result list nodes — activation,
+//! capture, locate, persist. Does not click results, play tracks, or implement
+//! candidate selection algorithms.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+#[cfg(target_os = "macos")]
+use auv_driver::LocalDriverSession;
+#[cfg(target_os = "macos")]
+use auv_driver_macos::{ApplicationControl, DEFAULT_AX_MAX_CHILDREN, DEFAULT_AX_MAX_DEPTH, ObservedAxNode, ObservedAxTreeSnapshot};
+
+pub const DEFAULT_MUSIC_APP_BUNDLE_ID: &str = "com.apple.Music";
+pub const DEFAULT_ACTIVATE_SETTLE_MS: u64 = 800;
+
+/// Inputs for the probe command.
+#[derive(Clone, Debug)]
+pub struct ProbeInputs {
+  pub bundle_id: String,
+  pub activate_settle_ms: u64,
+  pub artifact_dir: Option<PathBuf>,
+}
+
+impl Default for ProbeInputs {
+  fn default() -> Self {
+    Self {
+      bundle_id: DEFAULT_MUSIC_APP_BUNDLE_ID.to_string(),
+      activate_settle_ms: DEFAULT_ACTIVATE_SETTLE_MS,
+      artifact_dir: None,
+    }
+  }
+}
+
+/// A discovered AX node candidate (search field or result row).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DiscoveredNode {
+  pub path: String,
+  pub role: String,
+  pub subrole: String,
+  pub title: String,
+  pub value: String,
+  pub bounds_x: i64,
+  pub bounds_y: i64,
+  pub bounds_width: i64,
+  pub bounds_height: i64,
+}
+
+/// Output produced by the probe.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ProbeResult {
+  pub command: String,
+  pub bundle_id: String,
+  pub activated: bool,
+  pub ax_snapshot_captured: bool,
+  pub node_count: usize,
+  pub search_field_candidates: Vec<DiscoveredNode>,
+  pub result_row_candidates: Vec<DiscoveredNode>,
+  pub artifact: Option<String>,
+  pub diagnostics: Vec<String>,
+}
+
+pub fn run_probe(inputs: &ProbeInputs) -> Result<ProbeResult, String> {
+  #[cfg(target_os = "macos")]
+  {
+    run_probe_macos(inputs)
+  }
+  #[cfg(not(target_os = "macos"))]
+  {
+    let _ = inputs;
+    Err("Music.app AX probe is only supported on macOS".to_string())
+  }
+}
+
+#[cfg(target_os = "macos")]
+fn run_probe_macos(inputs: &ProbeInputs) -> Result<ProbeResult, String> {
+  let session = auv_driver::open_local().map_err(|error| error.to_string())?;
+  let LocalDriverSession::Macos(session) = session;
+
+  let mut result = ProbeResult {
+    command: "probe".to_string(),
+    bundle_id: inputs.bundle_id.clone(),
+    activated: false,
+    ax_snapshot_captured: false,
+    node_count: 0,
+    search_field_candidates: Vec::new(),
+    result_row_candidates: Vec::new(),
+    artifact: None,
+    diagnostics: Vec::new(),
+  };
+
+  // Step 1: activate Music.app
+  session
+    .activate_bundle_id(&inputs.bundle_id, Duration::from_millis(inputs.activate_settle_ms))
+    .map_err(|error| format!("Music.app activation failed: {error}"))?;
+  result.activated = true;
+
+  // Step 2: capture AX tree
+  let snapshot = session
+    .accessibility()
+    .capture_app_tree(&inputs.bundle_id, DEFAULT_AX_MAX_DEPTH, DEFAULT_AX_MAX_CHILDREN)
+    .map_err(|error| format!("AX tree capture failed: {error}"))?;
+  result.ax_snapshot_captured = true;
+  result.node_count = snapshot.nodes.len();
+
+  // Step 3: locate search field candidates
+  result.search_field_candidates = find_search_field_candidates(&snapshot);
+  if result.search_field_candidates.is_empty() {
+    result.diagnostics.push("no search field candidates found".to_string());
+  }
+
+  // Step 4: locate result row candidates
+  result.result_row_candidates = find_result_row_candidates(&snapshot);
+  if result.result_row_candidates.is_empty() {
+    result.diagnostics.push("no result row candidates found (search may need to be submitted first)".to_string());
+  }
+
+  // Step 5: persist artifact if requested
+  if let Some(dir) = &inputs.artifact_dir {
+    result.artifact = Some(save_probe_artifact(dir, &snapshot)?);
+  }
+
+  Ok(result)
+}
+
+#[cfg(target_os = "macos")]
+fn find_search_field_candidates(snapshot: &ObservedAxTreeSnapshot) -> Vec<DiscoveredNode> {
+  snapshot
+    .nodes
+    .iter()
+    .filter(|node| node.bounds.width > 0 && node.bounds.height > 0)
+    .filter(|node| is_search_field_candidate(node))
+    .map(node_to_discovered)
+    .collect()
+}
+
+#[cfg(target_os = "macos")]
+fn find_result_row_candidates(snapshot: &ObservedAxTreeSnapshot) -> Vec<DiscoveredNode> {
+  snapshot
+    .nodes
+    .iter()
+    .filter(|node| node.bounds.width > 0 && node.bounds.height > 0)
+    .filter(|node| is_result_row_candidate(node))
+    .map(node_to_discovered)
+    .collect()
+}
+
+#[cfg(target_os = "macos")]
+fn is_search_field_candidate(node: &ObservedAxNode) -> bool {
+  let role_match = node.role.eq_ignore_ascii_case("AXTextField") || node.role.eq_ignore_ascii_case("AXSearchField");
+  let subrole_match = node.subrole.eq_ignore_ascii_case("AXSearchField");
+  let placeholder_match = node.placeholder.to_lowercase().contains("search");
+  let title_match = node.title.to_lowercase().contains("search");
+
+  role_match || subrole_match || placeholder_match || title_match
+}
+
+#[cfg(target_os = "macos")]
+fn is_result_row_candidate(node: &ObservedAxNode) -> bool {
+  // Result rows in Music.app are typically AXRow or similar list items
+  let role_match = node.role.eq_ignore_ascii_case("AXRow") || node.role.eq_ignore_ascii_case("AXStaticText");
+  let has_content = !node.title.trim().is_empty() || !node.value.trim().is_empty();
+
+  role_match && has_content
+}
+
+#[cfg(target_os = "macos")]
+fn node_to_discovered(node: &ObservedAxNode) -> DiscoveredNode {
+  DiscoveredNode {
+    path: node.path.clone(),
+    role: node.role.clone(),
+    subrole: node.subrole.clone(),
+    title: node.title.clone(),
+    value: node.value.clone(),
+    bounds_x: node.bounds.x,
+    bounds_y: node.bounds.y,
+    bounds_width: node.bounds.width,
+    bounds_height: node.bounds.height,
+  }
+}
+
+#[cfg(target_os = "macos")]
+fn save_probe_artifact(dir: &std::path::Path, snapshot: &ObservedAxTreeSnapshot) -> Result<String, String> {
+  std::fs::create_dir_all(dir).map_err(|error| format!("create probe artifact directory failed: {error}"))?;
+  let timestamp = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).map(|duration| duration.as_millis()).unwrap_or(0);
+  let path = dir.join(format!("music-ax-probe-{timestamp}.json"));
+  let json = serde_json::to_string_pretty(snapshot).map_err(|error| format!("serialize AX snapshot failed: {error}"))?;
+  std::fs::write(&path, json).map_err(|error| format!("write probe artifact failed: {error}"))?;
+  Ok(path.to_string_lossy().into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[cfg(target_os = "macos")]
+  #[test]
+  fn is_search_field_candidate_matches_role() {
+    use auv_driver_macos::ObservedAxNode;
+    let node = ObservedAxNode {
+      depth: 2,
+      path: "0.1.2".to_string(),
+      role: "AXTextField".to_string(),
+      subrole: "AXSearchField".to_string(),
+      title: String::new(),
+      description: String::new(),
+      help: String::new(),
+      identifier: String::new(),
+      placeholder: String::new(),
+      value: String::new(),
+      focused: false,
+      bounds: auv_driver_macos::types::ObservedRect {
+        x: 10,
+        y: 20,
+        width: 200,
+        height: 30,
+      },
+    };
+
+    assert!(is_search_field_candidate(&node));
+  }
+
+  #[cfg(target_os = "macos")]
+  #[test]
+  fn is_search_field_candidate_matches_placeholder() {
+    use auv_driver_macos::ObservedAxNode;
+    let node = ObservedAxNode {
+      depth: 2,
+      path: "0.1.2".to_string(),
+      role: "AXTextField".to_string(),
+      subrole: String::new(),
+      title: String::new(),
+      description: String::new(),
+      help: String::new(),
+      identifier: String::new(),
+      placeholder: "Search Music".to_string(),
+      value: String::new(),
+      focused: false,
+      bounds: auv_driver_macos::types::ObservedRect {
+        x: 10,
+        y: 20,
+        width: 200,
+        height: 30,
+      },
+    };
+
+    assert!(is_search_field_candidate(&node));
+  }
+
+  #[cfg(target_os = "macos")]
+  #[test]
+  fn is_result_row_candidate_matches_row_with_content() {
+    use auv_driver_macos::ObservedAxNode;
+    let node = ObservedAxNode {
+      depth: 3,
+      path: "0.1.2.3".to_string(),
+      role: "AXRow".to_string(),
+      subrole: String::new(),
+      title: "Track Title - Artist Name".to_string(),
+      description: String::new(),
+      help: String::new(),
+      identifier: String::new(),
+      placeholder: String::new(),
+      value: String::new(),
+      focused: false,
+      bounds: auv_driver_macos::types::ObservedRect {
+        x: 10,
+        y: 100,
+        width: 400,
+        height: 40,
+      },
+    };
+
+    assert!(is_result_row_candidate(&node));
+  }
+}

--- a/crates/auv-apple-music/src/lib.rs
+++ b/crates/auv-apple-music/src/lib.rs
@@ -7,6 +7,9 @@ pub mod commands;
 pub use app::{AppleMusicWindow, resolve_window};
 pub use commands::launch::{LaunchResult, LaunchStep, run_open_window};
 pub use commands::playback::{MetadataSource, PlaybackState, PlaybackStatus, PlaybackStatusInputs, run_playback_status};
+pub use commands::probe_macos::{
+  DEFAULT_ACTIVATE_SETTLE_MS, DEFAULT_MUSIC_APP_BUNDLE_ID, DiscoveredNode, ProbeInputs, ProbeResult, run_probe,
+};
 pub use commands::search::{
   DEFAULT_RESULT_SELECTION_TIMEOUT_MS, DEFAULT_SEARCH_SETTLE_MS, DEFAULT_SEARCH_VERIFICATION_TIMEOUT_MS, SearchInputs, SearchResult,
   SearchResultMatch, SearchResultSelectInputs, SearchResultSelection, SearchVerification, SearchVerificationStatus, run_search,

--- a/docs/ai/references/INDEX.md
+++ b/docs/ai/references/INDEX.md
@@ -44,6 +44,7 @@ Do not put engineering slice codes (`a2`, `p14`, scan-step codes, etc.) in navig
 | [`scenebridge/`](scenebridge/INDEX.md) | Active | Cross-app scene identity / grounding | |
 | [`recognition/`](recognition/INDEX.md) | Active | RecognitionResult, detectors | |
 | [`apps/textedit/`](apps/textedit/INDEX.md) | Product | TextEdit document.write golden path | |
+| [`apps/apple-music/`](apps/apple-music/INDEX.md) | Probe | Apple Music macOS AX surface discovery | Bounded probe only, no product operation yet |
 | [`apps/netease-music/`](apps/netease-music/INDEX.md) | Product | Netease Cloud Music app-local commands | |
 | [`apps/qqmusic/`](apps/qqmusic/INDEX.md) | Historical | QQ Music probes | |
 | [`apps/minecraft/`](apps/minecraft/INDEX.md) | Paused | Minecraft spatial probe | |

--- a/docs/ai/references/apps/apple-music/2026-07-15-apple-music-macos-ax-probe.md
+++ b/docs/ai/references/apps/apple-music/2026-07-15-apple-music-macos-ax-probe.md
@@ -1,0 +1,51 @@
+# Apple Music macOS AX surface probe
+
+**Status:** bounded discovery only (no click, no play, no candidate algorithm)
+
+## Scope
+
+This slice adds `auv-apple-music probe-macos`, a bounded AX discovery probe for
+Music.app on macOS:
+
+1. Activate `com.apple.Music` via `ApplicationControl::activate_bundle_id`
+   (no `CGWindowID` / WindowServer discovery required, same seam as PR #106).
+2. Capture the AX tree via `AccessibilityApi::capture_app_tree`.
+3. Filter observed nodes into two candidate lists:
+   - `search_field_candidates`: nodes matching `AXTextField`/`AXSearchField`
+     role/subrole, or a search-related placeholder/title.
+   - `result_row_candidates`: `AXRow`/`AXStaticText` nodes with non-empty
+     title or value.
+4. Optionally persist the raw AX snapshot as JSON to `--artifact-dir`.
+
+## Explicitly not done in this slice
+
+- No click/press on any discovered node.
+- No playback action (play, pause, transport).
+- No `OperationResult` / `StepOutcome` contract (this is a probe command, not
+  a product operation).
+- No support-matrix row or evidence-level claim.
+- No general candidate-selection algorithm. The `is_search_field_candidate`
+  and `is_result_row_candidate` filters are heuristic role/text matchers for
+  probe output only; they are not the deterministic candidate contract that
+  `app.apple_music.search_and_play` will need.
+
+TODO(apple-music-search-and-play): candidate selection, action delivery, and
+now-playing verification are deferred until this probe's real AX shape from
+Music.app is captured on real macOS hardware. Do not implement
+`search_and_play` from this doc alone — it describes the shape AUV has not
+yet observed. Unlocked once an owner reviews a live-captured `--artifact-dir`
+snapshot and approves the next slice (search query submission, deterministic
+result selection, or now-playing verification) as a narrow follow-up.
+
+## Manual command
+
+```sh
+cargo run -p auv-apple-music --bin auv-apple-music -- \
+  probe-macos --artifact-dir /tmp/auv-music-probe --json
+```
+
+## Live result
+
+Not yet run on real macOS hardware. This doc records the bounded scope of the
+probe; a follow-up evidence note should record actual `search_field_candidates`
+and `result_row_candidates` output once run live.

--- a/docs/ai/references/apps/apple-music/2026-07-15-apple-music-macos-ax-probe.md
+++ b/docs/ai/references/apps/apple-music/2026-07-15-apple-music-macos-ax-probe.md
@@ -10,24 +10,30 @@ Music.app on macOS:
 1. Activate `com.apple.Music` via `ApplicationControl::activate_bundle_id`
    (no `CGWindowID` / WindowServer discovery required, same seam as PR #106).
 2. Capture the AX tree via `AccessibilityApi::capture_app_tree`.
-3. Filter observed nodes into two candidate lists:
-   - `search_field_candidates`: nodes matching `AXTextField`/`AXSearchField`
-     role/subrole, or a search-related placeholder/title.
-   - `result_row_candidates`: `AXRow`/`AXStaticText` nodes with non-empty
-     title or value.
+3. Filter observed nodes into `search_field_candidates`: nodes matching
+   `AXTextField`/`AXSearchField` role/subrole, or a search-related
+   placeholder/title.
 4. Optionally persist the raw AX snapshot as JSON to `--artifact-dir`.
 
 ## Explicitly not done in this slice
 
+- No search query is submitted. The probe only observes Music.app's
+  default/landing surface.
+- No result-row candidate list. An earlier draft of this probe classified
+  `AXRow`/`AXStaticText` nodes with non-empty text as "result rows" without
+  ever submitting a search — on the landing surface that heuristic would
+  misclassify sidebar labels, buttons, and recommendation copy as search
+  results. Removed until a query-submission slice can capture a real
+  post-search AX tree to validate against.
 - No click/press on any discovered node.
 - No playback action (play, pause, transport).
 - No `OperationResult` / `StepOutcome` contract (this is a probe command, not
   a product operation).
 - No support-matrix row or evidence-level claim.
-- No general candidate-selection algorithm. The `is_search_field_candidate`
-  and `is_result_row_candidate` filters are heuristic role/text matchers for
-  probe output only; they are not the deterministic candidate contract that
-  `app.apple_music.search_and_play` will need.
+- No general candidate-selection algorithm. `is_search_field_candidate` is a
+  heuristic role/text matcher for probe output only; it is not the
+  deterministic candidate contract that `app.apple_music.search_and_play`
+  will need.
 
 TODO(apple-music-search-and-play): candidate selection, action delivery, and
 now-playing verification are deferred until this probe's real AX shape from
@@ -44,8 +50,52 @@ cargo run -p auv-apple-music --bin auv-apple-music -- \
   probe-macos --artifact-dir /tmp/auv-music-probe --json
 ```
 
-## Live result
+## Live result (2026-07-15)
 
-Not yet run on real macOS hardware. This doc records the bounded scope of the
-probe; a follow-up evidence note should record actual `search_field_candidates`
-and `result_row_candidates` output once run live.
+Run on real macOS hardware (Darwin 27.0, macOS 27.0 build 26A5368g, arm64):
+
+```json
+{
+  "command": "probe-macos",
+  "bundle_id": "com.apple.Music",
+  "activated": true,
+  "ax_snapshot_captured": true,
+  "node_count": 77,
+  "search_field_candidates": [],
+  "artifact": "/tmp/auv-music-probe/music-ax-probe-1784176575772.json",
+  "diagnostics": ["no search field candidates found"]
+}
+```
+
+`search_field_candidates` is empty. The probe correctly reported failure
+rather than fabricating a match — the diagnostics path worked as designed.
+
+### Why the search field was not found
+
+Inspecting the full 77-node snapshot:
+
+- The left sidebar (`0.0.0.0.*`) contains navigation rows Search / Home /
+  Radio / Library / Artists / Albums / Songs / Store / Playlists etc. Node
+  `0.0.0.0.0.0.1` has `value="Search"`, but this is the sidebar's **"Search"
+  navigation item** (an `AXStaticText`), not a text input.
+- `0.1` is an `AXToolbar` at the window top (`980x52`, the plausible location
+  for a search field) — but it was captured with **zero children**.
+
+No node in the tree is `AXTextField`/`AXSearchField`, and the toolbar subtree
+where a search input would likely live was not expanded by the capture.
+Possible causes (unverified, listed as hypotheses only):
+
+1. The toolbar's search affordance is a collapsed magnifying-glass button
+   that only materializes an `AXTextField` after being clicked/expanded —
+   common in recent macOS toolbar search UIs.
+2. The AX tree capture's traversal (depth/children limits, or how it walks
+   `AXToolbar` specifically) did not descend into the toolbar subtree for
+   another reason.
+
+This is a **more upstream blocker than result-row classification** — before
+result rows can even be evaluated, the search field itself is not reachable
+in the tree this probe captures on the landing surface. No fix was attempted
+in this slice; this finding is recorded for the next slice to investigate
+(e.g., a probe that first activates/expands the toolbar search affordance,
+or one that captures with different traversal parameters, before re-checking
+for `AXTextField` nodes).

--- a/docs/ai/references/apps/apple-music/INDEX.md
+++ b/docs/ai/references/apps/apple-music/INDEX.md
@@ -1,0 +1,12 @@
+# apps/apple-music
+
+Apple Music macOS AX surface discovery (bounded probes only, no product operation yet)
+
+Count: **1**
+
+- [`2026-07-15-apple-music-macos-ax-probe.md`](2026-07-15-apple-music-macos-ax-probe.md)
+
+## Related
+
+- Parent index: [`../../INDEX.md`](../../INDEX.md)
+- Sibling core canary: [`../textedit/INDEX.md`](../textedit/INDEX.md)


### PR DESCRIPTION
## Summary

- Adds `auv-apple-music probe-macos`: activate Music.app through `ApplicationControl::activate_bundle_id`, capture the app AX tree through `AccessibilityApi::capture_app_tree`, locate search-field candidates, and optionally persist the raw AX snapshot as JSON.
- Keeps the probe bounded to Music.app's default/landing surface. It does not submit a search query and therefore does not classify or expose result-row candidates.
- Records the first real macOS run in `docs/ai/references/apps/apple-music/2026-07-15-apple-music-macos-ax-probe.md`.

## Live finding

A real macOS run completed activation and AX capture successfully:

```text
node_count = 77
search_field_candidates = []
AXToolbar path 0.1 = visible bounds, zero captured children
```

The probe reported the empty candidate set honestly. The current evidence shows that the search input is not present in the captured landing-surface AX tree. The document records two hypotheses, without claiming either as established: the toolbar search affordance may need expansion first, or the AX traversal may not be entering the toolbar subtree.

## Explicitly out of scope

- No search query submission.
- No result-row classification or candidate-selection algorithm.
- No click/press on discovered nodes.
- No playback action.
- No `OperationResult` / `StepOutcome` product contract.
- No support-matrix or evidence-level claim.
- No toolbar-expansion or AX-traversal fix in this slice.

## Validation

- `cargo check -p auv-apple-music`
- `cargo test -p auv-apple-music` → 21 passed
- `cargo fmt --check -p auv-apple-music`
- `cargo clippy -p auv-apple-music --all-targets --all-features` → no new warnings in the probe
- `cargo check --workspace`
- `cargo run -p auv-apple-music --bin auv-apple-music -- probe-macos --help`
- Real macOS probe: activation and 77-node AX snapshot capture succeeded; no search-field candidate was observed

## Next boundary

Do not implement `app.apple_music.search_and_play` from this evidence. The next narrow slice should investigate search-affordance reachability only: either expose/activate the toolbar search control or falsify the current AX traversal boundary, then recapture and look for a real `AXTextField` / `AXSearchField`.