### PR TITLE
feat(auv-runtime): surface typed control-layer failure through GetOperation

### DIFF
--- a/crates/auv-api-proto/src/lib.rs
+++ b/crates/auv-api-proto/src/lib.rs
@@ -13,7 +13,9 @@ mod tests {
   use std::collections::HashMap;
 
   use crate::v1::session::session_service_client::SessionServiceClient;
-  use crate::v1::session::{ArtifactRef, FILE_DESCRIPTOR_SET, GetOperationResponse, InvokeRequest, OperationRef, SessionRef};
+  use crate::v1::session::{
+    ArtifactRef, ControlFailure, FILE_DESCRIPTOR_SET, GetOperationResponse, InvokeRequest, OperationRef, SessionRef,
+  };
   use prost::Message;
   use prost_types::FileDescriptorSet;
 
@@ -53,6 +55,11 @@ mod tests {
       }],
       failure_message: "invalid payload".to_string(),
       known_limits: vec!["json_payload_max_bytes".to_string()],
+      control_failure: Some(ControlFailure {
+        layer: "control_failed".to_string(),
+        message: "accessibility permission was denied".to_string(),
+        recovery: "grant Accessibility in System Settings".to_string(),
+      }),
     };
 
     let encoded = response.encode_to_vec();
@@ -66,6 +73,10 @@ mod tests {
     assert_eq!(operation.operation_id, "minecraft.query");
     assert_eq!(decoded.artifacts.len(), 1);
     assert_eq!(decoded.signals.get("exit_code"), Some(&"1".to_string()));
+    let control_failure = decoded.control_failure.expect("control_failure should round-trip");
+    assert_eq!(control_failure.layer, "control_failed");
+    assert_eq!(control_failure.message, "accessibility permission was denied");
+    assert_eq!(control_failure.recovery, "grant Accessibility in System Settings");
   }
 
   #[test]

--- a/crates/auv-cli/src/run_read/query_wired_live_action.rs
+++ b/crates/auv-cli/src/run_read/query_wired_live_action.rs
@@ -180,14 +180,7 @@ fn is_activation_only_verification(verification: &VerificationResult) -> bool {
 }
 
 fn verification_failure_layer_label(layer: FailureLayer) -> &'static str {
-  match layer {
-    FailureLayer::GroundingFailed => "grounding_failed",
-    FailureLayer::CandidateExpired => "candidate_expired",
-    FailureLayer::ControlFailed => "control_failed",
-    FailureLayer::VerificationUnreliable => "verification_unreliable",
-    FailureLayer::StateChangedNoMatch => "state_changed_no_match",
-    FailureLayer::SemanticMismatch => "semantic_mismatch",
-  }
+  layer.as_str()
 }
 
 fn verification_claim_reason_snippet(verification: &VerificationResult) -> Option<String> {

--- a/crates/auv-cli/tests/textedit_document_write_parity.rs
+++ b/crates/auv-cli/tests/textedit_document_write_parity.rs
@@ -202,6 +202,29 @@ fn textedit_control_failure_persists_typed_classification_across_inspect_surface
     control_failure.message
   );
 
+  // Reload through a fresh SessionService handler: the GetOperation projection
+  // must read the canonical persisted OperationResult, not a process-local cache
+  // or the transient InvokeResult signal carrier.
+  let reloaded_handler = auv_runtime::api::session_service::handler::SessionApiHandler::new(root.clone());
+  let get_operation = reloaded_handler
+    .get_operation(auv_api_proto::v1::session::GetOperationRequest {
+      operation: Some(auv_api_proto::v1::session::OperationRef {
+        run_id: run_id.clone(),
+        operation_id: DOCUMENT_WRITE_COMMAND_ID.to_string(),
+      }),
+    })
+    .expect("GetOperation should reload the persisted TextEdit control failure");
+  assert_eq!(get_operation.status, "failed");
+  let get_control_failure = get_operation.control_failure.expect("GetOperation must expose persisted control_failure");
+  assert_eq!(get_control_failure.layer, "control_failed");
+  assert!(
+    !get_control_failure.message.contains("grant Accessibility to the terminal in System Settings"),
+    "GetOperation message must exclude the separately stored recovery hint: {}",
+    get_control_failure.message
+  );
+  assert_eq!(get_control_failure.message, control_failure.message);
+  assert_eq!(get_control_failure.recovery, "grant Accessibility to the terminal in System Settings");
+
   let run = store.read_run(&run_id).expect("run");
   assert_eq!(run.run.status_code, TraceStatusCode::Error);
 

