### PR TITLE
docs(contract): clarify OperationStatus evidence boundary

### DIFF
--- a/docs/TERMS_AND_CONCEPTS.md
+++ b/docs/TERMS_AND_CONCEPTS.md
@@ -625,6 +625,27 @@ call the same operation contract without going through CLI parsing.
 
 In code, the current type is `auv_driver::OperationSpec`.
 
+## Operation Status
+
+Operation status is the coarse recorded outcome on an `OperationResult`. It is
+not, by itself, proof that an action was delivered or that the expected world
+state was reached.
+
+`Completed` means the producer did not classify the operation as failed under
+that operation's current policy. `Failed` may represent refusal, backend or
+permission failure, or a required verification that did not match. Producers
+do not yet share one rule for whether semantic mismatch changes the coarse
+status, so consumers must not infer the failure layer from this enum alone.
+
+Action delivery evidence belongs in `InputActionResult` artifacts. Semantic
+evidence belongs in `VerificationResult.semantic_matched` together with its
+failure layer. A `Completed` result can therefore carry
+`semantic_matched = false`, and a `Failed` result can still show that input was
+delivered. The planned TextEdit parity/failure-semantics slice owns any future
+standardization of producer status policy.
+
+In code, the current type is `auv_runtime::contract::OperationStatus`.
+
 ## Operation Disturbance
 
 Operation disturbance is the coarse user-visible disturbance profile attached

--- a/docs/ai/references/runtime/2026-07-19-core-contract-ownership-review.md
+++ b/docs/ai/references/runtime/2026-07-19-core-contract-ownership-review.md
@@ -142,6 +142,6 @@ feature-frozen crates.
    sign-off given the frozen-crate rule.
 3. **`api_version` reader rejection** (`NOTICE(contract-api-version-reader-check)`):
    deferred until a non-additive record version lands.
-4. From PR 6: remove the dead `auv-media-macos` dependency and decide the
-   `auv-driver-macos` root target-gating — dependency-graph concerns, tracked in
-   the crate-tier inventory.
+4. From PR 6: decide the remaining `auv-driver-macos` root target-gating
+   question tracked in the crate-tier inventory. The separate dead
+   `auv-media-macos` root/CLI dependency was already removed in PR #121.

