### PR TITLE
feat(auv-runtime): persist typed control-layer driver failures as ControlFailed

### DIFF
--- a/crates/auv-cli/src/cli_frontend.rs
+++ b/crates/auv-cli/src/cli_frontend.rs
@@ -1116,6 +1116,7 @@ fn build_minecraft_operation_result(run_id: &auv_tracing_driver::trace::RunId, v
       message: Some("minecraft live click completed".to_string()),
     },
     verifications: vec![verification],
+    control_failure: None,
     freshness_basis: None,
     known_limits: Vec::new(),
   }
@@ -2394,6 +2395,7 @@ mod tests {
         verification: Box::new(verification.clone()),
       },
       verifications: vec![verification],
+      control_failure: None,
       freshness_basis: None,
       known_limits: Vec::new(),
     };

--- a/crates/auv-cli/src/inspect/goldens.rs
+++ b/crates/auv-cli/src/inspect/goldens.rs
@@ -221,6 +221,7 @@ fn golden_core_only_inspect_run() {
       verification: Box::new(verification.clone()),
     },
     verifications: vec![verification],
+    control_failure: None,
     freshness_basis: None,
     known_limits: Vec::new(),
   };

--- a/crates/auv-cli/src/integrations/minecraft/query_live_action.rs
+++ b/crates/auv-cli/src/integrations/minecraft/query_live_action.rs
@@ -116,6 +116,7 @@ pub fn build_query_wired_live_action_operation_result(
       message: Some(message),
     },
     verifications,
+    control_failure: None,
     freshness_basis,
     known_limits,
   }

--- a/crates/auv-cli/src/integrations/osu/query_live_action.rs
+++ b/crates/auv-cli/src/integrations/osu/query_live_action.rs
@@ -62,6 +62,7 @@ pub fn build_osu_query_wired_live_action_operation_result(
       message: Some(message),
     },
     verifications: Vec::new(),
+    control_failure: None,
     freshness_basis,
     known_limits: wiring.known_limits.clone(),
   }

--- a/crates/auv-cli/src/integrations/textedit/mod.rs
+++ b/crates/auv-cli/src/integrations/textedit/mod.rs
@@ -12,9 +12,9 @@ use auv_cli_invoke::{
   CommandGroup, InvokeCommandInput, InvokeCommandOutput, InvokeCommandResult, InvokeReport, InvokeReportField, InvokeReportSection,
   InvokeResult, invoke_command,
 };
-use auv_driver::{INPUT_ACTION_RESULT_ARTIFACT_ROLE, InputActionResult, InputDeliveryPath};
+use auv_driver::{DriverError, INPUT_ACTION_RESULT_ARTIFACT_ROLE, InputActionResult, InputDeliveryPath};
 use auv_runtime::contract::{
-  ArtifactRef, FailureLayer, OPERATION_RESULT_API_VERSION, OperationOutput, OperationResult, OperationStatus,
+  ArtifactRef, ControlFailure, FailureLayer, OPERATION_RESULT_API_VERSION, OperationOutput, OperationResult, OperationStatus,
   VERIFICATION_RESULT_API_VERSION, VerificationMethod, VerificationResult,
 };
 use auv_tracing_driver::artifact::ArtifactBytesSource;
