### PR TITLE
feat(auv-driver-macos): classify AX focus errors at driver boundary

### DIFF
--- a/crates/auv-driver-common/src/error.rs
+++ b/crates/auv-driver-common/src/error.rs
@@ -18,6 +18,21 @@ pub enum DriverError {
   InvalidInput {
     message: String,
   },
+  /// A recorded observation (e.g. an AX path or captured tree) no longer
+  /// resolves against the live UI — the tree shifted since it was observed.
+  /// Distinct from `NotFound` (which means a target was never located) and from
+  /// `InvalidInput` (which means the caller supplied a malformed request).
+  StaleObservation {
+    message: String,
+    recovery: Option<String>,
+  },
+  /// A node resolved at the requested location, but its role differs from the
+  /// expected role — a specific, recoverable form of tree drift that callers
+  /// may want to distinguish from a fully unresolved path.
+  RoleMismatch {
+    message: String,
+    recovery: Option<String>,
+  },
   Backend {
     message: String,
   },
@@ -39,6 +54,13 @@ impl fmt::Display for DriverError {
         recovery,
       } => {
         write!(f, "{permission} permission was denied")?;
+        if let Some(recovery) = recovery {
+          write!(f, ": {recovery}")?;
+        }
+        Ok(())
+      }
+      Self::StaleObservation { message, recovery } | Self::RoleMismatch { message, recovery } => {
+        f.write_str(message)?;
         if let Some(recovery) = recovery {
           write!(f, ": {recovery}")?;
         }

--- a/crates/auv-driver-common/src/error.rs
+++ b/crates/auv-driver-common/src/error.rs
@@ -13,6 +13,9 @@ pub enum DriverError {
   },
   PermissionDenied {
     permission: &'static str,
+    /// Raw backend detail when the permission failure came from a native
+    /// response. Locally detected gates may leave this empty.
+    message: Option<String>,
     recovery: Option<String>,
   },
   InvalidInput {
@@ -51,11 +54,15 @@ impl fmt::Display for DriverError {
       Self::NotFound { target } => write!(f, "{target} was not found"),
       Self::PermissionDenied {
         permission,
+        message,
         recovery,
       } => {
         write!(f, "{permission} permission was denied")?;
-        if let Some(recovery) = recovery {
-          write!(f, ": {recovery}")?;
+        match (message, recovery) {
+          (Some(message), Some(recovery)) => write!(f, ": {message}; recovery: {recovery}")?,
+          (Some(message), None) => write!(f, ": {message}")?,
+          (None, Some(recovery)) => write!(f, ": {recovery}")?,
+          (None, None) => {}
         }
         Ok(())
       }

--- a/crates/auv-driver-macos/native/swift/Sources/AuvMacosNative/AxTree.swift
+++ b/crates/auv-driver-macos/native/swift/Sources/AuvMacosNative/AxTree.swift
@@ -482,6 +482,13 @@ func set_ax_focused(request: NativeAxFocusRequest) -> NativeAxFocusResponse {
     )
   }
 
+  guard AXIsProcessTrusted() else {
+    return focusError(
+      "Accessibility permission is required to focus an AX node",
+      "grant Accessibility permission to the process running AUV, then retry the focus request"
+    )
+  }
+
   let current: AXUIElement
   switch axResolveObservedPath(pid: pid, path: pathRaw, expectedRole: expectedRole, operation: "focus", retry: "the focus request") {
   case .success(let resolved):

--- a/crates/auv-driver-macos/native/swift/Sources/AuvMacosNative/AxTree.swift
+++ b/crates/auv-driver-macos/native/swift/Sources/AuvMacosNative/AxTree.swift
@@ -145,7 +145,8 @@ private func axResolveObservedPath(
   path: String,
   expectedRole: String,
   operation: String,
-  retry: String
+  retry: String,
+  requireTrustedProcess: Bool = false
 ) -> Result<AXUIElement, AxPathResolutionFailure> {
   let indices: [Int]
   switch axObservedPathIndices(path: path, operation: operation, retry: retry) {
@@ -153,6 +154,15 @@ private func axResolveObservedPath(
     indices = parsed
   case .failure(let failure):
     return .failure(failure)
+  }
+
+  // Validate the caller-owned path before checking TCC so malformed input is
+  // classified as InvalidInput even when Accessibility permission is absent.
+  if requireTrustedProcess && !AXIsProcessTrusted() {
+    return .failure(AxPathResolutionFailure(
+      message: "Accessibility permission is required to \(operation) an AX node",
+      recovery: "grant Accessibility permission to the process running AUV, then retry \(retry)"
+    ))
   }
 
   let appElement = AXUIElementCreateApplication(pid)
@@ -482,15 +492,15 @@ func set_ax_focused(request: NativeAxFocusRequest) -> NativeAxFocusResponse {
     )
   }
 
-  guard AXIsProcessTrusted() else {
-    return focusError(
-      "Accessibility permission is required to focus an AX node",
-      "grant Accessibility permission to the process running AUV, then retry the focus request"
-    )
-  }
-
   let current: AXUIElement
-  switch axResolveObservedPath(pid: pid, path: pathRaw, expectedRole: expectedRole, operation: "focus", retry: "the focus request") {
+  switch axResolveObservedPath(
+    pid: pid,
+    path: pathRaw,
+    expectedRole: expectedRole,
+    operation: "focus",
+    retry: "the focus request",
+    requireTrustedProcess: true
+  ) {
   case .success(let resolved):
     current = resolved
   case .failure(let failure):

--- a/crates/auv-driver-macos/src/accessibility.rs
+++ b/crates/auv-driver-macos/src/accessibility.rs
@@ -45,7 +45,10 @@ pub fn capture_app_tree(app: &str, max_depth: i64, max_children: i64) -> DriverR
 }
 
 pub fn focus_node_path(pid: i32, path: &str, expected_role: &str) -> DriverResult<InputActionResult> {
-  let _ = crate::native::ax_tree::set_ax_focused_path(pid, path, expected_role).map_err(backend)?;
+  // `set_ax_focused_path` already returns a classified `DriverError` (stale
+  // path / role mismatch / permission / backend), so propagate it directly
+  // instead of flattening everything through `backend` into `Backend`.
+  let _ = crate::native::ax_tree::set_ax_focused_path(pid, path, expected_role)?;
   Ok(InputActionResult {
     selected_path: InputDeliveryPath::AxFocus,
     attempts: vec![InputAttempt {

--- a/crates/auv-driver-macos/src/native/ax_tree.rs
+++ b/crates/auv-driver-macos/src/native/ax_tree.rs
@@ -78,7 +78,7 @@ pub fn perform_ax_path_action(_pid: i32, _path: &str, _expected_role: &str, _act
 }
 
 #[cfg(target_os = "macos")]
-pub fn set_ax_focused_path(pid: i32, path: &str, expected_role: &str) -> AuvResult<NativeAxFocus> {
+pub fn set_ax_focused_path(pid: i32, path: &str, expected_role: &str) -> DriverResult<NativeAxFocus> {
   decode_ax_focus_response(DecodedAxFocusResponse::from(set_ax_focused(NativeAxFocusRequest {
     pid: i64::from(pid),
     path: path.to_string(),
@@ -87,8 +87,8 @@ pub fn set_ax_focused_path(pid: i32, path: &str, expected_role: &str) -> AuvResu
 }
 
 #[cfg(not(target_os = "macos"))]
-pub fn set_ax_focused_path(_pid: i32, _path: &str, _expected_role: &str) -> AuvResult<NativeAxFocus> {
-  Err("macOS native AX focus dispatch is unsupported on this target".to_string())
+pub fn set_ax_focused_path(_pid: i32, _path: &str, _expected_role: &str) -> DriverResult<NativeAxFocus> {
+  Err(DriverError::unsupported("macos.ax.set_focused_path"))
 }
 
 // NOTICE: unlike the sibling `native` AX helpers (which return `AuvResult` and
@@ -187,6 +187,13 @@ pub fn decode_ax_tree_response(response: DecodedAxTreeResponse) -> AuvResult<Nat
   })
 }
 
+// TODO(ax-typed-error-fanout): this decode still flattens to `AuvResult`
+// (String) via `native_result`, unlike `decode_ax_focus_response` which now
+// classifies into typed `DriverError` variants (see `classify_ax_native_error`).
+// `perform_ax_path_action` currently has no caller, so it is left un-migrated in
+// this slice; migrate it (and `decode_ax_node_inspection_response`) the same way
+// once a consumer needs classified action errors. See
+// `docs/ai/references/driver/2026-07-19-error-chain-inventory.md`.
 pub fn decode_ax_action_response(response: DecodedAxActionResponse) -> AuvResult<NativeAxAction> {
   if response.error_message.is_some() {
     return super::error::native_result("perform_ax_action", None, response.error_message, response.recovery_hint);
@@ -219,9 +226,66 @@ fn non_negative_count(value: i64) -> usize {
   usize::try_from(value).unwrap_or(0)
 }
 
-pub fn decode_ax_focus_response(response: DecodedAxFocusResponse) -> AuvResult<NativeAxFocus> {
+// Classifies a native AX failure message into a typed `DriverError`.
+//
+// This is the one place allowed to inspect the raw Swift error text: it is the
+// decode boundary that converts the unstructured native response into a
+// structured variant. Callers above this layer match on the variant, never on
+// the message string (AGENTS.md: no `contains("stale")` control flow in the
+// operation/CLI layers). The matched substrings are the observed-path failure
+// contract characterized in
+// `docs/ai/references/driver/2026-07-19-ax-path-resolution-characterization.md`.
+//
+// NOTICE(ax-native-error-kind): the ideal is for Swift to emit a structured
+// error kind over FFI so this layer maps a code, not a substring. That is
+// deferred — it requires a Swift/FFI/bridge change; this Rust-side slice proves
+// the classification pattern first. Unlock when a second native domain (OCR /
+// window) needs the same typing and the Swift-side kind pays for itself.
+//
+// Pure Rust (no AX calls) so it compiles on every target — `decode_ax_focus_response`
+// is not target-gated and its tests run on the CI Linux host too.
+fn classify_ax_native_error(message: Option<String>, recovery: Option<String>) -> DriverError {
+  let message = message.unwrap_or_else(|| "unknown native AX error".to_string());
+  let lowered = message.to_lowercase();
+
+  // Caller supplied a malformed observed path — not a live-tree problem.
+  if lowered.contains("must begin with 0") || lowered.contains("is not a non-negative integer") {
+    return DriverError::InvalidInput {
+      message: join_recovery(message, recovery),
+    };
+  }
+  // Accessibility permission gate.
+  if lowered.contains("permission") || lowered.contains("accessibility") {
+    return DriverError::PermissionDenied {
+      permission: "accessibility",
+      recovery,
+    };
+  }
+  // A node resolved but its role differs from the expected role.
+  if lowered.contains("expected role") {
+    return DriverError::RoleMismatch { message, recovery };
+  }
+  // The recorded path/tree no longer resolves against the live UI.
+  if lowered.contains("is out of range") || lowered.contains("tree likely shifted") || lowered.contains("could not resolve target") {
+    return DriverError::StaleObservation { message, recovery };
+  }
+  DriverError::Backend {
+    message: join_recovery(message, recovery),
+  }
+}
+
+// Folds a recovery hint into the message for variants that carry no dedicated
+// recovery field (`InvalidInput` / `Backend`), so the hint is never dropped.
+fn join_recovery(message: String, recovery: Option<String>) -> String {
+  match recovery {
+    Some(recovery) => format!("{message}; recovery: {recovery}"),
+    None => message,
+  }
+}
+
+pub fn decode_ax_focus_response(response: DecodedAxFocusResponse) -> DriverResult<NativeAxFocus> {
   if response.error_message.is_some() {
-    return super::error::native_result("set_ax_focused", None, response.error_message, response.recovery_hint);
+    return Err(classify_ax_native_error(response.error_message, response.recovery_hint));
   }
 
   Ok(NativeAxFocus {
@@ -564,14 +628,68 @@ mod tests {
   }
 
   #[test]
-  fn decode_ax_focus_rejects_native_error() {
+  fn decode_ax_focus_rejects_native_error_as_backend_and_preserves_detail() {
+    // An unrecognized AX error code falls through to Backend; the message and
+    // recovery hint are still preserved (folded into the Backend message).
     let mut response = base_focus_response();
     response.error_message = Some("AXUIElementSetAttributeValue returned -25204".to_string());
     response.recovery_hint = Some("element may not accept programmatic focus".to_string());
 
     let error = decode_ax_focus_response(response).unwrap_err();
 
-    assert!(error.contains("set_ax_focused failed"));
-    assert!(error.contains("AXUIElementSetAttributeValue returned -25204"));
+    assert!(matches!(error, DriverError::Backend { .. }), "expected Backend, got {error:?}");
+    let rendered = error.to_string();
+    assert!(rendered.contains("AXUIElementSetAttributeValue returned -25204"), "message lost: {rendered}");
+    assert!(rendered.contains("element may not accept programmatic focus"), "recovery lost: {rendered}");
+  }
+
+  // ROOT CAUSE:
+  //
+  // Before PR 5, `decode_ax_focus_response` flattened every native AX failure
+  // into one `Result<_, String>` via `native_result`, so callers could not tell
+  // a malformed path from a shifted tree from a role mismatch without parsing
+  // message text. This slice classifies the native message (the observed-path
+  // contract locked in the AX path characterization) into typed `DriverError`
+  // variants at the decode boundary. These tests pin that mapping.
+  fn focus_error(message: &str) -> DriverError {
+    let mut response = base_focus_response();
+    response.error_message = Some(message.to_string());
+    response.recovery_hint = Some("capture a fresh AX tree and retry the focus request".to_string());
+    decode_ax_focus_response(response).unwrap_err()
+  }
+
+  #[test]
+  fn classify_malformed_path_as_invalid_input() {
+    assert!(matches!(focus_error("AX focus path must begin with 0; got 1.2"), DriverError::InvalidInput { .. }));
+    assert!(matches!(focus_error("AX focus path segment x at offset 0 is not a non-negative integer"), DriverError::InvalidInput { .. }));
+  }
+
+  #[test]
+  fn classify_out_of_range_path_as_stale_observation() {
+    let error = focus_error("AX focus path index 3 is out of range at offset 1; element has 2 child(ren)");
+    assert!(matches!(error, DriverError::StaleObservation { .. }), "got {error:?}");
+    // recovery hint is preserved in the dedicated field (surfaces via Display)
+    assert!(error.to_string().contains("capture a fresh AX tree"));
+  }
+
+  #[test]
+  fn classify_role_mismatch_distinctly_from_stale() {
+    let error = focus_error("AX focus expected role AXTextField at path 0.1, got AXButton");
+    assert!(matches!(error, DriverError::RoleMismatch { .. }), "got {error:?}");
+  }
+
+  #[test]
+  fn classify_permission_denied() {
+    let error = focus_error("Accessibility permission is required to read the AX tree");
+    assert!(
+      matches!(
+        error,
+        DriverError::PermissionDenied {
+          permission: "accessibility",
+          ..
+        }
+      ),
+      "got {error:?}"
+    );
   }
 }

--- a/crates/auv-driver-macos/src/native/ax_tree.rs
+++ b/crates/auv-driver-macos/src/native/ax_tree.rs
@@ -258,6 +258,7 @@ fn classify_ax_native_error(message: Option<String>, recovery: Option<String>) -
   if lowered.contains("permission") || lowered.contains("accessibility") {
     return DriverError::PermissionDenied {
       permission: "accessibility",
+      message: Some(message),
       recovery,
     };
   }
@@ -680,16 +681,18 @@ mod tests {
 
   #[test]
   fn classify_permission_denied() {
-    let error = focus_error("Accessibility permission is required to read the AX tree");
-    assert!(
-      matches!(
-        error,
-        DriverError::PermissionDenied {
-          permission: "accessibility",
-          ..
-        }
-      ),
-      "got {error:?}"
-    );
+    let error = focus_error("Accessibility permission is required to focus an AX node");
+    match error {
+      DriverError::PermissionDenied {
+        permission,
+        message,
+        recovery,
+      } => {
+        assert_eq!(permission, "accessibility");
+        assert_eq!(message.as_deref(), Some("Accessibility permission is required to focus an AX node"));
+        assert_eq!(recovery.as_deref(), Some("capture a fresh AX tree and retry the focus request"));
+      }
+      other => panic!("expected PermissionDenied, got {other:?}"),
+    }
   }
 }

--- a/crates/auv-driver-macos/src/session.rs
+++ b/crates/auv-driver-macos/src/session.rs
@@ -1490,6 +1490,7 @@ fn display_targets_from_monitors(monitors: &[xcap::Monitor]) -> DriverResult<Vec
   if monitors.is_empty() {
     return Err(DriverError::PermissionDenied {
       permission: "screen_recording",
+      message: None,
       recovery: Some(
         "xcap returned no displays; run `auv doctor --json` and grant Screen Recording to the terminal or agent process that launches AUV"
           .to_string(),
@@ -2000,9 +2001,11 @@ mod no_steal_tests {
     match error {
       DriverError::PermissionDenied {
         permission,
+        message,
         recovery,
       } => {
         assert_eq!(permission, "screen_recording");
+        assert_eq!(message, None);
         assert!(recovery.as_deref().is_some_and(|message| message.contains("auv doctor --json")));
       }
       other => panic!("unexpected error: {other}"),


### PR DESCRIPTION
## Summary

Milestone Workstream 2 / **PR 5** — first typed AX error vertical slice on the live focus path:

```
Swift set_ax_focused
→ Rust decode_ax_focus_response
→ DriverError
→ accessibility::focus_node_path
```

The title intentionally says “at driver boundary”: TextEdit still formats its driver error into its current app-local String result. Mapping the typed variant into persisted operation/failure evidence belongs to the planned PR 8 parity slice, not this PR.

## What changed

- Adds `DriverError::StaleObservation` and `DriverError::RoleMismatch`.
- Changes `decode_ax_focus_response` and `set_ax_focused_path` to return `DriverResult`; the public focus path propagates the classified error instead of flattening it back to `Backend`.
- Classifies malformed path, stale observation, role mismatch, permission failure, and backend fallback once at the native decode boundary. Operation/CLI layers do not parse message strings.
- Preserves message and recovery details. `PermissionDenied` now carries optional raw backend detail as well as recovery; existing locally detected screen-recording gates use `message: None`.
- Adds a real `AXIsProcessTrusted()` check on the focus resolver path. The earlier branch only had a fabricated Rust permission test while Swift did not reliably emit a permission-specific message.
- Performs pure path validation before the TCC check, so malformed caller input remains `InvalidInput` even when Accessibility permission is absent.
- Keeps `TODO(ax-typed-error-fanout)` for unmigrated AX functions and `NOTICE(ax-native-error-kind)` for a future structured Swift error kind.

## Why substring classification is contained

The Swift bridge currently returns `error_message` and `recovery_hint`, not a structured kind. String inspection occurs only once at the Rust decode boundary. Every caller above it matches the machine-readable `DriverError` variant.

## Verification

Final branch rebased after #116, #117, #119, #120, and #121:

- `scripts/generate-swift-bridge`
- `swift build` in `crates/auv-driver-macos/native/swift`
- `cargo test -p auv-driver-common -p auv-driver-macos` — 21 + 88 passed
- `cargo fmt --check`
- `git diff --check`
- Full repository CI on this rebased branch

SwiftPM reports only the two pre-existing Vision downcast warnings and a linker search-path warning outside the touched focus code.

## Non-goals

- No migration of the other native functions.
- No operation-layer failure mapping.
- No TextEdit trait/result rewrite.
- No CLI presentation change.
- No broad error enum.