### PR TITLE
fix(ci): restore cross-platform workspace checks

### DIFF
--- a/crates/auv-cli-invoke/src/commands/display.rs
+++ b/crates/auv-cli-invoke/src/commands/display.rs
@@ -5,12 +5,14 @@ use crate::{
 use auv_cli_common::{TableRow, outputs::formats::table::TableOptions};
 use clap::Args;
 
-use auv_driver::overlay::{Overlay, components::CaptureFrame};
 use auv_tracing::ArtifactMetadata;
-use std::time::Duration;
 
 #[cfg(target_os = "macos")]
 use crate::artifact::emit_png_with_receipt;
+#[cfg(target_os = "macos")]
+use auv_driver::overlay::{Overlay, components::CaptureFrame};
+#[cfg(target_os = "macos")]
+use std::time::Duration;
 
 pub fn group() -> CommandGroup {
   // TODO(invoke-display-stubs): point commands stay intentionally unregistered
@@ -33,30 +35,33 @@ async fn capture_display(input: InvokeCommandInput, _args: CaptureDisplayArgs) -
     return Ok(InvokeCommandOutput::completed());
   }
   #[cfg(target_os = "macos")]
-  let session = auv_driver::open_local().map_err(|error| error.to_string())?;
-  #[cfg(target_os = "macos")]
-  let (result, artifact) = capture_primary_display_recorded_with_session(&session).await?;
+  {
+    let session = auv_driver::open_local().map_err(|error| error.to_string())?;
+    let (result, artifact) = capture_primary_display_recorded_with_session(&session).await?;
+    let capture_overlay = Overlay::new().with_layer(
+      CaptureFrame::new(result.display.frame)
+        .with_label(result.display.name.clone().unwrap_or_else(|| format!("display {}", result.display.id))),
+    );
+    let overlay = super::overlay::show_overlay(
+      &input,
+      &session,
+      capture_overlay,
+      auv_driver::overlay::ShowOptions::new()
+        .with_motion_ease(Duration::from_millis(120), auv_driver::overlay::Easing::EaseInOutExpo)
+        .with_auto_removal_after(Duration::from_millis(180)),
+    )?;
+    let mut report = display_capture_report(&result);
+    report.fields.push(overlay.report_field());
+    Ok(
+      InvokeCommandOutput::from_result(&super::display_capture_result(&result.display, &result.capture))?
+        .with_report(report)
+        .with_artifacts(artifact),
+    )
+  }
   #[cfg(not(target_os = "macos"))]
-  return Err("display.capture is only available on macOS through auv-driver-macos".to_string());
-  let capture_overlay = Overlay::new().with_layer(
-    CaptureFrame::new(result.display.frame)
-      .with_label(result.display.name.clone().unwrap_or_else(|| format!("display {}", result.display.id))),
-  );
-  let overlay = super::overlay::show_overlay(
-    &input,
-    &session,
-    capture_overlay,
-    auv_driver::overlay::ShowOptions::new()
-      .with_motion_ease(Duration::from_millis(120), auv_driver::overlay::Easing::EaseInOutExpo)
-      .with_auto_removal_after(Duration::from_millis(180)),
-  )?;
-  let mut report = display_capture_report(&result);
-  report.fields.push(overlay.report_field());
-  Ok(
-    InvokeCommandOutput::from_result(&super::display_capture_result(&result.display, &result.capture))?
-      .with_report(report)
-      .with_artifacts(artifact),
-  )
+  {
+    Err("display.capture is only available on macOS through auv-driver-macos".to_string())
+  }
 }
 
 pub async fn capture_primary_display() -> Result<auv_driver::DisplayCapture, String> {

--- a/crates/auv-cli-invoke/src/commands/input.rs
+++ b/crates/auv-cli-invoke/src/commands/input.rs
@@ -328,11 +328,11 @@ impl InputPolicyArg {
   input = ClickWindowPointArgs,
 )]
 async fn click_window_point(input: InvokeCommandInput, args: ClickWindowPointArgs) -> InvokeCommandResult {
+  let point = args.point(&input.command_id)?;
+  let options = args.click_options();
   #[cfg(target_os = "macos")]
   {
     let presentation_input = input.clone();
-    let point = args.point(&input.command_id)?;
-    let options = args.click_options();
     let capability = LocalWindowPointCapability::open()?;
     let outcome = click_resolved_point_with_capability(input, args.title.as_deref(), point, options, &capability).await?;
     let result = outcome.into_result();
@@ -352,7 +352,7 @@ async fn click_window_point(input: InvokeCommandInput, args: ClickWindowPointArg
   }
   #[cfg(not(target_os = "macos"))]
   {
-    let _ = input;
+    let _ = (input, point, options);
     Err("input.clickWindowPoint is only available on macOS".to_string())
   }
 }

--- a/crates/auv-cli/src/mcp.rs
+++ b/crates/auv-cli/src/mcp.rs
@@ -493,8 +493,17 @@ mod tests {
     }
   }
 