@@ -57,24 +57,33 @@ fn document_write_impl(input: InvokeCommandInput<'_>) -> InvokeCommandResult {
   // recorded mismatch tests can force a semantic mismatch without live TextEdit.
   // Expose a first-class flag only if the owner approves fixture controls.
   let fixture_observed_text = input.inputs.get("fixture_observed_text").cloned();
-  // TODO(textedit-pr8-b): these `.map_err(|error| error.to_string())` calls are
-  // the intentional String boundary for this slice (PR8-A keeps `DriverError`
-  // typed through `run_document_command`; only the CLI invoke adapter
-  // flattens it, per AGENTS.md's decode-boundary rule). PR8-B is the trigger:
-  // once persisted operation-failure classification exists, replace this with
-  // a `DriverError` -> `ControlFailed` mapping so the CLI/MCP/inspect surfaces
-  // regain the typed variant instead of losing it to `Display` text here.
+  // A typed `DriverError` from a control step (activate / focus / paste / open)
+  // is classified as a `ControlFailed` failure and carried forward on the
+  // `Ok(InvokeCommandOutput)` channel (via signals) rather than flattened to a
+  // String on the handler's `Err` channel. The invoke framework's handler error
+  // type is `String`, so `Err` cannot preserve the variant; finalize reads the
+  // carried classification, flips status to Failed, and persists it as
+  // `OperationResult.control_failure`. This mirrors how a semantic mismatch also
+  // rides `Ok` and is finalized to a typed `FailureLayer`.
   let report = match driver_kind {
     "fixture" => {
       let mut driver = FixtureTextEditDriver::from_write(&command);
       driver.observed_override = fixture_observed_text;
-      run_document_command(&DocumentCommand::Write(command.clone()), &mut driver).map_err(|error| error.to_string())?
+      // NOTICE(textedit-fixture-only): forces a typed control-layer DriverError
+      // so the control-failure path is testable without live macOS.
+      driver.control_error_kind = input.inputs.get("fixture_control_error").cloned();
+      match run_document_command(&DocumentCommand::Write(command.clone()), &mut driver) {
+        Ok(report) => report,
+        Err(error) => return Ok(control_failure_output(&command, &error)),
+      }
     }
     "live" => {
       #[cfg(target_os = "macos")]
       {
-        let mut driver = auv_apple_textedit::MacosTextEditDriver::open_local().map_err(|error| error.to_string())?;
-        run_document_command(&DocumentCommand::Write(command.clone()), &mut driver).map_err(|error| error.to_string())?
+        match open_and_write_live(&command) {
+          Ok(report) => report,
+          Err(error) => return Ok(control_failure_output(&command, &error)),
+        }
       }
       #[cfg(not(target_os = "macos"))]
       {
@@ -85,6 +94,122 @@ fn document_write_impl(input: InvokeCommandInput<'_>) -> InvokeCommandResult {
   };
 
   build_invoke_output_from_report(&report, &command)
+}
+
+#[cfg(target_os = "macos")]
+fn open_and_write_live(command: &DocumentWrite) -> auv_driver::DriverResult<DocumentCommandReport> {
+  let mut driver = auv_apple_textedit::MacosTextEditDriver::open_local()?;
+  run_document_command(&DocumentCommand::Write(command.clone()), &mut driver)
+}
+
+/// Signal keys used to carry a typed control failure from the handler across the
+/// `Ok(InvokeCommandOutput)` boundary to [`finalize_recorded_invoke`]. They are
+/// namespaced under `textedit.` like the other command signals; the invoke-time
+/// surfaces render them as ordinary signals (the typed persisted classification
+/// lives on `OperationResult.control_failure`, produced in finalize).
+// NOTICE(control-failure-signal-carrier): these live on the generic
+// `InvokeResult.signals` string bag, which the session-API summary path persists
+// into the `operation-summary` artifact (see `OperationSummaryRecord`). That is
+// an untyped string carrier, not the typed `OperationResult.control_failure`
+// field the owner deferred for the RPC surface, so it does not break the
+// inspect-family-only scope — but the same classification text does travel with
+// the summary. Drop these signals if a future slice wants the summary surface to
+// stay classification-free.
+const CONTROL_FAILURE_LAYER_SIGNAL: &str = "textedit.control_failure.layer";
+const CONTROL_FAILURE_MESSAGE_SIGNAL: &str = "textedit.control_failure.message";
+const CONTROL_FAILURE_RECOVERY_SIGNAL: &str = "textedit.control_failure.recovery";
+
+/// Build the invoke output for a control-layer driver failure. Carries the typed
+/// classification on signals so finalize can persist it; the human summary and
+/// `verification` note make the failure legible on the invoke-time surface too.
+fn control_failure_output(command: &DocumentWrite, error: &DriverError) -> InvokeCommandOutput {
+  let failure = classify_control_failure(error);
+  let mut output = InvokeCommandOutput::new(format!("TextEdit document.write control failure: {}", failure.message));
+  output.backend = Some("auv-apple-textedit.DocumentWrite".to_string());
+  output.signals.insert("textedit.command".to_string(), "document.write".to_string());
+  output.signals.insert("textedit.app_id".to_string(), command.app_id.clone());
+  output.signals.insert(CONTROL_FAILURE_LAYER_SIGNAL.to_string(), render_failure_layer_signal(failure.layer));
+  output.signals.insert(CONTROL_FAILURE_MESSAGE_SIGNAL.to_string(), failure.message.clone());
+  if let Some(recovery) = &failure.recovery {
+    output.signals.insert(CONTROL_FAILURE_RECOVERY_SIGNAL.to_string(), recovery.clone());
+  }
+  output.verification = Some("control failure before verification; no semantic VerificationResult was attached".to_string());
+  output.known_limits.push(TEXTEDIT_DOCUMENT_WRITE_KNOWN_LIMIT.to_string());
+  output
+}
+
+/// Map a typed [`DriverError`] to a persisted [`ControlFailure`]. Every driver
+/// control failure is classified as [`FailureLayer::ControlFailed`]; the driver
+/// error supplies the message, and the recovery hint is lifted from variants
+/// that carry one without also embedding it in the message.
+fn classify_control_failure(error: &DriverError) -> ControlFailure {
+  // NOTICE(control-failure-recovery): the recovery hint is read from the
+  // variants that own one so `message` and `recovery` stay non-overlapping in
+  // the persisted record. If `DriverError` grows a
+  // recovery-bearing variant, extend this match. A shared `DriverError::recovery`
+  // accessor in auv-driver-common is the cleaner home once a second consumer
+  // needs it; deferred to avoid widening that crate for one caller.
+  let (message, recovery) = match error {
+    DriverError::PermissionDenied {
+      permission,
+      message,
+      recovery,
+    } => {
+      let message = match message {
+        Some(detail) => format!("{permission} permission was denied: {detail}"),
+        None => format!("{permission} permission was denied"),
+      };
+      (message, recovery.clone())
+    }
+    DriverError::StaleObservation { message, recovery } | DriverError::RoleMismatch { message, recovery } => {
+      (message.clone(), recovery.clone())
+    }
+    DriverError::Unsupported { .. } | DriverError::NotFound { .. } | DriverError::InvalidInput { .. } | DriverError::Backend { .. } => {
+      (error.to_string(), None)
+    }
+  };
+  ControlFailure {
+    layer: FailureLayer::ControlFailed,
+    message,
+    recovery,
+  }
+}
+
+/// Serialize a [`FailureLayer`] to its wire token (`snake_case`) via serde, so
+/// the signal round-trip reuses the contract's own naming rather than a second
+/// hand-written table. `FailureLayer` is a fieldless enum, so this cannot fail.
+fn render_failure_layer_signal(layer: FailureLayer) -> String {
+  serde_json::to_value(layer).ok().and_then(|value| value.as_str().map(str::to_string)).unwrap_or_else(|| "control_failed".to_string())
+}
+
+/// Inverse of [`render_failure_layer_signal`]; returns `None` if the carried
+/// token is not a known `FailureLayer`.
+fn parse_failure_layer_signal(token: &str) -> Option<FailureLayer> {
+  serde_json::from_value(serde_json::Value::String(token.to_string())).ok()
+}
+
+/// Reconstruct a [`ControlFailure`] carried on the invoke result's signals by
+/// [`control_failure_output`], if the handler recorded one.
+///
+/// The message signal is the single "a control failure occurred" marker: its
+/// presence alone reconstructs the failure so finalize can flip status to
+/// Failed. The layer is best-effort — an absent or unknown token degrades to
+/// [`FailureLayer::ControlFailed`] (the only layer this producer emits) rather
+/// than dropping the whole classification. This deliberately decouples
+/// *failed-ness* from *clean layer parse* so a future signal-shape drift cannot
+/// silently downgrade a real driver failure to a persisted success.
+fn control_failure_from_signals(result: &InvokeResult) -> Option<ControlFailure> {
+  let message = result.signals.get(CONTROL_FAILURE_MESSAGE_SIGNAL)?.clone();
+  let layer = result
+    .signals
+    .get(CONTROL_FAILURE_LAYER_SIGNAL)
+    .and_then(|token| parse_failure_layer_signal(token))
+    .unwrap_or(FailureLayer::ControlFailed);
+  Some(ControlFailure {
+    layer,
+    message,
+    recovery: result.signals.get(CONTROL_FAILURE_RECOVERY_SIGNAL).cloned(),
+  })
 }
 
 /// Stages evidence artifacts only. Canonical `operation-result` is appended by
@@ -161,6 +286,19 @@ pub fn finalize_recorded_invoke(
     return Ok(());
   }
 
+  // A control failure short-circuits before any observation exists: the driver
+  // never delivered input, so there is no AX text to read or verify. Classify,
+  // mark the result failed, and persist the typed classification.
+  if let Some(control_failure) = control_failure_from_signals(result) {
+    apply_control_failure(result, &control_failure);
+    let operation = build_canonical_operation_result_with_control_failure(result, None, Some(control_failure));
+    let rendered = serde_json::to_string_pretty(&operation).map_err(|error| format!("serialize operation-result: {error}"))? + "\n";
+    let (artifact, path) = stage_operation_result_artifact(recording, run, producer_span, rendered.into_bytes())?;
+    result.artifacts.push(artifact);
+    result.artifact_paths.push(path);
+    return Ok(());
+  }
+
   let observation = read_ax_observation(recording, result)?;
   if let Some(verification) = observation.as_ref()
     && !verification.semantic_matched
@@ -177,6 +315,14 @@ pub fn finalize_recorded_invoke(
 }
 
 fn build_canonical_operation_result(result: &InvokeResult, observation: Option<&VerificationOutcome>) -> OperationResult {
+  build_canonical_operation_result_with_control_failure(result, observation, None)
+}
+
+fn build_canonical_operation_result_with_control_failure(
+  result: &InvokeResult,
+  observation: Option<&VerificationOutcome>,
+  control_failure: Option<ControlFailure>,
+) -> OperationResult {
   let run_id = RunId::new(result.run_id.as_str());
   let evidence_artifacts = result
     .artifacts
@@ -242,9 +388,27 @@ fn build_canonical_operation_result(result: &InvokeResult, observation: Option<&
       message: Some(result.output_summary.clone()),
     },
     verifications,
+    control_failure,
     freshness_basis: None,
     known_limits,
   }
+}
+
+/// Mark a control-layer driver failure on the transient result: coarse status
+/// Failed and a human failure string. The typed classification is persisted
+/// separately on `OperationResult.control_failure`.
+///
+// TODO(control-failure-invoke-time-typed): the invoke-time surface (this
+// `InvokeResult` and the CLI/MCP invoke renderers) intentionally stays untyped
+// in PR8-B — it keeps only the human `failure_message`, not a typed
+// `control_failure` field, per the owner's inspect-family-only scope. Trigger:
+// if a future slice wants CLI invoke stdout / the MCP invoke tool JSON to expose
+// the typed classification, add the field to `InvokeResult` in `auv-cli-invoke`
+// and populate it here rather than only on the persisted `OperationResult`.
+fn apply_control_failure(result: &mut InvokeResult, control_failure: &ControlFailure) {
+  result.status = auv_cli_invoke::RunStatus::Failed;
+  result.output_summary = format!("TextEdit document.write control failure: {}", control_failure.message);
+  result.failure_message = Some(control_failure.message.clone());
 }
 
 fn apply_semantic_mismatch(result: &mut InvokeResult, verification: &VerificationOutcome) {
@@ -431,6 +595,12 @@ struct FixtureTextEditDriver {
   role: String,
   /// When set, verify reads this observed body instead of pasted content.
   observed_override: Option<String>,
+  /// NOTICE(textedit-fixture-only): when set, `focus_text_input` returns a
+  /// typed `DriverError` of this kind so hermetic tests can exercise the
+  /// control-failure path without live macOS. `DriverError` is not `Clone`, so
+  /// the injection is stored as a token and the error is built at the failure
+  /// site. Kinds: `permission_denied`, `stale_observation`, `backend`.
+  control_error_kind: Option<String>,
 }
 
 impl FixtureTextEditDriver {
@@ -439,6 +609,25 @@ impl FixtureTextEditDriver {
       content: command.content.clone(),
       role: command.compare_role.clone(),
       observed_override: None,
+      control_error_kind: None,
+    }
+  }
+
+  /// Build the injected typed error for [`Self::control_error_kind`].
+  fn injected_control_error(kind: &str) -> DriverError {
+    match kind {
+      "permission_denied" => DriverError::PermissionDenied {
+        permission: "accessibility",
+        message: Some("fixture: TextEdit AX focus not authorized".to_string()),
+        recovery: Some("grant Accessibility to the terminal in System Settings".to_string()),
+      },
+      "stale_observation" => DriverError::StaleObservation {
+        message: "fixture: AX path 0.1.2 no longer resolves".to_string(),
+        recovery: Some("recapture the AX tree".to_string()),
+      },
+      _ => DriverError::Backend {
+        message: format!("fixture: injected backend control failure ({kind})"),
+      },
     }
   }
 }
@@ -453,6 +642,9 @@ impl TextEditDriver for FixtureTextEditDriver {
   }
 
   fn focus_text_input(&mut self, app_id: &str, query: &str, candidate: &str) -> auv_driver::DriverResult<StepOutcome> {
+    if let Some(kind) = &self.control_error_kind {
+      return Err(Self::injected_control_error(kind));
+    }
     Ok(StepOutcome {
       step_id: "focus",
       summary: format!("fixture focused {app_id} query={query} candidate={candidate}"),
@@ -584,6 +776,7 @@ mod tests {
       content: "pasted".to_string(),
       role: "AXTextArea".to_string(),
       observed_override: Some("observed-without-expected".to_string()),
+      control_error_kind: None,
     };
     let command = DocumentWrite::defaults_with_content("expected-marker");
     let report = run_document_command(&DocumentCommand::Write(command.clone()), &mut driver).expect("report");
@@ -593,6 +786,59 @@ mod tests {
 
     let output = build_invoke_output_from_report(&report, &command).expect("output");
     assert_eq!(output.signals.get("textedit.semantic_matched").map(String::as_str), Some("false"));
+  }
+
+  fn invoke_result_with_signals(signals: BTreeMap<String, String>) -> InvokeResult {
+    InvokeResult {
+      run_id: "run_ctrl".to_string(),
+      producer_span_id: auv_tracing_driver::trace::SpanId::new("0000000000000001"),
+      command_id: DOCUMENT_WRITE_COMMAND_ID.to_string(),
+      command_summary: "TextEdit document write".to_string(),
+      status: auv_cli_invoke::RunStatus::Completed,
+      output_summary: "ok".to_string(),
+      backend: None,
+      signals,
+      notes: Vec::new(),
+      known_limits: Vec::new(),
+      verification: None,
+      report: None,
+      artifacts: Vec::new(),
+      artifact_paths: Vec::new(),
+      failure_message: None,
+    }
+  }
+
+  // ROOT CAUSE:
+  //
+  // If control_failure_from_signals gated failed-ness on a clean layer-token
+  // parse, a real driver control failure whose layer signal was absent or
+  // carried an unknown token would reconstruct as None. Finalize would then fall
+  // through to the observation path and persist the operation as Completed — a
+  // silent success for a genuine failure.
+  //
+  // The fix keeps the message signal as the sole "a control failure occurred"
+  // marker and degrades an absent/unknown layer to ControlFailed, so failed-ness
+  // survives layer-signal drift.
+  #[test]
+  fn control_failure_message_signal_alone_reconstructs_as_control_failed() {
+    let mut signals = BTreeMap::new();
+    signals.insert(CONTROL_FAILURE_MESSAGE_SIGNAL.to_string(), "accessibility permission was denied".to_string());
+    // No layer signal at all.
+    let reconstructed =
+      control_failure_from_signals(&invoke_result_with_signals(signals)).expect("message alone must reconstruct a control failure");
+    assert_eq!(reconstructed.layer, FailureLayer::ControlFailed);
+    assert_eq!(reconstructed.message, "accessibility permission was denied");
+    assert_eq!(reconstructed.recovery, None);
+
+    // An unknown/garbled layer token must also degrade to ControlFailed, never drop the failure.
+    let mut garbled = BTreeMap::new();
+    garbled.insert(CONTROL_FAILURE_MESSAGE_SIGNAL.to_string(), "backend failure".to_string());
+    garbled.insert(CONTROL_FAILURE_LAYER_SIGNAL.to_string(), "not_a_real_layer".to_string());
+    let reconstructed = control_failure_from_signals(&invoke_result_with_signals(garbled)).expect("garbled layer must not drop the failure");
+    assert_eq!(reconstructed.layer, FailureLayer::ControlFailed);
+
+    // No message signal means no control failure was recorded.
+    assert!(control_failure_from_signals(&invoke_result_with_signals(BTreeMap::new())).is_none());
   }
 
   // ROOT CAUSE:

--- a/crates/auv-cli/tests/fixtures/inspect_goldens/balatro.txt
+++ b/crates/auv-cli/tests/fixtures/inspect_goldens/balatro.txt
@@ -40,6 +40,9 @@ Input Actions:
 Verifications:
 - none
 
+Control Failure:
+- none
+
 Observations:
 - none
 

--- a/crates/auv-cli/tests/fixtures/inspect_goldens/core.txt
+++ b/crates/auv-cli/tests/fixtures/inspect_goldens/core.txt
@@ -22,6 +22,9 @@ Input Actions:
 Verifications:
 - method=text_visible executed=true state_changed=true semantic_matched=true failure_layer=n/a evidence=0 observed_label=hello
 
+Control Failure:
+- none
+
 Observations:
 - snapshot_golden span=span_root source=visual nodes=0 evidence=0 limits=1
 

--- a/crates/auv-cli/tests/fixtures/inspect_goldens/minecraft.txt
+++ b/crates/auv-cli/tests/fixtures/inspect_goldens/minecraft.txt
@@ -21,6 +21,9 @@ Input Actions:
 Verifications:
 - none
 
+Control Failure:
+- none
+
 Observations:
 - none
 

--- a/crates/auv-cli/tests/fixtures/inspect_goldens/osu.txt
+++ b/crates/auv-cli/tests/fixtures/inspect_goldens/osu.txt
@@ -28,6 +28,9 @@ Input Actions:
 Verifications:
 - none
 
+Control Failure:
+- none
+
 Observations:
 - none
 

--- a/crates/auv-cli/tests/textedit_document_write_parity.rs
+++ b/crates/auv-cli/tests/textedit_document_write_parity.rs
@@ -137,6 +137,96 @@ fn textedit_document_write_same_run_cli_mcp_inspect_parity() {
   let _ = std::fs::remove_dir_all(root);
 }
 
+// ROOT CAUSE:
+//
+// A typed driver control failure (activate/focus/paste returning DriverError)
+// used to be flattened to a String at the CLI invoke adapter and never
+// persisted as a classification, so inspect surfaces could only show a free-text
+// failure message. PR8-B maps DriverError -> FailureLayer::ControlFailed and
+// persists it on OperationResult.control_failure.
+//
+// This regression locks that the typed classification is produced once and read
+// identically across the inspect-family surfaces (CLI inspect, MCP run_inspect
+// text, HTTP enrichment JSON).
+#[test]
+fn textedit_control_failure_persists_typed_classification_across_inspect_surfaces() {
+  let root = tempfile_dir("textedit-control-failure-parity");
+  let store = LocalStore::new(root.clone()).expect("store");
+  let recording = RunRecordingBackend::new(store.clone(), Arc::new(MemoryRunRecorder::new()));
+  let registry = product_registry();
+
+  let mut inputs = BTreeMap::new();
+  inputs.insert("content".to_string(), "AUV_TEXTEDIT_FIXTURE_MARKER".to_string());
+  inputs.insert("driver".to_string(), "fixture".to_string());
+  // Force a typed control-layer DriverError (PermissionDenied) at focus, before
+  // any verification could run — hermetic, no live macOS.
+  inputs.insert("fixture_control_error".to_string(), "permission_denied".to_string());
+  inputs.insert("verify".to_string(), "true".to_string());
+
+  let result = invoke_recorded(
+    &recording,
+    &registry,
+    InvokeRequest {
+      command_id: DOCUMENT_WRITE_COMMAND_ID.to_string(),
+      target: ExecutionTarget {
+        application_id: Some("com.apple.TextEdit".to_string()),
+        target_label: None,
+      },
+      inputs,
+      dry_run: false,
+    },
+  )
+  .expect("fixture control-failure invoke completes (failure rides Ok output, not handler Err)");
+
+  let run_id = result.run_id.clone();
+  assert_ne!(run_id, "unassigned");
+  // Invoke-time surface stays untyped (owner decision): a human failure string,
+  // no typed classification field on the transient result.
+  assert!(
+    result.failure_message.as_deref().is_some_and(|message| message.contains("permission was denied")),
+    "{:?}",
+    result.failure_message
+  );
+
+  // Persisted OperationResult carries the typed control-layer classification.
+  let operation = run_read::read_operation_result(&store, &run_id).expect("read operation-result").expect("operation-result should exist");
+  assert_eq!(operation.status, OperationStatus::Failed);
+  assert!(operation.verifications.is_empty(), "a control failure runs before verification, so no VerificationResult is attached");
+  let control_failure = operation.control_failure.as_ref().expect("control_failure must be persisted for a driver control failure");
+  assert_eq!(control_failure.layer, FailureLayer::ControlFailed);
+  assert!(control_failure.message.contains("permission was denied"), "{}", control_failure.message);
+  assert_eq!(control_failure.recovery.as_deref(), Some("grant Accessibility to the terminal in System Settings"));
+  assert!(
+    !control_failure.message.contains("grant Accessibility to the terminal in System Settings"),
+    "recovery must remain a separate typed field, not be duplicated in message: {}",
+    control_failure.message
+  );
+
+  let run = store.read_run(&run_id).expect("run");
+  assert_eq!(run.run.status_code, TraceStatusCode::Error);
+
+  // Inspect-family parity: the typed classification is readable identically
+  // across CLI inspect text, MCP run_inspect text, and HTTP enrichment JSON.
+  let composer = inspect::build_product_inspect_composer().expect("composer");
+  let cli_text = inspect::inspect_run_with(&composer, &store, &run_id).expect("cli inspect");
+  assert!(cli_text.contains("Control Failure:"), "cli inspect must render a Control Failure section:\n{cli_text}");
+  assert!(cli_text.contains("failure_layer=control_failed"), "cli inspect must render the typed layer:\n{cli_text}");
+
+  let mcp_text = composer.collect_document(&store, &run).expect("mcp-style document").render_text();
+  assert!(mcp_text.contains("failure_layer=control_failed"), "mcp run_inspect text must render the typed layer:\n{mcp_text}");
+  assert_eq!(extract_section_ids(&cli_text), extract_section_ids(&mcp_text));
+
+  let projection = ProductInspectReadProjection::default();
+  let enrichment = projection.run_enrichment(&store, &run).expect("enrichment");
+  let enriched = enrichment.control_failure.as_ref().expect("HTTP enrichment must expose control_failure");
+  assert_eq!(enriched["layer"], "control_failed");
+  assert!(enriched["message"].as_str().is_some_and(|message| message.contains("permission was denied")));
+  assert_eq!(enriched["recovery"], "grant Accessibility to the terminal in System Settings");
+  assert!(enrichment.verifications.is_empty(), "no verification claim on a control-failure run");
+
+  let _ = std::fs::remove_dir_all(root);
+}
+
 #[test]
 fn product_help_lists_textedit_command_once() {
   let help = auv_cli_invoke::render_help_index(&product_registry());

--- a/crates/auv-inspect-server/src/read_projection.rs
+++ b/crates/auv-inspect-server/src/read_projection.rs
@@ -54,6 +54,11 @@ pub struct InspectRunEnrichment {
   /// Serialized `InputActionResult` from `input-action-result` artifacts.
   #[serde(default, skip_serializing_if = "Vec::is_empty")]
   pub input_action_results: Vec<serde_json::Value>,
+  /// Serialized `ControlFailure` lifted from the run's `operation-result`, when
+  /// a driver control step failed before verification. Absent otherwise, so the
+  /// HTTP surface reports the same typed classification as the inspect text.
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub control_failure: Option<serde_json::Value>,
   pub view_parser: ViewParserInspect,
   pub view_parser_summary: ViewParserListSummary,
 }

--- a/crates/auv-inspect-server/src/server.rs
+++ b/crates/auv-inspect-server/src/server.rs
@@ -305,6 +305,7 @@ async fn get_run(State(state): State<InspectServerState>, Path(run_id): Path<Str
     observation_snapshots,
     detector_recognition_lineage,
     input_action_results,
+    control_failure,
     view_parser,
     view_parser_summary,
   } = state.projection.run_enrichment(state.store.as_ref(), &run).map_err(InspectHttpError::from_store)?;
@@ -316,6 +317,7 @@ async fn get_run(State(state): State<InspectServerState>, Path(run_id): Path<Str
       observation_snapshots,
       detector_recognition_lineage,
       input_action_results,
+      control_failure,
       view_parser,
       view_parser_summary,
     })
@@ -491,6 +493,8 @@ struct InspectRunResponse {
   detector_recognition_lineage: Vec<serde_json::Value>,
   #[serde(default, skip_serializing_if = "Vec::is_empty")]
   input_action_results: Vec<serde_json::Value>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  control_failure: Option<serde_json::Value>,
   view_parser: ViewParserInspect,
   view_parser_summary: ViewParserListSummary,
 }
@@ -856,6 +860,11 @@ mod tests {
           "focus_disturbance": "none",
           "clipboard_disturbance": "none"
         })],
+        control_failure: Some(serde_json::json!({
+          "layer": "control_failed",
+          "message": "accessibility permission was denied",
+          "recovery": "grant Accessibility in System Settings"
+        })),
         ..Default::default()
       })
     }