--- a/proto/auv/api/v1/session.proto
+++ b/proto/auv/api/v1/session.proto
@@ -65,6 +65,19 @@ message GetOperationRequest {
   OperationRef operation = 1;
 }
 
+// Typed control-layer failure classification, projected read-side from the
+// persisted OperationResult.control_failure. Present only when a control step
+// (activate / focus / paste, etc.) failed before any verification ran, so the
+// failure cannot be expressed as a verification outcome.
+message ControlFailure {
+  // Which pipeline layer failed, as a snake_case string from the internal
+  // FailureLayer taxonomy (e.g. "control_failed"). String, not enum, matching
+  // the experimental status-as-string convention on this surface.
+  string layer = 1;
+  string message = 2; // human-readable failure detail
+  string recovery = 3; // optional recovery hint; empty when absent
+}
+
 message GetOperationResponse {
   OperationRef operation = 1;
   string status = 2; // same vocabulary as InvokeResponse: "completed" | "failed"
@@ -73,6 +86,9 @@ message GetOperationResponse {
   repeated ArtifactRef artifacts = 5;
   string failure_message = 6; // empty when absent
   repeated string known_limits = 7; // aligns with InvokeResponse / internal OperationResult
+  // Typed control-layer failure from the persisted OperationResult; unset when
+  // the operation had no control-layer failure (proto3 message presence).
+  ControlFailure control_failure = 8;
 }
 
 message StreamSessionEventsRequest {

--- a/src/api/session_service/handler.rs
+++ b/src/api/session_service/handler.rs
@@ -375,6 +375,47 @@ mod tests {
     let _ = std::fs::remove_dir_all(root);
   }
 
+  #[test]
+  fn get_operation_after_new_handler_reads_persisted_control_failure_without_runtime_cache() {
+    use crate::api::session_service::test_fixtures::{music_search_operation, persist_operation_result_on_store};
+    use crate::contract::{ControlFailure, FailureLayer, OperationStatus};
+
+    let root = unique_temp_dir("session-api-persisted-control-failure");
+    let handler = SessionApiHandler::new(root.clone());
+    let store = handler.open_store().expect("open store");
+    let run_id = "run-persisted-control-failure";
+    let mut operation = music_search_operation(run_id);
+    operation.operation_id = "app.textedit.document.write".to_string();
+    operation.status = OperationStatus::Failed;
+    operation.control_failure = Some(ControlFailure {
+      layer: FailureLayer::ControlFailed,
+      message: "accessibility permission was denied".to_string(),
+      recovery: Some("grant Accessibility in System Settings".to_string()),
+    });
+    persist_operation_result_on_store(&store, &root, run_id, &operation);
+
+    // A fresh handler has no process-local runtime summary cache. The typed
+    // classification must still come from the persisted OperationResult.
+    let reloaded_handler = SessionApiHandler::new(root.clone());
+    assert!(reloaded_handler.summaries.lock().expect("summary cache mutex poisoned").is_empty());
+    let response = reloaded_handler
+      .get_operation(proto::GetOperationRequest {
+        operation: Some(proto::OperationRef {
+          run_id: run_id.to_string(),
+          operation_id: String::new(),
+        }),
+      })
+      .expect("get_operation should reload persisted control failure");
+
+    assert_eq!(response.status, "failed");
+    let control_failure = response.control_failure.expect("persisted control failure should survive reload");
+    assert_eq!(control_failure.layer, "control_failed");
+    assert_eq!(control_failure.message, "accessibility permission was denied");
+    assert_eq!(control_failure.recovery, "grant Accessibility in System Settings");
+
+    let _ = std::fs::remove_dir_all(root);
+  }
+
   #[cfg(unix)]
   #[test]
   fn get_operation_reads_preseeded_skeleton_when_invoke_durability_writes_fail() {

--- a/src/api/session_service/mapper.rs
+++ b/src/api/session_service/mapper.rs
@@ -10,7 +10,7 @@ use auv_tracing_driver::trace::ArtifactRecordV1Alpha1;
 
 use crate::api::session_service::SessionApiError;
 use crate::api::session_service::summary::{ARTIFACT_ROLE_UNAVAILABLE_KNOWN_LIMIT, JoinedOperationSummary};
-use crate::contract::{ArtifactRef as ContractArtifactRef, OperationStatus};
+use crate::contract::{ArtifactRef as ContractArtifactRef, ControlFailure, OperationStatus};
 
 /// Status string shared by `InvokeResponse` and `GetOperationResponse`
 /// (`"completed"` | `"failed"`).
@@ -119,6 +119,18 @@ pub fn invoke_result_to_response(command_id: &str, result: &InvokeResult, extra_
   }
 }
 
+// API-R2 read side: project the persisted typed control-layer failure onto the
+// proto surface. `layer` uses the shared `FailureLayer::as_str` snake_case wire
+// spelling (single source of truth, also used by inspect text render); recovery
+// collapses `None` to the empty string per the proto "empty when absent" rule.
+fn control_failure_to_proto(control_failure: &ControlFailure) -> proto::ControlFailure {
+  proto::ControlFailure {
+    layer: control_failure.layer.as_str().to_string(),
+    message: control_failure.message.clone(),
+    recovery: control_failure.recovery.clone().unwrap_or_default(),
+  }
+}
+
 /// Map a joined two-source summary (API-P7) to a proto `GetOperationResponse`.
 pub fn joined_to_get_operation_response(joined: &JoinedOperationSummary) -> proto::GetOperationResponse {
   let mut known_limits = joined.known_limits.clone();
@@ -150,6 +162,7 @@ pub fn joined_to_get_operation_response(joined: &JoinedOperationSummary) -> prot
       .collect(),
     failure_message,
     known_limits,
+    control_failure: joined.control_failure.as_ref().map(control_failure_to_proto),
   }
 }
 
@@ -162,7 +175,7 @@ mod tests {
   use super::{decode_invoke_payload, invoke_result_to_response, joined_to_get_operation_response};
   use crate::api::session_service::SessionApiError;
   use crate::api::session_service::summary::{ARTIFACT_ROLE_UNAVAILABLE_KNOWN_LIMIT, JoinedOperationSummary, RuntimeOperationSummary};
-  use crate::contract::{ArtifactRef as ContractArtifactRef, OperationStatus};
+  use crate::contract::{ArtifactRef as ContractArtifactRef, ControlFailure, FailureLayer, OperationStatus};
   use auv_tracing_driver::trace::{ArtifactId, RunId, SpanId};
 
   #[test]
@@ -251,6 +264,7 @@ mod tests {
       known_limits: vec!["lim".to_string()],
       artifacts: Vec::new(),
       artifact_roles: BTreeMap::new(),
+      control_failure: None,
       runtime: Some(RuntimeOperationSummary {
         output_summary: "did the thing".to_string(),
         signals: BTreeMap::from([("k".to_string(), "v".to_string())]),
@@ -275,6 +289,7 @@ mod tests {
       known_limits: Vec::new(),
       artifacts: Vec::new(),
       artifact_roles: BTreeMap::new(),
+      control_failure: None,
       runtime: None,
     };
     let response = joined_to_get_operation_response(&joined);
@@ -295,6 +310,7 @@ mod tests {
       ],
       artifacts: Vec::new(),
       artifact_roles: BTreeMap::new(),
+      control_failure: None,
       runtime: Some(RuntimeOperationSummary {
         output_summary: "runtime failed".to_string(),
         signals: BTreeMap::new(),
@@ -323,6 +339,7 @@ mod tests {
         captured_event_id: None,
       }],
       artifact_roles: BTreeMap::from([(artifact_id.as_str().to_string(), "evidence-pack".to_string())]),
+      control_failure: None,
       runtime: None,
     };
     let response = joined_to_get_operation_response(&joined);
@@ -346,10 +363,52 @@ mod tests {
         captured_event_id: None,
       }],
       artifact_roles: BTreeMap::new(),
+      control_failure: None,
       runtime: None,
     };
     let response = joined_to_get_operation_response(&joined);
     assert!(response.artifacts[0].role.is_empty());
     assert!(response.known_limits.iter().any(|limit| limit == ARTIFACT_ROLE_UNAVAILABLE_KNOWN_LIMIT));
+  }
+
+  #[test]
+  fn joined_surfaces_persisted_control_failure() {
+    let joined = JoinedOperationSummary {
+      run_id: "run-cf".to_string(),
+      domain_operation_id: "app.textedit.document.write".to_string(),
+      command_id: Some("app.textedit.document.write".to_string()),
+      status: OperationStatus::Failed,
+      known_limits: Vec::new(),
+      artifacts: Vec::new(),
+      artifact_roles: BTreeMap::new(),
+      control_failure: Some(ControlFailure {
+        layer: FailureLayer::ControlFailed,
+        message: "accessibility permission was denied".to_string(),
+        recovery: Some("grant Accessibility in System Settings".to_string()),
+      }),
+      runtime: None,
+    };
+    let response = joined_to_get_operation_response(&joined);
+    let control_failure = response.control_failure.expect("control_failure should be surfaced");
+    assert_eq!(control_failure.layer, "control_failed");
+    assert_eq!(control_failure.message, "accessibility permission was denied");
+    assert_eq!(control_failure.recovery, "grant Accessibility in System Settings");
+  }
+
+  #[test]
+  fn joined_without_control_failure_leaves_proto_field_unset() {
+    let joined = JoinedOperationSummary {
+      run_id: "run-no-cf".to_string(),
+      domain_operation_id: "op".to_string(),
+      command_id: Some("music.search".to_string()),
+      status: OperationStatus::Completed,
+      known_limits: Vec::new(),
+      artifacts: Vec::new(),
+      artifact_roles: BTreeMap::new(),
+      control_failure: None,
+      runtime: None,
+    };
+    let response = joined_to_get_operation_response(&joined);
+    assert!(response.control_failure.is_none());
   }
 }

--- a/src/api/session_service/operation_result_store.rs
+++ b/src/api/session_service/operation_result_store.rs
@@ -48,11 +48,11 @@ fn synthetic_operation_result_from_invoke(command_id: &str, result: &InvokeResul
       message: Some(result.output_summary.clone()),
     },
     verifications: Vec::new(),
-    // TODO(control-failure-session-api): this synthetic OperationResult mirrors
-    // a transient InvokeResult, whose typed control-failure classification is
-    // not carried across the session-API boundary in PR8-B (invoke-time surface
-    // stays untyped by owner decision). Populate once the RPC surface is meant
-    // to expose ControlFailed.
+    // NOTICE(control-failure-session-api): GetOperation projects a typed
+    // control failure only from a persisted OperationResult. This synthetic
+    // session record is built from the untyped InvokeResult boundary, so it
+    // intentionally keeps this field absent; the invoke-time boundary remains
+    // untyped (see TODO(control-failure-invoke-time-typed)).
     control_failure: None,
     evidence_artifacts,
     freshness_basis: None,

--- a/src/api/session_service/summary.rs
+++ b/src/api/session_service/summary.rs
@@ -28,7 +28,7 @@ use std::collections::BTreeMap;
 use auv_cli_invoke::{OperationSummary, OperationSummarySource, RunStatus};
 use auv_tracing_driver::store::LocalStore;
 
-use crate::contract::{ArtifactRef, OperationResult, OperationStatus};
+use crate::contract::{ArtifactRef, ControlFailure, OperationResult, OperationStatus};
 use crate::model::AuvResult;
 use crate::run_read;
 
@@ -87,6 +87,11 @@ pub struct JoinedOperationSummary {
   pub artifacts: Vec<ArtifactRef>,
   /// Run artifact catalog `artifact_id` → `role` (API-P12).
   pub artifact_roles: BTreeMap<String, String>,
+  /// Typed control-layer failure lifted from the persisted `OperationResult`
+  /// (`None` when the operation had no control-layer failure). The read
+  /// projection carries it through to the `GetOperation` response rather than
+  /// dropping the persisted classification.
+  pub control_failure: Option<ControlFailure>,
   // InvokeResult-sourced (runtime return value, may be absent).
   pub runtime: Option<RuntimeOperationSummary>,
 }
@@ -125,6 +130,7 @@ pub fn join_operation_summary(
     known_limits,
     artifacts: operation.evidence_artifacts.clone(),
     artifact_roles,
+    control_failure: operation.control_failure.clone(),
     runtime: runtime.map(RuntimeOperationSummary::from_source),
   }
 }
