### PR TITLE
refactor(driver): dedupe ObservedRect into auv-driver-common

### DIFF
--- a/crates/auv-driver-common/src/geometry.rs
+++ b/crates/auv-driver-common/src/geometry.rs
@@ -184,6 +184,18 @@ impl RatioRect {
   }
 }
 
+/// An integer-pixel rectangle observed directly from a platform report (for
+/// example, a parsed macOS AX/window/OCR report line). Distinct from `Rect`
+/// (logical f64 coordinates): this type preserves the raw pixel units a
+/// driver observed before any coordinate-space normalization.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ObservedRect {
+  pub x: i64,
+  pub y: i64,
+  pub width: i64,
+  pub height: i64,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "kind")]
 pub enum ProjectionSourceSpace {

--- a/crates/auv-driver-common/src/lib.rs
+++ b/crates/auv-driver-common/src/lib.rs
@@ -15,8 +15,8 @@ pub use capture::{Activation, Capture, CaptureBinding, CaptureOptions, DisplayCa
 pub use display::{Display, ObservedDisplays};
 pub use error::{DriverError, DriverResult};
 pub use geometry::{
-  CameraPoint, CoordinateSpace, Point, Point3, ProjectionBasis, ProjectionDerivationFamily, ProjectionSourceSpace, RatioRect, Rect,
-  ScreenPoint, Size, WindowPoint, WorldPoint,
+  CameraPoint, CoordinateSpace, ObservedRect, Point, Point3, ProjectionBasis, ProjectionDerivationFamily, ProjectionSourceSpace, RatioRect,
+  Rect, ScreenPoint, Size, WindowPoint, WorldPoint,
 };
 pub use input::{
   ActivationPolicy, Click, ClickOptions, DisturbanceLevel, INPUT_ACTION_RESULT_ARTIFACT_ROLE, InputActionResult, InputAttempt,

--- a/crates/auv-driver-macos/src/types.rs
+++ b/crates/auv-driver-macos/src/types.rs
@@ -2,15 +2,9 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
-pub type AuvResult<T> = Result<T, String>;
+pub use auv_driver_common::ObservedRect;
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ObservedRect {
-  pub x: i64,
-  pub y: i64,
-  pub width: i64,
-  pub height: i64,
-}
+pub type AuvResult<T> = Result<T, String>;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct ObservedDisplay {

--- a/src/app/analysis.rs
+++ b/src/app/analysis.rs
@@ -29,8 +29,8 @@ use super::infra::first_non_empty_string;
 use super::{
   APP_ANALYSIS_VERSION, AppAnalysis, AppAvailableSurfaces, AppCandidateCompatibility, AppCandidateGroundingTaxonomy,
   AppCandidatePromotionGate, AppCandidatePromotionStatus, AppControlAssessment, AppDisturbanceProfile, AppGroundingAssessment, AppIdentity,
-  AppPermissionState, AppPoint, AppProbe, AppProbeArtifact, AppProbeStep, AppRecommendedStrategy, AppRect, AppSurfaceCandidate,
-  AppVerificationAssessment, AppWindowContext, AssessmentStatus,
+  AppPermissionState, AppPoint, AppProbe, AppProbeArtifact, AppProbeStep, AppRecommendedStrategy, AppSurfaceCandidate,
+  AppVerificationAssessment, AppWindowContext, AssessmentStatus, rect_center, rect_center_point, rect_relative_point, render_compact_rect,
 };
 
 #[derive(Clone, Debug)]
@@ -68,7 +68,7 @@ pub(crate) fn build_app_analysis(probe_path: &Path, probe: &AppProbe) -> AuvResu
 
   let primary_window = choose_primary_window(&window_snapshot.windows);
   let primary_window_bounds =
-    primary_window.map(|window| AppRect::from_observed(&window.bounds)).or_else(|| primary_window_bounds_from_ax_snapshot(&ax_snapshot));
+    primary_window.map(|window| window.bounds.clone()).or_else(|| primary_window_bounds_from_ax_snapshot(&ax_snapshot));
   let primary_window_display_scale =
     primary_window_bounds.as_ref().and_then(|bounds| display_scale_for_rect_center(&display_snapshot, bounds));
 
@@ -137,7 +137,7 @@ pub(crate) fn build_app_analysis(probe_path: &Path, probe: &AppProbe) -> AuvResu
   }
   let mut stable_region_candidates = Vec::new();
   if let Some(bounds) = primary_window_bounds.as_ref() {
-    stable_region_candidates.push(format!("primaryWindow={}", bounds.render_compact()));
+    stable_region_candidates.push(format!("primaryWindow={}", render_compact_rect(bounds)));
   }
   stable_region_candidates.push("fullWindowCapture".to_string());
 
@@ -340,7 +340,7 @@ pub(crate) fn summarize_failed_probe_steps(probe: &AppProbe) -> Vec<String> {
 pub(crate) fn build_annotation_candidates(
   app: &AppIdentity,
   primary_window: Option<&ObservedWindow>,
-  primary_window_bounds: Option<&AppRect>,
+  primary_window_bounds: Option<&ObservedRect>,
   ax_snapshot: &ObservedAxTreeSnapshot,
   ocr_snapshot: &OcrTextSnapshot,
   probe_steps: &[AppProbeStep],
@@ -349,8 +349,8 @@ pub(crate) fn build_annotation_candidates(
   let mut candidates = Vec::new();
 
   if let Some(bounds) = primary_window_bounds.cloned() {
-    let compact_bounds = bounds.render_compact();
-    let click_point = bounds.center_point();
+    let compact_bounds = render_compact_rect(&bounds);
+    let click_point = rect_center_point(&bounds);
     let input_bindings = window_region_input_bindings(&compact_bounds, &click_point, &bounds);
     let evidence_step_id = if primary_window.is_some() {
       "list-windows"
@@ -428,7 +428,7 @@ pub(crate) fn build_annotation_candidates(
   }
 
   for matched in ocr_snapshot.matches.iter().take(8) {
-    let bounds = AppRect::from_observed(&matched.bounds);
+    let bounds = matched.bounds.clone();
     let area = "ocr-visible-text";
     let mut notes = vec!["Visible OCR text candidate from the sampled screenshot artifact.".to_string()];
     if matched.text == ocr_snapshot.query {
@@ -454,7 +454,7 @@ pub(crate) fn build_annotation_candidates(
       secondary_text: String::new(),
       query_value: matched.text.clone(),
       coordinate_space: "global-logical".to_string(),
-      click_point: Some(bounds.center_point()),
+      click_point: Some(rect_center_point(&bounds)),
       bounds: Some(bounds),
       confidence: Some(matched.confidence),
       evidence_step_id: "ocr-sample".to_string(),
@@ -479,9 +479,9 @@ pub(crate) fn build_annotation_candidates(
   candidates
 }
 
-fn window_region_input_bindings(compact_bounds: &str, click_point: &AppPoint, bounds: &AppRect) -> BTreeMap<String, String> {
+fn window_region_input_bindings(compact_bounds: &str, click_point: &AppPoint, bounds: &ObservedRect) -> BTreeMap<String, String> {
   let mut bindings = BTreeMap::from([("window_bounds".to_string(), compact_bounds.to_string())]);
-  if let Some((relative_x, relative_y)) = bounds.relative_point(click_point) {
+  if let Some((relative_x, relative_y)) = rect_relative_point(bounds, click_point) {
     bindings.insert("relative_x".to_string(), format!("{relative_x:.6}"));
     bindings.insert("relative_y".to_string(), format!("{relative_y:.6}"));
   }
@@ -499,7 +499,7 @@ fn ax_focus_candidate(
   compatibility: AppCandidateCompatibility,
   note: &str,
 ) -> AppSurfaceCandidate {
-  let bounds = AppRect::from_observed(&node.bounds);
+  let bounds = node.bounds.clone();
   let focus_query = query_value.clone();
   let mut candidate = AppSurfaceCandidate {
     candidate_id: candidate_id.to_string(),
@@ -511,7 +511,7 @@ fn ax_focus_candidate(
     secondary_text: format!("role={} path={}", node.role, node.path),
     query_value: query_value.clone(),
     coordinate_space: "global-logical".to_string(),
-    click_point: Some(bounds.center_point()),
+    click_point: Some(rect_center_point(&bounds)),
     bounds: Some(bounds),
     confidence: None,
     evidence_step_id: evidence_step_id.to_string(),
@@ -532,7 +532,7 @@ fn group_ocr_rows_from_ocr_snapshot(snapshot: &OcrTextSnapshot) -> Vec<ObservedO
 }
 
 fn row_candidate(row: ObservedOcrRow, evidence_refs: Vec<crate::contract::ArtifactRef>) -> AppSurfaceCandidate {
-  let bounds = AppRect::from_observed(&row.bounds);
+  let bounds = row.bounds.clone();
   let mut candidate = AppSurfaceCandidate {
     candidate_id: format!("visible-row-{}", row.row_index + 1),
     area: "result-selection".to_string(),
@@ -543,7 +543,7 @@ fn row_candidate(row: ObservedOcrRow, evidence_refs: Vec<crate::contract::Artifa
     secondary_text: format!("rowIndex={}", row.row_index + 1),
     query_value: format!("{}", row.row_index + 1),
     coordinate_space: "global-logical".to_string(),
-    click_point: Some(bounds.center_point()),
+    click_point: Some(rect_center_point(&bounds)),
     bounds: Some(bounds),
     confidence: None,
     evidence_step_id: "ocr-sample".to_string(),
@@ -997,7 +997,7 @@ fn choose_primary_window(windows: &[ObservedWindow]) -> Option<&ObservedWindow> 
   })
 }
 
-fn primary_window_bounds_from_ax_snapshot(snapshot: &ObservedAxTreeSnapshot) -> Option<AppRect> {
+fn primary_window_bounds_from_ax_snapshot(snapshot: &ObservedAxTreeSnapshot) -> Option<ObservedRect> {
   snapshot
     .nodes
     .iter()
@@ -1006,11 +1006,11 @@ fn primary_window_bounds_from_ax_snapshot(snapshot: &ObservedAxTreeSnapshot) -> 
         && node.bounds.width > 0
         && node.bounds.height > 0
     })
-    .map(|node| AppRect::from_observed(&node.bounds))
+    .map(|node| node.bounds.clone())
 }
 
-fn display_scale_for_rect_center(snapshot: &ObservedDisplaySnapshot, rect: &AppRect) -> Option<f64> {
-  let (x, y) = rect.center();
+fn display_scale_for_rect_center(snapshot: &ObservedDisplaySnapshot, rect: &ObservedRect) -> Option<f64> {
+  let (x, y) = rect_center(rect);
   snapshot.displays.iter().find(|display| contains_point(&display.bounds, x, y)).map(|display| display.scale_factor)
 }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -164,7 +164,7 @@ pub struct AppWindowContext {
   pub frontmost_app_name: String,
   pub frontmost_window_title: String,
   pub primary_window_title: String,
-  pub primary_window_bounds: Option<AppRect>,
+  pub primary_window_bounds: Option<ObservedRect>,
   pub primary_window_display_scale: Option<f64>,
 }
 
@@ -314,7 +314,7 @@ pub struct AppSurfaceCandidate {
   pub query_value: String,
   #[serde(default)]
   pub coordinate_space: String,
-  pub bounds: Option<AppRect>,
+  pub bounds: Option<ObservedRect>,
   pub click_point: Option<AppPoint>,
   pub confidence: Option<f64>,
   pub evidence_step_id: String,
@@ -374,45 +374,26 @@ pub struct AppRecommendedStrategy {
   pub rationale: String,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct AppRect {
-  pub x: i64,
-  pub y: i64,
-  pub width: i64,
-  pub height: i64,
+pub(crate) fn rect_center(rect: &ObservedRect) -> (i64, i64) {
+  (rect.x + rect.width / 2, rect.y + rect.height / 2)
 }
 
-impl AppRect {
-  fn from_observed(rect: &ObservedRect) -> Self {
-    Self {
-      x: rect.x,
-      y: rect.y,
-      width: rect.width,
-      height: rect.height,
-    }
-  }
+pub(crate) fn rect_center_point(rect: &ObservedRect) -> AppPoint {
+  let (x, y) = rect_center(rect);
+  AppPoint { x, y }
+}
 
-  fn center(&self) -> (i64, i64) {
-    (self.x + self.width / 2, self.y + self.height / 2)
-  }
+pub(crate) fn render_compact_rect(rect: &ObservedRect) -> String {
+  format!("{},{},{},{}", rect.x, rect.y, rect.width, rect.height)
+}
 
-  fn center_point(&self) -> AppPoint {
-    let (x, y) = self.center();
-    AppPoint { x, y }
+pub(crate) fn rect_relative_point(rect: &ObservedRect, point: &AppPoint) -> Option<(f64, f64)> {
+  if rect.width <= 0 || rect.height <= 0 {
+    return None;
   }
-
-  fn render_compact(&self) -> String {
-    format!("{},{},{},{}", self.x, self.y, self.width, self.height)
-  }
-
-  fn relative_point(&self, point: &AppPoint) -> Option<(f64, f64)> {
-    if self.width <= 0 || self.height <= 0 {
-      return None;
-    }
-    let relative_x = (point.x - self.x) as f64 / self.width as f64;
-    let relative_y = (point.y - self.y) as f64 / self.height as f64;
-    Some((relative_x, relative_y))
-  }
+  let relative_x = (point.x - rect.x) as f64 / rect.width as f64;
+  let relative_y = (point.y - rect.y) as f64 / rect.height as f64;
+  Some((relative_x, relative_y))
 }
 
 pub fn probe_app(project_root: &Path, runtime: &Runtime, bundle_id: &str, output_dir: Option<PathBuf>) -> AuvResult<AppProbe> {

--- a/src/app/report.rs
+++ b/src/app/report.rs
@@ -1,5 +1,5 @@
 // File: src/app/report.rs
-use super::AppAnalysis;
+use super::{AppAnalysis, render_compact_rect};
 
 pub(crate) fn render_app_analysis_report(analysis: &AppAnalysis) -> String {
   let mut lines = vec![
@@ -38,7 +38,7 @@ pub(crate) fn render_app_analysis_report(analysis: &AppAnalysis) -> String {
   }
   lines.push(format!("- current window count: `{}`", analysis.window_context.observed_window_count));
   if let Some(bounds) = analysis.window_context.primary_window_bounds.as_ref() {
-    lines.push(format!("- primary window bounds: `{}`", bounds.render_compact()));
+    lines.push(format!("- primary window bounds: `{}`", render_compact_rect(bounds)));
   }
   if let Some(scale) = analysis.window_context.primary_window_display_scale {
     lines.push(format!("- primary window display scale: `{scale:.3}`"));
@@ -114,7 +114,7 @@ pub(crate) fn render_app_analysis_report(analysis: &AppAnalysis) -> String {
         lines.push(format!("  - coordinateSpace: `{}`", candidate.coordinate_space));
       }
       if let Some(bounds) = &candidate.bounds {
-        lines.push(format!("  - bounds: `{}`", bounds.render_compact()));
+        lines.push(format!("  - bounds: `{}`", render_compact_rect(bounds)));
       }
       if let Some(point) = &candidate.click_point {
         lines.push(format!("  - clickPoint: `{}, {}`", point.x, point.y));

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -230,7 +230,7 @@ fn report_analysis_fixture() -> AppAnalysis {
       frontmost_app_name: "Example".to_string(),
       frontmost_window_title: "Example".to_string(),
       primary_window_title: "Example".to_string(),
-      primary_window_bounds: Some(AppRect {
+      primary_window_bounds: Some(ObservedRect {
         x: 0,
         y: 0,
         width: 100,
@@ -290,7 +290,7 @@ fn report_analysis_fixture() -> AppAnalysis {
       secondary_text: "role=AXTextField path=0.1".to_string(),
       query_value: "Search".to_string(),
       coordinate_space: "global-logical".to_string(),
-      bounds: Some(AppRect {
+      bounds: Some(ObservedRect {
         x: 10,
         y: 10,
         width: 80,


### PR DESCRIPTION
## Summary

First narrow slice of the "root去macOS耦合" cleanup lane: dedupe the one
genuinely cross-platform type the root `auv-runtime` crate was reaching into
`auv-driver-macos` for.

- `ObservedRect` (flat i64 pixel rect, zero macOS/FFI deps) moves from
  `auv-driver-macos::types` into `auv-driver-common::geometry` as the shared
  home. `auv-driver-macos::types` re-exports it unchanged, so all 10 internal
  macOS call sites and the `auv-netease-music`/`auv-apple-music` construction
  sites are untouched.
- Root's `AppRect` — a byte-identical struct that existed only to dodge the
  orphan rule (root can't add inherent impls to a type it doesn't own) — is
  deleted. Root now uses `ObservedRect` directly.
- `AppRect`'s 4 inherent methods (`center`, `center_point`, `render_compact`,
  `relative_point`) become free functions in `src/app/mod.rs`
  (`rect_center`, `rect_center_point`, `render_compact_rect`,
  `rect_relative_point`), since root still can't add inherent impls to the
  now-shared type.

## Scope note

`auv-driver-common` already holds a differently-shaped `Display`/`Window`/
`OcrMatch` family (f64 coordinates, string ids — the current typed-session
model). This PR only relocates the flat i64 `ObservedRect`; it intentionally
does **not** relocate the rest of the macOS `Observed*` legacy-report family
(`ObservedDisplay`, `ObservedWindow`, `OcrTextMatch`, etc.), since that would
create a parallel duplicate of the existing common types rather than
deduping anything. That's a separate, larger decision (migrate root's
report-text parsing to typed driver results) left for a future slice.

`auv-driver-macos::types`/`support`/`native` remain `#[doc(hidden)]` with
their existing `TODO(driver-crates)` markers — unchanged by this PR.

## Testing

- `cargo build` (default-members, full workspace green)
- `cargo test --package auv-driver-common --package auv-driver-macos --package auv-runtime` — 157 passed, 0 failed
- `cargo check` across `auv-netease-music`, `auv-apple-music`, `auv-apple-notes`, `auv-apple-textedit` (macOS consumers of the moved/re-exported symbol)
- `cargo fmt --check`, `git diff --check` clean