@@ -1770,6 +1779,9 @@ mod tests {
     assert_eq!(run["detector_recognition_lineage"][0]["status"], "ready");
     assert_eq!(run["input_action_results"][0]["selected_path"], "foreground_system_events");
     assert_eq!(run["input_action_results"][0]["attempts"][0]["succeeded"], true);
+    assert_eq!(run["control_failure"]["layer"], "control_failed");
+    assert_eq!(run["control_failure"]["message"], "accessibility permission was denied");
+    assert_eq!(run["control_failure"]["recovery"], "grant Accessibility in System Settings");
     assert!(run["command_boundary_claims"].as_array().is_some_and(|claims| !claims.is_empty()));
     assert!(run["verifications"].as_array().is_some_and(|verifications| !verifications.is_empty()));
     assert!(run["observation_snapshots"].as_array().is_some_and(|snapshots| !snapshots.is_empty()));

--- a/docs/TERMS_AND_CONCEPTS.md
+++ b/docs/TERMS_AND_CONCEPTS.md
@@ -646,6 +646,24 @@ standardization of producer status policy.
 
 In code, the current type is `auv_runtime::contract::OperationStatus`.
 
+## Control Failure
+
+A control failure is a typed operation-level classification for a driver
+control step that failed before, or instead of, semantic verification. It is
+persisted as `OperationResult.control_failure`, separately from
+`VerificationResult`, because no verification claim exists when activation,
+focus, or input delivery fails first.
+
+The current `ControlFailure` record carries a shared `FailureLayer`, a human
+message, and an optional recovery hint. The only active producer is TextEdit's
+typed driver-error path, which emits `FailureLayer::ControlFailed`; other
+pipeline-layer producers remain intentionally deferred. A control failure makes
+the coarse operation status `Failed`, but consumers should read the typed field
+for the layer and recovery detail rather than inferring either from status or
+free text.
+
+In code, the current type is `auv_runtime::contract::ControlFailure`.
+
 ## Operation Disturbance
 
 Operation disturbance is the coarse user-visible disturbance profile attached

--- a/src/api/session_service/operation_result_store.rs
+++ b/src/api/session_service/operation_result_store.rs
@@ -48,6 +48,12 @@ fn synthetic_operation_result_from_invoke(command_id: &str, result: &InvokeResul
       message: Some(result.output_summary.clone()),
     },
     verifications: Vec::new(),
+    // TODO(control-failure-session-api): this synthetic OperationResult mirrors
+    // a transient InvokeResult, whose typed control-failure classification is
+    // not carried across the session-API boundary in PR8-B (invoke-time surface
+    // stays untyped by owner decision). Populate once the RPC surface is meant
+    // to expose ControlFailed.
+    control_failure: None,
     evidence_artifacts,
     freshness_basis: None,
     known_limits: vec![INVOKE_SYNTHETIC_OPERATION_RESULT_KNOWN_LIMIT.to_string()],

--- a/src/api/session_service/test_fixtures.rs
+++ b/src/api/session_service/test_fixtures.rs
@@ -129,6 +129,7 @@ pub fn music_search_operation(run_id: &str) -> OperationResult {
     evidence_artifacts: Vec::new(),
     output: OperationOutput::Acknowledged { message: None },
     verifications: Vec::new(),
+    control_failure: None,
     freshness_basis: None,
     known_limits: vec!["semantic_shaping_synthetic".to_string()],
   }

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -168,8 +168,55 @@ pub struct OperationResult {
   /// alongside its acknowledged output.
   #[serde(default, skip_serializing_if = "Vec::is_empty")]
   pub verifications: Vec<VerificationResult>,
+  /// Typed classification for a *control-layer* failure — one that happened
+  /// before (or instead of) any verification, so it cannot be expressed as a
+  /// [`VerificationResult`]. A driver control call (activate / focus / paste)
+  /// that returns a typed `DriverError` lands here as
+  /// [`FailureLayer::ControlFailed`] with the driver's message and any recovery
+  /// hint, keeping the failure classifiable instead of collapsing to free text.
+  ///
+  /// Distinct from [`Self::verifications`]: `failure_layer` there classifies a
+  /// verification that *ran and disagreed* (e.g. `SemanticMismatch`); this
+  /// classifies a control step that never produced a verification at all.
+  /// Serialized as absent when the operation had no control-layer failure, and
+  /// accepted as missing for back-compat with older OperationResult JSON.
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub control_failure: Option<ControlFailure>,
   pub freshness_basis: Option<FreshnessBasis>,
   pub known_limits: Vec<String>,
+}
+
+/// A classified control-layer failure attached to an [`OperationResult`].
+///
+/// # Seam role
+///
+/// - **Produced by** command handlers that map a typed driver failure into a
+///   persisted classification (currently `app.textedit.document.write` maps
+///   `DriverError` -> [`FailureLayer::ControlFailed`] at its invoke finalize).
+/// - **Consumed by** the inspect-family read path (`run_read`, core inspect
+///   text render, and the HTTP inspect enrichment) so CLI `inspect`, MCP
+///   `run_inspect`, and the HTTP surface all report the same typed
+///   classification for a driver control failure.
+///
+/// `layer` reuses the shared [`FailureLayer`] taxonomy rather than a private
+/// enum. Today the only producer emits [`FailureLayer::ControlFailed`]; the
+/// wider taxonomy (`GroundingFailed`, `CandidateExpired`, ...) is deliberately
+/// left to future producers on this same field.
+// TODO(control-failure-producers): only `ControlFailed` is produced today
+// (textedit driver-error path). `GroundingFailed` / `CandidateExpired` remain
+// unproduced on purpose — add them when a real grounding/candidate producer
+// needs a persisted control-layer classification, not speculatively.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ControlFailure {
+  /// Which pipeline layer failed. See [`FailureLayer`].
+  pub layer: FailureLayer,
+  /// Human-readable failure detail, excluding any separately stored recovery
+  /// hint.
+  pub message: String,
+  /// Optional recovery hint carried from the driver error when it had one
+  /// (e.g. `PermissionDenied` / `StaleObservation` / `RoleMismatch`).
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub recovery: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -1035,15 +1082,72 @@ mod tests {
         notes: vec!["window-scoped OCR rows".to_string()],
       }),
       known_limits: Vec::new(),
