### PR TITLE
fix(auv-runtime): align app probe OCR query step ids

### DIFF
--- a/src/app/analysis.rs
+++ b/src/app/analysis.rs
@@ -907,8 +907,10 @@ fn default_ocr_snapshot(app: &AppIdentity) -> OcrTextSnapshot {
 }
 
 pub(crate) fn resolve_probe_ocr_sample_query(app: &AppIdentity, steps: &[AppProbeStep]) -> String {
-  let window_report = read_probe_step_artifact_text(steps, "observe-windows", None);
-  let ax_report = read_probe_step_artifact_text(steps, "observe-window-tree", None);
+  // `probe.json` v0 has used both id sets. Prefer the live producer ids while
+  // retaining read compatibility for historical probe records.
+  let window_report = ["list-windows", "observe-windows"].iter().find_map(|step_id| read_probe_step_artifact_text(steps, step_id, None));
+  let ax_report = ["capture-ax-tree", "observe-window-tree"].iter().find_map(|step_id| read_probe_step_artifact_text(steps, step_id, None));
   first_non_empty_string(&[
     window_report.as_deref().and_then(|report| report_value(report, "frontmostWindowTitle=")).map(str::to_string),
     window_report.as_deref().and_then(|report| report_value(report, "frontmostAppName=")).map(str::to_string),

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -118,25 +118,45 @@ fn invoke_probe_step_preserves_direct_command_artifact_boundary() {
 }
 
 #[test]
-fn resolve_probe_ocr_sample_query_prefers_frontmost_window_or_app_name() {
+fn resolve_probe_ocr_sample_query_supports_legacy_step_ids() {
   let root = temp_dir("probe-ocr-query");
-  let windows_path = root.join("observe-windows.txt");
-  let ax_path = root.join("observe-window-tree.txt");
-  fs::write(&windows_path, "frontmostAppName=Netease Music\nfrontmostWindowTitle=\nobservedAt=2026-05-20T00:00:00Z\nwindowCount=0\n")
-    .expect("window report should write");
-  fs::write(
-    &ax_path,
+  let window_step =
+    report_probe_step_fixture(&root, "observe-windows", "window.list", "frontmostAppName=Netease Music\nfrontmostWindowTitle=\n");
+  let ax_step = report_probe_step_fixture(
+    &root,
+    "observe-window-tree",
+    "window.captureAxTree",
     "observedAt=2026-05-20T00:00:00Z\nappName=Netease Music\nbundleId=com.netease.163music\nwindowTitle=\nrootRole=AXWindow\nnodeCount=0\n",
-  )
-  .expect("ax report should write");
+  );
+  let app = app_identity_fixture("com.netease.163music", "NeteaseMusic");
 
-  let steps = vec![
-    probe_step_fixture("observe-windows", "window.list", vec![windows_path]),
-    probe_step_fixture("observe-window-tree", "window.captureAxTree", vec![ax_path]),
+  assert_eq!(resolve_probe_ocr_sample_query(&app, &[window_step]), "Netease Music");
+  assert_eq!(resolve_probe_ocr_sample_query(&app, &[ax_step]), "Netease Music");
+  let _ = fs::remove_dir_all(root);
+}
+
+// ROOT CAUSE:
+//
+// If app probe reached the OCR sample, its query fell back to app identity
+// because the resolver only recognized retired probe step ids.
+//
+// Before the fix, the live `list-windows` and `capture-ax-tree` steps were
+// ignored. The fix prefers their evidence while retaining legacy probe reads.
+#[test]
+fn resolve_probe_ocr_sample_query_prefers_current_probe_step_ids() {
+  let root = temp_dir("probe-ocr-query-current-ids");
+  let window_steps = vec![
+    report_probe_step_fixture(&root, "observe-windows", "window.list", "frontmostAppName=Legacy Music\nfrontmostWindowTitle=\n"),
+    report_probe_step_fixture(&root, "list-windows", "window.list", "frontmostAppName=Netease Music\nfrontmostWindowTitle=\n"),
+  ];
+  let ax_steps = vec![
+    report_probe_step_fixture(&root, "observe-window-tree", "window.captureAxTree", "appName=Legacy Music\nwindowTitle=\n"),
+    report_probe_step_fixture(&root, "capture-ax-tree", "window.captureAxTree", "appName=Netease Music\nwindowTitle=\n"),
   ];
   let app = app_identity_fixture("com.netease.163music", "NeteaseMusic");
 
-  assert_eq!(resolve_probe_ocr_sample_query(&app, &steps), "Netease Music");
+  assert_eq!(resolve_probe_ocr_sample_query(&app, &window_steps), "Netease Music");
+  assert_eq!(resolve_probe_ocr_sample_query(&app, &ax_steps), "Netease Music");
   let _ = fs::remove_dir_all(root);
 }
 
@@ -365,6 +385,12 @@ fn app_identity_fixture(bundle_id: &str, app_name: &str) -> AppIdentity {
     launch_services_resolved: true,
     resolution_notes: Vec::new(),
   }
+}
+
+fn report_probe_step_fixture(root: &Path, id: &str, command_id: &str, report: &str) -> AppProbeStep {
+  let path = root.join(format!("{id}.txt"));
+  fs::write(&path, report).expect("probe report should write");
+  probe_step_fixture(id, command_id, vec![path])
 }
 
 fn probe_step_fixture(id: &str, command_id: &str, artifact_paths: Vec<PathBuf>) -> AppProbeStep {


### PR DESCRIPTION
## Summary

- prefer the live `list-windows` and `capture-ax-tree` probe step ids when deriving the OCR sample query
- retain read compatibility for historical `observe-windows` and `observe-window-tree` v0 probe records
- cover both window and AX sources, including conflicting mixed records where current ids must win

## Root cause

`probe_app_into_run` emits `list-windows` and `capture-ax-tree`, but `resolve_probe_ocr_sample_query` still searched only the retired step ids. The live path therefore ignored recorded window/AX labels and silently fell back to the app identity.

The regression test failed before the fix with `left: "NeteaseMusic"` and `right: "Netease Music"`.

## Scope decision

Classification: narrow bug fix.

This does not revive #122: `AppRect` remains the app-analysis projection and macOS `Observed*` types remain owned by `auv-driver-macos`. The audit found no existing common observation contract that preserves the display/window/AX/OCR semantics required here, so this PR deliberately avoids moving types, inventing a parallel schema, target-gating the manifest alone, or wiring the broader typed AX/OCR migration into the same change.

The next independently reviewable architecture slice is producer/consumer alignment around structured macOS window or AX artifacts, not another shape-only type move.

## Verification

- `cargo fmt --check`
- `cargo check`
- `cargo test`
- `git diff --check`
- `cargo run --quiet -- invoke --help`
- focused current/legacy step-id regression tests

Swift/FFI sources were not touched, so bridge regeneration and SwiftPM builds are not required.