--- a/docs/ai/references/runtime/2026-07-19-core-contract-ownership-review.md
+++ b/docs/ai/references/runtime/2026-07-19-core-contract-ownership-review.md
@@ -1,0 +1,139 @@
+# Core Contract Ownership Review
+
+Date: 2026-07-19
+Responsibility: runtime (core result contracts)
+Type: review
+Milestone: Workstream 3 / PR 7
+
+## Purpose
+
+Review the six core result contracts for ownership, stable-vs-platform fields,
+duplicate schemas, unreachable states, and — the milestone's central concern —
+whether a delivered action is ever mistaken for semantic success. Per the
+milestone, this PR **fixes one clearest inconsistency**, not rewrites six types.
+
+## Scope answered per contract
+
+For each of the six the milestone named:
+1. owner crate, 2. stable fields vs platform detail, 3. do CLI/MCP/library read
+the same result, 4. is the same fact persisted in run/artifact, 5. duplicate
+schema, 6. unreachable state, 7. is a successful action mistaken for semantic
+success.
+
+## Findings — 5 of 6 are cleanly owned
+
+### 1. `InputActionResult` — owner `auv-driver-common` (`input.rs:325`)
+- Single owner; re-exported by `auv-driver`. CLI/MCP/library all consume the
+  same type via the driver session APIs.
+- Persisted as an `input-action-result` artifact (read-side projection added in
+  #115).
+- **No duplicate**: grep for a parallel `struct InputActionResult` in donor
+  crates returns nothing.
+- **Action vs semantic**: correct by construction — the struct carries only
+  delivery evidence (`selected_path`, `attempts`, `fallback_reason`,
+  disturbance levels) and has **no** semantic-success field. Semantic success
+  is never claimed here. ✅
+
+### 2. `VerificationResult` — owner `src/contract.rs:446` (root `auv-runtime`)
+- Single owner. Exemplary separation of axes: `executed` (did the check run),
+  `state_changed` (did the world move), `semantic_matched: Option<bool>` (did it
+  reach the expected state), `failure_layer` (where it failed). No duplicate in
+  any donor crate.
+- **Action vs semantic**: this is the type that *carries* the semantic claim,
+  explicitly separate from execution. ✅
+
+### 3. `OperationResult` / `OperationStatus` — owner `src/contract.rs:126` / `:100`
+- Core struct is well-owned and documented; `OperationStatus` **was not** (see
+  the fix below).
+- **Duplicate-name collision** (follow-up, not fixed here): three crates define
+  `pub type OperationResult<T> = Result<T, String>` — `auv-apple-notes`,
+  `auv-apple-textedit`, `auv-qqmusic` — shadowing the core contract name (~75
+  usages total). And `auv-game-balatro` has a placeholder
+  `struct OperationResult { _private: () }` (intentional, `TODO(balatro-operations-v1)`).
+  These are naming smells in feature-frozen reference/experimental crates;
+  renaming ~75 sites across 3 crates is out of scope for PR 7's "one narrow fix"
+  and touches crates whose feature work is paused. Recorded as a follow-up.
+- **Unreachable state**: `OperationStatus { Completed, Failed }` — both
+  reachable. ✅
+
+### 4. `ArtifactRef` — owner `auv-tracing-driver` (`artifact.rs:6`)
+- Single owner; `src/contract.rs:39` re-exports it (`pub use
+  auv_tracing_driver::ArtifactRef`). Not redefined anywhere.
+- `ArtifactRefView` (`auv-inspect-model:41`) is a **read-side enrichment
+  projection** (adds `role`/`path`/`summary`/`resolved`), documented with an
+  explicit anti-fork guard ("Owned here so game crates can parse artifacts
+  without depending on `auv-cli`. Do not fork a same-shape copy."). This is a
+  justified projection, **not** a duplicate. ✅
+
+### 5. `CandidateRef` — owner `src/contract.rs:92`
+- Cross-run pointer (`source_run_id`, `source_span_id`, `source_operation_id`,
+  `source_artifact_id`, `candidate_local_id`), distinct from the inline
+  `Candidate` struct (`:269`). Not a duplicate — different concept (reference vs
+  inline value). ✅
+
+### 6. Failure layer (`FailureLayer`) — owner `src/contract.rs:523`
+- Single owner; consumed by inspect rendering (`src/inspect/mod.rs`). Not
+  redefined in any donor crate. ✅
+
+## The one fix landed here: document + lock the OperationStatus / semantic axis
+
+**The clearest inconsistency**: `OperationStatus { Completed, Failed }` had
+**zero documentation**. I verified all four producers derive status from the
+**execution/dispatch** path and never from `semantic_matched`:
+
+- `src/api/session_service/operation_result_store.rs:27` — from `RunStatus`.
+- `crates/auv-cli/src/integrations/query_wired_live_action_status.rs:59`
+  (`operation_status_and_message`) — `Completed` when a click summary exists,
+  `Failed` when refused. Used by both minecraft and osu `query_live_action`.
+- `crates/auv-cli/src/cli_frontend.rs:1107` (`build_minecraft_operation_result`)
+  — `Completed` because it is only reached *after* the click was dispatched
+  (refusal returns `Err` earlier); the semantic verdict is carried separately in
+  `verifications[0]`.
+
+So the codebase is **consistent** — `OperationStatus` = execution outcome,
+semantic success = `verifications[].semantic_matched` + `failure_layer` — but
+that load-bearing separation (the milestone's #1 principle, "action delivered ≠
+semantic success") was protected **only by convention**. A future producer
+could set `Failed` on a semantic mismatch, or a consumer could read `Completed`
+as "succeeded", silently collapsing the two axes.
+
+**Fix** (narrow, core-only, `src/contract.rs`):
+1. Documented `OperationStatus`: `Completed`/`Failed` are the execution/dispatch
+   outcome, **not** semantic success; semantic success is a separate axis in
+   `VerificationResult::semantic_matched` + `failure_layer`. Cross-referenced
+   from `OperationResult::status`.
+2. Added a contract regression test
+   `operation_status_completed_is_independent_of_semantic_outcome`: an
+   `OperationResult` with `status == Completed` and
+   `verifications[0].semantic_matched == Some(false)` (+ `failure_layer =
+   StateChangedNoMatch`) is valid and round-trips — locking the two axes as
+   independent so no future change can collapse them.
+
+Chosen over the `OperationResult` alias rename because it is **core, narrow, and
+directly answers the milestone review question** ("是否存在成功 action 被误当成
+semantic success?"), whereas the rename is a large mechanical sweep across
+feature-frozen crates.
+
+## Stable vs provisional fields (summary)
+
+- **Stable**: all six contracts' core identity fields (run/span/operation IDs,
+  `status`, `executed`/`state_changed`/`semantic_matched`, artifact IDs).
+- **Provisional / wire-versioned**: `api_version` on `OperationResult`,
+  `VerificationResult`, `ObservationSnapshot` — stamped on write, but readers do
+  **not** reject unknown values yet (`NOTICE(contract-api-version-reader-check)`
+  in `contract.rs`). Graduation trigger for reader-side rejection: a real
+  non-additive `v1alpha2` of the same record. Deferred, marked at the code site.
+
+## Follow-ups (NOT done in this PR)
+
+1. **`OperationResult` name collision**: rename the three
+   `type OperationResult<T> = Result<T, String>` aliases
+   (apple-notes/textedit/qqmusic) to a non-shadowing, non-`Result<_,String>`
+   name. ~75 sites, 3 feature-frozen crates. Also ties into the error-chain
+   inventory's goal of retiring `Result<T,String>` boundaries. Needs owner
+   sign-off given the frozen-crate rule.
+2. **`api_version` reader rejection** (`NOTICE(contract-api-version-reader-check)`):
+   deferred until a non-additive record version lands.
+3. From PR 6: remove the dead `auv-media-macos` dependency and decide the
+   `auv-driver-macos` root target-gating — dependency-graph concerns, tracked in
+   the crate-tier inventory.

--- a/docs/ai/references/runtime/2026-07-19-core-contract-ownership-review.md
+++ b/docs/ai/references/runtime/2026-07-19-core-contract-ownership-review.md
@@ -75,49 +75,54 @@ success.
 - Single owner; consumed by inspect rendering (`src/inspect/mod.rs`). Not
   redefined in any donor crate. ✅
 
-## The one fix landed here: document + lock the OperationStatus / semantic axis
+## The one fix landed here: define what OperationStatus can and cannot prove
 
 **The clearest inconsistency**: `OperationStatus { Completed, Failed }` had
-**zero documentation**. I verified all four producers derive status from the
-**execution/dispatch** path and never from `semantic_matched`:
+**zero documentation**, and the first review incorrectly assumed every producer
+derived it only from execution/dispatch. A full producer audit found two real
+policies:
 
-- `src/api/session_service/operation_result_store.rs:27` — from `RunStatus`.
-- `crates/auv-cli/src/integrations/query_wired_live_action_status.rs:59`
-  (`operation_status_and_message`) — `Completed` when a click summary exists,
-  `Failed` when refused. Used by both minecraft and osu `query_live_action`.
-- `crates/auv-cli/src/cli_frontend.rs:1107` (`build_minecraft_operation_result`)
-  — `Completed` because it is only reached *after* the click was dispatched
-  (refusal returns `Err` earlier); the semantic verdict is carried separately in
-  `verifications[0]`.
+- `src/api/session_service/operation_result_store.rs` maps persisted
+  `OperationStatus` from `RunStatus`.
+- `crates/auv-cli/src/integrations/query_wired_live_action_status.rs` uses
+  `Completed` when dispatch produced a click summary and `Failed` when refused.
+- `crates/auv-cli/src/cli_frontend.rs` builds a completed Minecraft operation
+  after dispatch and carries semantic mismatch in `verifications[0]`.
+- `crates/auv-cli/src/integrations/textedit/mod.rs` deliberately changes both
+  `RunStatus` and `OperationStatus` to `Failed` when required AX text
+  verification reports `semantic_matched == false`; its parity tests lock that
+  behavior.
 
-So the codebase is **consistent** — `OperationStatus` = execution outcome,
-semantic success = `verifications[].semantic_matched` + `failure_layer` — but
-that load-bearing separation (the milestone's #1 principle, "action delivered ≠
-semantic success") was protected **only by convention**. A future producer
-could set `Failed` on a semantic mismatch, or a consumer could read `Completed`
-as "succeeded", silently collapsing the two axes.
+Therefore `OperationStatus` is **not currently an execution-only axis**. It is a
+coarse producer outcome whose policy is not yet uniform. What is uniform is the
+evidence boundary: status alone proves neither delivery nor semantic success.
+Delivery belongs in `InputActionResult`; semantic evidence belongs in
+`VerificationResult.semantic_matched` plus `failure_layer`.
 
-**Fix** (narrow, core-only, `src/contract.rs`):
-1. Documented `OperationStatus`: `Completed`/`Failed` are the execution/dispatch
-   outcome, **not** semantic success; semantic success is a separate axis in
-   `VerificationResult::semantic_matched` + `failure_layer`. Cross-referenced
-   from `OperationResult::status`.
-2. Added a contract regression test
-   `operation_status_completed_is_independent_of_semantic_outcome`: an
-   `OperationResult` with `status == Completed` and
-   `verifications[0].semantic_matched == Some(false)` (+ `failure_layer =
-   StateChangedNoMatch`) is valid and round-trips — locking the two axes as
-   independent so no future change can collapse them.
+**Fix** (narrow contract clarification, not a producer rewrite):
+1. Documented the actual coarse status semantics in `src/contract.rs` and the
+   shared vocabulary in `docs/TERMS_AND_CONCEPTS.md`.
+2. Added `TODO(operation-status-policy)` at the enum because standardizing
+   whether required semantic mismatch changes status belongs to the planned
+   TextEdit parity/failure-semantics slice, not this review PR.
+3. Renamed the regression test to
+   `operation_status_completed_does_not_imply_semantic_match`: a completed
+   result with `semantic_matched == Some(false)` remains a valid combination,
+   proving consumers cannot treat `Completed` as semantic evidence.
 
-Chosen over the `OperationResult` alias rename because it is **core, narrow, and
-directly answers the milestone review question** ("是否存在成功 action 被误当成
-semantic success?"), whereas the rename is a large mechanical sweep across
+Chosen over silently changing TextEdit's run/trace/operation status parity:
+that behavior is explicitly tested and belongs to PR 8. Also chosen over the
+`OperationResult` alias rename because that is a large mechanical sweep across
 feature-frozen crates.
 
 ## Stable vs provisional fields (summary)
 
 - **Stable**: all six contracts' core identity fields (run/span/operation IDs,
-  `status`, `executed`/`state_changed`/`semantic_matched`, artifact IDs).
+  `OperationStatus` vocabulary, `executed`/`state_changed`/
+  `semantic_matched`, artifact IDs).
+- **Provisional policy**: whether a required semantic mismatch changes coarse
+  `OperationStatus`; producers currently differ and explicit verification
+  evidence remains authoritative.
 - **Provisional / wire-versioned**: `api_version` on `OperationResult`,
   `VerificationResult`, `ObservationSnapshot` — stamped on write, but readers do
   **not** reject unknown values yet (`NOTICE(contract-api-version-reader-check)`
@@ -126,14 +131,17 @@ feature-frozen crates.
 
 ## Follow-ups (NOT done in this PR)
 
-1. **`OperationResult` name collision**: rename the three
+1. **`OperationStatus` producer policy**: decide in the TextEdit parity slice
+   whether required semantic mismatch must change coarse status, then align
+   producers and parity/read-side checks under one approved rule.
+2. **`OperationResult` name collision**: rename the three
    `type OperationResult<T> = Result<T, String>` aliases
    (apple-notes/textedit/qqmusic) to a non-shadowing, non-`Result<_,String>`
    name. ~75 sites, 3 feature-frozen crates. Also ties into the error-chain
    inventory's goal of retiring `Result<T,String>` boundaries. Needs owner
    sign-off given the frozen-crate rule.
-2. **`api_version` reader rejection** (`NOTICE(contract-api-version-reader-check)`):
+3. **`api_version` reader rejection** (`NOTICE(contract-api-version-reader-check)`):
    deferred until a non-additive record version lands.
-3. From PR 6: remove the dead `auv-media-macos` dependency and decide the
+4. From PR 6: remove the dead `auv-media-macos` dependency and decide the
    `auv-driver-macos` root target-gating — dependency-graph concerns, tracked in
    the crate-tier inventory.

--- a/docs/ai/references/runtime/INDEX.md
+++ b/docs/ai/references/runtime/INDEX.md
@@ -2,7 +2,7 @@
 
 Execution, contract, action seam, admission, query readiness, core roadmaps
 
-Count: **33**
+Count: **31**
 
 - [`2026-05-27-action-resolver-v0.md`](2026-05-27-action-resolver-v0.md)
 - [`2026-06-13-core-graduation-local-handoff.md`](2026-06-13-core-graduation-local-handoff.md)
@@ -33,10 +33,11 @@ Count: **33**
 - [`2026-07-06-action-seam-closeout.md`](2026-07-06-action-seam-closeout.md)
 - [`2026-07-07-archived-candidate-action-removal-plan.md`](2026-07-07-archived-candidate-action-removal-plan.md)
 - [`2026-07-07-archived-candidate-action-removal-spec.md`](2026-07-07-archived-candidate-action-removal-spec.md)
+- [`2026-07-19-core-contract-ownership-review.md`](2026-07-19-core-contract-ownership-review.md)
+- [`2026-07-19-core-dependency-and-crate-tier-inventory.md`](2026-07-19-core-dependency-and-crate-tier-inventory.md)
 
 ## Related
 
 - Parent index: [`../INDEX.md`](../INDEX.md)
 - Docs overview: [`../../../README.md`](../../../README.md)
 - Shared vocabulary: [`../../../TERMS_AND_CONCEPTS.md`](../../../TERMS_AND_CONCEPTS.md)
-- [`2026-07-19-core-dependency-and-crate-tier-inventory.md`](2026-07-19-core-dependency-and-crate-tier-inventory.md)

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -97,26 +97,26 @@ pub struct CandidateRef {
   pub candidate_local_id: String,
 }
 
-/// Execution outcome of a typed command — **not** its semantic outcome.
+/// Coarse recorded outcome of an operation, not proof of action delivery or
+/// semantic success.
 ///
-/// `Completed` means the operation ran to the end of its dispatch path (the
-/// action was delivered, or an observe/verify command executed); `Failed` means
-/// it could not execute (refused before dispatch, a backend/permission error,
-/// or a failed run). Every producer in the codebase derives this from the
-/// execution/dispatch path — via run status, dispatched-vs-refused, or a
-/// backend error — and **never** from whether the world reached the expected
-/// state.
+/// `Completed` means the producer did not classify the operation as failed
+/// under that operation's current policy. `Failed` means it did; the reason may
+/// be refusal before dispatch, a backend or permission error, or a required
+/// verification that did not match. The status alone does not identify which
+/// layer failed.
 ///
-/// Semantic success is a *separate axis*, carried by
-/// [`VerificationResult::semantic_matched`] (with [`VerificationResult::failure_layer`])
-/// inside [`OperationResult::verifications`]. The two are independent: an
-/// operation can be `Completed` while its verification reports
-/// `semantic_matched == Some(false)` — the action was delivered, but the world
-/// did not match. Consumers MUST NOT read `Completed` as "the operation
-/// succeeded semantically", and producers MUST NOT downgrade to `Failed` on a
-/// semantic mismatch. AUV's value is "the world is in the expected state, and
-/// here is the evidence" — that claim lives in the verification, not in this
-/// status. Keeping the axes separate is the whole point of the seam.
+/// Consumers must use [`InputActionResult`] artifacts for delivery evidence and
+/// [`VerificationResult::semantic_matched`] together with
+/// [`VerificationResult::failure_layer`] for semantic evidence. In particular,
+/// `Completed` can coexist with `semantic_matched == Some(false)` and therefore
+/// must not be read as semantic success; `Failed` does not imply that no action
+/// was delivered.
+///
+/// TODO(operation-status-policy): producers do not yet share one rule for
+/// whether a semantic mismatch changes this coarse status. Standardize that in
+/// the TextEdit parity/failure-semantics slice, then tighten this contract if
+/// the owner approves one policy.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum OperationStatus {
@@ -149,8 +149,8 @@ pub struct OperationResult {
   #[serde(default = "default_operation_result_api_version")]
   pub api_version: String,
   pub run_id: RunId,
-  /// Execution outcome only — see [`OperationStatus`]. Semantic success is a
-  /// separate axis in [`Self::verifications`], not implied by `Completed`.
+  /// Coarse recorded outcome — see [`OperationStatus`]. Delivery and semantic
+  /// evidence live in artifacts and [`Self::verifications`], respectively.
   pub status: OperationStatus,
   pub operation_id: String,
   pub evidence_artifacts: Vec<ArtifactRef>,
@@ -1438,16 +1438,14 @@ mod tests {
 
   // ROOT CAUSE:
   //
-  // `OperationStatus` had no documentation, so "Completed" could be misread as
-  // "the operation succeeded semantically" and a producer could wrongly
-  // downgrade to `Failed` on a semantic mismatch. Every producer actually
-  // derives status from the execution/dispatch path, never from
-  // `semantic_matched` — status (execution) and semantic outcome are separate
-  // axes. This test locks that invariant into the contract: a delivered action
-  // whose world did not match stays `Completed` with `semantic_matched ==
-  // Some(false)`, so the two axes never collapse into one.
+  // `OperationStatus` had no documentation, so `Completed` could be misread as
+  // semantic success. Producers currently use different coarse status policy:
+  // some keep `Completed` when verification does not match, while TextEdit
+  // marks a required semantic mismatch `Failed`. This test locks the invariant
+  // shared by both policies: status never replaces the explicit verification
+  // evidence, and `Completed` alone cannot prove a semantic match.
   #[test]
-  fn operation_status_completed_is_independent_of_semantic_outcome() {
+  fn operation_status_completed_does_not_imply_semantic_match() {
     let mut mismatch = sample_verification(VerificationMethod::StateChanged);
     mismatch.state_changed = true; // the action was delivered and the world moved,
     mismatch.semantic_matched = Some(false); // but it did NOT reach the expected state,
@@ -1456,7 +1454,7 @@ mod tests {
     let result = OperationResult {
       api_version: OPERATION_RESULT_API_VERSION.to_string(),
       run_id: RunId::new("run_delivered_no_match"),
-      status: OperationStatus::Completed, // yet the operation still ran to completion.
+      status: OperationStatus::Completed, // this producer keeps a coarse completed status.
       operation_id: "music.result.play".to_string(),
       evidence_artifacts: vec![artifact_ref()],
       output: OperationOutput::Acknowledged {
@@ -1468,7 +1466,7 @@ mod tests {
     };
 
     let value = serde_json::to_value(&result).expect("result should serialize");
-    // Execution outcome and semantic outcome are independent fields, not one collapsed flag.
+    // Coarse status and semantic evidence remain separate fields, not one collapsed flag.
     assert_eq!(value["status"], json!("completed"), "status reflects execution, not semantic match");
     assert_eq!(value["verifications"][0]["semantic_matched"], json!(false), "semantic failure lives in the verification");
     assert_eq!(value["verifications"][0]["failure_layer"], json!("state_changed_no_match"));

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -97,6 +97,26 @@ pub struct CandidateRef {
   pub candidate_local_id: String,
 }
 
+/// Execution outcome of a typed command — **not** its semantic outcome.
+///
+/// `Completed` means the operation ran to the end of its dispatch path (the
+/// action was delivered, or an observe/verify command executed); `Failed` means
+/// it could not execute (refused before dispatch, a backend/permission error,
+/// or a failed run). Every producer in the codebase derives this from the
+/// execution/dispatch path — via run status, dispatched-vs-refused, or a
+/// backend error — and **never** from whether the world reached the expected
+/// state.
+///
+/// Semantic success is a *separate axis*, carried by
+/// [`VerificationResult::semantic_matched`] (with [`VerificationResult::failure_layer`])
+/// inside [`OperationResult::verifications`]. The two are independent: an
+/// operation can be `Completed` while its verification reports
+/// `semantic_matched == Some(false)` — the action was delivered, but the world
+/// did not match. Consumers MUST NOT read `Completed` as "the operation
+/// succeeded semantically", and producers MUST NOT downgrade to `Failed` on a
+/// semantic mismatch. AUV's value is "the world is in the expected state, and
+/// here is the evidence" — that claim lives in the verification, not in this
+/// status. Keeping the axes separate is the whole point of the seam.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum OperationStatus {
@@ -129,6 +149,8 @@ pub struct OperationResult {
   #[serde(default = "default_operation_result_api_version")]
   pub api_version: String,
   pub run_id: RunId,
+  /// Execution outcome only — see [`OperationStatus`]. Semantic success is a
+  /// separate axis in [`Self::verifications`], not implied by `Completed`.
   pub status: OperationStatus,
   pub operation_id: String,
   pub evidence_artifacts: Vec<ArtifactRef>,
@@ -1412,5 +1434,47 @@ mod tests {
     assert_eq!(value["verifications"].as_array().map(|a| a.len()), Some(2), "multi-claim verifications must round-trip");
     let parsed: OperationResult = serde_json::from_value(value).expect("result should deserialize");
     assert_eq!(parsed.verifications.len(), 2);
+  }
+
+  // ROOT CAUSE:
+  //
+  // `OperationStatus` had no documentation, so "Completed" could be misread as
+  // "the operation succeeded semantically" and a producer could wrongly
+  // downgrade to `Failed` on a semantic mismatch. Every producer actually
+  // derives status from the execution/dispatch path, never from
+  // `semantic_matched` — status (execution) and semantic outcome are separate
+  // axes. This test locks that invariant into the contract: a delivered action
+  // whose world did not match stays `Completed` with `semantic_matched ==
+  // Some(false)`, so the two axes never collapse into one.
+  #[test]
+  fn operation_status_completed_is_independent_of_semantic_outcome() {
+    let mut mismatch = sample_verification(VerificationMethod::StateChanged);
+    mismatch.state_changed = true; // the action was delivered and the world moved,
+    mismatch.semantic_matched = Some(false); // but it did NOT reach the expected state,
+    mismatch.failure_layer = Some(FailureLayer::StateChangedNoMatch);
+
+    let result = OperationResult {
+      api_version: OPERATION_RESULT_API_VERSION.to_string(),
+      run_id: RunId::new("run_delivered_no_match"),
+      status: OperationStatus::Completed, // yet the operation still ran to completion.
+      operation_id: "music.result.play".to_string(),
+      evidence_artifacts: vec![artifact_ref()],
+      output: OperationOutput::Acknowledged {
+        message: Some("click delivered".to_string()),
+      },
+      verifications: vec![mismatch],
+      freshness_basis: None,
+      known_limits: Vec::new(),
+    };
+
+    let value = serde_json::to_value(&result).expect("result should serialize");
+    // Execution outcome and semantic outcome are independent fields, not one collapsed flag.
+    assert_eq!(value["status"], json!("completed"), "status reflects execution, not semantic match");
+    assert_eq!(value["verifications"][0]["semantic_matched"], json!(false), "semantic failure lives in the verification");
+    assert_eq!(value["verifications"][0]["failure_layer"], json!("state_changed_no_match"));
+
+    let parsed: OperationResult = serde_json::from_value(value).expect("result should deserialize");
+    assert_eq!(parsed.status, OperationStatus::Completed);
+    assert_eq!(parsed.verifications[0].semantic_matched, Some(false));
   }
 }


### PR DESCRIPTION
## Summary

Milestone Workstream 3 / **PR 7** — ownership review for the six core result contracts, with one narrow contract inconsistency fixed.

## Review result

| Contract | Owner | Verdict |
|---|---|---|
| `InputActionResult` | `auv-driver-common` | Single owner; delivery evidence only |
| `VerificationResult` | `src/contract.rs` | Single owner; explicit semantic evidence and failure layer |
| `OperationResult` / `OperationStatus` | `src/contract.rs` | Single owner; status semantics were undocumented |
| `ArtifactRef` | `auv-tracing-driver` | Single owner; inspect view is an enrichment projection |
| `CandidateRef` | `src/contract.rs` | Cross-run pointer, distinct from inline candidate |
| `FailureLayer` | `src/contract.rs` | Single owner |

## The inconsistency fixed

The initial review incorrectly described `OperationStatus` as execution-only. A complete producer audit found two real policies:

- session/query/Minecraft paths generally derive coarse status from run or dispatch outcome;
- TextEdit deliberately marks required semantic mismatch as `Failed`, with run/trace/operation parity locked by tests.

So the current contract is not an execution-only axis. `OperationStatus` is a coarse producer outcome. It proves neither delivery nor semantic success by itself:

- delivery evidence belongs in `InputActionResult`;
- semantic evidence belongs in `VerificationResult.semantic_matched` and `failure_layer`;
- `Completed` can coexist with `semantic_matched = false`;
- `Failed` does not imply that no action was delivered.

## Changes

- Documents the honest status boundary on `OperationStatus` and `OperationResult::status`.
- Adds the term to `docs/TERMS_AND_CONCEPTS.md`, the durable shared vocabulary.
- Adds `TODO(operation-status-policy)`: standardizing whether required semantic mismatch changes status belongs to PR 8 TextEdit parity/failure semantics.
- Keeps `operation_status_completed_does_not_imply_semantic_match` to prevent consumers from treating `Completed` as semantic evidence.
- Records why silently changing TextEdit's tested parity here was rejected.
- Reconciles the runtime reference index after #119: both new records are in the main list and the audited count is **31**. This also corrects #119's accidental count jump from 29 to 33.

## Verification

- `cargo fmt --check`
- `cargo test -p auv-runtime --lib contract::` — 24 passed
- `git diff --check`
- Full repository CI on the rebased branch

## Non-goals

- No producer status-policy rewrite.
- No rewrite of the six contracts.
- No `OperationResult` alias rename across frozen reference/experimental crates.
- No `api_version` reader-policy change.