+      control_failure: None,
     };
 
     let value = serde_json::to_value(&result).expect("operation result should serialize");
     assert_eq!(value["status"], json!("completed"));
     assert_eq!(value["output"]["kind"], json!("candidates"));
     assert_eq!(value["output"]["candidates"][0]["target_spec"]["grounding"], json!("ocr_anchor"));
+    // A success operation carries no control failure and must not serialize the field.
+    assert!(value.get("control_failure").is_none());
 
     let parsed: OperationResult = serde_json::from_value(value).expect("operation result should deserialize");
     assert_eq!(parsed, result);
+  }
+
+  #[test]
+  fn operation_result_control_failure_round_trips_and_omits_when_absent() {
+    let result = OperationResult {
+      api_version: OPERATION_RESULT_API_VERSION.to_string(),
+      run_id: RunId::new("run_ctrl"),
+      status: OperationStatus::Failed,
+      operation_id: "app.textedit.document.write".to_string(),
+      evidence_artifacts: Vec::new(),
+      output: OperationOutput::Acknowledged {
+        message: Some("TextEdit document.write control failure".to_string()),
+      },
+      verifications: Vec::new(),
+      control_failure: Some(ControlFailure {
+        layer: FailureLayer::ControlFailed,
+        message: "accessibility permission was denied: not authorized".to_string(),
+        recovery: Some("grant Accessibility in System Settings".to_string()),
+      }),
+      freshness_basis: None,
+      known_limits: Vec::new(),
+    };
+
+    let value = serde_json::to_value(&result).expect("operation result should serialize");
+    assert_eq!(value["status"], json!("failed"));
+    assert_eq!(value["control_failure"]["layer"], json!("control_failed"));
+    assert_eq!(value["control_failure"]["message"], json!("accessibility permission was denied: not authorized"));
+    assert_eq!(value["control_failure"]["recovery"], json!("grant Accessibility in System Settings"));
+
+    let parsed: OperationResult = serde_json::from_value(value).expect("operation result should deserialize");
+    assert_eq!(parsed, result);
+  }
+
+  // ROOT CAUSE:
+  //
+  // `control_failure` is an additive field on the persisted `OperationResult`
+  // wire shape. If it were not `#[serde(default)]`, older `operation-result`
+  // JSON (written before PR8-B) would fail to deserialize once readers upgrade.
+  // This locks the back-compat guarantee: absent field -> `None`.
+  #[test]
+  fn operation_result_without_control_failure_field_parses_as_none() {
+    let legacy = json!({
+      "api_version": OPERATION_RESULT_API_VERSION,
+      "run_id": "run_legacy",
+      "status": "failed",
+      "operation_id": "app.textedit.document.write",
+      "evidence_artifacts": [],
+      "output": { "kind": "acknowledged", "message": "legacy failure" },
+      "freshness_basis": null,
+      "known_limits": []
+    });
+
+    let parsed: OperationResult = serde_json::from_value(legacy).expect("legacy operation result should deserialize");
+    assert_eq!(parsed.control_failure, None);
   }
 
   #[test]
