### PR TITLE
test(auv-driver-macos): characterize AX path parse layer with CI gate

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -50,5 +50,8 @@ jobs:
       - run: cargo test
       - run: cargo run --quiet -- invoke --help
       - run: bash scripts/ci/public-claims-check.sh
+      - name: AX path parse characterization
+        if: runner.os == 'macOS'
+        run: bash scripts/ci/ax-path-characterization.sh
       - run: bash scripts/ci/install-smoke.sh
       - run: git diff --check

--- a/crates/auv-driver-macos/native/swift/Sources/AuvMacosNative/AxPath.swift
+++ b/crates/auv-driver-macos/native/swift/Sources/AuvMacosNative/AxPath.swift
@@ -1,0 +1,48 @@
+// Pure, Accessibility-free parse layer for observed AX paths.
+//
+// This file deliberately imports nothing and touches no `AXUIElement`, Rust
+// bridge, or system API. Keeping the path-string parsing separate from the
+// live tree walk (`axResolveObservedPath` in `AxTree.swift`) lets a standalone
+// `swiftc` harness compile and characterize this layer in CI without linking
+// the full `AuvMacosNative` module — which cannot link under `swift test`
+// because the generated `SwiftBridgeCore.swift` references Rust FFI symbols
+// that only exist in the cargo-built static library.
+//
+// Symbols are `internal` (not `private`) so both `axResolveObservedPath` (same
+// module) and the characterization harness (which compiles this exact source
+// file directly) can reach them. Behavior is unchanged from the original
+// `private` definitions extracted from `AxTree.swift`.
+
+struct AxPathResolutionFailure: Error {
+  let message: String
+  let recovery: String
+}
+
+/// Parses a dotted observed AX path (e.g. `0.1.2`) into child indices.
+///
+/// The observed-path contract: the first segment must be the window/app root
+/// marker `0`, and every following segment must be a non-negative integer child
+/// index. `operation` and `retry` are interpolated into the failure message and
+/// recovery hint so the caller (action / focus / inspection) reports the right
+/// verb. Returns the parsed indices *after* the leading `0`.
+func axObservedPathIndices(path: String, operation: String, retry: String) -> Result<[Int], AxPathResolutionFailure> {
+  let segments = path.split(separator: ".").map(String.init)
+  guard segments.first == "0" else {
+    return .failure(AxPathResolutionFailure(
+      message: "AX \(operation) path must begin with 0; got \(path)",
+      recovery: "capture a fresh AX tree and retry \(retry)"
+    ))
+  }
+
+  var indices: [Int] = []
+  for (offset, segment) in segments.dropFirst().enumerated() {
+    guard let index = Int(segment), index >= 0 else {
+      return .failure(AxPathResolutionFailure(
+        message: "AX \(operation) path segment \(segment) at offset \(offset) is not a non-negative integer",
+        recovery: "capture a fresh AX tree and retry \(retry)"
+      ))
+    }
+    indices.append(index)
+  }
+  return .success(indices)
+}