@@ -304,6 +310,24 @@ mod tests {
     assert!(joined.known_limits.iter().any(|limit| limit == "auv.api.session.runtime_status_mismatch"));
     let runtime = joined.runtime.expect("runtime summary should be present");
     assert_eq!(runtime.failure_message.as_deref(), Some("boom"));
+  }
+
+  #[test]
+  fn join_carries_persisted_control_failure() {
+    let mut operation = sample_operation("run-cf");
+    operation.control_failure = Some(crate::contract::ControlFailure {
+      layer: crate::contract::FailureLayer::ControlFailed,
+      message: "accessibility permission was denied".to_string(),
+      recovery: Some("grant Accessibility in System Settings".to_string()),
+    });
+    let (command_id, roles) = join_args("app.textedit.document.write");
+
+    let joined = join_operation_summary(&operation, None, command_id, roles);
+
+    let control_failure = joined.control_failure.expect("control_failure should carry through the join");
+    assert_eq!(control_failure.layer, crate::contract::FailureLayer::ControlFailed);
+    assert_eq!(control_failure.message, "accessibility permission was denied");
+    assert_eq!(control_failure.recovery.as_deref(), Some("grant Accessibility in System Settings"));
   }
 
   #[test]

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -598,6 +598,23 @@ pub enum FailureLayer {
   SemanticMismatch,
 }
 