@@ -1375,6 +1479,7 @@ mod tests {
         message: Some("Issued play".to_string()),
       },
       verifications: vec![verification.clone()],
+      control_failure: None,
       freshness_basis: None,
       known_limits: Vec::new(),
     };
@@ -1426,6 +1531,7 @@ mod tests {
         sample_verification(VerificationMethod::StateChanged),
         sample_verification(VerificationMethod::SemanticMatch),
       ],
+      control_failure: None,
       freshness_basis: None,
       known_limits: Vec::new(),
     };
@@ -1461,6 +1567,7 @@ mod tests {
         message: Some("click delivered".to_string()),
       },
       verifications: vec![mismatch],
+      control_failure: None,
       freshness_basis: None,
       known_limits: Vec::new(),
     };

--- a/src/inspect/mod.rs
+++ b/src/inspect/mod.rs
@@ -11,7 +11,7 @@ use auv_view::memory::{ViewMemory, ViewParserInspect, format_view_resolution_sum
 
 use auv_driver::{DisturbanceLevel, InputActionResult, InputDeliveryPath};
 
-use crate::contract::{FailureLayer, ObservationSnapshot, ObservationSource, VerificationMethod, VerificationResult};
+use crate::contract::{ControlFailure, FailureLayer, ObservationSnapshot, ObservationSource, VerificationMethod, VerificationResult};
 use crate::model::AuvResult;
 use crate::run_read::DetectorRecognitionLineage;
 use crate::{scene_state_read, view_parser_read};
@@ -63,9 +63,17 @@ pub(crate) fn inspect_run_core_prefix_body(store: &LocalStore, run_id: &str) -> 
   let canonical = read_run(store, run_id)?;
   let input_action_results = crate::run_read::extract_input_action_results(store, &canonical)?;
   let verifications = crate::run_read::extract_verifications(store, &canonical)?;
+  let control_failure = crate::run_read::extract_control_failure(store, &canonical)?;
   let observation_snapshots = crate::run_read::extract_observation_snapshots(store, &canonical)?;
   let detector_recognition_lineage = crate::run_read::extract_detector_recognition_lineage(store, &canonical)?;
-  Ok(render_core_run_text(&canonical, &input_action_results, &verifications, &observation_snapshots, &detector_recognition_lineage))
+  Ok(render_core_run_text(
+    &canonical,
+    &input_action_results,
+    &verifications,
+    control_failure.as_ref(),
+    &observation_snapshots,
+    &detector_recognition_lineage,
+  ))
 }
 
 pub(crate) fn inspect_run_core_suffix_body(store: &LocalStore, run_id: &str) -> AuvResult<String> {
@@ -107,6 +115,7 @@ fn render_core_run_text(
   run: &CanonicalRun,
   input_action_results: &[InputActionResult],
   verifications: &[VerificationResult],
+  control_failure: Option<&ControlFailure>,
   observation_snapshots: &[ObservationSnapshot],
   detector_recognition_lineage: &[DetectorRecognitionLineage],
 ) -> String {
@@ -203,6 +212,20 @@ fn render_core_run_text(
         verification.observed_label.as_deref().unwrap_or("n/a")
       ));
     }
