### PR TITLE
docs(ops): converge app probe docs to current CLI truth

### DIFF
--- a/docs/ai/references/ops/2026-05-18-app-probe-analyze-workflow.md
+++ b/docs/ai/references/ops/2026-05-18-app-probe-analyze-workflow.md
@@ -2,7 +2,28 @@
 
 Date: 2026-05-18
 
-Status: active reference
+Status: historical workflow note
+
+## Current Status
+
+This note records the May 2026 four-stage phase-2 workflow:
+
+`probe -> analyze -> distill -> validate`
+
+That is no longer the current CLI contract.
+
+As of `main` at `a41f4c29`, `crates/auv-cli/src/cli.rs` only supports:
+
+- `auv app probe <bundle-id> [--output-dir <dir>]`
+- `auv app analyze <probe-dir-or-probe-json>`
+
+and `parse_app()` rejects `app distill` / `app validate` with:
+
+`app recipe distillation has been removed; use app-local Rust commands instead`
+
+Use [`2026-07-24-app-probe-analyze-current-state-reference.md`](2026-07-24-app-probe-analyze-current-state-reference.md)
+for the live contract. The remainder of this note is preserved as historical
+phase-2 design context.
 
 ## Purpose
 

--- a/docs/ai/references/ops/2026-05-19-v2-docs-contract.md
+++ b/docs/ai/references/ops/2026-05-19-v2-docs-contract.md
@@ -2,7 +2,26 @@
 
 Date: 2026-05-19
 
-Status: working phase-2 contract
+Status: historical phase-2 contract
+
+## Current Status
+
+This note assumes the old app-surface product lane:
+
+`probe -> analyze -> distill -> validate -> promote`
+
+That lane is no longer the current repo contract.
+
+As of `main` at `a41f4c29`, `crates/auv-cli/src/cli.rs` only keeps:
+
+- `app probe`
+- `app analyze`
+
+and rejects `app distill` / `app validate`.
+
+Use [`2026-07-24-app-probe-analyze-current-state-reference.md`](2026-07-24-app-probe-analyze-current-state-reference.md)
+for current CLI truth. The remainder of this note is retained as historical
+phase-2 design material.
 
 ## Purpose
 

--- a/docs/ai/references/ops/2026-07-24-app-probe-analyze-current-state-reference.md
+++ b/docs/ai/references/ops/2026-07-24-app-probe-analyze-current-state-reference.md
@@ -1,0 +1,97 @@
+# App Probe / Analyze Current State Reference
+
+Date: 2026-07-24
+
+Status: active reference
+
+## Purpose
+
+This note replaces the old four-stage `probe -> analyze -> distill -> validate`
+workflow as the current repo truth.
+
+As of `main` at `a41f4c29`, the supported app-surface lane is:
+
+`probe -> analyze`
+
+The old distillation and validation stages were removed from the CLI surface and
+should be read as historical design material, not current behavior.
+
+## Live CLI Truth
+
+The current root CLI help advertises only:
+
+- `auv app probe <bundle-id> [--output-dir <dir>]`
+- `auv app analyze <probe-dir-or-probe-json>`
+
+See:
+
+- `crates/auv-cli/src/cli.rs` `help_text()`
+- `crates/auv-cli/src/cli.rs` `parse_app()`
+
+`parse_app()` now hard-errors on the removed subcommands:
+
+- `app distill`
+- `app validate`
+
+with:
+
+`app recipe distillation has been removed; use app-local Rust commands instead`
+
+That removal is also locked by `parse_app_distill_and_validate_are_removed()`
+in the same file.
+
+## Current Runtime Boundary
+
+The current app module describes itself as:
+
+`App-centric workflows: probe -> analyze.`
+
+See `src/app/mod.rs`.
+
+This boundary is important:
+
+- `app probe` records deterministic app-surface evidence into `probe.json`
+- `app analyze` consumes that probe and writes:
+  - `analysis.json`
+  - `report.md`
+- the lane is review/evidence oriented, not recipe promotion
+
+## Current Probe Step Shape
+
+`probe_app_into_run()` in `src/app/mod.rs` currently records these steps:
+
+1. `probe-permissions` -> `app.probePermissions`
+2. `list-displays` -> `display.list`
+3. `activate-target-app` -> `app.activate` when AppleScript activation is available
+4. `list-windows` -> `window.list`
+5. `capture-ax-tree` -> `window.captureAxTree`
+6. `capture-window` -> `window.capture`
+7. `ocr-sample` -> `window.observeRegion`
+
+The exact set is probe-scoped and may record partial failure instead of
+aborting the entire probe.
+
+## Current Analyze Boundary
+
+`app analyze` remains a deterministic read-side step over `probe.json`, not a
+validator or promotion engine.
+
+The important honesty boundary is still:
+
+- analyze may emit reviewable candidates and known limits
+- analyze does not promote those surfaces into action-grade runtime truth
+
+The code boundary for that lane lives in:
+
+- `src/app/analysis.rs`
+- `src/app/report.rs`
+
+## Historical Note
+
+The following older ops notes still describe the retired four-stage workflow and
+should be treated as historical phase-2 design material:
+
+- `2026-05-18-app-probe-analyze-workflow.md`
+- `2026-05-19-v2-docs-contract.md`
+
+Keep them for design history, but do not cite them as the current CLI contract.

--- a/docs/ai/references/ops/INDEX.md
+++ b/docs/ai/references/ops/INDEX.md
@@ -2,7 +2,7 @@
 
 Setup, tooling, feature gates, cross-cutting notes
 
-Count: **27**
+Count: **28**
 
 - [`2026-05-12-setup.md`](2026-05-12-setup.md)
 - [`2026-05-13-airi-desktop-reuse.md`](2026-05-13-airi-desktop-reuse.md)
@@ -31,6 +31,7 @@ Count: **27**
 - [`2026-06-26-apple-music-windows-command-reference.md`](2026-06-26-apple-music-windows-command-reference.md)
 - [`2026-07-03-qodana-operating-model.md`](2026-07-03-qodana-operating-model.md)
 - [`2026-07-07-inference-task-object-detection-simplification-plan.md`](2026-07-07-inference-task-object-detection-simplification-plan.md)
+- [`2026-07-24-app-probe-analyze-current-state-reference.md`](2026-07-24-app-probe-analyze-current-state-reference.md)
 
 ## Related
 


### PR DESCRIPTION
## Summary
- add a current-state ops reference for the surviving `app probe` / `app analyze` lane
- mark the old four-stage app-surface workflow and V2 contract notes as historical
- update the ops index for the new current-state note

## Why
PR #130 is open and dirty elsewhere, so this keeps docs convergence narrow and off its changed files while fixing active docs that still describe removed `app distill` / `app validate` commands.

## Verification
- `git diff --check`
- confirmed the updated ops files are not in PR #130 changed files
