### PR TITLE
refactor(auv-driver-macos): return DriverResult from inspect_ax_node_path

### DIFF
--- a/crates/auv-driver-macos/src/native/ax_tree.rs
+++ b/crates/auv-driver-macos/src/native/ax_tree.rs
@@ -5,6 +5,8 @@ use super::binding::ffi::{
   NativeAxNodeInspectionResponse, NativeAxTreeRequest, NativeAxTreeResponse, capture_ax_tree, inspect_ax_node, perform_ax_action,
   set_ax_focused,
 };
+use auv_driver_common::error::{DriverError, DriverResult};
+
 use super::types::{AuvResult, ObservedAxNode, ObservedAxTreeSnapshot, ObservedRect};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -89,8 +91,14 @@ pub fn set_ax_focused_path(_pid: i32, _path: &str, _expected_role: &str) -> AuvR
   Err("macOS native AX focus dispatch is unsupported on this target".to_string())
 }
 
+// NOTICE: unlike the sibling `native` AX helpers (which return `AuvResult` and
+// are wrapped into `DriverError` by `accessibility.rs` before leaving the
+// crate), this one is consumed directly by the Apple Music probe. It converts
+// the native String failure to `DriverError` here so no `Result<_, String>`
+// crosses the crate boundary. AGENTS.md: "Internal FFI decode may use strings;
+// convert to DriverError ... before leaving the crate."
 #[cfg(target_os = "macos")]
-pub fn inspect_ax_node_path(pid: i32, path: &str, expected_role: &str) -> AuvResult<AxNodeInspection> {
+pub fn inspect_ax_node_path(pid: i32, path: &str, expected_role: &str) -> DriverResult<AxNodeInspection> {
   decode_ax_node_inspection_response(
     path.to_string(),
     DecodedAxNodeInspectionResponse::from(inspect_ax_node(NativeAxNodeInspectionRequest {
@@ -99,11 +107,12 @@ pub fn inspect_ax_node_path(pid: i32, path: &str, expected_role: &str) -> AuvRes
       expected_role: expected_role.to_string(),
     })),
   )
+  .map_err(|message| DriverError::Backend { message })
 }
 
 #[cfg(not(target_os = "macos"))]
-pub fn inspect_ax_node_path(_pid: i32, _path: &str, _expected_role: &str) -> AuvResult<AxNodeInspection> {
-  Err("macOS native AX node inspection is unsupported on this target".to_string())
+pub fn inspect_ax_node_path(_pid: i32, _path: &str, _expected_role: &str) -> DriverResult<AxNodeInspection> {
+  Err(DriverError::unsupported("macos.ax.inspect_node_path"))
 }
 
 pub fn decode_ax_tree_response(response: DecodedAxTreeResponse) -> AuvResult<NativeAxTreeCapture> {


### PR DESCRIPTION
## Summary

Follow-up hardening on the AX inspection surface landed in #111.

`native::ax_tree::inspect_ax_node_path` is the **only** native AX helper consumed
directly by an app crate — the Apple Music `probe-macos` command calls it as
`auv_driver_macos::native::ax_tree::inspect_ax_node_path(...)`. Its siblings
(`capture_ax_tree_snapshot`, `set_ax_focused_path`, …) return
`AuvResult<_> = Result<_, String>` but are wrapped into `DriverError` by
`accessibility.rs` **before leaving the crate**, so their String errors never
cross a crate boundary. `inspect_ax_node_path` had no such wrapper, so a
`Result<_, String>` crossed the public (doc-hidden) crate boundary into
`auv-apple-music` — the exact shape `AGENTS.md` forbids:

> Do not expose `Result<T, String>` across public crate boundaries. Internal
> FFI decode may use strings; convert to `DriverError` … before leaving the crate.

## Change

- `inspect_ax_node_path` now returns `DriverResult<AxNodeInspection>`, converting
  the native String failure to `DriverError::Backend` at the seam (and
  `DriverError::unsupported(...)` on the non-macOS stub).
- The `AxNodeInspection` diagnostic type **stays** on the doc-hidden
  `native::ax_tree` compatibility surface — deliberately *not* promoted to
  `AccessibilityApi`/`types`/crate root. Routing it through a stable session API
  would re-introduce the one-probe-diagnostic-in-public-API anti-pattern that
  #111 was careful to avoid, so this is the resolution that satisfies both
  constraints at once.

## Scope / non-goals

- No behavior change: error text is preserved via `DriverError::Backend`'s
  `Display`; the app's `.map_err(|e| e.to_string())` is unchanged.
- The app still reaches into `native::ax_tree` directly. That layering is the
  intended cost of keeping the diagnostic off the stable API (documented in the
  Apple Music AX reference note); this PR only removes the `Result<_, String>`
  boundary crossing, which is the part `AGENTS.md` actually forbids.
- Does **not** touch `ProbeResult.activated` / `ax_snapshot_captured` (a separate,
  owner-decided schema question) or capture traversal.

## Verification

- `cargo fmt --check` — clean.
- `cargo test -p auv-driver-macos -p auv-apple-music` — 22 + 84 passed, 0 failed.
- `cargo clippy -p auv-driver-macos -p auv-apple-music --all-targets` — no
  warnings in the touched file.
- Swift bridge unchanged (no FFI struct change); `build.rs` swiftc path exercised
  by the driver test build.

Maintenance-level impact: `auv-driver-macos` is `core-maintained`. No stable core
public API added (the type remains doc-hidden), no new provisional term, and the
change *removes* a `Result<T, String>` crate-boundary crossing rather than adding
a new error type.