+  }
+
+  // Control-layer failure classification (a driver control step that failed
+  // before any verification could run). Separate from Verifications: this is a
+  // failure_layer with no accompanying verification claim.
+  output.push_str("\nControl Failure:\n");
+  match control_failure {
+    None => output.push_str("- none\n"),
+    Some(control_failure) => output.push_str(&format!(
+      "- failure_layer={} message={} recovery={}\n",
+      render_failure_layer(Some(control_failure.layer)),
+      control_failure.message,
+      control_failure.recovery.as_deref().unwrap_or("n/a")
+    )),
   }
 
   output.push_str("\nObservations:\n");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,10 @@ impl auv_inspect_server::InspectReadProjection for RootInspectReadProjection {
         .map(serde_json::to_value)
         .collect::<Result<Vec<_>, _>>()
         .map_err(|error| format!("failed to encode input action result inspect values: {error}"))?,
+      control_failure: run_read::extract_control_failure(store, run)?
+        .map(serde_json::to_value)
+        .transpose()
+        .map_err(|error| format!("failed to encode control failure inspect value: {error}"))?,
       view_parser,
       view_parser_summary,
     })

--- a/src/run_read/mod.rs
+++ b/src/run_read/mod.rs
@@ -12,7 +12,8 @@
 //!   double-counting artifacts that also populate `OperationResult.verifications`
 
 use crate::contract::{
-  ArtifactRef, ObservationSnapshot, OperationOutput, OperationResult, RecognitionResult, RecognitionSource, VerificationResult,
+  ArtifactRef, ControlFailure, ObservationSnapshot, OperationOutput, OperationResult, RecognitionResult, RecognitionSource,
+  VerificationResult,
 };
 use crate::model::AuvResult;
 use crate::scroll_scan::ScrollScanArtifact;
