### PR TITLE
refactor(apps): enforce platform integration boundaries

### DIFF
--- a/crates/auv-apple-music/src/cli.rs
+++ b/crates/auv-apple-music/src/cli.rs
@@ -4,14 +4,12 @@ use std::process::ExitCode;
 
 use clap::{Args, Parser, Subcommand};
 
-use crate::commands::launch::OpenWindowInputs;
-use crate::commands::playback::PlaybackStatusInputs;
-use crate::commands::probe_macos::{DEFAULT_ACTIVATE_SETTLE_MS, DEFAULT_MUSIC_APP_BUNDLE_ID, ProbeInputs};
-use crate::commands::search::{
+use crate::{DEFAULT_ACTIVATE_SETTLE_MS, DEFAULT_MUSIC_APP_BUNDLE_ID, OpenWindowInputs, PlaybackStatusInputs, ProbeInputs};
+use crate::{
   DEFAULT_RESULT_SELECTION_TIMEOUT_MS, DEFAULT_SEARCH_SETTLE_MS, DEFAULT_SEARCH_VERIFICATION_TIMEOUT_MS, SearchInputs,
   SearchResultSelectInputs,
 };
-use crate::commands::transport::{TransportAction, TransportInputs};
+use crate::{TransportAction, TransportInputs};
 use crate::{run_open_window, run_playback_status, run_probe, run_search, run_search_result_select, run_transport_action};
 
 #[derive(Clone, Debug, Parser)]

--- a/crates/auv-apple-music/src/commands/mod.rs
+++ b/crates/auv-apple-music/src/commands/mod.rs
@@ -1,5 +1,0 @@
-pub mod launch;
-pub mod playback;
-pub mod probe_macos;
-pub mod search;
-pub mod transport;

--- a/crates/auv-apple-music/src/lib.rs
+++ b/crates/auv-apple-music/src/lib.rs
@@ -1,19 +1,6 @@
-//! Apple Music Windows app integration: window resolution and launch.
+//! Apple Music app integration.
 
-pub mod app;
 pub mod cli;
-pub mod commands;
+mod platforms;
 
-pub use app::{AppleMusicWindow, resolve_window};
-pub use commands::launch::{LaunchResult, LaunchStep, run_open_window};
-pub use commands::playback::{MetadataSource, PlaybackState, PlaybackStatus, PlaybackStatusInputs, run_playback_status};
-pub use commands::probe_macos::{
-  DEFAULT_ACTIVATE_SETTLE_MS, DEFAULT_MUSIC_APP_BUNDLE_ID, DiscoveredNode, ProbeInputs, ProbeResult, ToolbarChildCounts, ToolbarInspection,
-  run_probe,
-};
-pub use commands::search::{
-  DEFAULT_RESULT_SELECTION_TIMEOUT_MS, DEFAULT_SEARCH_SETTLE_MS, DEFAULT_SEARCH_VERIFICATION_TIMEOUT_MS, SearchInputs, SearchResult,
-  SearchResultMatch, SearchResultSelectInputs, SearchResultSelection, SearchVerification, SearchVerificationStatus, run_search,
-  run_search_result_select,
-};
-pub use commands::transport::{TransportAction, TransportInputs, TransportResult, run_transport_action};
+pub use platforms::*;

--- a/crates/auv-apple-music/src/platforms/launch_windows.rs
+++ b/crates/auv-apple-music/src/platforms/launch_windows.rs
@@ -1,4 +1,4 @@
-//! `open-window` command: ensure Apple Music is running and its window is
+//! Ensure Apple Music is running through Windows app tooling and its window is
 //! visible, optionally waiting for the window to appear after launch.
 //!
 //! The command tries three steps in order:
@@ -13,10 +13,10 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::app::{AppleMusicWindow, ResolveOptions, resolve_window};
+use super::window_windows::{AppleMusicWindow, ResolveOptions, resolve_window};
 
 #[cfg(target_os = "windows")]
-use crate::app::APPLE_MUSIC_TITLE;
+use super::window_windows::APPLE_MUSIC_TITLE;
 #[cfg(target_os = "windows")]
 use std::time::{Duration, Instant};
 

--- a/crates/auv-apple-music/src/platforms/mod.rs
+++ b/crates/auv-apple-music/src/platforms/mod.rs
@@ -1,0 +1,31 @@
+//! Platform-owned Apple Music integrations.
+//!
+//! Each module owns one cohesive capability on one operating system, including
+//! driver calls, platform UI interpretation, and platform-only verification.
+//! Platform-neutral frontends consume the typed results re-exported here.
+
+// TODO(apple-music-view-parser-platform): Apple Music has no approved view
+// parser slice yet. When one is approved, keep its platform acquisition and
+// adapter in a `<capability>_<platform>.rs` module here while shared parser IR
+// remains platform-neutral.
+
+mod launch_windows;
+mod playback_windows;
+mod probe_macos;
+mod search_windows;
+mod transport_windows;
+mod window_windows;
+
+pub use launch_windows::{LaunchResult, LaunchStep, OpenWindowInputs, run_open_window};
+pub use playback_windows::{MetadataSource, PlaybackState, PlaybackStatus, PlaybackStatusInputs, run_playback_status};
+pub use probe_macos::{
+  DEFAULT_ACTIVATE_SETTLE_MS, DEFAULT_MUSIC_APP_BUNDLE_ID, DiscoveredNode, ProbeInputs, ProbeResult, ToolbarChildCounts, ToolbarInspection,
+  run_probe,
+};
+pub use search_windows::{
+  DEFAULT_RESULT_SELECTION_TIMEOUT_MS, DEFAULT_SEARCH_SETTLE_MS, DEFAULT_SEARCH_VERIFICATION_TIMEOUT_MS, SearchInputs, SearchResult,
+  SearchResultMatch, SearchResultSelectInputs, SearchResultSelection, SearchVerification, SearchVerificationStatus, run_search,
+  run_search_result_select,
+};
+pub use transport_windows::{TransportAction, TransportInputs, TransportResult, run_transport_action};
+pub use window_windows::{AppleMusicWindow, ResolveOptions, resolve_window};

--- a/crates/auv-apple-music/src/platforms/playback_windows.rs
+++ b/crates/auv-apple-music/src/platforms/playback_windows.rs
@@ -1,4 +1,4 @@
-//! `playback status` command: read play/pause state, track title, and artist
+//! Read play/pause state, track title, and artist through the Windows driver
 //! from the running Apple Music window on Windows.
 //!
 //! ## Detection strategy
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::path::PathBuf;
 
-use crate::app::ResolveOptions;
+use super::window_windows::ResolveOptions;
 
 // NOTICE: bottom-bar strip covers the now-playing bar at the bottom of the
 // Apple Music window. 0.82–1.0 captures the transport area on typical window
@@ -133,8 +133,8 @@ mod platform {
   use auv_driver::geometry::RatioRect;
   use auv_driver::vision::TextRecognitionOptions;
 
+  use super::super::window_windows::resolve_window;
   use super::{BOTTOM_BAR_TOP, MetadataSource, PlaybackState, PlaybackStatus, PlaybackStatusInputs};
-  use crate::app::resolve_window;
   pub fn run(inputs: &PlaybackStatusInputs) -> Result<PlaybackStatus, String> {
     let mut diagnostics: Vec<String> = Vec::new();
 

--- a/crates/auv-apple-music/src/platforms/probe_macos.rs
+++ b/crates/auv-apple-music/src/platforms/probe_macos.rs
@@ -1,4 +1,4 @@
-//! macOS Music.app AX surface probe.
+//! Bounded macOS Accessibility probe for Apple Music.
 //!
 //! Bounded search-field discovery plus toolbar reachability diagnostics. See
 //! `docs/ai/references/apps/apple-music/2026-07-15-apple-music-macos-ax-probe.md`.

--- a/crates/auv-apple-music/src/platforms/search_windows.rs
+++ b/crates/auv-apple-music/src/platforms/search_windows.rs
@@ -1,4 +1,4 @@
-//! Search submission for Apple Music on Windows.
+//! Search Apple Music through the Windows driver.
 //!
 //! The command composes the typed Windows driver surfaces:
 //!
@@ -19,7 +19,7 @@ use auv_driver::input::InputActionResult;
 use auv_driver::window::WindowMutationResult;
 use serde::{Deserialize, Serialize};
 
-use crate::app::ResolveOptions;
+use super::window_windows::ResolveOptions;
 
 pub const DEFAULT_SEARCH_SETTLE_MS: u64 = 300;
 pub const DEFAULT_SEARCH_VERIFICATION_TIMEOUT_MS: u64 = 5_000;
@@ -222,7 +222,7 @@ mod platform {
   impl super::SearchDriver for UnsupportedSearchDriver {
     fn prepare_window(
       &mut self,
-      _resolve: &crate::app::ResolveOptions,
+      _resolve: &super::super::window_windows::ResolveOptions,
       _settle: std::time::Duration,
     ) -> Result<(Option<String>, auv_driver::window::WindowMutationResult), String> {
       unreachable!("non-Windows search driver cannot be opened")
@@ -265,11 +265,11 @@ mod platform {
   use auv_driver::window::{Window, WindowMutationOptions, WindowMutationVerification};
   use auv_driver_windows::WindowsDriverSession;
 
+  use super::super::window_windows::{ResolveOptions, resolve_window};
   use super::{
     SearchDriver, SearchResultMatch, SearchVerification, SearchVerificationStatus, normalized, resolve_result_match, search_input_path,
     selection_navigation_evidence, uia_query_evidence,
   };
-  use crate::app::{ResolveOptions, resolve_window};
   pub(super) struct WindowsSearchDriver {
     session: WindowsDriverSession,
     window: Option<Window>,

--- a/crates/auv-apple-music/src/platforms/transport_windows.rs
+++ b/crates/auv-apple-music/src/platforms/transport_windows.rs
@@ -1,4 +1,4 @@
-//! Transport control commands: play/pause, next track, previous track.
+//! Transport controls through Windows media-key delivery.
 //!
 //! ## Delivery mechanism
 //!
@@ -22,7 +22,7 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
-use crate::app::ResolveOptions;
+use super::window_windows::ResolveOptions;
 
 /// A transport action to perform.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -112,8 +112,8 @@ mod platform {
 
   use auv_driver::input::KeyPressOptions;
 
+  use super::super::window_windows::resolve_window;
   use super::{TransportInputs, TransportResult, media_key_name};
-  use crate::app::resolve_window;
   pub fn run(inputs: &TransportInputs) -> Result<TransportResult, String> {
     let mut diagnostics: Vec<String> = Vec::new();
     let key = media_key_name(inputs.action);

--- a/crates/auv-apple-music/src/platforms/window_windows.rs
+++ b/crates/auv-apple-music/src/platforms/window_windows.rs
@@ -1,4 +1,4 @@
-//! Apple Music window resolution via the Windows driver.
+//! Apple Music window resolution through the Windows driver.
 //!
 //! Apple Music ships as a Microsoft Store (MSIX) package on Windows. Its
 //! top-level window carries the title "Apple Music" and its process is named

--- a/docs/ai/references/apps/apple-music/2026-07-25-platform-integration-layout.md
+++ b/docs/ai/references/apps/apple-music/2026-07-25-platform-integration-layout.md
@@ -1,0 +1,50 @@
+# Apple Music platform integration layout
+
+Date: 2026-07-25
+
+Status: accepted app-crate layout and alint convention
+
+## Decision
+
+Apple Music keeps app automation and other platform-owned integration code in
+`src/platforms/`. Each file owns one cohesive capability on one platform and
+uses the `<capability>_<platform>.rs` form:
+
+```text
+src/platforms/
+  launch_windows.rs
+  playback_windows.rs
+  probe_macos.rs
+  search_windows.rs
+  transport_windows.rs
+  window_windows.rs
+```
+
+`platforms` is the boundary name because it also covers observation-only
+probes and future platform-specific view parser acquisition. `actions` would
+incorrectly imply that every module delivers input, while `interaction`
+already names the orchestration layer above drivers in AUV's shared
+vocabulary.
+
+The capability file owns driver setup, platform UI interpretation, input
+delivery, platform fallback policy, and platform verification for that flow.
+It should not be split into one file or wrapper per driver call. CLI parsing
+and presentation remain outside this directory. Platform-neutral contracts
+and reusable parser IR may also remain outside it.
+
+Apple Music does not currently have an approved view parser slice. If one is
+added, its platform acquisition and adapters belong in a capability/platform
+file under `src/platforms/`; this decision does not authorize implementing the
+parser itself.
+
+## Enforcement
+
+The alint rule `require-platform-scoped-app-integration` reviews an app crate
+as a directory so it can identify misplaced automation, unclear platform file
+ownership, scattered wrappers, and platform-specific view parser code mixed
+into neutral parser modules. Its review prompt states the architectural
+conventions directly and uses filesystem inspection plus semantic judgment.
+
+The rule is enabled for the current desktop app integration crates in
+`js/packages/alint-config/src/config.ts`, including Apple Music, Apple Notes,
+Apple TextEdit, NetEase Music, QQMusic, and GNOME Control Center.

--- a/docs/ai/references/apps/apple-music/INDEX.md
+++ b/docs/ai/references/apps/apple-music/INDEX.md
@@ -2,9 +2,10 @@
 
 Apple Music macOS AX surface discovery (bounded probes only, no product operation yet)
 
-Count: **1**
+Count: **2**
 
 - [`2026-07-15-apple-music-macos-ax-probe.md`](2026-07-15-apple-music-macos-ax-probe.md)
+- [`2026-07-25-platform-integration-layout.md`](2026-07-25-platform-integration-layout.md)
 
 ## Related
 

--- a/js/packages/alint-config/package.json
+++ b/js/packages/alint-config/package.json
@@ -15,11 +15,16 @@
   ],
   "scripts": {
     "build": "tsdown",
+    "test": "vitest run",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
     "@alint-js/agent-apeira": "^0.0.33",
+    "@alint-js/core": "^0.0.33",
     "@alint-js/plugin": "^0.0.33",
     "@alint-js/tools-fs": "^0.0.33"
+  },
+  "devDependencies": {
+    "vitest": "catalog:vitest"
   }
 }

--- a/js/packages/alint-config/src/config.ts
+++ b/js/packages/alint-config/src/config.ts
@@ -19,6 +19,24 @@ export default defineConfig([
     },
   },
   {
+    name: "auv/app-integration-directories",
+    directories: [
+      "crates/auv-apple-music",
+      "crates/auv-apple-notes",
+      "crates/auv-apple-textedit",
+      "crates/auv-gnome-control-center",
+      "crates/auv-netease-music",
+      "crates/auv-qqmusic",
+    ],
+    agent: createApeiraAdapter(),
+    plugins: {
+      rust: auv,
+    },
+    rules: {
+      "rust/require-platform-scoped-app-integration": "warn",
+    },
+  },
+  {
     name: "auv/repo-text-and-scripts",
     files: ["**/*.{toml,md,yml,yaml,json,js,mjs,cjs,ts,tsx,mts,cts,vue}"],
   },

--- a/js/packages/alint-config/src/plugins/auv/index.ts
+++ b/js/packages/alint-config/src/plugins/auv/index.ts
@@ -3,15 +3,18 @@ import { definePlugin } from "@alint-js/plugin";
 import { vacantControlBoundaryRule } from "./rules/no-vacant-control-boundary";
 import { privateSchemaToolkitRule } from "./rules/no-private-schema-toolkit";
 import { establishedFoundationRule } from "./rules/prefer-established-foundation";
+import { platformScopedAppIntegrationRule } from "./rules/require-platform-scoped-app-integration";
 
 export { vacantControlBoundaryRule } from "./rules/no-vacant-control-boundary";
 export { privateSchemaToolkitRule } from "./rules/no-private-schema-toolkit";
 export { establishedFoundationRule } from "./rules/prefer-established-foundation";
+export { platformScopedAppIntegrationRule } from "./rules/require-platform-scoped-app-integration";
 
 export default definePlugin({
   rules: {
     "no-vacant-control-boundary": vacantControlBoundaryRule,
     "no-private-schema-toolkit": privateSchemaToolkitRule,
     "prefer-established-foundation": establishedFoundationRule,
+    "require-platform-scoped-app-integration": platformScopedAppIntegrationRule,
   },
 });

--- a/js/packages/alint-config/src/plugins/auv/rules/require-platform-scoped-app-integration/index.ts
+++ b/js/packages/alint-config/src/plugins/auv/rules/require-platform-scoped-app-integration/index.ts
@@ -1,0 +1,2 @@
+export { platformScopedAppIntegrationPrompt } from "./prompt";
+export { platformScopedAppIntegrationRule } from "./rule";

--- a/js/packages/alint-config/src/plugins/auv/rules/require-platform-scoped-app-integration/prompt.ts
+++ b/js/packages/alint-config/src/plugins/auv/rules/require-platform-scoped-app-integration/prompt.ts
@@ -1,0 +1,21 @@
+export const platformScopedAppIntegrationPrompt = `
+AUV app integrations must keep platform-owned behavior behind a visible platform boundary.
+
+Apply these conventions to application crates that integrate AUV with a desktop app:
+
+- Production code that calls an AUV driver, invokes operating-system application tooling, or directly automates a computer or application belongs under src/platforms/.
+- Each cohesive capability and platform combination belongs in one file named <capability>_<platform>.rs, such as search_macos.rs or playback_windows.rs. The capability name should describe the app behavior, not the driver method used to implement one step.
+- Keep one platform workflow cohesive. Driver setup, platform UI interpretation, input delivery, platform fallback policy, and platform verification for the same capability should not be scattered across thin wrappers or one-step helper files.
+- Platform-specific view parser acquisition and adapters follow the same placement and file naming convention. Pure parser contracts, platform-neutral reconstruction, and reusable typed IR may remain outside src/platforms/.
+- CLI parsing and presentation stay outside src/platforms/. Platform-neutral typed requests, results, and artifact mappings may also stay outside when they do not depend on platform APIs.
+- Shared AUV driver crates and platform-neutral runtime/framework crates are not app integrations and do not need this app-crate layout.
+
+Report only concrete violations demonstrated by files in the inspected crate. Use one of these categories:
+
+- automation-placement: platform-owned automation or operating-system app tooling lives outside src/platforms/.
+- platform-file: a platform implementation lacks a clear <capability>_<platform>.rs owner.
+- scattered-wrapper: one platform capability is fragmented into thin wrappers or driver-step files instead of one cohesive workflow owner.
+- view-parser-platform: platform-specific view parser acquisition, adaptation, or UI interpretation is mixed into a platform-neutral parser module.
+
+Do not report naming taste, file size by itself, test code, generated code, platform-neutral domain logic, or a cohesive private helper that supports its owning platform workflow. When evidence is incomplete, submit no finding.
+`.trim();

--- a/js/packages/alint-config/src/plugins/auv/rules/require-platform-scoped-app-integration/rule.test.ts
+++ b/js/packages/alint-config/src/plugins/auv/rules/require-platform-scoped-app-integration/rule.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from "vitest";
+
+import auvPlugin from "../../index";
+import { platformScopedAppIntegrationPrompt } from "./prompt";
+import { platformScopedAppIntegrationRule } from "./rule";
+
+describe("require-platform-scoped-app-integration", () => {
+  it("states the app integration conventions as semantic responsibilities", () => {
+    expect(platformScopedAppIntegrationPrompt).toContain("src/platforms/");
+    expect(platformScopedAppIntegrationPrompt).toContain("<capability>_<platform>.rs");
+    expect(platformScopedAppIntegrationPrompt).toContain("Platform-specific view parser");
+    expect(platformScopedAppIntegrationPrompt).toContain("one platform workflow cohesive");
+  });
+
+  it("is registered by the AUV plugin", () => {
+    expect(auvPlugin.rules?.["require-platform-scoped-app-integration"]).toBe(platformScopedAppIntegrationRule);
+  });
+
+  it("reports a valid directory-level finding", async () => {
+    const report = vi.fn();
+    const recordUsage = vi.fn();
+    const context = createContext({
+      agent: async (request: { tools: Array<{ execute: (input: unknown) => unknown; name: string }> }) => {
+        const submit = request.tools.find(tool => tool.name === "submit_platform_review");
+        expect(submit).toBeDefined();
+        await submit!.execute({
+          findings: [
+            {
+              category: "automation-placement",
+              confidence: "high",
+              filePath: "src/commands/search.rs",
+              line: 3,
+              message: "Search automation is owned by a command module.",
+              suggestion: "Move the cohesive Windows search workflow to src/platforms/search_windows.rs.",
+            },
+          ],
+        });
+        return { answer: "", usage: { inputTokens: 10, outputTokens: 4, totalTokens: 14 } };
+      },
+      recordUsage,
+      report,
+    });
+
+    await runDirectoryRule(context, "/repo/crates/auv-example-app");
+
+    expect(report).toHaveBeenCalledWith(expect.objectContaining({
+      evidence: expect.objectContaining({ category: "automation-placement", confidence: "high" }),
+      filePath: "/repo/crates/auv-example-app/src/commands/search.rs",
+      loc: { start: { column: 0, line: 3 } },
+    }));
+    expect(recordUsage).toHaveBeenCalledWith(expect.objectContaining({ totalTokens: 14 }));
+  });
+
+  it("drops findings whose reported line is outside the source file", async () => {
+    const report = vi.fn();
+    const context = createContext({
+      agent: async (request: { tools: Array<{ execute: (input: unknown) => unknown; name: string }> }) => {
+        const submit = request.tools.find(tool => tool.name === "submit_platform_review")!;
+        await submit.execute({
+          findings: [
+            {
+              category: "platform-file",
+              confidence: "medium",
+              filePath: "src/search.rs",
+              line: 99,
+              message: "The platform owner is unclear.",
+              suggestion: "Use a capability and platform file owner.",
+            },
+          ],
+        });
+        return { answer: "" };
+      },
+      report,
+    });
+
+    await runDirectoryRule(context, "/repo/crates/auv-example-app");
+
+    expect(report).not.toHaveBeenCalled();
+  });
+});
+
+function createContext(options: {
+  agent: (request: any) => Promise<any>;
+  recordUsage?: ReturnType<typeof vi.fn>;
+  report: ReturnType<typeof vi.fn>;
+}) {
+  return {
+    agent: options.agent,
+    cwd: "/repo",
+    id: "rust/require-platform-scoped-app-integration",
+    localId: "require-platform-scoped-app-integration",
+    logger: { debug: vi.fn() },
+    metering: { recordUsage: options.recordUsage ?? vi.fn() },
+    model: async () => ({ id: "test-model", provider: { endpoint: "http://unused", headers: {}, id: "test" } }),
+    options: [],
+    report: options.report,
+    settings: {},
+    src: {
+      getText: vi.fn(),
+      readFile: async (filePath: string) => ({
+        language: "text/plain",
+        lines: ["one", "two", "three", "four"],
+        path: filePath,
+        text: "one\ntwo\nthree\nfour\n",
+      }),
+    },
+  };
+}
+
+async function runDirectoryRule(context: ReturnType<typeof createContext>, path: string): Promise<void> {
+  const handlers = platformScopedAppIntegrationRule.create(context as never);
+  if (!("onTargetDirectory" in handlers) || !handlers.onTargetDirectory) {
+    throw new Error("directory handler missing");
+  }
+  await handlers.onTargetDirectory({ kind: "directory", path });
+}

--- a/js/packages/alint-config/src/plugins/auv/rules/require-platform-scoped-app-integration/rule.ts
+++ b/js/packages/alint-config/src/plugins/auv/rules/require-platform-scoped-app-integration/rule.ts
@@ -1,0 +1,209 @@
+import type { AgentTool } from "@alint-js/core/agent";
+import type { RuleContext } from "@alint-js/plugin";
+
+import { isAbsolute, relative, resolve, sep } from "node:path";
+
+import { defineTool, requireAgent } from "@alint-js/core/agent";
+import { defineRule } from "@alint-js/plugin";
+import { createTools, DEFAULT_IGNORE_PATTERNS } from "@alint-js/tools-fs";
+
+import { platformScopedAppIntegrationPrompt } from "./prompt";
+
+const categories = ["automation-placement", "platform-file", "scattered-wrapper", "view-parser-platform"] as const;
+type FindingCategory = (typeof categories)[number];
+
+interface Finding {
+  category: FindingCategory;
+  confidence: "high" | "medium" | "low";
+  filePath: string;
+  line: number;
+  message: string;
+  suggestion: string;
+}
+
+export const platformScopedAppIntegrationRule = defineRule({
+  create: ctx => ({
+    async onTargetDirectory(target) {
+      const submission = createSubmissionTool(target.path);
+      const model = await ctx.model();
+      const result = await requireAgent(ctx)({
+        instructions: [
+          "Inspect the requested Rust crate as a directory-level architecture review.",
+          "Use the filesystem tools to inspect the manifest and relevant production source before deciding.",
+          "Finish by calling submit_platform_review exactly once, with an empty findings array when the crate complies or is not an app integration.",
+        ].join("\n"),
+        model,
+        prompt: platformScopedAppIntegrationPrompt,
+        tools: [
+          ...createTools(target.path, { ignore: [...DEFAULT_IGNORE_PATTERNS, "**/target/**"] }),
+          submission.tool,
+        ],
+      });
+
+      recordUsage(ctx, target.path, model, result.usage);
+
+      const findings = submission.getFindings();
+      if (!findings) {
+        throw new Error("Platform-scoped app integration review ended without a submission.");
+      }
+
+      await reportFindings(ctx, target.path, findings);
+    },
+  }),
+});
+
+function createSubmissionTool(cratePath: string): { getFindings: () => Finding[] | undefined; tool: AgentTool } {
+  let submitted: Finding[] | undefined;
+  return {
+    getFindings: () => submitted,
+    tool: defineTool({
+      description: "Submit all platform-boundary findings, or an empty array when the reviewed crate complies.",
+      execute(input) {
+        if (submitted) {
+          return "review rejected: findings were already submitted";
+        }
+        const parsed = parseSubmission(cratePath, input);
+        if (typeof parsed === "string") {
+          return `review rejected: ${parsed}`;
+        }
+        submitted = parsed;
+        return "review submitted";
+      },
+      name: "submit_platform_review",
+      parameters: submissionParameters(),
+    }),
+  };
+}
+
+function submissionParameters(): Record<string, unknown> {
+  return {
+    additionalProperties: false,
+    properties: {
+      findings: {
+        items: {
+          additionalProperties: false,
+          properties: {
+            category: { enum: categories, type: "string" },
+            confidence: { enum: ["high", "medium", "low"], type: "string" },
+            filePath: { description: "Path relative to the reviewed crate.", minLength: 1, type: "string" },
+            line: { minimum: 1, type: "integer" },
+            message: { minLength: 1, type: "string" },
+            suggestion: { minLength: 1, type: "string" },
+          },
+          required: ["category", "confidence", "filePath", "line", "message", "suggestion"],
+          type: "object",
+        },
+        type: "array",
+      },
+    },
+    required: ["findings"],
+    type: "object",
+  };
+}
+
+function parseSubmission(cratePath: string, input: unknown): Finding[] | string {
+  if (!input || typeof input !== "object" || !Array.isArray((input as { findings?: unknown }).findings)) {
+    return "findings must be an array";
+  }
+
+  const findings: Finding[] = [];
+  const seen = new Set<string>();
+  for (const value of (input as { findings: unknown[] }).findings) {
+    const finding = parseFinding(cratePath, value);
+    if (typeof finding === "string") {
+      return finding;
+    }
+    const identity = `${finding.category}:${finding.filePath}:${finding.line}`;
+    if (!seen.has(identity)) {
+      seen.add(identity);
+      findings.push(finding);
+    }
+  }
+  return findings;
+}
+
+function parseFinding(cratePath: string, value: unknown): Finding | string {
+  if (!value || typeof value !== "object") {
+    return "each finding must be an object";
+  }
+  const finding = value as Partial<Finding>;
+  if (!categories.includes(finding.category as FindingCategory)) {
+    return "finding category is invalid";
+  }
+  if (finding.confidence !== "high" && finding.confidence !== "medium" && finding.confidence !== "low") {
+    return "finding confidence is invalid";
+  }
+  if (typeof finding.filePath !== "string" || !finding.filePath || isAbsolute(finding.filePath)) {
+    return "finding filePath must be relative to the reviewed crate";
+  }
+  if (!Number.isInteger(finding.line) || (finding.line ?? 0) < 1) {
+    return "finding line must be a positive integer";
+  }
+  if (typeof finding.message !== "string" || !finding.message.trim()) {
+    return "finding message must not be empty";
+  }
+  if (typeof finding.suggestion !== "string" || !finding.suggestion.trim()) {
+    return "finding suggestion must not be empty";
+  }
+
+  const absolutePath = resolve(cratePath, finding.filePath);
+  const relativePath = relative(resolve(cratePath), absolutePath);
+  if (relativePath === ".." || relativePath.startsWith(`..${sep}`) || isAbsolute(relativePath)) {
+    return "finding filePath must stay inside the reviewed crate";
+  }
+
+  return {
+    category: finding.category as FindingCategory,
+    confidence: finding.confidence,
+    filePath: relativePath,
+    line: finding.line!,
+    message: finding.message.trim(),
+    suggestion: finding.suggestion.trim(),
+  };
+}
+
+async function reportFindings(ctx: RuleContext, cratePath: string, findings: readonly Finding[]): Promise<void> {
+  for (const finding of findings) {
+    const filePath = resolve(cratePath, finding.filePath);
+    let file;
+    try {
+      file = await ctx.src.readFile(filePath);
+    } catch {
+      continue;
+    }
+    if (finding.line > file.lines.length) {
+      continue;
+    }
+    ctx.report({
+      evidence: {
+        category: finding.category,
+        confidence: finding.confidence,
+        suggestion: finding.suggestion,
+      },
+      filePath,
+      loc: { start: { column: 0, line: finding.line } },
+      message: finding.message,
+    });
+  }
+}
+
+function recordUsage(
+  ctx: RuleContext,
+  cratePath: string,
+  model: Awaited<ReturnType<RuleContext["model"]>>,
+  usage: { inputTokens?: number; outputTokens?: number; totalTokens?: number } | undefined,
+): void {
+  if (!usage) {
+    return;
+  }
+  ctx.metering.recordUsage({
+    filePath: cratePath,
+    inputTokens: usage.inputTokens,
+    metadata: { operation: "platform-scoped-app-integration-review" },
+    modelId: model.id,
+    outputTokens: usage.outputTokens,
+    providerId: model.provider.id,
+    ruleId: ctx.id,
+    totalTokens: usage.totalTokens,
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,7 @@ importers:
     devDependencies:
       '@alint-js/cli':
         specifier: 'catalog:'
-        version: 0.0.33(@valibot/to-json-schema@1.7.1(valibot@1.4.2(typescript@6.0.3)))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.0)(magicast@0.5.3)(typescript@6.0.3)
+        version: 0.0.33(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.0)(magicast@0.5.3)(typescript@6.0.3)
       '@auv/alint-config':
         specifier: workspace:*
         version: link:js/packages/alint-config
@@ -88,12 +88,19 @@ importers:
       '@alint-js/agent-apeira':
         specifier: ^0.0.33
         version: 0.0.33(@alint-js/core@0.0.33(typescript@6.0.3))(@valibot/to-json-schema@1.7.1(valibot@1.4.2(typescript@6.0.3)))
+      '@alint-js/core':
+        specifier: ^0.0.33
+        version: 0.0.33(typescript@6.0.3)
       '@alint-js/plugin':
         specifier: ^0.0.33
         version: 0.0.33
       '@alint-js/tools-fs':
         specifier: ^0.0.33
         version: 0.0.33
+    devDependencies:
+      vitest:
+        specifier: catalog:vitest
+        version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0))
 
 packages:
 
@@ -1960,9 +1967,9 @@ snapshots:
       - zod
       - zod-to-json-schema
 
-  '@alint-js/cli@0.0.33(@valibot/to-json-schema@1.7.1(valibot@1.4.2(typescript@6.0.3)))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.0)(magicast@0.5.3)(typescript@6.0.3)':
+  '@alint-js/cli@0.0.33(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.0)(magicast@0.5.3)(typescript@6.0.3)':
     dependencies:
-      '@alint-js/config': 0.0.33(@valibot/to-json-schema@1.7.1(valibot@1.4.2(typescript@6.0.3)))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.0)(magicast@0.5.3)(typescript@6.0.3)
+      '@alint-js/config': 0.0.33(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.0)(magicast@0.5.3)(typescript@6.0.3)
       '@alint-js/core': 0.0.33(typescript@6.0.3)
       '@clack/prompts': 1.7.0
       '@moeru/std': 0.1.0-beta.20
@@ -1991,7 +1998,7 @@ snapshots:
       - zod
       - zod-to-json-schema
 
-  '@alint-js/config@0.0.33(@valibot/to-json-schema@1.7.1(valibot@1.4.2(typescript@6.0.3)))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.0)(magicast@0.5.3)(typescript@6.0.3)':
+  '@alint-js/config@0.0.33(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.0)(magicast@0.5.3)(typescript@6.0.3)':
     dependencies:
       '@alint-js/core': 0.0.33(typescript@6.0.3)
       '@alint-js/tools-fs': 0.0.33
@@ -2067,11 +2074,11 @@ snapshots:
       - zod
       - zod-to-json-schema
 
-  '@apeira/session@0.0.7(@apeira/core@0.0.7(@valibot/to-json-schema@1.7.1(valibot@1.4.2(typescript@6.0.3))))':
+  '@apeira/session@0.0.7(@apeira/core@0.0.7)':
     dependencies:
       '@apeira/core': 0.0.7(@valibot/to-json-schema@1.7.1(valibot@1.4.2(typescript@6.0.3)))
 
-  '@apeira/storage@0.0.7(@apeira/core@0.0.7(@valibot/to-json-schema@1.7.1(valibot@1.4.2(typescript@6.0.3))))':
+  '@apeira/storage@0.0.7(@apeira/core@0.0.7)':
     dependencies:
       '@apeira/core': 0.0.7(@valibot/to-json-schema@1.7.1(valibot@1.4.2(typescript@6.0.3)))
 
@@ -2815,8 +2822,8 @@ snapshots:
   apeira@0.0.7(@valibot/to-json-schema@1.7.1(valibot@1.4.2(typescript@6.0.3))):
     dependencies:
       '@apeira/core': 0.0.7(@valibot/to-json-schema@1.7.1(valibot@1.4.2(typescript@6.0.3)))
-      '@apeira/session': 0.0.7(@apeira/core@0.0.7(@valibot/to-json-schema@1.7.1(valibot@1.4.2(typescript@6.0.3))))
-      '@apeira/storage': 0.0.7(@apeira/core@0.0.7(@valibot/to-json-schema@1.7.1(valibot@1.4.2(typescript@6.0.3))))
+      '@apeira/session': 0.0.7(@apeira/core@0.0.7)
+      '@apeira/storage': 0.0.7(@apeira/core@0.0.7)
     transitivePeerDependencies:
       - '@valibot/to-json-schema'
       - arktype


### PR DESCRIPTION
## What changed

- move Apple Music platform-owned automation into `src/platforms/`
- name each cohesive implementation as `<capability>_<platform>.rs`
- add the directory-level alint rule `require-platform-scoped-app-integration`
- enable the rule for current desktop app integration crates
- document the platform integration boundary and the deferred view-parser slice

## Why

App automation, operating-system integration, and future platform-specific view parser adapters need one visible ownership boundary. Capability/platform files keep complete workflows cohesive without treating CLI commands or individual driver calls as architectural owners.

The alint rule enforces the convention semantically: it reviews app crates with filesystem context and reports concrete placement, naming, fragmentation, or view-parser boundary violations. It does not use pattern-matching heuristics.

## Impact

Apple Music behavior and public commands remain unchanged; this is a module-layout refactor plus a warning-level architecture rule. The rule is configured for Apple Music, Apple Notes, Apple TextEdit, GNOME Control Center, NetEase Music, and QQMusic.

## Verification

- `cargo test -p auv-apple-music --all-features` (22 passed)
- `cargo check -p auv-apple-music --all-features`
- `cargo fmt --check`
- `pnpm --filter @auv/alint-config typecheck`
- `pnpm --filter @auv/alint-config test` (4 passed)
- `pnpm --filter @auv/alint-config build`
- `git diff --check`

## Known baseline

`cargo clippy --no-deps -p auv-apple-music --all-targets --all-features -- -D warnings` continues to report pre-existing macOS-host dead-code warnings for Windows-only implementation helpers. This PR only relocates those helpers and does not broaden scope into warning cleanup.