+impl FailureLayer {
+  /// Stable snake_case wire string for this layer, matching the serde
+  /// `rename_all = "snake_case"` representation. Shared by the inspect text
+  /// render and the session-API proto mapper so the taxonomy has one wire
+  /// spelling rather than a hand-written copy per consumer.
+  pub fn as_str(&self) -> &'static str {
+    match self {
+      Self::GroundingFailed => "grounding_failed",
+      Self::CandidateExpired => "candidate_expired",
+      Self::ControlFailed => "control_failed",
+      Self::VerificationUnreliable => "verification_unreliable",
+      Self::StateChangedNoMatch => "state_changed_no_match",
+      Self::SemanticMismatch => "semantic_mismatch",
+    }
+  }
+}
+
 /// Coarse evidence source for an [`ObservationSnapshot`]. AX trees, OCR
 /// fragments, visual detectors, and fused outputs all project into one
 /// [`SurfaceNode`] shape — the snapshot still tags its origin so downstream
@@ -1581,5 +1598,32 @@ mod tests {
     let parsed: OperationResult = serde_json::from_value(value).expect("result should deserialize");
     assert_eq!(parsed.status, OperationStatus::Completed);
     assert_eq!(parsed.verifications[0].semantic_matched, Some(false));
+  }
+
+  // ROOT CAUSE:
+  //
+  // `FailureLayer::as_str` is a hand-written token table used by the proto
+  // mapper and the inspect text render, while the persisted `OperationResult`
+  // JSON, the HTTP inspect enrichment, and the textedit signal round-trip use
+  // serde's `rename_all = "snake_case"` spelling. If the two ever disagree, the
+  // RPC/inspect-text layer string would silently diverge from the JSON spelling
+  // for the same failure.
+  //
+  // This pins `as_str()` to the serde token for every variant so the "single
+  // wire spelling" invariant is enforced, not just asserted in a doc comment.
+  // The match is exhaustive, so a new variant forces a new arm here too.
+  #[test]
+  fn failure_layer_as_str_matches_serde_token_for_every_variant() {
+    for layer in [
+      FailureLayer::GroundingFailed,
+      FailureLayer::CandidateExpired,
+      FailureLayer::ControlFailed,
+      FailureLayer::VerificationUnreliable,
+      FailureLayer::StateChangedNoMatch,
+      FailureLayer::SemanticMismatch,
+    ] {
+      let serde_token = serde_json::to_value(layer).expect("layer serializes").as_str().expect("layer serializes as a string").to_string();
+      assert_eq!(layer.as_str(), serde_token, "as_str must equal the serde snake_case token for {layer:?}");
+    }
   }
 }

