### PR TITLE
feat(inspect): project input action results from run artifacts

### DIFF
--- a/crates/auv-cli-invoke/src/commands/input.rs
+++ b/crates/auv-cli-invoke/src/commands/input.rs
@@ -401,7 +401,7 @@ fn input_action_output(summary: &str, backend: &str, result: &auv_driver::InputA
   if let Some(reason) = &result.fallback_reason {
     output.signals.insert("input.fallback_reason".to_string(), reason.clone());
   }
-  output.artifacts.push(input_action_artifact(result, "input-action-result")?);
+  output.artifacts.push(input_action_artifact(result, auv_driver::INPUT_ACTION_RESULT_ARTIFACT_ROLE)?);
   output.verification = Some("activation-only; semantic success requires a separate verification result".to_string());
   output
     .known_limits
@@ -432,7 +432,7 @@ fn report_field(label: &str, value: impl Into<String>) -> InvokeReportField {
 
 #[cfg(target_os = "macos")]
 fn input_action_artifact(result: &auv_driver::InputActionResult, label: &str) -> Result<auv_tracing_driver::ProducedArtifact, String> {
-  json_artifact("input-action-result", label, result, "Typed InputActionResult recorded by the invoke handler.")
+  json_artifact(auv_driver::INPUT_ACTION_RESULT_ARTIFACT_ROLE, label, result, "Typed InputActionResult recorded by the invoke handler.")
 }
 
 #[cfg(test)]

--- a/crates/auv-cli/src/integrations/textedit/mod.rs
+++ b/crates/auv-cli/src/integrations/textedit/mod.rs
@@ -12,7 +12,7 @@ use auv_cli_invoke::{
   CommandGroup, InvokeCommandInput, InvokeCommandOutput, InvokeCommandResult, InvokeReport, InvokeReportField, InvokeReportSection,
   InvokeResult, invoke_command,
 };
-use auv_driver::{InputActionResult, InputDeliveryPath};
+use auv_driver::{INPUT_ACTION_RESULT_ARTIFACT_ROLE, InputActionResult, InputDeliveryPath};
 use auv_runtime::contract::{
   ArtifactRef, FailureLayer, OPERATION_RESULT_API_VERSION, OperationOutput, OperationResult, OperationStatus,
   VERIFICATION_RESULT_API_VERSION, VerificationMethod, VerificationResult,
@@ -104,7 +104,7 @@ pub(crate) fn build_invoke_output_from_report(report: &DocumentCommandReport, co
   for outcome in &report.outcomes {
     if let Some(result) = &outcome.input_action_result {
       output.artifacts.push(json_artifact(
-        "input-action-result",
+        INPUT_ACTION_RESULT_ARTIFACT_ROLE,
         &format!("textedit-{}-input-action", outcome.step_id.replace('.', "-")),
         result,
         "Typed InputActionResult from TextEdit document.write step.",
@@ -174,7 +174,7 @@ fn build_canonical_operation_result(result: &InvokeResult, observation: Option<&
   let evidence_artifacts = result
     .artifacts
     .iter()
-    .filter(|artifact| artifact.role == "input-action-result" || artifact.role == "ax-text-observation")
+    .filter(|artifact| artifact.role == INPUT_ACTION_RESULT_ARTIFACT_ROLE || artifact.role == "ax-text-observation")
     .map(|artifact| ArtifactRef {
       run_id: run_id.clone(),
       artifact_id: artifact.artifact_id.clone(),
@@ -506,7 +506,7 @@ mod tests {
       dry_run: false,
     };
     let output = document_write_impl(input).expect("fixture write");
-    assert!(output.artifacts.iter().any(|artifact| artifact.kind == "input-action-result"));
+    assert!(output.artifacts.iter().any(|artifact| artifact.kind == INPUT_ACTION_RESULT_ARTIFACT_ROLE));
     assert!(output.artifacts.iter().any(|artifact| artifact.kind == "ax-text-observation"));
     assert!(!output.artifacts.iter().any(|artifact| artifact.kind == "operation-result"));
     assert_eq!(output.backend.as_deref(), Some("auv-apple-textedit.DocumentWrite"));

--- a/crates/auv-cli/tests/fixtures/inspect_goldens/balatro.txt
+++ b/crates/auv-cli/tests/fixtures/inspect_goldens/balatro.txt
@@ -34,6 +34,9 @@ Artifacts: 8
 Command Boundary Claims:
 - none
 
+Input Actions:
+- none
+
 Verifications:
 - none
 

--- a/crates/auv-cli/tests/fixtures/inspect_goldens/core.txt
+++ b/crates/auv-cli/tests/fixtures/inspect_goldens/core.txt
@@ -16,6 +16,9 @@ Artifacts: 2
 Command Boundary Claims:
 - none
 
+Input Actions:
+- none
+
 Verifications:
 - method=text_visible executed=true state_changed=true semantic_matched=true failure_layer=n/a evidence=0 observed_label=hello
 

--- a/crates/auv-cli/tests/fixtures/inspect_goldens/minecraft.txt
+++ b/crates/auv-cli/tests/fixtures/inspect_goldens/minecraft.txt
@@ -15,6 +15,9 @@ Artifacts: 1
 Command Boundary Claims:
 - none
 
+Input Actions:
+- none
+
 Verifications:
 - none
 

--- a/crates/auv-cli/tests/fixtures/inspect_goldens/osu.txt
+++ b/crates/auv-cli/tests/fixtures/inspect_goldens/osu.txt
@@ -22,6 +22,9 @@ Artifacts: 2
 Command Boundary Claims:
 - none
 
+Input Actions:
+- none
+
 Verifications:
 - none
 

--- a/crates/auv-driver-common/src/input.rs
+++ b/crates/auv-driver-common/src/input.rs
@@ -305,12 +305,15 @@ impl InputAttempt {
 ///   `InputActionResult` when it attempts typed delivery. Direct driver-
 ///   API consumers (recipes, typed commands invoking driver primitives)
 ///   construct `InputActionResult` the same way.
-/// - **Downstream**: action-bearing operations attach this (and any
-///   current verification records) to the resulting `OperationResult`
-///   artifact (`src/contract.rs`) as delivery evidence.
+/// - **Downstream**: persisted as a standalone `input-action-result` JSON
+///   artifact — **not** embedded in `OperationResult`. Read-side seam:
+///   see `src/contract.rs` module docs.
 ///
 /// Do not introduce a new action-result schema beside `InputActionResult`
 /// without owner approval.
+///
+/// TODO(operation-result-iar-ref): whether `OperationResult.evidence_artifacts`
+/// should explicitly cite the standalone artifact is a separate slice.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct InputActionResult {
   pub selected_path: InputDeliveryPath,

--- a/crates/auv-driver-common/src/input.rs
+++ b/crates/auv-driver-common/src/input.rs
@@ -287,6 +287,9 @@ impl InputAttempt {
   }
 }
 
+/// Artifact role for persisted [`InputActionResult`] JSON records.
+pub const INPUT_ACTION_RESULT_ARTIFACT_ROLE: &str = "input-action-result";
+
 /// Persisted record of one driver input delivery — clicks, scrolls,
 /// text submission, etc. Captures the attempt sequence, the path that
 /// ultimately succeeded (or the failure mode), and the disturbance
@@ -314,6 +317,10 @@ impl InputAttempt {
 ///
 /// TODO(operation-result-iar-ref): whether `OperationResult.evidence_artifacts`
 /// should explicitly cite the standalone artifact is a separate slice.
+///
+/// TODO(input-action-result-api-version): this existing wire shape has no
+/// version discriminator. Add producer stamping and reader validation together
+/// only when an owner-approved versioning slice defines the compatibility rule.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct InputActionResult {
   pub selected_path: InputDeliveryPath,

--- a/crates/auv-driver-common/src/lib.rs
+++ b/crates/auv-driver-common/src/lib.rs
@@ -19,9 +19,9 @@ pub use geometry::{
   ScreenPoint, Size, WindowPoint, WorldPoint,
 };
 pub use input::{
-  ActivationPolicy, Click, ClickOptions, DisturbanceLevel, InputActionResult, InputAttempt, InputDeliveryPath, InputPolicy,
-  InputPreparationLease, KeyPressOptions, PasteTextOptions, PrepareForInputOptions, Scroll, ScrollDeliveryCandidate, ScrollDeliveryStrategy,
-  ScrollOptions, TextSubmit, TypeTextOptions, WaitOptions, WindowClickStrategy,
+  ActivationPolicy, Click, ClickOptions, DisturbanceLevel, INPUT_ACTION_RESULT_ARTIFACT_ROLE, InputActionResult, InputAttempt,
+  InputDeliveryPath, InputPolicy, InputPreparationLease, KeyPressOptions, PasteTextOptions, PrepareForInputOptions, Scroll,
+  ScrollDeliveryCandidate, ScrollDeliveryStrategy, ScrollOptions, TextSubmit, TypeTextOptions, WaitOptions, WindowClickStrategy,
 };
 pub use operation::{OperationDisturbance, OperationNamespace, OperationSpec};
 pub use permission::{PermissionProbe, PermissionStatus};

--- a/crates/auv-inspect-server/src/read_projection.rs
+++ b/crates/auv-inspect-server/src/read_projection.rs
@@ -51,6 +51,9 @@ pub struct InspectRunEnrichment {
   pub observation_snapshots: Vec<serde_json::Value>,
   #[serde(default, skip_serializing_if = "Vec::is_empty")]
   pub detector_recognition_lineage: Vec<serde_json::Value>,
+  /// Serialized `InputActionResult` from `input-action-result` artifacts.
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  pub input_action_results: Vec<serde_json::Value>,
   pub view_parser: ViewParserInspect,
   pub view_parser_summary: ViewParserListSummary,
 }

--- a/crates/auv-inspect-server/src/server.rs
+++ b/crates/auv-inspect-server/src/server.rs
@@ -304,6 +304,7 @@ async fn get_run(State(state): State<InspectServerState>, Path(run_id): Path<Str
     verifications,
     observation_snapshots,
     detector_recognition_lineage,
+    input_action_results,
     view_parser,
     view_parser_summary,
   } = state.projection.run_enrichment(state.store.as_ref(), &run).map_err(InspectHttpError::from_store)?;
@@ -314,6 +315,7 @@ async fn get_run(State(state): State<InspectServerState>, Path(run_id): Path<Str
       verifications,
       observation_snapshots,
       detector_recognition_lineage,
+      input_action_results,
       view_parser,
       view_parser_summary,
     })
@@ -478,6 +480,8 @@ struct InspectRunResponse {
   observation_snapshots: Vec<serde_json::Value>,
   #[serde(default, skip_serializing_if = "Vec::is_empty")]
   detector_recognition_lineage: Vec<serde_json::Value>,
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  input_action_results: Vec<serde_json::Value>,
   view_parser: ViewParserInspect,
   view_parser_summary: ViewParserListSummary,
 }
@@ -835,6 +839,14 @@ mod tests {
         verifications: vec![serde_json::json!({"method":{"kind":"semantic_match"}})],
         observation_snapshots: vec![serde_json::json!({"snapshot_id":"snapshot_projection_test"})],
         detector_recognition_lineage: vec![serde_json::json!({"status":"ready"})],
+        input_action_results: vec![serde_json::json!({
+          "selected_path": "foreground_system_events",
+          "attempts": [{"path": "foreground_system_events", "succeeded": true, "message": null}],
+          "fallback_reason": null,
+          "mouse_disturbance": "none",
+          "focus_disturbance": "none",
+          "clipboard_disturbance": "none"
+        })],
         ..Default::default()
       })
     }
@@ -1683,6 +1695,8 @@ mod tests {
     assert_eq!(run["verifications"][0]["method"]["kind"], "semantic_match");
     assert_eq!(run["observation_snapshots"][0]["snapshot_id"], "snapshot_projection_test");
     assert_eq!(run["detector_recognition_lineage"][0]["status"], "ready");
+    assert_eq!(run["input_action_results"][0]["selected_path"], "foreground_system_events");
+    assert_eq!(run["input_action_results"][0]["attempts"][0]["succeeded"], true);
     assert!(run["command_boundary_claims"].as_array().is_some_and(|claims| !claims.is_empty()));
     assert!(run["verifications"].as_array().is_some_and(|verifications| !verifications.is_empty()));
     assert!(run["observation_snapshots"].as_array().is_some_and(|snapshots| !snapshots.is_empty()));

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -21,7 +21,7 @@
 //!   -> OperationResult / VerificationResult / ObservationSnapshot
 //!        (this file; the persisted, reader-consumable records)
 //!   -> trace artifacts
-//!        (src/run_read.rs reads them back via `extract_verifications`,
+//!        (src/run_read/mod.rs reads them back via `extract_verifications`,
 //!         `extract_observation_snapshots`, and
 //!         `extract_input_action_results`)
 //! ```

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -16,21 +16,20 @@
 //! ```text
 //! recognition / AX / candidates
 //!   -> auv-driver InputActionResult
-//!        (crates/auv-driver/src/input.rs;
-//!         `InputActionResult`, pub, full serde,
-//!         records the actual delivery attempts + disturbance levels)
+//!        (standalone `input-action-result` artifact; read via
+//!         `run_read::extract_input_action_results`)
 //!   -> OperationResult / VerificationResult / ObservationSnapshot
 //!        (this file; the persisted, reader-consumable records)
 //!   -> trace artifacts
-//!        (src/run_read.rs reads them back via `extract_verifications`
-//!         and `extract_observation_snapshots`; src/recorded_operation.rs
-//!         is the orchestration bridge, not a contract record)
+//!        (src/run_read.rs reads them back via `extract_verifications`,
+//!         `extract_observation_snapshots`, and
+//!         `extract_input_action_results`)
 //! ```
 //!
 //! The archived candidate-action `ActionResolverDecision` schema was removed.
-//! Current input delivery evidence should use `InputActionResult` together
-//! with current `OperationResult` and `VerificationResult` records. Do not
-//! introduce a replacement action-result schema without owner approval.
+//! Current input delivery evidence is the standalone `InputActionResult`
+//! artifact plus separate `OperationResult` / `VerificationResult` records.
+//! Do not introduce a replacement action-result schema without owner approval.
 //!
 //! Reader-side `api_version` rejection is deferred; see
 //! `NOTICE(contract-api-version-reader-check)` immediately below.
@@ -111,9 +110,9 @@ pub enum OperationStatus {
 ///
 /// - **Produced by** typed driver / runtime command handlers via
 ///   `Runtime::record_operation` (see [`auv_tracing_driver::recorded_operation`]).
-///   Action commands attach current input delivery evidence such as
-///   `InputActionResult` from `crates/auv-driver` and any verification
-///   claims to the resulting `OperationResult` here.
+///   Verification claims attach here. Input delivery evidence is persisted
+///   separately as an `input-action-result` artifact (`InputActionResult`),
+///   not as a field on this record.
 /// - **Consumed by** `run_read::extract_verifications` (which scans
 ///   `operation-result` JSON artifacts and lifts both top-level
 ///   `verifications` and the legacy `OperationOutput::Verification`),

--- a/src/inspect/mod.rs
+++ b/src/inspect/mod.rs
@@ -61,10 +61,10 @@ pub fn inspect_run_with(composer: &InspectComposer, store: &LocalStore, run_id: 
 
 pub(crate) fn inspect_run_core_prefix_body(store: &LocalStore, run_id: &str) -> AuvResult<String> {
   let canonical = read_run(store, run_id)?;
-  let input_action_results = list_input_action_results(store, run_id)?;
-  let verifications = list_verifications(store, run_id)?;
-  let observation_snapshots = list_observation_snapshots(store, run_id)?;
-  let detector_recognition_lineage = list_detector_recognition_lineage(store, run_id)?;
+  let input_action_results = crate::run_read::extract_input_action_results(store, &canonical)?;
+  let verifications = crate::run_read::extract_verifications(store, &canonical)?;
+  let observation_snapshots = crate::run_read::extract_observation_snapshots(store, &canonical)?;
+  let detector_recognition_lineage = crate::run_read::extract_detector_recognition_lineage(store, &canonical)?;
   Ok(render_core_run_text(&canonical, &input_action_results, &verifications, &observation_snapshots, &detector_recognition_lineage))
 }
 
@@ -388,7 +388,7 @@ mod tests {
         &span_id,
         None,
         auv_tracing_driver::ArtifactFileSource {
-          role: "input-action-result".to_string(),
+          role: auv_driver::INPUT_ACTION_RESULT_ARTIFACT_ROLE.to_string(),
           source_path: source,
           preferred_name: "iar.json".to_string(),
           summary: None,

--- a/src/inspect/mod.rs
+++ b/src/inspect/mod.rs
@@ -1,13 +1,15 @@
 //! Core human-readable run inspection (library-only).
 //!
 //! App-specific sections live in `auv-product`. This module emits only core
-//! sections: run summary, verifications, observations, detector reads,
-//! view-parser proof, and scene state. Product frontends inject their composer
-//! rather than adding app wiring here.
+//! sections: run summary, input actions, verifications, observations, detector
+//! reads, view-parser proof, and scene state. Product frontends inject their
+//! composer rather than adding app wiring here.
 
 use auv_inspect_model::InspectComposer;
 use auv_tracing_driver::store::{CanonicalRun, LocalStore};
 use auv_view::memory::{ViewMemory, ViewParserInspect, format_view_resolution_summary_text};
+
+use auv_driver::{DisturbanceLevel, InputActionResult, InputDeliveryPath};
 
 use crate::contract::{FailureLayer, ObservationSnapshot, ObservationSource, VerificationMethod, VerificationResult};
 use crate::model::AuvResult;
@@ -28,6 +30,10 @@ pub fn list_verifications(store: &LocalStore, run_id: &str) -> AuvResult<Vec<Ver
 
 pub fn list_observation_snapshots(store: &LocalStore, run_id: &str) -> AuvResult<Vec<ObservationSnapshot>> {
   crate::run_read::list_observation_snapshots(store, run_id)
+}
+
+pub fn list_input_action_results(store: &LocalStore, run_id: &str) -> AuvResult<Vec<InputActionResult>> {
+  crate::run_read::list_input_action_results(store, run_id)
 }
 
 pub fn list_detector_recognition_lineage(store: &LocalStore, run_id: &str) -> AuvResult<Vec<DetectorRecognitionLineage>> {
@@ -55,10 +61,11 @@ pub fn inspect_run_with(composer: &InspectComposer, store: &LocalStore, run_id: 
 
 pub(crate) fn inspect_run_core_prefix_body(store: &LocalStore, run_id: &str) -> AuvResult<String> {
   let canonical = read_run(store, run_id)?;
+  let input_action_results = list_input_action_results(store, run_id)?;
   let verifications = list_verifications(store, run_id)?;
   let observation_snapshots = list_observation_snapshots(store, run_id)?;
   let detector_recognition_lineage = list_detector_recognition_lineage(store, run_id)?;
-  Ok(render_core_run_text(&canonical, &verifications, &observation_snapshots, &detector_recognition_lineage))
+  Ok(render_core_run_text(&canonical, &input_action_results, &verifications, &observation_snapshots, &detector_recognition_lineage))
 }
 
 pub(crate) fn inspect_run_core_suffix_body(store: &LocalStore, run_id: &str) -> AuvResult<String> {
@@ -98,6 +105,7 @@ fn append_scene_state_text_from_run(store: &LocalStore, run: &CanonicalRun, outp
 
 fn render_core_run_text(
   run: &CanonicalRun,
+  input_action_results: &[InputActionResult],
   verifications: &[VerificationResult],
   observation_snapshots: &[ObservationSnapshot],
   detector_recognition_lineage: &[DetectorRecognitionLineage],
@@ -158,6 +166,24 @@ fn render_core_run_text(
     }
     for event in command_known_limits {
       output.push_str(&format!("- known_limit={} span={}\n", event.message.as_deref().unwrap_or("n/a"), event.span_id));
+    }
+  }
+
+  // Neutral delivery facts only — do not collapse attempts[*].succeeded into success.
+  output.push_str("\nInput Actions:\n");
+  if input_action_results.is_empty() {
+    output.push_str("- none\n");
+  } else {
+    for result in input_action_results {
+      output.push_str(&format!(
+        "- path={} attempts={} fallback={} mouse={} focus={} clipboard={}\n",
+        render_input_delivery_path(result.selected_path),
+        result.attempts.len(),
+        result.fallback_reason.as_deref().unwrap_or("n/a"),
+        render_disturbance_level(result.mouse_disturbance),
+        render_disturbance_level(result.focus_disturbance),
+        render_disturbance_level(result.clipboard_disturbance)
+      ));
     }
   }
 
@@ -241,6 +267,33 @@ fn render_detector_status(status: &crate::run_read::DetectorRecognitionLineageSt
   }
 }
 
+fn render_input_delivery_path(path: InputDeliveryPath) -> &'static str {
+  match path {
+    InputDeliveryPath::Noop => "noop",
+    InputDeliveryPath::AxPress => "ax_press",
+    InputDeliveryPath::AxFocus => "ax_focus",
+    InputDeliveryPath::AxSetValue => "ax_set_value",
+    InputDeliveryPath::AxScroll => "ax_scroll",
+    InputDeliveryPath::AxSelectedText => "ax_selected_text",
+    InputDeliveryPath::WindowTargetedMouse => "window_targeted_mouse",
+    InputDeliveryPath::WindowTargetedWheel => "window_targeted_wheel",
+    InputDeliveryPath::WindowTargetedKeyboard => "window_targeted_keyboard",
+    InputDeliveryPath::WindowTargetedKeyboardScroll => "window_targeted_keyboard_scroll",
+    InputDeliveryPath::ClipboardPaste => "clipboard_paste",
+    InputDeliveryPath::ForegroundSystemEvents => "foreground_system_events",
+    InputDeliveryPath::Unsupported => "unsupported",
+  }
+}
+
+fn render_disturbance_level(level: DisturbanceLevel) -> &'static str {
+  match level {
+    DisturbanceLevel::None => "none",
+    DisturbanceLevel::Temporary => "temporary",
+    DisturbanceLevel::Foreground => "foreground",
+    DisturbanceLevel::Unknown => "unknown",
+  }
+}
+
 fn render_optional_bool(value: Option<bool>) -> &'static str {
   match value {
     Some(true) => "true",
@@ -290,5 +343,103 @@ fn render_recognition_source(source: crate::contract::RecognitionSource) -> &'st
     crate::contract::RecognitionSource::SegmentedRegion => "segmented_region",
     crate::contract::RecognitionSource::IconMatch => "icon_match",
     crate::contract::RecognitionSource::Custom => "custom",
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::collections::BTreeMap;
+  use std::fs;
+  use std::path::PathBuf;
+
+  use auv_driver::{DisturbanceLevel, InputActionResult, InputAttempt, InputDeliveryPath};
+  use auv_tracing_driver::store::{CanonicalRun, LocalStore};
+  use auv_tracing_driver::trace::{
+    RUN_API_VERSION, RunId, RunRecordV1Alpha1, RunType, SPAN_API_VERSION, SpanId, SpanRecordV1Alpha1, TraceId, TraceState, TraceStatusCode,
+  };
+
+  use super::inspect_run_core_prefix_body;
+
+  #[test]
+  fn core_inspect_text_projects_input_action_facts_without_success_claim() {
+    let root = PathBuf::from(std::env::temp_dir()).join(format!("auv-inspect-iar-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).expect("temp");
+    let store = LocalStore::new(root.clone()).expect("store");
+    let run_id = RunId::new("run_inspect_iar");
+    let span_id = SpanId::new("0000000000000001");
+    let result = InputActionResult {
+      selected_path: InputDeliveryPath::ForegroundSystemEvents,
+      attempts: vec![
+        InputAttempt::failure(InputDeliveryPath::WindowTargetedKeyboard, "first path missed"),
+        InputAttempt::success(InputDeliveryPath::ForegroundSystemEvents),
+      ],
+      fallback_reason: Some("foreground_required".to_string()),
+      mouse_disturbance: DisturbanceLevel::None,
+      focus_disturbance: DisturbanceLevel::Temporary,
+      clipboard_disturbance: DisturbanceLevel::None,
+    };
+    let source = root.join("iar.json");
+    fs::write(&source, serde_json::to_string_pretty(&result).unwrap() + "\n").expect("write");
+    let artifact = store
+      .stage_artifact_file(
+        &run_id,
+        0,
+        &span_id,
+        None,
+        auv_tracing_driver::ArtifactFileSource {
+          role: "input-action-result".to_string(),
+          source_path: source,
+          preferred_name: "iar.json".to_string(),
+          summary: None,
+        },
+      )
+      .expect("stage");
+    store
+      .write_run_snapshot(&CanonicalRun {
+        run: RunRecordV1Alpha1 {
+          api_version: RUN_API_VERSION.to_string(),
+          run_id: run_id.clone(),
+          trace_id: TraceId::new("trace_inspect_iar"),
+          run_type: RunType::Command,
+          state: TraceState::Ended,
+          status_code: TraceStatusCode::Ok,
+          started_at_millis: 1,
+          finished_at_millis: Some(2),
+          root_span_id: span_id.clone(),
+          attributes: BTreeMap::new(),
+          summary: None,
+          failure: None,
+        },
+        spans: vec![SpanRecordV1Alpha1 {
+          api_version: SPAN_API_VERSION.to_string(),
+          span_id,
+          parent_span_id: None,
+          name: "auv.command".to_string(),
+          state: TraceState::Ended,
+          status_code: TraceStatusCode::Ok,
+          started_at_millis: 1,
+          finished_at_millis: Some(2),
+          attributes: BTreeMap::new(),
+          summary: None,
+          failure: None,
+        }],
+        events: Vec::new(),
+        artifacts: vec![artifact],
+      })
+      .expect("write run");
+
+    let text = inspect_run_core_prefix_body(&store, "run_inspect_iar").expect("inspect");
+    let input_section = text.split("\nVerifications:\n").next().expect("input section");
+    assert!(input_section.contains("Input Actions:"), "{text}");
+    assert!(
+      input_section
+        .contains("path=foreground_system_events attempts=2 fallback=foreground_required mouse=none focus=temporary clipboard=none"),
+      "{text}"
+    );
+    // Neutral projection: delivery attempts are not collapsed into a success bit.
+    assert!(!input_section.contains("succeeded="), "{text}");
+
+    let _ = fs::remove_dir_all(root);
   }
 }

--- a/src/inspect/sections.rs
+++ b/src/inspect/sections.rs
@@ -7,7 +7,8 @@ use auv_tracing_driver::store::{CanonicalRun, LocalStore};
 
 use super::{inspect_run_core_prefix_body, inspect_run_core_suffix_body};
 
-/// Core prefix: run header through Detector Recognition Lineage.
+/// Core prefix: run header through Input Actions / Verifications / Observations /
+/// Detector Recognition Lineage.
 pub struct CorePrefixSection;
 
 impl InspectSection for CorePrefixSection {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,11 @@ impl auv_inspect_server::InspectReadProjection for RootInspectReadProjection {
         .map(serde_json::to_value)
         .collect::<Result<Vec<_>, _>>()
         .map_err(|error| format!("failed to encode detector recognition lineage inspect values: {error}"))?,
+      input_action_results: run_read::extract_input_action_results(store, run)?
+        .into_iter()
+        .map(serde_json::to_value)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| format!("failed to encode input action result inspect values: {error}"))?,
       view_parser,
       view_parser_summary,
     })

--- a/src/run_read/mod.rs
+++ b/src/run_read/mod.rs
@@ -16,7 +16,7 @@ use crate::contract::{
 };
 use crate::model::AuvResult;
 use crate::scroll_scan::ScrollScanArtifact;
-use auv_driver::InputActionResult;
+use auv_driver::{INPUT_ACTION_RESULT_ARTIFACT_ROLE, InputActionResult};
 use auv_inspect_model::{artifact_record_view, is_json_mime, read_artifact_json};
 use auv_tracing_driver::store::{CanonicalRun, LocalStore};
 use auv_tracing_driver::trace::ArtifactRecordV1Alpha1;
@@ -26,8 +26,6 @@ pub fn read_run(store: &LocalStore, run_id: &str) -> AuvResult<CanonicalRun> {
 }
 
 const DETECTOR_RECOGNITION_ARTIFACT_ROLE: &str = "detector-recognition";
-const INPUT_ACTION_RESULT_ARTIFACT_ROLE: &str = "input-action-result";
-
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DetectorRecognitionLineageStatus {
@@ -329,7 +327,8 @@ mod tests {
   };
   use serde::Serialize;
 
-  use super::{INPUT_ACTION_RESULT_ARTIFACT_ROLE, extract_input_action_results, list_input_action_results};
+  use super::{extract_input_action_results, list_input_action_results};
+  use auv_driver::INPUT_ACTION_RESULT_ARTIFACT_ROLE;
 
   fn temp_root(label: &str) -> PathBuf {
     let root = std::env::temp_dir().join(format!("auv-run-read-iar-{label}-{}", std::process::id()));

--- a/src/run_read/mod.rs
+++ b/src/run_read/mod.rs
@@ -6,6 +6,8 @@
 //!
 //! - verification claims come from `operation-result` JSON artifacts
 //! - observation snapshots come from `scroll-scan` JSON artifacts
+//! - input delivery evidence comes from standalone `input-action-result`
+//!   JSON artifacts (`auv_driver::InputActionResult`)
 //! - legacy `OperationOutput::Verification` remains readable without
 //!   double-counting artifacts that also populate `OperationResult.verifications`
 
@@ -14,6 +16,7 @@ use crate::contract::{
 };
 use crate::model::AuvResult;
 use crate::scroll_scan::ScrollScanArtifact;
+use auv_driver::InputActionResult;
 use auv_inspect_model::{artifact_record_view, is_json_mime, read_artifact_json};
 use auv_tracing_driver::store::{CanonicalRun, LocalStore};
 use auv_tracing_driver::trace::ArtifactRecordV1Alpha1;
@@ -23,6 +26,7 @@ pub fn read_run(store: &LocalStore, run_id: &str) -> AuvResult<CanonicalRun> {
 }
 
 const DETECTOR_RECOGNITION_ARTIFACT_ROLE: &str = "detector-recognition";
+const INPUT_ACTION_RESULT_ARTIFACT_ROLE: &str = "input-action-result";
 
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -135,6 +139,32 @@ pub(crate) fn extract_observation_snapshots(store: &LocalStore, run: &CanonicalR
     snapshots.extend(scroll_scan_artifact.snapshots);
   }
   Ok(snapshots)
+}
+
+/// List typed input-delivery records persisted as `input-action-result` artifacts.
+///
+/// Delivery evidence is a standalone artifact role today; it is not embedded in
+/// [`OperationResult`]. Callers must not treat presence or `attempts[*].succeeded`
+/// as semantic success — that remains a separate verification claim.
+pub(crate) fn list_input_action_results(store: &LocalStore, run_id: &str) -> AuvResult<Vec<InputActionResult>> {
+  let run = store.read_run(run_id)?;
+  extract_input_action_results(store, &run)
+}
+
+/// Scan a loaded run for `input-action-result` JSON artifacts in artifact order.
+///
+/// Non-matching roles and non-JSON MIME types are skipped. Matching role with
+/// malformed JSON returns an error (no silent drop).
+pub(crate) fn extract_input_action_results(store: &LocalStore, run: &CanonicalRun) -> AuvResult<Vec<InputActionResult>> {
+  let mut results = Vec::new();
+  for artifact in &run.artifacts {
+    if artifact.role != INPUT_ACTION_RESULT_ARTIFACT_ROLE || !is_json_mime(&artifact.mime_type) {
+      continue;
+    }
+    let result: InputActionResult = read_artifact_json(store, run.run.run_id.as_str(), artifact, INPUT_ACTION_RESULT_ARTIFACT_ROLE)?;
+    results.push(result);
+  }
+  Ok(results)
 }
 
 pub(crate) fn list_detector_recognition_lineage(store: &LocalStore, run_id: &str) -> AuvResult<Vec<DetectorRecognitionLineage>> {
@@ -284,3 +314,203 @@ pub use crate::view_parser_read::{
   build_view_parser_inspect, build_view_resolution_summary, extract_playlist_select_result_wires, extract_reacquisition_records,
   extract_view_memory_writes, list_view_memory_writes,
 };
+
+#[cfg(test)]
+mod tests {
+  use std::collections::BTreeMap;
+  use std::fs;
+  use std::path::{Path, PathBuf};
+
+  use auv_driver::{DisturbanceLevel, InputActionResult, InputAttempt, InputDeliveryPath};
+  use auv_tracing_driver::store::{CanonicalRun, LocalStore};
+  use auv_tracing_driver::trace::{
+    ArtifactRecordV1Alpha1, RUN_API_VERSION, RunId, RunRecordV1Alpha1, RunType, SPAN_API_VERSION, SpanId, SpanRecordV1Alpha1, TraceId,
+    TraceState, TraceStatusCode,
+  };
+  use serde::Serialize;
+
+  use super::{INPUT_ACTION_RESULT_ARTIFACT_ROLE, extract_input_action_results, list_input_action_results};
+
+  fn temp_root(label: &str) -> PathBuf {
+    let root = std::env::temp_dir().join(format!("auv-run-read-iar-{label}-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).expect("temp root");
+    root
+  }
+
+  fn stage_file(
+    store: &LocalStore,
+    root: &Path,
+    run_id: &RunId,
+    span_id: &SpanId,
+    index: usize,
+    role: &str,
+    preferred_name: &str,
+    bytes: &[u8],
+  ) -> ArtifactRecordV1Alpha1 {
+    let source_path = root.join(format!("source-{index}-{preferred_name}"));
+    fs::write(&source_path, bytes).expect("write source");
+    store
+      .stage_artifact_file(
+        run_id,
+        index,
+        span_id,
+        None,
+        auv_tracing_driver::ArtifactFileSource {
+          role: role.to_string(),
+          source_path,
+          preferred_name: preferred_name.to_string(),
+          summary: None,
+        },
+      )
+      .expect("stage artifact")
+  }
+
+  fn stage_json<T: Serialize>(
+    store: &LocalStore,
+    root: &Path,
+    run_id: &RunId,
+    span_id: &SpanId,
+    index: usize,
+    role: &str,
+    preferred_name: &str,
+    value: &T,
+  ) -> ArtifactRecordV1Alpha1 {
+    let rendered = serde_json::to_string_pretty(value).expect("serialize") + "\n";
+    stage_file(store, root, run_id, span_id, index, role, preferred_name, rendered.as_bytes())
+  }
+
+  fn write_run(store: &LocalStore, run_id: &str, artifacts: Vec<ArtifactRecordV1Alpha1>) {
+    let run_id = RunId::new(run_id);
+    let span_id = SpanId::new("0000000000000001");
+    store
+      .write_run_snapshot(&CanonicalRun {
+        run: RunRecordV1Alpha1 {
+          api_version: RUN_API_VERSION.to_string(),
+          run_id: run_id.clone(),
+          trace_id: TraceId::new("trace_iar"),
+          run_type: RunType::Command,
+          state: TraceState::Ended,
+          status_code: TraceStatusCode::Ok,
+          started_at_millis: 1,
+          finished_at_millis: Some(2),
+          root_span_id: span_id.clone(),
+          attributes: BTreeMap::new(),
+          summary: Some("iar fixture".to_string()),
+          failure: None,
+        },
+        spans: vec![SpanRecordV1Alpha1 {
+          api_version: SPAN_API_VERSION.to_string(),
+          span_id,
+          parent_span_id: None,
+          name: "auv.command".to_string(),
+          state: TraceState::Ended,
+          status_code: TraceStatusCode::Ok,
+          started_at_millis: 1,
+          finished_at_millis: Some(2),
+          attributes: BTreeMap::new(),
+          summary: None,
+          failure: None,
+        }],
+        events: Vec::new(),
+        artifacts,
+      })
+      .expect("write run");
+  }
+
+  fn sample_iar(path: InputDeliveryPath) -> InputActionResult {
+    InputActionResult {
+      selected_path: path,
+      attempts: vec![InputAttempt::success(path)],
+      fallback_reason: None,
+      mouse_disturbance: DisturbanceLevel::None,
+      focus_disturbance: DisturbanceLevel::Temporary,
+      clipboard_disturbance: DisturbanceLevel::None,
+    }
+  }
+
+  #[test]
+  fn extract_input_action_results_reads_valid_artifacts_in_order() {
+    let root = temp_root("valid");
+    let store = LocalStore::new(root.clone()).expect("store");
+    let run_id = RunId::new("run_iar_valid");
+    let span_id = SpanId::new("0000000000000001");
+    let first = sample_iar(InputDeliveryPath::ForegroundSystemEvents);
+    let second = sample_iar(InputDeliveryPath::WindowTargetedKeyboard);
+    let artifacts = vec![
+      stage_json(&store, &root, &run_id, &span_id, 0, INPUT_ACTION_RESULT_ARTIFACT_ROLE, "iar-0.json", &first),
+      stage_json(&store, &root, &run_id, &span_id, 1, "operation-result", "op.json", &serde_json::json!({"ignored": true})),
+      stage_json(&store, &root, &run_id, &span_id, 2, INPUT_ACTION_RESULT_ARTIFACT_ROLE, "iar-1.json", &second),
+    ];
+    write_run(&store, "run_iar_valid", artifacts);
+
+    let results = list_input_action_results(&store, "run_iar_valid").expect("list");
+    assert_eq!(results, vec![first, second]);
+
+    let _ = fs::remove_dir_all(root);
+  }
+
+  #[test]
+  fn extract_input_action_results_ignores_unrelated_roles_and_non_json() {
+    let root = temp_root("filters");
+    let store = LocalStore::new(root.clone()).expect("store");
+    let run_id = RunId::new("run_iar_filters");
+    let span_id = SpanId::new("0000000000000001");
+    let kept = sample_iar(InputDeliveryPath::ClipboardPaste);
+    // Non-JSON preferred name → text/plain mime; matching role but ignored by mime filter.
+    let artifacts = vec![
+      stage_file(
+        &store,
+        &root,
+        &run_id,
+        &span_id,
+        0,
+        INPUT_ACTION_RESULT_ARTIFACT_ROLE,
+        "iar.txt",
+        br#"{"selected_path":"clipboard_paste"}"#,
+      ),
+      stage_json(&store, &root, &run_id, &span_id, 1, "scroll-scan", "scan.json", &serde_json::json!({"snapshots": []})),
+      stage_json(&store, &root, &run_id, &span_id, 2, INPUT_ACTION_RESULT_ARTIFACT_ROLE, "iar.json", &kept),
+    ];
+    write_run(&store, "run_iar_filters", artifacts);
+
+    let results = extract_input_action_results(&store, &store.read_run("run_iar_filters").expect("read")).expect("extract");
+    assert_eq!(results, vec![kept]);
+
+    let _ = fs::remove_dir_all(root);
+  }
+
+  #[test]
+  fn extract_input_action_results_errors_on_malformed_matching_json() {
+    let root = temp_root("malformed");
+    let store = LocalStore::new(root.clone()).expect("store");
+    let run_id = RunId::new("run_iar_bad");
+    let span_id = SpanId::new("0000000000000001");
+    let artifacts = vec![stage_file(
+      &store,
+      &root,
+      &run_id,
+      &span_id,
+      0,
+      INPUT_ACTION_RESULT_ARTIFACT_ROLE,
+      "iar-bad.json",
+      b"{not-valid-json",
+    )];
+    write_run(&store, "run_iar_bad", artifacts);
+
+    let error = list_input_action_results(&store, "run_iar_bad").expect_err("malformed must fail");
+    assert!(error.contains("input-action-result"), "error={error}");
+
+    let _ = fs::remove_dir_all(root);
+  }
+
+  #[test]
+  fn extract_input_action_results_returns_empty_when_absent() {
+    let root = temp_root("empty");
+    let store = LocalStore::new(root.clone()).expect("store");
+    write_run(&store, "run_iar_empty", Vec::new());
+    let results = list_input_action_results(&store, "run_iar_empty").expect("list");
+    assert!(results.is_empty());
+    let _ = fs::remove_dir_all(root);
+  }
+}


### PR DESCRIPTION
## Summary
- Add `run_read` extract/list for standalone `input-action-result` artifacts (`auv_driver::InputActionResult`).
- Project neutral `Input Actions:` facts into core inspect text and additive `input_action_results` on inspect-server `GET /runs/:id`.
- Correct stale seam docs that implied IAR was embedded in `OperationResult`; refresh inspect goldens.

## Scope / non-goals
- No IAR wire-shape / `api_version` / `OperationResult` field changes
- No `input.pasteText`, media-control, viewer cards, or semantic-success derivation
- No C2e / runtime dead-method cleanup

## Maintenance
- Primary crates: `auv-runtime` (core-maintained), `auv-inspect-server` (core-maintained), `auv-driver-common` (core-maintained)
- Core public API: additive inspect helper + additive HTTP enrichment field only
- No new provisional term; no new error type

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo check`
- [x] focused `run_read` / inspect projection tests
- [x] `cargo test -p auv-inspect-server run_detail_serializes`
- [x] `cargo test -p auv-cli --lib`
- [x] `git diff --check`
- [ ] Review inspect text does not claim delivery ⇒ semantic success


Made with [Cursor](https://cursor.com)