### PR TITLE
refactor(auv-apple-textedit): preserve typed driver errors through document commands

### DIFF
--- a/crates/auv-apple-textedit/src/commands/document.rs
+++ b/crates/auv-apple-textedit/src/commands/document.rs
@@ -1,8 +1,9 @@
 use std::time::Duration;
 
+use auv_driver::DriverResult;
 use serde::{Deserialize, Serialize};
 
-use crate::driver::{OperationResult, StepOutcome, TextEditDriver, VerificationOutcome};
+use crate::driver::{StepOutcome, TextEditDriver, VerificationOutcome};
 
 pub const DEFAULT_APP_ID: &str = "com.apple.TextEdit";
 pub const DEFAULT_MARKER_TEXT: &str = "AUV_TEXTEDIT_MARKER_2026_05_17";
@@ -71,7 +72,7 @@ pub struct DocumentCommandReport {
   pub verification: Option<VerificationOutcome>,
 }
 
-pub fn run_document_command(command: &DocumentCommand, driver: &mut impl TextEditDriver) -> OperationResult<DocumentCommandReport> {
+pub fn run_document_command(command: &DocumentCommand, driver: &mut impl TextEditDriver) -> DriverResult<DocumentCommandReport> {
   match command {
     DocumentCommand::Write(command) => run_write(command, driver),
     DocumentCommand::Compare(command) => run_compare(command, driver),
@@ -79,7 +80,7 @@ pub fn run_document_command(command: &DocumentCommand, driver: &mut impl TextEdi
   }
 }
 
-fn run_write(command: &DocumentWrite, driver: &mut impl TextEditDriver) -> OperationResult<DocumentCommandReport> {
+fn run_write(command: &DocumentWrite, driver: &mut impl TextEditDriver) -> DriverResult<DocumentCommandReport> {
   let mut outcomes = vec![
     driver.activate_app(&command.app_id, Duration::from_millis(command.activate_settle_ms))?,
     driver.focus_text_input(&command.app_id, &command.focus_query, &command.focus_candidate)?,
@@ -103,7 +104,7 @@ fn run_write(command: &DocumentWrite, driver: &mut impl TextEditDriver) -> Opera
   })
 }
 
-fn run_compare(command: &DocumentCompare, driver: &mut impl TextEditDriver) -> OperationResult<DocumentCommandReport> {
+fn run_compare(command: &DocumentCompare, driver: &mut impl TextEditDriver) -> DriverResult<DocumentCommandReport> {
   let verification = driver.verify_ax_text(&command.app_id, &command.content, &command.role)?;
   Ok(DocumentCommandReport {
     command: "document.compare",
@@ -112,7 +113,7 @@ fn run_compare(command: &DocumentCompare, driver: &mut impl TextEditDriver) -> O
   })
 }
 
-fn run_focus(command: &DocumentFocus, driver: &mut impl TextEditDriver) -> OperationResult<DocumentCommandReport> {
+fn run_focus(command: &DocumentFocus, driver: &mut impl TextEditDriver) -> DriverResult<DocumentCommandReport> {
   let outcome = driver.focus_text_input(&command.app_id, &command.query, &command.candidate)?;
   Ok(DocumentCommandReport {
     command: "document.focus",
@@ -135,7 +136,7 @@ fn normalize_write_step_ids(outcomes: &mut [StepOutcome]) {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use auv_driver::{InputActionResult, InputDeliveryPath};
+  use auv_driver::{DriverResult, InputActionResult, InputDeliveryPath};
 
   #[derive(Default)]
   struct RecordingTextEditDriver {
@@ -143,7 +144,7 @@ mod tests {
   }
 
   impl TextEditDriver for RecordingTextEditDriver {
-    fn activate_app(&mut self, app_id: &str, settle: Duration) -> OperationResult<StepOutcome> {
+    fn activate_app(&mut self, app_id: &str, settle: Duration) -> DriverResult<StepOutcome> {
       self.calls.push(format!("activate:{app_id}:{}", settle.as_millis()));
       Ok(StepOutcome {
         step_id: "activate",
@@ -152,7 +153,7 @@ mod tests {
       })
     }
 
-    fn focus_text_input(&mut self, app_id: &str, query: &str, candidate: &str) -> OperationResult<StepOutcome> {
+    fn focus_text_input(&mut self, app_id: &str, query: &str, candidate: &str) -> DriverResult<StepOutcome> {
       self.calls.push(format!("focus:{app_id}:{query}:{candidate}"));
       Ok(StepOutcome {
         step_id: "focus",
@@ -167,7 +168,7 @@ mod tests {
       text: &str,
       replace_existing: bool,
       settle: Duration,
-    ) -> OperationResult<StepOutcome> {
+    ) -> DriverResult<StepOutcome> {
       self.calls.push(format!("paste:{app_id}:{text}:{replace_existing}:{}", settle.as_millis()));
       Ok(StepOutcome {
         step_id: "paste",
@@ -176,7 +177,7 @@ mod tests {
       })
     }
 
-    fn verify_ax_text(&mut self, app_id: &str, target_text: &str, target_role: &str) -> OperationResult<VerificationOutcome> {
+    fn verify_ax_text(&mut self, app_id: &str, target_text: &str, target_role: &str) -> DriverResult<VerificationOutcome> {
       self.calls.push(format!("compare:{app_id}:{target_text}:{target_role}"));
       Ok(VerificationOutcome {
         matched_role: target_role.to_string(),
@@ -248,5 +249,74 @@ mod tests {
     assert_eq!(report.command, "document.focus");
     assert_eq!(driver.calls, vec!["focus:com.apple.TextEdit:First Text View:"]);
     assert_eq!(report.outcomes.len(), 1);
+  }
+
+  // Regression: typed DriverError variants must propagate through
+  // run_document_command without being flattened to String. These tests
+  // assert on the enum variant directly — no `.contains()` text matching.
+
+  #[test]
+  fn permission_denied_propagates_as_typed_variant() {
+    use auv_driver::DriverError;
+
+    struct PermissionDriver;
+
+    impl TextEditDriver for PermissionDriver {
+      fn activate_app(&mut self, _: &str, _: Duration) -> DriverResult<StepOutcome> {
+        Err(DriverError::PermissionDenied {
+          permission: "accessibility",
+          message: Some("not authorized".to_string()),
+          recovery: Some("grant in System Preferences".to_string()),
+        })
+      }
+      fn focus_text_input(&mut self, _: &str, _: &str, _: &str) -> DriverResult<StepOutcome> {
+        unreachable!()
+      }
+      fn paste_text_preserve_clipboard(&mut self, _: &str, _: &str, _: bool, _: Duration) -> DriverResult<StepOutcome> {
+        unreachable!()
+      }
+      fn verify_ax_text(&mut self, _: &str, _: &str, _: &str) -> DriverResult<VerificationOutcome> {
+        unreachable!()
+      }
+    }
+
+    let command = DocumentCommand::Write(DocumentWrite::marker_defaults());
+    let mut driver = PermissionDriver;
+    let error = run_document_command(&command, &mut driver).expect_err("should fail");
+    assert!(matches!(error, DriverError::PermissionDenied { .. }));
+  }
+
+  #[test]
+  fn stale_observation_propagates_as_typed_variant() {
+    use auv_driver::DriverError;
+
+    struct StaleDriver;
+
+    impl TextEditDriver for StaleDriver {
+      fn activate_app(&mut self, _: &str, _: Duration) -> DriverResult<StepOutcome> {
+        Ok(StepOutcome {
+          step_id: "activate",
+          summary: "ok".to_string(),
+          input_action_result: None,
+        })
+      }
+      fn focus_text_input(&mut self, _: &str, _: &str, _: &str) -> DriverResult<StepOutcome> {
+        Err(DriverError::StaleObservation {
+          message: "AX path 0.1.2 no longer resolves".to_string(),
+          recovery: Some("recapture tree".to_string()),
+        })
+      }
+      fn paste_text_preserve_clipboard(&mut self, _: &str, _: &str, _: bool, _: Duration) -> DriverResult<StepOutcome> {
+        unreachable!()
+      }
+      fn verify_ax_text(&mut self, _: &str, _: &str, _: &str) -> DriverResult<VerificationOutcome> {
+        unreachable!()
+      }
+    }
+
+    let command = DocumentCommand::Write(DocumentWrite::marker_defaults());
+    let mut driver = StaleDriver;
+    let error = run_document_command(&command, &mut driver).expect_err("should fail");
+    assert!(matches!(error, DriverError::StaleObservation { .. }));
   }
 }

--- a/crates/auv-apple-textedit/src/driver.rs
+++ b/crates/auv-apple-textedit/src/driver.rs
@@ -1,9 +1,7 @@
 use std::time::Duration;
 
-use auv_driver::InputActionResult;
+use auv_driver::{DriverResult, InputActionResult};
 use serde::{Deserialize, Serialize};
-
-pub type OperationResult<T> = Result<T, String>;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StepOutcome {
@@ -28,9 +26,9 @@ pub struct VerificationOutcome {
 }
 
 pub trait TextEditDriver {
-  fn activate_app(&mut self, app_id: &str, settle: Duration) -> OperationResult<StepOutcome>;
+  fn activate_app(&mut self, app_id: &str, settle: Duration) -> DriverResult<StepOutcome>;
 
-  fn focus_text_input(&mut self, app_id: &str, query: &str, candidate: &str) -> OperationResult<StepOutcome>;
+  fn focus_text_input(&mut self, app_id: &str, query: &str, candidate: &str) -> DriverResult<StepOutcome>;
 
   fn paste_text_preserve_clipboard(
     &mut self,
@@ -38,9 +36,9 @@ pub trait TextEditDriver {
     text: &str,
     replace_existing: bool,
     settle: Duration,
-  ) -> OperationResult<StepOutcome>;
+  ) -> DriverResult<StepOutcome>;
 
-  fn verify_ax_text(&mut self, app_id: &str, target_text: &str, target_role: &str) -> OperationResult<VerificationOutcome>;
+  fn verify_ax_text(&mut self, app_id: &str, target_text: &str, target_role: &str) -> DriverResult<VerificationOutcome>;
 }
 
 #[cfg(target_os = "macos")]
@@ -51,15 +49,15 @@ mod macos {
   use auv_driver::{InputActionResult, InputDeliveryPath, PasteTextOptions, TextSubmit};
   use auv_driver_macos::{ApplicationControl, MacosDriverSession};
 
-  use super::{OperationResult, StepOutcome, TextEditDriver, VerificationOutcome};
+  use super::{DriverResult, StepOutcome, TextEditDriver, VerificationOutcome};
 
   pub struct MacosTextEditDriver {
     session: LocalDriverSession,
   }
 
   impl MacosTextEditDriver {
-    pub fn open_local() -> OperationResult<Self> {
-      let session = auv_driver::open_local().map_err(|error| error.to_string())?;
+    pub fn open_local() -> DriverResult<Self> {
+      let session = auv_driver::open_local()?;
       Ok(Self { session })
     }
 
@@ -71,8 +69,8 @@ mod macos {
   }
 
   impl TextEditDriver for MacosTextEditDriver {
-    fn activate_app(&mut self, app_id: &str, settle: Duration) -> OperationResult<StepOutcome> {
-      self.session.activate_bundle_id(app_id, settle).map_err(|error| format!("TextEdit activation failed: {error}"))?;
+    fn activate_app(&mut self, app_id: &str, settle: Duration) -> DriverResult<StepOutcome> {
+      self.session.activate_bundle_id(app_id, settle)?;
       Ok(StepOutcome {
         step_id: "activate-target-app",
         summary: format!("activated foreground TextEdit application for {app_id} without requiring WindowServer discovery"),
@@ -80,12 +78,8 @@ mod macos {
       })
     }
 
-    fn focus_text_input(&mut self, app_id: &str, query: &str, candidate: &str) -> OperationResult<StepOutcome> {
-      let observation = self
-        .session
-        .accessibility()
-        .focus_text_by_query(app_id, query, Some("AXTextArea"), candidate)
-        .map_err(|error| format!("TextEdit AX focus failed: {error}"))?;
+    fn focus_text_input(&mut self, app_id: &str, query: &str, candidate: &str) -> DriverResult<StepOutcome> {
+      let observation = self.session.accessibility().focus_text_by_query(app_id, query, Some("AXTextArea"), candidate)?;
       Ok(StepOutcome {
         step_id: "focus-text-input",
         summary: format!("focused TextEdit AX text input path={} role={}", observation.path, observation.role),
@@ -99,17 +93,13 @@ mod macos {
       text: &str,
       replace_existing: bool,
       settle: Duration,
-    ) -> OperationResult<StepOutcome> {
-      self
-        .session
-        .input()
-        .paste_text(PasteTextOptions {
-          text: text.to_string(),
-          replace_existing,
-          submit: TextSubmit::No,
-          settle,
-        })
-        .map_err(|error| error.to_string())?;
+    ) -> DriverResult<StepOutcome> {
+      self.session.input().paste_text(PasteTextOptions {
+        text: text.to_string(),
+        replace_existing,
+        submit: TextSubmit::No,
+        settle,
+      })?;
       Ok(StepOutcome {
         step_id: "document-write",
         summary: "pasted TextEdit document body through auv-driver-macos clipboard input".to_string(),
@@ -117,14 +107,10 @@ mod macos {
       })
     }
 
-    fn verify_ax_text(&mut self, app_id: &str, target_text: &str, target_role: &str) -> OperationResult<VerificationOutcome> {
+    fn verify_ax_text(&mut self, app_id: &str, target_text: &str, target_role: &str) -> DriverResult<VerificationOutcome> {
       // Observation is independent of expected text; mismatch returns Ok with
       // semantic_matched=false so callers can persist a VerificationResult.
-      let observation = self
-        .session
-        .accessibility()
-        .verify_text(app_id, target_text, target_role)
-        .map_err(|error| format!("TextEdit AX text observation failed: {error}"))?;
+      let observation = self.session.accessibility().verify_text(app_id, target_text, target_role)?;
       Ok(VerificationOutcome {
         matched_role: observation.role,
         matched_text: observation.matched_text,
@@ -147,19 +133,25 @@ pub struct MacosTextEditDriver;
 
 #[cfg(not(target_os = "macos"))]
 impl MacosTextEditDriver {
-  pub fn open_local() -> OperationResult<Self> {
-    Err("MacosTextEditDriver requires macOS".to_string())
+  pub fn open_local() -> DriverResult<Self> {
+    Err(auv_driver::DriverError::Unsupported {
+      operation: "MacosTextEditDriver.open_local",
+    })
   }
 }
 
 #[cfg(not(target_os = "macos"))]
 impl TextEditDriver for MacosTextEditDriver {
-  fn activate_app(&mut self, _app_id: &str, _settle: Duration) -> OperationResult<StepOutcome> {
-    Err("MacosTextEditDriver requires macOS".to_string())
+  fn activate_app(&mut self, _app_id: &str, _settle: Duration) -> DriverResult<StepOutcome> {
+    Err(auv_driver::DriverError::Unsupported {
+      operation: "MacosTextEditDriver.activate_app",
+    })
   }
 
-  fn focus_text_input(&mut self, _app_id: &str, _query: &str, _candidate: &str) -> OperationResult<StepOutcome> {
-    Err("MacosTextEditDriver requires macOS".to_string())
+  fn focus_text_input(&mut self, _app_id: &str, _query: &str, _candidate: &str) -> DriverResult<StepOutcome> {
+    Err(auv_driver::DriverError::Unsupported {
+      operation: "MacosTextEditDriver.focus_text_input",
+    })
   }
 
   fn paste_text_preserve_clipboard(
@@ -168,11 +160,15 @@ impl TextEditDriver for MacosTextEditDriver {
     _text: &str,
     _replace_existing: bool,
     _settle: Duration,
-  ) -> OperationResult<StepOutcome> {
-    Err("MacosTextEditDriver requires macOS".to_string())
+  ) -> DriverResult<StepOutcome> {
+    Err(auv_driver::DriverError::Unsupported {
+      operation: "MacosTextEditDriver.paste_text_preserve_clipboard",
+    })
   }
 
-  fn verify_ax_text(&mut self, _app_id: &str, _target_text: &str, _target_role: &str) -> OperationResult<VerificationOutcome> {
-    Err("MacosTextEditDriver requires macOS".to_string())
+  fn verify_ax_text(&mut self, _app_id: &str, _target_text: &str, _target_role: &str) -> DriverResult<VerificationOutcome> {
+    Err(auv_driver::DriverError::Unsupported {
+      operation: "MacosTextEditDriver.verify_ax_text",
+    })
   }
 }

--- a/crates/auv-apple-textedit/src/lib.rs
+++ b/crates/auv-apple-textedit/src/lib.rs
@@ -2,8 +2,9 @@ pub mod cli;
 pub mod commands;
 pub mod driver;
 
+pub use auv_driver::DriverResult;
 pub use commands::document::{
   DEFAULT_APP_ID, DEFAULT_BODY_ROLE, DEFAULT_FOCUS_QUERY, DEFAULT_MARKER_TEXT, DEFAULT_SETTLE_MS, DocumentCommand, DocumentCommandReport,
   DocumentCompare, DocumentFocus, DocumentWrite, run_document_command,
 };
-pub use driver::{MacosTextEditDriver, OperationResult, StepOutcome, TextEditDriver, VerificationOutcome};
+pub use driver::{MacosTextEditDriver, StepOutcome, TextEditDriver, VerificationOutcome};

--- a/crates/auv-cli/src/integrations/textedit/mod.rs
+++ b/crates/auv-cli/src/integrations/textedit/mod.rs
@@ -57,17 +57,24 @@ fn document_write_impl(input: InvokeCommandInput<'_>) -> InvokeCommandResult {
   // recorded mismatch tests can force a semantic mismatch without live TextEdit.
   // Expose a first-class flag only if the owner approves fixture controls.
   let fixture_observed_text = input.inputs.get("fixture_observed_text").cloned();
+  // TODO(textedit-pr8-b): these `.map_err(|error| error.to_string())` calls are
+  // the intentional String boundary for this slice (PR8-A keeps `DriverError`
+  // typed through `run_document_command`; only the CLI invoke adapter
+  // flattens it, per AGENTS.md's decode-boundary rule). PR8-B is the trigger:
+  // once persisted operation-failure classification exists, replace this with
+  // a `DriverError` -> `ControlFailed` mapping so the CLI/MCP/inspect surfaces
+  // regain the typed variant instead of losing it to `Display` text here.
   let report = match driver_kind {
     "fixture" => {
       let mut driver = FixtureTextEditDriver::from_write(&command);
       driver.observed_override = fixture_observed_text;
-      run_document_command(&DocumentCommand::Write(command.clone()), &mut driver)?
+      run_document_command(&DocumentCommand::Write(command.clone()), &mut driver).map_err(|error| error.to_string())?
     }
     "live" => {
       #[cfg(target_os = "macos")]
       {
-        let mut driver = auv_apple_textedit::MacosTextEditDriver::open_local()?;
-        run_document_command(&DocumentCommand::Write(command.clone()), &mut driver)?
+        let mut driver = auv_apple_textedit::MacosTextEditDriver::open_local().map_err(|error| error.to_string())?;
+        run_document_command(&DocumentCommand::Write(command.clone()), &mut driver).map_err(|error| error.to_string())?
       }
       #[cfg(not(target_os = "macos"))]
       {
@@ -437,7 +444,7 @@ impl FixtureTextEditDriver {
 }
 
 impl TextEditDriver for FixtureTextEditDriver {
-  fn activate_app(&mut self, app_id: &str, settle: Duration) -> Result<StepOutcome, String> {
+  fn activate_app(&mut self, app_id: &str, settle: Duration) -> auv_driver::DriverResult<StepOutcome> {
     Ok(StepOutcome {
       step_id: "activate",
       summary: format!("fixture activated {app_id} settle_ms={}", settle.as_millis()),
@@ -445,7 +452,7 @@ impl TextEditDriver for FixtureTextEditDriver {
     })
   }
 
-  fn focus_text_input(&mut self, app_id: &str, query: &str, candidate: &str) -> Result<StepOutcome, String> {
+  fn focus_text_input(&mut self, app_id: &str, query: &str, candidate: &str) -> auv_driver::DriverResult<StepOutcome> {
     Ok(StepOutcome {
       step_id: "focus",
       summary: format!("fixture focused {app_id} query={query} candidate={candidate}"),
@@ -459,7 +466,7 @@ impl TextEditDriver for FixtureTextEditDriver {
     text: &str,
     replace_existing: bool,
     settle: Duration,
-  ) -> Result<StepOutcome, String> {
+  ) -> auv_driver::DriverResult<StepOutcome> {
     self.content = text.to_string();
     Ok(StepOutcome {
       step_id: "paste",
@@ -468,7 +475,7 @@ impl TextEditDriver for FixtureTextEditDriver {
     })
   }
 
-  fn verify_ax_text(&mut self, _app_id: &str, target_text: &str, target_role: &str) -> Result<VerificationOutcome, String> {
+  fn verify_ax_text(&mut self, _app_id: &str, target_text: &str, target_role: &str) -> auv_driver::DriverResult<VerificationOutcome> {
     self.role = target_role.to_string();
     let observed = self.observed_override.clone().unwrap_or_else(|| self.content.clone());
     Ok(VerificationOutcome {


### PR DESCRIPTION
## Summary

TextEdit **PR8-A**: preserve the typed `DriverError` all the way to the app-command boundary. Replaces the flattened `OperationResult<T> = Result<T, String>` alias with the canonical `DriverResult<T>` (over `auv-driver-common::DriverError`) so `PermissionDenied` / `StaleObservation` / `RoleMismatch` / `Backend` survive `run_document_command` instead of collapsing to `Display` text at the driver layer.

## Scope

- Delete `driver::OperationResult` alias; `TextEditDriver` trait, `run_document_command`, `run_write`/`run_compare`/`run_focus`, and both platform impls now return `DriverResult<_>`.
- `MacosTextEditDriver` drops per-call `.to_string()`/`format!` error flattening and propagates via `?` (the underlying `auv-driver` / `auv-driver-macos` session calls already return `DriverResult`).
- Non-macOS stubs return typed `DriverError::Unsupported { operation }` (per-method operation labels) instead of `String` literals.
- String formatting is confined to the `auv-cli` invoke adapter's existing decode boundary (`document_write_impl`), via `.map_err(|e| e.to_string())`.
- Two regression tests assert typed-variant propagation through `run_document_command` with `matches!` — no `.contains()` type-sniffing.

## Deferral (PR8-B)

A `TODO(textedit-pr8-b)` marker at the CLI conversion point records the follow-up: once persisted operation-failure classification exists, map `DriverError -> ControlFailed` so CLI/MCP/inspect regain the typed variant instead of losing it to `Display` here. This slice deliberately does **not** attempt CLI/MCP/inspect failure parity, root macOS target-gating, a new TextEdit-private error enum, or any change to `FailureLayer` / the `contract::OperationResult` wire shape.

## Testing

- `cargo fmt --check`
- `cargo check -p auv-apple-textedit -p auv-cli`
- `cargo test -p auv-apple-textedit -p auv-cli` (all green; new tests `permission_denied_propagates_as_typed_variant`, `stale_observation_propagates_as_typed_variant` pass)