+  // https://github.com/moeru-ai/auv/actions/runs/30577666189/job/90989876962
   #[tokio::test]
   async fn mcp_uses_the_same_typed_range_validation_as_cli() {
+    // ROOT CAUSE:
+    //
+    // If invalid window-point coordinates were invoked outside macOS, the
+    // platform rejection won because typed coordinate validation lived inside
+    // the macOS-only command body.
+    //
+    // Before the fix, Linux CI observed a platform error instead of the shared
+    // validation error. The fix validates command inputs before platform dispatch.
     let adapters = core_invoke_adapters();
     let adapter = adapters.iter().find(|adapter| adapter.command_id == "input.clickWindowPoint").expect("click-window-point adapter");
     let error = adapter

--- a/crates/auv-driver-linux/src/native/portal/input.rs
+++ b/crates/auv-driver-linux/src/native/portal/input.rs
@@ -9,7 +9,7 @@ use zbus::blocking::{Connection, Proxy};
 use zbus::zvariant::{OwnedObjectPath, OwnedValue, Value};
 
 use crate::capture::list_displays;
-use crate::error::backend;
+use crate::error::{backend, invalid_input};
 
 use super::request::{close_session, create_remote_desktop_session, portal_proxy, session_connection, session_request};
 use super::{ScreenCastStream, decode_streams, select_monitor_sources};
@@ -97,12 +97,9 @@ impl InputSession {
   }
 
   pub fn click_at(&mut self, point: Point, click: Click) -> DriverResult<()> {
+    let (count, interval) = click_parts(&click)?;
     self.require_pointer()?;
     self.move_pointer_to(point)?;
-    let (count, interval) = match click {
-      Click::Single => (1, Duration::ZERO),
-      Click::Double { interval } => (2, interval),
-    };
     for index in 0..count {
       self.notify_pointer_button(MouseButton::Left, STATE_PRESSED)?;
       self.notify_pointer_button(MouseButton::Left, STATE_RELEASED)?;
@@ -228,6 +225,14 @@ impl Drop for InputSession {
   fn drop(&mut self) {
     let _ = close_session(&self.connection, &self.session_handle);
   }
+}
+
+fn click_parts(click: &Click) -> DriverResult<(u8, Duration)> {
+  let count = click.count();
+  if count == 0 {
+    return Err(invalid_input("repeated click count must be greater than zero"));
+  }
+  Ok((count, click.interval().unwrap_or(Duration::ZERO)))
 }
 
 fn start_remote_desktop(connection: &Connection, session_handle: &OwnedObjectPath) -> DriverResult<HashMap<String, OwnedValue>> {

--- a/crates/auv-driver-linux/src/native/portal/input_test.rs
+++ b/crates/auv-driver-linux/src/native/portal/input_test.rs
@@ -1,5 +1,33 @@
 use super::*;
 
+// https://github.com/moeru-ai/auv/actions/runs/30574130256/job/90978006386
+#[test]
+fn ci_90978006386_click_parts_support_repeated_clicks() {
+  // ROOT CAUSE:
+  //
+  // If Click::Repeated was passed to the Linux portal driver, the crate failed
+  // to compile because click_at still matched only the older single/double shape.
+  //
+  // Before the fix, Ubuntu CI stopped at a non-exhaustive match.
+  // The fix keeps every shared Click variant mapped to portal count/interval values.
+  assert_eq!(
+    click_parts(&Click::Repeated {
+      count: 3,
+      interval: Duration::from_millis(60),
+    })
+    .expect("repeated click"),
+    (3, Duration::from_millis(60))
+  );
+  assert!(matches!(
+    click_parts(&Click::Repeated {
+      count: 0,
+      interval: Duration::from_millis(60),
+    }),
+    Err(auv_driver_common::error::DriverError::InvalidInput { message })
+      if message == "repeated click count must be greater than zero"
+  ));
+}
+
 #[test]
 fn device_mask_requests_keyboard_and_pointer() {
   assert_eq!(DEVICE_KEYBOARD | DEVICE_POINTER, 3);

--- a/crates/auv-driver-windows/src/input.rs
+++ b/crates/auv-driver-windows/src/input.rs
@@ -50,16 +50,17 @@ struct KeyChord {
 }
 
 pub fn click_at(point: Point, click: Click) -> DriverResult<InputActionResult> {
-  let count = match click {
-    Click::Single => 1u32,
-    Click::Double { .. } => 2,
-  };
-  let interval = match click {
-    Click::Single => Duration::ZERO,
-    Click::Double { interval } => interval,
-  };
+  let (count, interval) = click_parts(&click)?;
   native::click(point, count, interval)?;
   Ok(foreground_result(DisturbanceLevel::Temporary, DisturbanceLevel::Unknown, DisturbanceLevel::None))
+}
+
+fn click_parts(click: &Click) -> DriverResult<(u32, Duration)> {
+  let count = click.count();
+  if count == 0 {
+    return Err(invalid_input("repeated click count must be greater than zero"));
+  }
+  Ok((u32::from(count), click.interval().unwrap_or(Duration::ZERO)))
 }
 
 pub fn scroll_at(point: Point, scroll: Scroll, settle: Duration) -> DriverResult<InputActionResult> {

--- a/crates/auv-driver-windows/src/input_test.rs
+++ b/crates/auv-driver-windows/src/input_test.rs
@@ -1,5 +1,33 @@
 use super::*;
 
+// https://github.com/moeru-ai/auv/actions/runs/30574130256/job/90978006366
+#[test]
+fn ci_90978006366_click_parts_support_repeated_clicks() {
+  // ROOT CAUSE:
+  //
+  // If Click::Repeated was passed to the Windows driver, the crate failed to
+  // compile because click_at still matched only the older single/double shape.
+  //
+  // Before the fix, Windows CI stopped at a non-exhaustive match.
+  // The fix keeps every shared Click variant mapped to native count/interval values.
+  assert_eq!(
+    click_parts(&Click::Repeated {
+      count: 3,
+      interval: Duration::from_millis(60),
+    })
+    .expect("repeated click"),
+    (3, Duration::from_millis(60))
+  );
+  assert!(matches!(
+    click_parts(&Click::Repeated {
+      count: 0,
+      interval: Duration::from_millis(60),
+    }),
+    Err(auv_driver_common::error::DriverError::InvalidInput { message })
+      if message == "repeated click count must be greater than zero"
+  ));
+}
+
 #[test]
 fn normalize_absolute_maps_axis_endpoints() {
   // A 1920-wide desktop starting at origin 0 maps x=0 -> 0 and x=1919 -> 65535.


### PR DESCRIPTION
## What changed

- map the shared `Click::Repeated` variant to native count/interval values in the Linux portal and Windows input drivers
- reject a zero repeat count as typed invalid input before native delivery
- keep the complete macOS `display.capture` live path inside one platform cfg block
- validate `input.clickWindowPoint` coordinates before platform dispatch so CLI and MCP keep the same typed contract on every host
- add or annotate focused regressions linked to the failing Actions jobs

## Root causes

1. Commit `3e08bdfd` extended the shared `Click` contract with `Repeated`, but Linux and Windows driver matches still covered only `Single` and `Double`, producing E0004.
2. The same refactor compiled out macOS-only `display.capture` local variables one statement at a time while leaving their consumers subject to non-macOS name resolution, producing E0425.
3. The shared window-point coordinate validation lived inside the macOS-only command body, so Linux tests observed platform rejection before the typed range error expected by both CLI and MCP.

## Impact

Linux and Windows builds consume the complete shared click contract again. Repeated-click validation agrees with macOS, non-macOS builds retain explicit unsupported live-operation results, and platform-independent argument validation remains consistent across CLI and MCP.

## Validation

- `cargo fmt --check`
- `cargo check`
- `cargo test`
- `cargo run --quiet -- invoke --help`
- `git diff --check`
- `cargo check --target x86_64-pc-windows-msvc`
- Linux container: workspace `cargo check`
- Linux container: repeated-click regression
- Linux container: `cargo test -p auv-cli mcp_uses_the_same_typed_range_validation_as_cli`

