### PR TITLE
refactor(auv-driver-macos): rename ax_tree module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -400,7 +400,7 @@ Use this root-cause block format in regression tests when relevant:
 ## Platform-Native Interop
 
 - Prefer capability-oriented module names for platform-native interop layers,
-  such as `screen`, `window`, `ax_tree`, `keyboard`, `clipboard`, `app`, and
+  such as `screen`, `window`, `tree`, `keyboard`, `clipboard`, `app`, and
   `permission`.
 - Keep FFI and generated binding details behind narrow modules named `native`,
   `binding`, or `ffi`.

--- a/crates/auv-apple-music/src/commands/probe_macos.rs
+++ b/crates/auv-apple-music/src/commands/probe_macos.rs
@@ -162,7 +162,7 @@ fn inspect_toolbar_nodes(snapshot: &ObservedAxTreeSnapshot) -> (Vec<ToolbarInspe
   let mut diagnostics = Vec::new();
 
   for node in snapshot.nodes.iter().filter(|node| node.role.eq_ignore_ascii_case("AXToolbar")) {
-    let inspection = auv_driver_macos::native::ax_tree::inspect_ax_node_path(snapshot.pid, &node.path, &node.role)
+    let inspection = auv_driver_macos::native::tree::inspect_ax_node_path(snapshot.pid, &node.path, &node.role)
       .map(|inspection| ToolbarInspection {
         path: inspection.path,
         role: inspection.role,

--- a/crates/auv-driver-macos/src/accessibility.rs
+++ b/crates/auv-driver-macos/src/accessibility.rs
@@ -40,7 +40,7 @@ pub struct AxTextObservation {
 }
 
 pub fn capture_app_tree(app: &str, max_depth: i64, max_children: i64) -> DriverResult<ObservedAxTreeSnapshot> {
-  let capture = crate::native::ax_tree::capture_ax_tree_snapshot(app, max_depth, max_children).map_err(backend)?;
+  let capture = crate::native::tree::capture_ax_tree_snapshot(app, max_depth, max_children).map_err(backend)?;
   Ok(capture.snapshot)
 }
 
@@ -48,7 +48,7 @@ pub fn focus_node_path(pid: i32, path: &str, expected_role: &str) -> DriverResul
   // `set_ax_focused_path` already returns a classified `DriverError` (stale
   // path / role mismatch / permission / backend), so propagate it directly
   // instead of flattening everything through `backend` into `Backend`.
-  let _ = crate::native::ax_tree::set_ax_focused_path(pid, path, expected_role)?;
+  let _ = crate::native::tree::set_ax_focused_path(pid, path, expected_role)?;
   Ok(InputActionResult {
     selected_path: InputDeliveryPath::AxFocus,
     attempts: vec![InputAttempt {

--- a/crates/auv-driver-macos/src/native.rs
+++ b/crates/auv-driver-macos/src/native.rs
@@ -1,5 +1,4 @@
 pub mod auth;
-pub mod ax_tree;
 #[cfg(target_os = "macos")]
 mod binding;
 pub mod capture;
@@ -9,5 +8,6 @@ pub mod input;
 pub mod ocr;
 pub mod permission;
 pub mod pointer;
+pub mod tree;
 pub mod types;
 pub mod window;

--- a/crates/auv-driver-macos/src/native/tree.rs
+++ b/crates/auv-driver-macos/src/native/tree.rs
@@ -1,4 +1,4 @@
-// File: src/driver/macos/native/ax_tree.rs
+// File: src/driver/macos/native/tree.rs
 #[cfg(target_os = "macos")]
 use super::binding::ffi::{
   NativeAxActionRequest, NativeAxActionResponse, NativeAxFocusRequest, NativeAxFocusResponse, NativeAxNodeInspectionRequest,

--- a/crates/auv-netease-music/src/lib.rs
+++ b/crates/auv-netease-music/src/lib.rs
@@ -62,7 +62,7 @@ use auv_driver::selector::{App, Window};
 #[cfg(target_os = "macos")]
 use auv_driver::{ActivationPolicy, Click, InputPolicy, LocalDriverSession, PrepareForInputOptions, Scroll, ScrollOptions, WindowPoint};
 #[cfg(target_os = "macos")]
-use auv_driver_macos::native::ax_tree::capture_ax_tree_snapshot;
+use auv_driver_macos::native::tree::capture_ax_tree_snapshot;
 #[cfg(target_os = "macos")]
 use auv_driver_macos::types::ObservedAxNode;
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
## Summary

- rename the Rust module file from `native/ax_tree.rs` to `native/tree.rs`
- update the module declaration and all semantic Rust callers across the macOS driver, Apple Music, and NetEase Music crates
- update the current platform-native module naming example in `AGENTS.md`

## Scope

This is a narrow, move-only refactor. It does not rename the AX-specific FFI functions, public functions, public types, Swift source, the independent `window.captureAxTree` CLI stub, or historical documents under `docs/ai/references/**`.

## Validation

- RustRover inspections on every changed Rust file: no errors
- RustRover project build: successful
- `cargo fmt --check`
- `cargo check`
- `cargo test`
- `cargo run --quiet -- invoke --help`
- `git diff --check`

Closes #109