@@ -80,6 +81,26 @@ pub(crate) fn extract_verifications(store: &LocalStore, run: &CanonicalRun) -> A
     }
   }
   Ok(verifications)
+}
+
+/// Lift the typed control-layer failure from a run's `operation-result`
+/// artifacts, if one was recorded.
+///
+/// Mirrors [`extract_verifications`]' role/mime scan so the inspect-family
+/// surfaces (core inspect text render and the HTTP enrichment) read one shared
+/// policy. Returns the first `control_failure` found; a driver control failure
+/// produces exactly one `operation-result`.
+pub(crate) fn extract_control_failure(store: &LocalStore, run: &CanonicalRun) -> AuvResult<Option<ControlFailure>> {
+  for artifact in &run.artifacts {
+    if artifact.role != "operation-result" || !is_json_mime(&artifact.mime_type) {
+      continue;
+    }
+    let operation_result: OperationResult = read_artifact_json(store, run.run.run_id.as_str(), artifact, "operation-result")?;
+    if let Some(control_failure) = operation_result.control_failure {
+      return Ok(Some(control_failure));
+    }
+  }
+  Ok(None)
 }
 
 /// Read the persisted `OperationResult` for a run, if one was recorded.


### PR DESCRIPTION
## Summary

**PR8-B** (follow-up to #127): map a typed driver **control** failure (`activate` / `focus` / `paste` returning `DriverError`) into a persisted `FailureLayer::ControlFailed` classification, and surface it identically across the inspect-family read surfaces.

Before this, a driver control failure was flattened to a `String` at the CLI invoke adapter (#127's intentional boundary) and never persisted as a classification: at finalize `observation` was `None`, so no `VerificationResult` and no `failure_layer` were recorded — the persisted `OperationResult` carried only `status: Failed` plus a generic acknowledged message. `FailureLayer::ControlFailed` was a defined-but-never-produced variant. This is its first producer.

## Design (owner-approved in plan mode)

- **Persist as a new field**, not by reusing `VerificationResult.failure_layer`: `ControlFailure { layer, message, recovery }` on a new additive `OperationResult.control_failure: Option<ControlFailure>`. A `VerificationResult` means "a verification ran and here's the evidence"; a control failure ran *before* any verification, so representing it as one would be a same-shape-≠-same-concept error. Additive wire shape (`#[serde(default, skip_serializing_if)]`) — pre-PR8-B `operation-result` JSON still parses.
- **Producer**: the invoke handler's error channel is `String`-typed, so a `DriverError` can't be preserved on `Err`. The handler catches it and carries the classification on the `Ok(InvokeCommandOutput)` channel via signals; finalize reconstructs the `ControlFailure`, flips status to `Failed`, and persists it — mirroring how a semantic mismatch already rides `Ok`. The **message signal alone** drives failed-ness; the layer degrades to `ControlFailed` rather than dropping the failure, so signal-shape drift can never silently downgrade a real failure to a persisted success.

## Parity scope (owner decision: inspect-family only)

The typed classification is read identically by CLI `inspect`, MCP `run_inspect` text (shared composer), and the HTTP inspect enrichment JSON. Invoke-time surfaces (CLI `invoke` stdout, MCP `invoke` tool) intentionally stay untyped this slice — they keep the human `failure_message` string only.

## Deferrals (marked at the code sites)

- `TODO(control-failure-session-api)` — session-API `GetOperation` mapper does not surface the typed field via RPC yet.
- `TODO(control-failure-invoke-time-typed)` — invoke-time `InvokeResult` stays untyped.
- `TODO(control-failure-producers)` — `ControlFailed` is textedit-only; other `FailureLayer` layers have no producer yet.
- `NOTICE(control-failure-recovery)` — recovery hint lifted from the `DriverError` variants that own one; a shared accessor is deferred until a second consumer exists.

## Testing

- `cargo fmt --check`, `cargo check`, `cargo test` (full workspace green), `git diff --check`.
- New contract round-trip + backward-compat tests (old JSON without the field → `None`).
- New cross-surface regression test: hermetic `DriverError::PermissionDenied` (fixture injection, no live macOS) → asserts persisted `control_failure == Some(ControlFailed)` with message/recovery, read identically across CLI inspect, MCP `run_inspect`, and HTTP enrichment; asserts `status=Failed` + `TraceStatusCode::Error`.
- New unit test locking the failed-ness/layer-parse decoupling (message-only and garbled-layer both reconstruct as `ControlFailed`).
- Golden inspect fixtures updated: purely the additive `Control Failure:` section.

Reviewed adversarially (RustRover-backed, high effort): no blocking findings; the one SHOULD-FIX (latent false-success coupling) is fixed in this branch.
