### PR TITLE
docs(runtime): confirm auv-media-macos as core-adjacent, not driver-tier

### DIFF
--- a/docs/ai/references/runtime/2026-07-19-core-dependency-and-crate-tier-inventory.md
+++ b/docs/ai/references/runtime/2026-07-19-core-dependency-and-crate-tier-inventory.md
@@ -323,11 +323,22 @@ core-adjacent.
    types behind a platform-agnostic trait in `auv-driver-common`, or (c)
    document why runtime is intentionally macOS-specific and accept the coupling
    (contradicts the library-only positioning).
-2. **Confirm `auv-media-macos` tier**: I classified it as **core-adjacent** (a
-   platform capability with a clean contract, not in the exec seam but not
-   experimental either). The owner may prefer **driver-tier / core platform
-   capability** instead. Clarify the distinction between "driver-tier" and
-   "core-adjacent platform capability" for future classification.
+2. ~~**Confirm `auv-media-macos` tier**~~ — **Resolved (owner-confirmed
+   2026-07-21): core-adjacent, not driver-tier.** Driver-tier in this
+   workspace means implementing or extending the `auv-driver-common` contract
+   (`Driver`/`DriverSession`, `DriverError`, `InputActionResult`) that
+   `ActionResolver` and the CLI/library frontends dispatch through — the seam
+   AGENTS.md names explicitly. `auv-media-macos` doesn't participate in it:
+   Cargo exposes an implicit library target from `src/lib.rs` plus the explicit
+   `[[bin]]` companion, but the library returns its own `Result<_, MediaError>`
+   rather than `DriverResult` and does not implement `Driver` or
+   `DriverSession`. It is an app-agnostic system now-playing capability
+   (vendored `mediaremote-adapter` via `/usr/bin/perl`) whose only current
+   consumer is product `auv-netease-music`. Like the other confirmed
+   core-adjacent crates (`auv-file`, `auv-query-readiness`,
+   `auv-stage-status`), it owns a narrow reusable contract outside the active
+   driver execution seam and is not root-owned; consumer count is not the tier
+   criterion. No tier change; table label stands.
 
 Resolved, not an open decision: PR #121 removed the dead root/CLI
 `auv-media-macos` declarations while keeping the product consumer intact.


### PR DESCRIPTION
## Summary

[#119](https://github.com/moeru-ai/auv/pull/119)'s crate-tier inventory classified `auv-media-macos` as core-adjacent but left the tier as an open owner decision ("the owner may prefer driver-tier / core platform capability instead").

Resolves it in favor of the original core-adjacent label, with the structural distinction spelled out: driver-tier in this workspace means implementing or extending the `auv-driver-common` contract (`Driver`/`DriverSession`, `DriverError`, `InputActionResult`) that `ActionResolver` and the CLI/library frontends dispatch through.

`auv-media-macos` does not participate in that seam:
- Cargo exposes an implicit library target from `src/lib.rs` plus the explicit `[[bin]]` companion
- the library owns `MediaError` and now-playing types rather than implementing `Driver`, `DriverSession`, or returning `DriverResult`
- it is an app-agnostic system now-playing capability using the vendored `mediaremote-adapter` via `/usr/bin/perl`
- its only current consumer is product `auv-netease-music`

The core-adjacent decision rests on the narrow reusable contract, app-agnostic platform scope, and position outside the active driver execution seam. Consumer count is recorded as evidence, not treated as the tier criterion.

No tier change and no code touched. This closes the open question so future readers do not have to re-litigate it.

## Validation

- `cargo metadata --no-deps --format-version 1` confirms library, binary, and build-script targets
- RustRover search confirms driver-family `Driver` / `DriverSession` implementations and no corresponding implementation in `auv-media-macos`
- `git diff --check`

Docs-only.