--- a/crates/auv-driver-macos/native/swift/Sources/AuvMacosNative/AxPath.swift
+++ b/crates/auv-driver-macos/native/swift/Sources/AuvMacosNative/AxPath.swift
@@ -26,7 +26,11 @@ struct AxPathResolutionFailure: Error {
 /// recovery hint so the caller (action / focus / inspection) reports the right
 /// verb. Returns the parsed indices *after* the leading `0`.
 func axObservedPathIndices(path: String, operation: String, retry: String) -> Result<[Int], AxPathResolutionFailure> {
-  let segments = path.split(separator: ".").map(String.init)
+  // TODO(ax-path-empty-segments): Swift's split currently omits leading,
+  // repeated, and trailing empty segments, so `.0`, `0..1`, and `0.` are
+  // accepted. Rejecting them is a behavior change; keep the current behavior
+  // characterized until the owner approves a path-validation bug-fix slice.
+  let segments = path.split(separator: ".", omittingEmptySubsequences: true).map(String.init)
   guard segments.first == "0" else {
     return .failure(AxPathResolutionFailure(
       message: "AX \(operation) path must begin with 0; got \(path)",

--- a/crates/auv-driver-macos/native/swift/Sources/AuvMacosNative/AxTree.swift
+++ b/crates/auv-driver-macos/native/swift/Sources/AuvMacosNative/AxTree.swift
@@ -132,32 +132,13 @@ private func axFirstWindow(_ appElement: AXUIElement) -> AXUIElement? {
   return axElementArrayAttribute(appElement, kAXWindowsAttribute as String).first
 }
 
-private struct AxPathResolutionFailure: Error {
-  let message: String
-  let recovery: String
-}
-
-private func axObservedPathIndices(path: String, operation: String, retry: String) -> Result<[Int], AxPathResolutionFailure> {
-  let segments = path.split(separator: ".").map(String.init)
-  guard segments.first == "0" else {
-    return .failure(AxPathResolutionFailure(
-      message: "AX \(operation) path must begin with 0; got \(path)",
-      recovery: "capture a fresh AX tree and retry \(retry)"
-    ))
-  }
-
-  var indices: [Int] = []
-  for (offset, segment) in segments.dropFirst().enumerated() {
-    guard let index = Int(segment), index >= 0 else {
-      return .failure(AxPathResolutionFailure(
-        message: "AX \(operation) path segment \(segment) at offset \(offset) is not a non-negative integer",
-        recovery: "capture a fresh AX tree and retry \(retry)"
-      ))
-    }
-    indices.append(index)
-  }
-  return .success(indices)
-}
+// NOTICE: `AxPathResolutionFailure` and `axObservedPathIndices` live in
+// `AxPath.swift` — the pure, AX-free parse layer. They are `internal` (not
+// `private`) so a standalone `swiftc` characterization harness can compile that
+// one file in isolation (the full module cannot be linked under `swift test`
+// because the generated `SwiftBridgeCore.swift` references Rust FFI symbols only
+// present in the cargo-built static lib). See
+// `docs/ai/references/driver/2026-07-19-ax-path-resolution-characterization.md`.
 
 private func axResolveObservedPath(
   pid: pid_t,

--- a/crates/auv-driver-macos/native/swift/characterization/AxPathCharacterization.swift
+++ b/crates/auv-driver-macos/native/swift/characterization/AxPathCharacterization.swift
@@ -1,0 +1,112 @@
+// Characterization harness for the pure AX path parse layer.
+//
+// This file is compiled by `scripts/ci/ax-path-characterization.sh` together
+// with the REAL `Sources/AuvMacosNative/AxPath.swift` in a single standalone
+// `swiftc` invocation. It links nothing from the rest of `AuvMacosNative`, so
+// it runs on headless CI (no Accessibility grant, no Rust static lib).
+//
+// It is intentionally NOT a SwiftPM target and NOT under `Sources/`, so:
+//   - `build.rs` (which globs only `Sources/AuvMacosNative/*.swift`) never
+//     compiles it into the shipped static library.
+//   - SwiftPM's `AuvMacosNative` target never sees it.
+//
+// Scope: this locks the OBSERVED-PATH PARSE contract only (root marker,
+// non-negative integer segments, offset reporting, verb interpolation). The
+// live tree-walk cases (out-of-range, role mismatch, stale tree,
+// first-window-vs-app-root, empty children) require a real AX tree and are
+// characterized by documentation in
+// `docs/ai/references/driver/2026-07-19-ax-path-resolution-characterization.md`,
+// not here — headless CI cannot grant Accessibility permission.
+
+import Foundation
+
+@main
+struct AxPathCharacterization {
+  static var failures = 0
+
+  static func check(_ condition: Bool, _ label: String) {
+    if condition {
+      print("ok   - \(label)")
+    } else {
+      print("FAIL - \(label)")
+      failures += 1
+    }
+  }
+
+  static func expectSuccess(_ path: String, _ expected: [Int], _ label: String) {
+    switch axObservedPathIndices(path: path, operation: "action", retry: "the action") {
+    case .success(let indices):
+      check(indices == expected, "\(label): indices == \(expected) (got \(indices))")
+    case .failure(let failure):
+      check(false, "\(label): expected success, got failure \(failure.message)")
+    }
+  }
+
+  static func expectFailure(
+    _ path: String,
+    operation: String,
+    retry: String,
+    messageContains: String,
+    recoveryContains: String,
+    _ label: String
+  ) {
+    switch axObservedPathIndices(path: path, operation: operation, retry: retry) {
+    case .success(let indices):
+      check(false, "\(label): expected failure, got success \(indices)")
+    case .failure(let failure):
+      check(failure.message.contains(messageContains), "\(label): message contains \"\(messageContains)\" (got \"\(failure.message)\")")
+      check(failure.recovery.contains(recoveryContains), "\(label): recovery contains \"\(recoveryContains)\" (got \"\(failure.recovery)\")")
+    }
+  }
+
+  static func main() {
+    // --- success cases ---
+    expectSuccess("0", [], "root-only path yields no child indices")
+    expectSuccess("0.1.2", [1, 2], "valid multi-segment path")
+    expectSuccess("0.0.0", [0, 0], "zero child indices are valid")
+
+    // --- root-marker case ---
+    expectFailure(
+      "1.2", operation: "action", retry: "the action",
+      messageContains: "path must begin with 0; got 1.2",
+      recoveryContains: "capture a fresh AX tree and retry the action",
+      "non-zero first segment rejected"
+    )
+    expectFailure(
+      "", operation: "action", retry: "the action",
+      messageContains: "path must begin with 0; got ",
+      recoveryContains: "capture a fresh AX tree",
+      "empty path rejected as missing root"
+    )
+
+    // --- non-integer / negative segment cases ---
+    expectFailure(
+      "0.x", operation: "focus", retry: "the focus request",
+      messageContains: "path segment x at offset 0 is not a non-negative integer",
+      recoveryContains: "retry the focus request",
+      "non-integer segment rejected with offset"
+    )
+    expectFailure(
+      "0.1.-1", operation: "inspection", retry: "the inspection",
+      messageContains: "path segment -1 at offset 1 is not a non-negative integer",
+      recoveryContains: "retry the inspection",
+      "negative segment rejected with offset 1"
+    )
+
+    // --- verb interpolation is per-operation ---
+    expectFailure(
+      "9", operation: "inspection", retry: "the inspection",
+      messageContains: "AX inspection path must begin with 0",
+      recoveryContains: "retry the inspection",
+      "operation verb interpolated into message"
+    )
+
+    if failures == 0 {
+      print("AX path characterization: ALL PASS")
+      exit(0)
+    } else {
+      print("AX path characterization: \(failures) FAILED")
+      exit(1)
+    }
+  }
+}

--- a/crates/auv-driver-macos/native/swift/characterization/AxPathCharacterization.swift
+++ b/crates/auv-driver-macos/native/swift/characterization/AxPathCharacterization.swift
@@ -64,6 +64,11 @@ struct AxPathCharacterization {
     expectSuccess("0", [], "root-only path yields no child indices")
     expectSuccess("0.1.2", [1, 2], "valid multi-segment path")
     expectSuccess("0.0.0", [0, 0], "zero child indices are valid")
+    // Swift String.split omits empty subsequences. These surprising cases are
+    // current behavior, not an endorsement; AxPath.swift carries the deferral.
+    expectSuccess(".0", [], "leading empty segment is currently omitted")
+    expectSuccess("0..1", [1], "repeated empty segment is currently omitted")
+    expectSuccess("0.", [], "trailing empty segment is currently omitted")
 
     // --- root-marker case ---
     expectFailure(

--- a/docs/ai/references/driver/2026-07-19-ax-path-resolution-characterization.md
+++ b/docs/ai/references/driver/2026-07-19-ax-path-resolution-characterization.md
@@ -30,6 +30,8 @@ compiles that real source file with a standalone `swiftc` invocation (via
 
 - root-only path `0` → no child indices;
 - valid multi-segment `0.1.2` → `[1, 2]`; `0.0.0` → `[0, 0]`;
+- leading, repeated, and trailing empty segments are currently omitted by
+  Swift `String.split`, so `.0` → `[]`, `0..1` → `[1]`, and `0.` → `[]`;
 - non-`0` first segment → `AX <op> path must begin with 0; got <path>`;
 - empty path → same root-marker failure;
 - non-integer segment → `AX <op> path segment <seg> at offset <n> is not a non-negative integer`;
@@ -86,6 +88,9 @@ not in headless CI.
 
 - No change to resolver behavior, error strings, or error *type* (that is the
   later typed-error vertical slice).
+- No tightening of empty-segment validation. `AxPath.swift` carries
+  `TODO(ax-path-empty-segments)` because rejecting the currently accepted forms
+  is a behavior change that needs an owner-approved bug-fix slice.
 - No XCTest target, no `swift test` in CI, no `build.rs` change (see reasons
   above).
 - No automation of the live-AX tree-walk cases.

--- a/docs/ai/references/driver/2026-07-19-ax-path-resolution-characterization.md
+++ b/docs/ai/references/driver/2026-07-19-ax-path-resolution-characterization.md
@@ -1,0 +1,91 @@
+# AX Path Resolution Characterization
+
+Date: 2026-07-19
+Responsibility: driver (macOS AX observed-path resolution)
+Type: reference / characterization
+
+## What this locks
+
+The macOS Swift AX layer resolves a stored *observed path* (a dotted string
+like `0.1.2`) back to a live `AXUIElement` for three operations that share one
+resolver (extracted in #111): `perform_ax_action`, `set_ax_focused`, and
+`inspect_ax_node`. This note records the resolver's current behavior so a later
+typed-error slice (milestone Workstream 2 / PR 5) can change error
+*classification* against a known baseline.
+
+The resolver has two layers with very different testability:
+
+| Layer | Symbol | Pure? | How it is characterized |
+|---|---|---|---|
+| Parse | `axObservedPathIndices` (`AxPath.swift`) | Yes — only `String`/`Int`/`Result`, no AX, no Rust bridge | **Automated**, CI-gated (see below) |
+| Tree walk | `axResolveObservedPath` (`AxTree.swift`) | No — calls `AXUIElementCreateApplication`, `axChildren`, `axStringAttribute` | **Documented only** (needs a live AX tree) |
+
+## Automated parse-layer characterization
+
+`crates/auv-driver-macos/native/swift/Sources/AuvMacosNative/AxPath.swift`
+holds the pure parse layer. The characterization harness at
+`crates/auv-driver-macos/native/swift/characterization/AxPathCharacterization.swift`
+compiles that real source file with a standalone `swiftc` invocation (via
+`scripts/ci/ax-path-characterization.sh`) and asserts:
+
+- root-only path `0` → no child indices;
+- valid multi-segment `0.1.2` → `[1, 2]`; `0.0.0` → `[0, 0]`;
+- non-`0` first segment → `AX <op> path must begin with 0; got <path>`;
+- empty path → same root-marker failure;
+- non-integer segment → `AX <op> path segment <seg> at offset <n> is not a non-negative integer`;
+- negative segment → same, with the correct zero-based `offset`;
+- `<op>` verb (`action` / `focus` / `inspection`) and `retry` phrase are
+  interpolated per operation into message and recovery hint.
+
+### Why a standalone `swiftc` harness, not `swift test`
+
+Three repo facts make `swift test` the wrong tool here, documented so the next
+reader does not "fix" it by adding an XCTest target:
+
+1. The `AuvMacosNative` module cannot link as a test executable: its generated
+   `SwiftBridgeCore.swift` references ~121 `__swift_bridge__$…` C symbols that
+   only exist in the cargo-built Rust static library, not in a bare
+   `swift test` link.
+2. `crates/auv-driver-macos/build.rs` globs `Sources/AuvMacosNative/*.swift`
+   into a single flat `swiftc -emit-library` call. Splitting the parse layer
+   into a separate SwiftPM *target* (with an `import`) would desync the cargo
+   build from the SwiftPM build.
+3. CI's `macos-14` runner has no Accessibility (TCC) grant, so the tree-walk
+   layer cannot run there regardless.
+
+The parse layer is therefore isolated into its own **file** (still inside the
+`AuvMacosNative` target directory, so `build.rs` and SwiftPM both keep compiling
+it into the real library) and its symbols are `internal` rather than `private`
+so the harness can compile that one file directly. This adds no SwiftPM target,
+no `build.rs` change, and no Rust link dependency.
+
+## Documented tree-walk contract (live AX, not automated)
+
+`axResolveObservedPath` walks from the app's first window (or the app element
+if there is no window) through the parsed indices, then checks the resolved
+node's role. Current behavior, recorded for the baseline:
+
+- **Out of range**: `AX <op> path index <i> is out of range at offset <n>;
+  element has <k> child(ren)`; recovery: "the AX tree likely shifted since
+  observation; capture a fresh tree and retry <retry>".
+- **Empty children**: a node with zero children makes any index out of range at
+  that offset (same message, `<k>` = 0).
+- **First window vs app root**: resolution starts at `axFirstWindow(appElement)`
+  and falls back to the app element when no window is present.
+- **Role mismatch**: when `expectedRole` is non-empty and the resolved node's
+  role differs → `AX <op> expected role <role> at path <path>, got <actual>`;
+  same "tree likely shifted" recovery.
+- **Stale tree**: manifests as either out-of-range or role-mismatch above,
+  because a shifted tree changes child counts or roles at the recorded path.
+
+These require a real running app with an AX tree; they are exercised in live
+runs (e.g. the TextEdit reference integration and the Apple Music AX probe),
+not in headless CI.
+
+## Non-goals
+
+- No change to resolver behavior, error strings, or error *type* (that is the
+  later typed-error vertical slice).
+- No XCTest target, no `swift test` in CI, no `build.rs` change (see reasons
+  above).
+- No automation of the live-AX tree-walk cases.

--- a/docs/ai/references/driver/INDEX.md
+++ b/docs/ai/references/driver/INDEX.md
@@ -2,7 +2,7 @@
 
 Platform drivers, input, window, capture, permissions
 
-Count: **20**
+Count: **21**
 
 - [`2026-05-20-macos-driver-namespace-after-window-screen-design.md`](2026-05-20-macos-driver-namespace-after-window-screen-design.md)
 - [`2026-05-20-macos-osascript-backend-design.md`](2026-05-20-macos-osascript-backend-design.md)
@@ -24,6 +24,7 @@ Count: **20**
 - [`2026-06-11-windows-driver-feasibility-and-delivery-paths.md`](2026-06-11-windows-driver-feasibility-and-delivery-paths.md)
 - [`2026-06-16-tracing-driver-extraction-implementation-plan.md`](2026-06-16-tracing-driver-extraction-implementation-plan.md)
 - [`2026-06-18-driver-windows-v0-implementation.md`](2026-06-18-driver-windows-v0-implementation.md)
+- [`2026-07-19-ax-path-resolution-characterization.md`](2026-07-19-ax-path-resolution-characterization.md)
 
 ## Related
 

--- a/scripts/ci/ax-path-characterization.sh
+++ b/scripts/ci/ax-path-characterization.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Characterizes the pure AX observed-path parse layer
+# (`crates/auv-driver-macos/native/swift/Sources/AuvMacosNative/AxPath.swift`).
+#
+# Compiles that REAL source file together with the standalone harness in a
+# single `swiftc` invocation and runs it. No SwiftPM, no Rust static lib, no
+# Accessibility permission required, so it runs on headless macOS CI.
+#
+# macOS-only: `swiftc` is not present on the Linux CI runner. The caller
+# (.github/workflows/check.yml) guards this with `if: runner.os == 'macOS'`.
+set -euo pipefail
+
+if ! command -v swiftc >/dev/null 2>&1; then
+  echo "ax-path-characterization: swiftc not found; this check is macOS-only" >&2
+  exit 1
+fi
+
+workspace="$(git rev-parse --show-toplevel)"
+swift_root="$workspace/crates/auv-driver-macos/native/swift"
+parse_source="$swift_root/Sources/AuvMacosNative/AxPath.swift"
+harness_source="$swift_root/characterization/AxPathCharacterization.swift"
+
+for source in "$parse_source" "$harness_source"; do
+  if [ ! -f "$source" ]; then
+    echo "ax-path-characterization: missing source $source" >&2
+    exit 1
+  fi
+done
+
+binary="$(mktemp -t ax-path-characterization)"
+trap 'rm -f "$binary"' EXIT
+
+swiftc "$parse_source" "$harness_source" -o "$binary"
+"$binary"


### PR DESCRIPTION
## Summary

Milestone Workstream 2 / **PR 2** — characterize the existing AX observed-path resolver before later typed-error work changes classification. This PR changes no resolver behavior.

## What changed

- Extracts the pure `axObservedPathIndices` parser into `AxPath.swift` while keeping it in the real `AuvMacosNative` target.
- Adds a standalone `swiftc` characterization harness and a macOS CI gate without introducing a SwiftPM test target or Rust-link dependency.
- Documents the live AX tree-walk contract that cannot run on headless CI: out-of-range, empty children, first-window/app-root selection, role mismatch, stale-tree recovery.
- Records a previously missed parser fact: Swift `String.split` omits empty subsequences, so `.0`, `0..1`, and `0.` are currently accepted. The harness now locks that current behavior.
- Adds `TODO(ax-path-empty-segments)` at the parser: rejecting these forms is a behavior change and needs an owner-approved bug-fix slice rather than being smuggled into characterization.

## Why standalone swiftc

The full Swift target cannot link as a test executable without the Cargo-built Rust bridge library, and headless CI has no Accessibility grant for live AX traversal. Compiling the real pure parser source with a small harness gives a hermetic gate without desynchronizing Cargo and SwiftPM.

## Verification

- `bash scripts/ci/ax-path-characterization.sh` — all cases pass.
- Existing branch CI verifies Rust on macOS/Linux and the macOS characterization gate.
- `git diff --check`.

## Non-goals

- No path-validation behavior change.
- No error-type or error-message change.
- No live AX automation in headless CI.
- No XCTest target or build-system restructuring.

This branch is rebased onto current `main` after #121.