--- a/src/inspect/mod.rs
+++ b/src/inspect/mod.rs
@@ -327,12 +327,7 @@ fn render_optional_bool(value: Option<bool>) -> &'static str {
 
 fn render_failure_layer(layer: Option<FailureLayer>) -> &'static str {
   match layer {
-    Some(FailureLayer::GroundingFailed) => "grounding_failed",
-    Some(FailureLayer::CandidateExpired) => "candidate_expired",
-    Some(FailureLayer::ControlFailed) => "control_failed",
-    Some(FailureLayer::VerificationUnreliable) => "verification_unreliable",
-    Some(FailureLayer::StateChangedNoMatch) => "state_changed_no_match",
-    Some(FailureLayer::SemanticMismatch) => "semantic_mismatch",
+    Some(layer) => layer.as_str(),
     None => "n/a",
   }
 }


### PR DESCRIPTION
## Summary

**PR8-C** (follow-up to #128): project the persisted `OperationResult.control_failure` onto the session-API `GetOperation` gRPC surface, completing the "every read surface reads the same typed classification" line. #128 landed the producer + inspect-family parity but explicitly deferred the RPC surface (`TODO(control-failure-session-api)`); this closes that deferral.

## Changes

**proto** — new `ControlFailure { layer, message, recovery }` message + `GetOperationResponse.control_failure` (field 8, additive; proto3 message-presence expresses "no control-layer failure"). `layer`/`recovery` are strings, matching this surface's experimental status-as-string convention.

**read projection** — `JoinedOperationSummary.control_failure` is lifted from the **persisted** `OperationResult` during `join_operation_summary` (never from the transient `InvokeResult`). The mapper projects it via `control_failure_to_proto`, reusing the new `FailureLayer::as_str` wire spelling; `recovery: None` collapses to `""` per the proto "empty when absent" rule. The synthetic session record built from the untyped `InvokeResult` boundary keeps `control_failure` absent on purpose (`NOTICE`), and the invoke-time typed field stays deferred (`TODO(control-failure-invoke-time-typed)`).

**`FailureLayer::as_str`** — new shared snake_case accessor; the inspect text render now delegates to it instead of a hand-written table, giving the layer taxonomy one wire spelling across the proto mapper and inspect render (resolves the #128 review NIT about two sources of truth). A new contract test pins `as_str()` to the serde `rename_all` token for **every** variant, so the RPC/inspect-text spelling can't silently drift from the persisted-JSON/HTTP spelling.

## Testing

- `cargo fmt --check`, `cargo check` (proto regenerated), `cargo test` (full workspace green), `git diff --check`.
- Handler test reloads through a **fresh** `SessionApiHandler` with an empty runtime cache, proving the typed classification is read from the persisted `OperationResult`, not a process-local cache — the crux of the two-source join.
- Mapper surfaced/unset tests, summary join-carries test, api-proto proto round-trip test.
- The cross-surface TextEdit parity test gains a **fourth surface**: `GetOperation` via a fresh handler, asserting layer/message/recovery and that message excludes the separately stored recovery hint (message and recovery stay non-overlapping).
- New `FailureLayer::as_str` ↔ serde-token equivalence test across all six variants.

Reviewed adversarially (high effort): no blocking findings; the one SHOULD-FIX (unenforced `as_str`/serde single-source-of-truth) is fixed in this branch with the equivalence test.
