### PR TITLE
fix: honor foreground-preferred click delivery

### DIFF
--- a/crates/auv-cli-invoke/src/commands/input.rs
+++ b/crates/auv-cli-invoke/src/commands/input.rs
@@ -624,7 +624,14 @@ fn focus_text_output(result: &auv_driver::AxFocusResult, candidate: &str) -> Inv
 pub(super) fn input_action_report_fields(result: &auv_driver::InputActionResult) -> Vec<InvokeReportField> {
   let mut fields = vec![
     InvokeReportField::new("Delivery", "delivered"),
-    InvokeReportField::new("Verification", "delivery_only"),
+    InvokeReportField::new(
+      "Verification",
+      if result.verified {
+        "verified"
+      } else {
+        "delivery_only"
+      },
+    ),
     InvokeReportField::new("Path", result.selected_path.as_str()),
     InvokeReportField::new("Attempts", result.attempts.len().to_string()),
     InvokeReportField::new("Mouse disturbance", result.mouse_disturbance.as_str()),

--- a/crates/auv-cli-invoke/src/commands/input_test.rs
+++ b/crates/auv-cli-invoke/src/commands/input_test.rs
@@ -219,6 +219,7 @@ async fn invalid_input_artifact_does_not_change_the_typed_call_or_reexecute_driv
     attempts: vec![auv_driver::InputAttempt::success(
       InputDeliveryPath::AxPress,
     )],
+    verified: false,
     mouse_disturbance: auv_driver::DisturbanceLevel::None,
     focus_disturbance: auv_driver::DisturbanceLevel::None,
     clipboard_disturbance: auv_driver::DisturbanceLevel::None,
@@ -254,6 +255,7 @@ async fn input_action_emission_short_circuits_without_run_context() {
     attempts: vec![auv_driver::InputAttempt::success(
       InputDeliveryPath::AxPress,
     )],
+    verified: false,
     mouse_disturbance: auv_driver::DisturbanceLevel::None,
     focus_disturbance: auv_driver::DisturbanceLevel::None,
     clipboard_disturbance: auv_driver::DisturbanceLevel::None,
@@ -269,6 +271,7 @@ fn input_action_artifact_enforces_domain_and_four_mibibyte_bounds() {
     attempts: vec![auv_driver::InputAttempt::success(
       InputDeliveryPath::AxPress,
     )],
+    verified: false,
     mouse_disturbance: auv_driver::DisturbanceLevel::None,
     focus_disturbance: auv_driver::DisturbanceLevel::None,
     clipboard_disturbance: auv_driver::DisturbanceLevel::None,
@@ -282,6 +285,7 @@ fn input_action_artifact_enforces_domain_and_four_mibibyte_bounds() {
       auv_driver::InputAttempt::failure(InputDeliveryPath::AxPress, "x".repeat(ROOT_STRUCTURED_ARTIFACT_JSON_BYTE_LIMIT as usize)),
       auv_driver::InputAttempt::success(InputDeliveryPath::WindowTargetedMouse),
     ],
+    verified: false,
     mouse_disturbance: auv_driver::DisturbanceLevel::None,
     focus_disturbance: auv_driver::DisturbanceLevel::None,
     clipboard_disturbance: auv_driver::DisturbanceLevel::None,
@@ -382,6 +386,7 @@ fn input_action_output_reports_explicit_domain_values() {
   let result = InputActionResult {
     selected_path: InputDeliveryPath::WindowTargetedKeyboardScroll,
     attempts: vec![],
+    verified: false,
     mouse_disturbance: auv_driver::DisturbanceLevel::None,
     focus_disturbance: auv_driver::DisturbanceLevel::Foreground,
     clipboard_disturbance: auv_driver::DisturbanceLevel::Temporary,
@@ -397,6 +402,17 @@ fn input_action_output_reports_explicit_domain_values() {
   assert_eq!(field_value(report, "Focus disturbance"), "foreground");
   assert_eq!(field_value(report, "Clipboard disturbance"), "temporary");
   assert_eq!(output.result(), Some(&serde_json::to_value(&result).expect("fixture should serialize")));
+}
+
+#[test]
+fn input_action_output_reports_semantic_verification_when_present() {
+  let mut result = InputActionResult::single_success(InputDeliveryPath::AxPress);
+  result.verified = true;
+
+  let output = input_action_output(&result).expect("verified input result should serialize");
+  let report = output.report.as_ref().expect("input action report");
+
+  assert_eq!(field_value(report, "Verification"), "verified");
 }
 
 #[test]

--- a/crates/auv-driver-common/src/input.rs
+++ b/crates/auv-driver-common/src/input.rs
@@ -403,6 +403,13 @@ pub const INPUT_ACTION_RESULT_PURPOSE: &str = "auv.driver.input_action_result";
 pub struct InputActionResult {
   pub selected_path: InputDeliveryPath,
   pub attempts: Vec<InputAttempt>,
+  /// Whether a post-action observation proved the requested semantic effect.
+  ///
+  /// NOTICE(input-delivery-verification): A successful OS/driver dispatch is
+  /// not consumption evidence. Raw CGEvent, SendInput, XTest, and AX action
+  /// APIs can report success while the target ignores the event, so producers
+  /// must leave this false unless they performed an explicit read-back.
+  pub verified: bool,
   pub mouse_disturbance: DisturbanceLevel,
   pub focus_disturbance: DisturbanceLevel,
   pub clipboard_disturbance: DisturbanceLevel,
@@ -413,6 +420,7 @@ impl InputActionResult {
     Self {
       selected_path: path,
       attempts: vec![InputAttempt::success(path)],
+      verified: false,
       mouse_disturbance: DisturbanceLevel::None,
       focus_disturbance: DisturbanceLevel::None,
       clipboard_disturbance: DisturbanceLevel::None,

--- a/crates/auv-driver-common/src/input_test.rs
+++ b/crates/auv-driver-common/src/input_test.rs
@@ -1,6 +1,15 @@
 use super::*;
 
 #[test]
+fn dispatched_input_is_explicitly_unverified_on_the_wire() {
+  let result = InputActionResult::single_success(InputDeliveryPath::WindowTargetedMouse);
+  let encoded = serde_json::to_value(&result).expect("serialize input action result");
+
+  assert!(!result.verified);
+  assert_eq!(encoded["verified"], false);
+}
+
+#[test]
 fn fallback_reason_is_derived_from_attempts_and_not_duplicated_on_the_wire() {
   let result = InputActionResult {
     selected_path: InputDeliveryPath::ForegroundSystemEvents,
@@ -8,6 +17,7 @@ fn fallback_reason_is_derived_from_attempts_and_not_duplicated_on_the_wire() {
       InputAttempt::failure(InputDeliveryPath::WindowTargetedMouse, "background delivery failed"),
       InputAttempt::success(InputDeliveryPath::ForegroundSystemEvents),
     ],
+    verified: false,
     mouse_disturbance: DisturbanceLevel::Temporary,
     focus_disturbance: DisturbanceLevel::Foreground,
     clipboard_disturbance: DisturbanceLevel::None,
@@ -22,6 +32,7 @@ fn input_action_result_rejects_success_on_a_path_other_than_the_selected_path() 
   let result = InputActionResult {
     selected_path: InputDeliveryPath::WindowTargetedMouse,
     attempts: vec![InputAttempt::success(InputDeliveryPath::AxPress)],
+    verified: false,
     mouse_disturbance: DisturbanceLevel::None,
     focus_disturbance: DisturbanceLevel::None,
     clipboard_disturbance: DisturbanceLevel::None,

--- a/crates/auv-driver-linux/src/accessibility.rs
+++ b/crates/auv-driver-linux/src/accessibility.rs
@@ -62,6 +62,7 @@ pub fn focus_node(window: &Window, node_path: &str) -> DriverResult<InputActionR
   Ok(InputActionResult {
     selected_path: InputDeliveryPath::AxFocus,
     attempts,
+    verified: false,
     mouse_disturbance: DisturbanceLevel::None,
     focus_disturbance: DisturbanceLevel::Foreground,
     clipboard_disturbance: DisturbanceLevel::None,
@@ -77,6 +78,7 @@ pub fn select_node(window: &Window, node_path: &str) -> DriverResult<InputAction
       succeeded: true,
       message: Some(result.action_name),
     }],
+    verified: false,
     mouse_disturbance: DisturbanceLevel::None,
     focus_disturbance: DisturbanceLevel::Foreground,
     clipboard_disturbance: DisturbanceLevel::None,

--- a/crates/auv-driver-linux/src/accessibility_test.rs
+++ b/crates/auv-driver-linux/src/accessibility_test.rs
@@ -12,6 +12,7 @@ fn select_node_reports_atspi_action_path() {
       succeeded: true,
       message: Some("click".to_string()),
     }],
+    verified: false,
     mouse_disturbance: DisturbanceLevel::None,
     focus_disturbance: DisturbanceLevel::Foreground,
     clipboard_disturbance: DisturbanceLevel::None,
@@ -40,6 +41,7 @@ fn focus_result_uses_ax_focus_path() {
   let result = InputActionResult {
     selected_path: InputDeliveryPath::AxFocus,
     attempts: vec![InputAttempt::success(InputDeliveryPath::AxFocus)],
+    verified: false,
     mouse_disturbance: DisturbanceLevel::None,
     focus_disturbance: DisturbanceLevel::Foreground,
     clipboard_disturbance: DisturbanceLevel::None,

--- a/crates/auv-driver-linux/src/input.rs
+++ b/crates/auv-driver-linux/src/input.rs
@@ -98,6 +98,7 @@ pub(crate) fn paste_text(state: &Arc<Mutex<LinuxDriverSessionState>>, options: P
     (Ok(()), Ok(())) => Ok(InputActionResult {
       selected_path: InputDeliveryPath::ClipboardPaste,
       attempts: vec![InputAttempt::success(InputDeliveryPath::ClipboardPaste)],
+      verified: false,
       mouse_disturbance: DisturbanceLevel::None,
       focus_disturbance: DisturbanceLevel::Unknown,
       clipboard_disturbance: DisturbanceLevel::Temporary,
@@ -118,6 +119,7 @@ pub fn reserved_input_result(reason: impl Into<String>) -> InputActionResult {
       InputDeliveryPath::Unsupported,
       reason.clone(),
     )],
+    verified: false,
     mouse_disturbance: DisturbanceLevel::None,
     focus_disturbance: DisturbanceLevel::None,
     clipboard_disturbance: DisturbanceLevel::None,
@@ -141,6 +143,7 @@ fn keyboard_result() -> InputActionResult {
     attempts: vec![InputAttempt::success(
       InputDeliveryPath::ForegroundSystemEvents,
     )],
+    verified: false,
     mouse_disturbance: DisturbanceLevel::None,
     focus_disturbance: DisturbanceLevel::Unknown,
     clipboard_disturbance: DisturbanceLevel::None,
@@ -153,6 +156,7 @@ fn pointer_result() -> InputActionResult {
     attempts: vec![InputAttempt::success(
       InputDeliveryPath::ForegroundSystemEvents,
     )],
+    verified: false,
     mouse_disturbance: DisturbanceLevel::Temporary,
     focus_disturbance: DisturbanceLevel::Unknown,
     clipboard_disturbance: DisturbanceLevel::None,

--- a/crates/auv-driver-macos/src/accessibility.rs
+++ b/crates/auv-driver-macos/src/accessibility.rs
@@ -30,6 +30,7 @@ pub fn focus_node_path(pid: i32, path: &str, expected_role: &str) -> DriverResul
       succeeded: true,
       message: Some(format!("focused AX path {path} role {expected_role}")),
     }],
+    verified: false,
     mouse_disturbance: DisturbanceLevel::None,
     focus_disturbance: DisturbanceLevel::Temporary,
     clipboard_disturbance: DisturbanceLevel::None,

--- a/crates/auv-driver-macos/src/session.rs
+++ b/crates/auv-driver-macos/src/session.rs
@@ -328,9 +328,32 @@ impl WindowApi<'_> {
   }
 
   fn click_impl(&self, window: &Window, point: WindowPoint, options: ClickOptions) -> DriverResult<InputActionResult> {
+    let screen_point = self.to_screen_point(window, point)?;
+    if click_attempt_candidates(options.policy) == [InputDeliveryPath::ForegroundSystemEvents] {
+      // NOTICE(qemu-foreground-click): A pid-targeted CGEvent can be accepted
+      // by macOS while a focus-sensitive host window (notably QEMU) discards
+      // it before forwarding input to its guest. ForegroundPreferred must use
+      // the global HID route first; remove this note only if the native route
+      // gains consumption evidence rather than dispatch-only success.
+      let lease = self.prepare_for_input(window, foreground_prepare_options(Duration::from_millis(50)))?;
+      let action_result = self.session.input().click_at(screen_point.point(), options.click);
+      let restore_result = self.restore_input(lease);
+      action_result?;
+      restore_result?;
+      return Ok(InputActionResult {
+        selected_path: InputDeliveryPath::ForegroundSystemEvents,
+        attempts: vec![InputAttempt::success(
+          InputDeliveryPath::ForegroundSystemEvents,
+        )],
+        verified: false,
+        mouse_disturbance: DisturbanceLevel::Temporary,
+        focus_disturbance: DisturbanceLevel::Foreground,
+        clipboard_disturbance: DisturbanceLevel::None,
+      });
+    }
+
     let pid = window_pid(window)?;
     let number = window_number(window)?;
-    let screen_point = self.to_screen_point(window, point)?;
     let screen = screen_point.point();
     let window_point = point.point();
     let (click_count, click_interval_ms) = click_parts(&options.click)?;
@@ -338,7 +361,7 @@ impl WindowApi<'_> {
       WindowClickStrategy::ChromiumCompatible => 0,
       WindowClickStrategy::PidTargeted => 1,
     };
-    let background_result = crate::native::input::click_window_point(
+    crate::native::input::click_window_point(
       pid,
       number,
       screen.x,
@@ -350,32 +373,8 @@ impl WindowApi<'_> {
       click_interval_ms,
       window_strategy_code,
     )
-    .map_err(backend);
-
-    match background_result {
-      Ok(()) => Ok(InputActionResult::single_success(InputDeliveryPath::WindowTargetedMouse)),
-      Err(background_error) => match options.policy {
-        InputPolicy::BackgroundOnly | InputPolicy::BackgroundPreferred => Err(background_error),
-        InputPolicy::ForegroundPreferred => {
-          let fallback_reason = background_error.to_string();
-          let lease = self.prepare_for_input(window, foreground_prepare_options(Duration::ZERO))?;
-          let action_result = self.session.input().click_at(screen_point.point(), options.click.clone());
-          let restore_result = self.restore_input(lease);
-          action_result?;
-          restore_result?;
-          Ok(InputActionResult {
-            selected_path: InputDeliveryPath::ForegroundSystemEvents,
-            attempts: vec![
-              InputAttempt::failure(InputDeliveryPath::WindowTargetedMouse, fallback_reason.clone()),
-              InputAttempt::success(InputDeliveryPath::ForegroundSystemEvents),
-            ],
-            mouse_disturbance: DisturbanceLevel::Temporary,
-            focus_disturbance: DisturbanceLevel::Foreground,
-            clipboard_disturbance: DisturbanceLevel::None,
-          })
-        }
-      },
-    }
+    .map_err(backend)?;
+    Ok(InputActionResult::single_success(InputDeliveryPath::WindowTargetedMouse))
   }
 
   pub fn type_text(&self, window: &Window, text: &str, options: TypeTextOptions) -> DriverResult<InputActionResult> {
@@ -407,6 +406,7 @@ impl WindowApi<'_> {
               InputAttempt::failure(InputDeliveryPath::WindowTargetedKeyboard, fallback_reason.clone()),
               InputAttempt::success(InputDeliveryPath::ClipboardPaste),
             ],
+            verified: false,
             mouse_disturbance: DisturbanceLevel::None,
             focus_disturbance: DisturbanceLevel::Foreground,
             clipboard_disturbance: DisturbanceLevel::Temporary,
@@ -435,6 +435,7 @@ impl WindowApi<'_> {
             return Ok(InputActionResult {
               selected_path: InputDeliveryPath::WindowTargetedWheel,
               attempts,
+              verified: false,
               mouse_disturbance: DisturbanceLevel::None,
               focus_disturbance: DisturbanceLevel::None,
               clipboard_disturbance: DisturbanceLevel::None,
@@ -462,6 +463,7 @@ impl WindowApi<'_> {
           return Ok(InputActionResult {
             selected_path: result.selected_path,
             attempts,
+            verified: result.verified,
             mouse_disturbance: result.mouse_disturbance,
             focus_disturbance: result.focus_disturbance,
             clipboard_disturbance: result.clipboard_disturbance,
@@ -610,6 +612,7 @@ impl InputApi<'_> {
       attempts: vec![InputAttempt::success(
         InputDeliveryPath::ForegroundSystemEvents,
       )],
+      verified: false,
       mouse_disturbance: DisturbanceLevel::Temporary,
       focus_disturbance: DisturbanceLevel::Unknown,
       clipboard_disturbance: DisturbanceLevel::None,
@@ -677,6 +680,7 @@ impl InputApi<'_> {
       (Ok(()), Ok(())) => Ok(InputActionResult {
         selected_path: InputDeliveryPath::ClipboardPaste,
         attempts: vec![InputAttempt::success(InputDeliveryPath::ClipboardPaste)],
+        verified: false,
         mouse_disturbance: DisturbanceLevel::None,
         focus_disturbance: DisturbanceLevel::Unknown,
         clipboard_disturbance: DisturbanceLevel::Temporary,
@@ -1121,6 +1125,7 @@ fn foreground_system_events_result(
     attempts: vec![InputAttempt::success(
       InputDeliveryPath::ForegroundSystemEvents,
     )],
+    verified: false,
     mouse_disturbance,
     focus_disturbance,
     clipboard_disturbance,
@@ -1140,6 +1145,13 @@ fn scroll_attempt_candidates(options: &ScrollOptions) -> Vec<ScrollDeliveryCandi
       options.delivery_strategy.candidates.iter().copied().filter(|candidate| *candidate != ScrollDeliveryCandidate::ForegroundHid).collect()
     }
     InputPolicy::BackgroundPreferred => options.delivery_strategy.candidates.clone(),
+  }
+}
+
+fn click_attempt_candidates(policy: InputPolicy) -> Vec<InputDeliveryPath> {
+  match policy {
+    InputPolicy::ForegroundPreferred => vec![InputDeliveryPath::ForegroundSystemEvents],
+    InputPolicy::BackgroundOnly | InputPolicy::BackgroundPreferred => vec![InputDeliveryPath::WindowTargetedMouse],
   }
 }
 
@@ -1409,19 +1421,25 @@ fn foreground_prepare_options(settle: Duration) -> PrepareForInputOptions {
 }
 
 fn activate_app_for_window(window: &Window) -> DriverResult<()> {
-  if let Some(bundle_id) = &window.app_bundle_id {
-    run_osascript(&[&format!(
-      "tell application id \"{}\" to activate",
-      escape_applescript(bundle_id)
-    )])
-  } else if let Some(app_name) = &window.app_name {
-    run_osascript(&[&format!(
-      "tell application \"{}\" to activate",
-      escape_applescript(app_name)
-    )])
-  } else {
-    Ok(())
+  run_osascript(&[&foreground_activation_script(window)?])
+}
+
+fn foreground_activation_script(window: &Window) -> DriverResult<String> {
+  if let Some(pid) = window.process_id {
+    // NOTICE(bundleless-window-activation): `tell application ... to activate`
+    // cannot resolve executables without a bundle id, including Android
+    // Emulator's `qemu-system-aarch64`. System Events can activate the owning
+    // application process by pid. Keep the bundle/name fallback only for
+    // legacy Window values without an observed owner pid.
+    return Ok(format!("tell application \"System Events\" to set frontmost of first application process whose unix id is {pid} to true"));
   }
+  if let Some(bundle_id) = &window.app_bundle_id {
+    return Ok(format!("tell application id \"{}\" to activate", escape_applescript(bundle_id)));
+  }
+  if let Some(app_name) = &window.app_name {
+    return Ok(format!("tell application \"{}\" to activate", escape_applescript(app_name)));
+  }
+  Err(invalid_input("foreground input requires a window owner pid, bundle id, or application name"))
 }
 
 #[derive(Clone, Debug)]

--- a/crates/auv-driver-macos/src/session_test.rs
+++ b/crates/auv-driver-macos/src/session_test.rs
@@ -396,6 +396,28 @@ mod no_steal_tests {
   }
 
   #[test]
+  fn click_attempt_candidates_foreground_preferred_uses_foreground_hid_first() {
+    // ROOT CAUSE:
+    //
+    // If a pid-targeted CGEvent was accepted by macOS but ignored by a
+    // focus-sensitive host window such as QEMU, ForegroundPreferred stopped
+    // because dispatch success was mistaken for guest-visible success.
+    //
+    // Before the fix, click always attempted WindowTargetedMouse first.
+    // The fix makes the policy name literal and selects foreground HID first.
+    let candidates = click_attempt_candidates(InputPolicy::ForegroundPreferred);
+
+    assert_eq!(candidates, vec![InputDeliveryPath::ForegroundSystemEvents]);
+  }
+
+  #[test]
+  fn foreground_activation_targets_bundleless_windows_by_pid() {
+    let script = foreground_activation_script(&sample_window()).expect("foreground activation script");
+
+    assert_eq!(script, "tell application \"System Events\" to set frontmost of first application process whose unix id is 123 to true");
+  }
+
+  #[test]
   fn scroll_attempt_candidates_foreground_preferred_uses_foreground_hid_first() {
     let candidates = scroll_attempt_candidates(&ScrollOptions {
       policy: InputPolicy::ForegroundPreferred,

--- a/crates/auv-driver-windows/src/accessibility.rs
+++ b/crates/auv-driver-windows/src/accessibility.rs
@@ -69,6 +69,7 @@ pub fn focus_node(window: &Window, node_path: &str) -> DriverResult<InputActionR
   Ok(InputActionResult {
     selected_path: InputDeliveryPath::AxFocus,
     attempts: vec![InputAttempt::success(InputDeliveryPath::AxFocus)],
+    verified: false,
     mouse_disturbance: DisturbanceLevel::None,
     focus_disturbance: DisturbanceLevel::Foreground,
     clipboard_disturbance: DisturbanceLevel::None,
@@ -101,6 +102,7 @@ pub fn select_node(window: &Window, node_path: &str) -> DriverResult<InputAction
         message: Some(selected_pattern.to_string()),
       }]
     },
+    verified: false,
     mouse_disturbance: DisturbanceLevel::None,
     focus_disturbance: DisturbanceLevel::Foreground,
     clipboard_disturbance: DisturbanceLevel::None,

--- a/crates/auv-driver-windows/src/input.rs
+++ b/crates/auv-driver-windows/src/input.rs
@@ -115,6 +115,7 @@ fn foreground_result(
     attempts: vec![InputAttempt::success(
       InputDeliveryPath::ForegroundSystemEvents,
     )],
+    verified: false,
     mouse_disturbance,
     focus_disturbance,
     clipboard_disturbance,

--- a/docs/TERMS_AND_CONCEPTS.md
+++ b/docs/TERMS_AND_CONCEPTS.md
@@ -647,9 +647,11 @@ into operation failure.
 
 Delivery and semantic verification remain separate domain facts. A typed
 `InputActionResult` can prove which input path was delivered without proving
-the expected UI state; an app-owned typed result can state what was checked and
-what the app observed without redefining the operation's Rust return type. V1
-intentionally has no shared `VerificationResult`, `VerificationMethod`,
+the expected UI state. Its `verified` field is `false` for dispatch-only
+results and may be `true` only when a post-action observation proved the
+requested semantic effect. An app-owned typed result can state what was checked
+and what the app observed without redefining the operation's Rust return type.
+V1 intentionally has no shared `VerificationResult`, `VerificationMethod`,
 `OperationStatus`, `ControlFailure`, or persisted operation-result record in
 `auv-tracing`.
 

--- a/docs/ai/references/driver/2026-08-01-qemu-window-input-framework-research.md
+++ b/docs/ai/references/driver/2026-08-01-qemu-window-input-framework-research.md
@@ -1,0 +1,226 @@
+# QEMU window input delivery: AUV, CUA, and KWWK
+
+Date: 2026-08-01
+
+## Question
+
+Why can AUV report a successful macOS window-targeted click against Android
+Emulator while the Android guest receives no tap, and how do comparable
+computer-use frameworks handle this boundary?
+
+## Conclusion
+
+The reproduced failure is not a coordinate or OCR failure. macOS accepted the
+request to post a mouse event to the QEMU process, but that does not prove that
+the emulator's host UI forwarded a complete click into the guest. QEMU-style
+display frontends commonly gate guest input on window focus or mouse-grab
+state.
+
+AUV at the reproduced base revision treated a successful event-posting call as
+a successful attempt. For click operations, `ForegroundPreferred` tried the background
+`WindowTargetedMouse` path first and only falls back when that path returns an
+error. A silent no-op therefore prevents the foreground rung from running.
+
+The most transferable patterns from comparable frameworks are:
+
+1. Distinguish event delivery from semantic verification.
+2. Make background and foreground delivery explicit ladder rungs.
+3. Verify the effect after an unverifiable click before escalating.
+4. For Android, prefer a guest-aware transport such as ADB over synthetic input
+   aimed at the host QEMU window.
+
+## Local reproduction
+
+The test used the `auv` binary built from local `main` in an isolated worktree.
+
+```text
+window: Android Emulator - Pixel_10:5554
+process: qemu-system-aarch64
+pid: 16296
+window id: 545200
+```
+
+Before and after this command, Android UIAutomator reported `tap 4`:
+
+```sh
+auv invoke window.clickText 'Native button' \
+  --title 'Android Emulator - Pixel_10:5554' \
+  --input-policy foreground-preferred \
+  --no-overlay \
+  --store-root /tmp/auv-window-click-text-qemu \
+  --json \
+  --detail
+```
+
+The result was:
+
+```text
+run_id: 019fb956-d421-7b32-a2cf-b74403c7d00e
+status: completed
+matched_text: Native button
+point: 312,89
+selected_path: window_targeted_mouse
+attempts: [{ path: window_targeted_mouse, succeeded: true }]
+focus_disturbance: none
+```
+
+This reproduces the exact `window.clickText` question: OCR resolved the text,
+but `ForegroundPreferred` stopped after the background event-post operation
+reported no API error.
+
+Two control paths changed Android state:
+
+- `adb -s emulator-5554 shell input tap X Y`
+- after raising the emulator window with AX, `screen.clickText`, which uses the
+  global HID path
+
+That isolates the failure to host-window targeted delivery into the emulator,
+not OCR or the window-local coordinate conversion.
+
+## AUV behavior before the fix
+
+`ForegroundPreferred` is exposed by the CLI. It has not been removed. The
+problem is the click attempt ordering and success definition:
+
+```text
+WindowTargetedMouse -> if API error, then foreground HID
+                    -> if API accepted event, stop
+```
+
+The driver can observe that it constructed and posted an event; it cannot
+observe whether QEMU accepted it or whether Android handled it. The current
+`succeeded: true` field therefore means transport dispatch succeeded, not
+semantic click success.
+
+There is also an internal policy inconsistency: the scroll implementation's
+`ForegroundPreferred` ordering starts with foreground HID, while click starts
+with window-targeted background delivery.
+
+## CUA
+
+Current CUA source has two explicit click delivery modes:
+
+- `background`: AX action or process-targeted CGEvent without fronting
+- `foreground`: briefly front the concrete window, perform the action, allow
+  transient UI to settle, then restore the previous frontmost application
+
+CUA labels both forms `verified: false`; its tool description tells the agent
+to use a ladder of background AX, screenshot, background pixel, screenshot,
+then foreground delivery. Its global desktop click posts at the HID event tap,
+not to a PID.
+
+CUA's foreground helper is window-centric rather than bundle-ID-centric. It
+uses the target PID and window ID with WindowServer/SkyLight process and window
+operations, so a bundleless executable is not inherently excluded. These are
+private macOS interfaces and remain best-effort.
+
+For Android, CUA also has an ADB transport. It captures via
+`adb exec-out screencap -p`, executes guest shell commands through ADB, and has
+a root/multitouch route using `sendevent`. This avoids relying on whether the
+host QEMU window forwards a background CGEvent into the Android guest.
+
+No QEMU-specific exception was found in CUA's macOS process-targeted mouse
+implementation. The important handling is architectural: explicit foreground
+escalation for host windows and a guest-aware transport for Android.
+
+The CUA binary was not installed locally, so upstream CUA was not executed
+against this emulator. AUV's window-targeted path uses the same family of
+process-targeted CGEvent techniques, and that path was tested directly.
+
+## KWWK
+
+KWWK's click flow prefers an accessibility action when an element supports one
+and otherwise uses `BackgroundMouseDispatcher`. The dispatcher stamps PID,
+window-number, and window-local fields on CGEvents and finishes with
+`event.postToPid(targetPID)`.
+
+KWWK adds a `BackgroundActivationSession`: it posts AppKit-defined activation
+events and a window-center mouse primer while suppressing focus messages that
+would disturb the previously foreground application. This is more elaborate
+than a bare `postToPid`, but it still cannot prove that a guest consumed the
+event. No Android Emulator or QEMU special case was found.
+
+KWWK does compare snapshots for some operations. For example, its scroll output
+warns when neither an AX scroll nor a `postToPid` fallback produces observable
+state change. Its click API, however, does not expose a CUA-style explicit
+foreground delivery rung.
+
+The KWWK binary was not installed locally, so this conclusion is from current
+source inspection. Given its final mouse transport, the expectation that it
+can silently no-op on this QEMU window is an inference, not a direct KWWK run.
+
+## QEMU focus and mouse-grab boundary
+
+Upstream QEMU's macOS Cocoa frontend documents and implements the relevant
+boundary explicitly. Its stable source says button events must not be sent to
+the guest unless the mouse is grabbed or the window has focus; a click on a
+background window is treated as activation and intentionally not passed
+through. Current source continues to track `isMouseGrabbed`, and mouse-up can
+establish the grab after an earlier mouse-down was not accepted as guest input.
+
+Android Emulator uses Google's QEMU-derived emulator and a Qt host UI, so the
+upstream Cocoa source is not proof of its exact event handler. It is strong
+supporting evidence for the general host-window/guest-input boundary, while the
+local AUV, global-HID, and ADB controls are the direct evidence for this case.
+
+## Other computer-use frameworks
+
+Anthropic's reference computer-use environment runs a controlled Linux desktop
+inside Docker and sends input with `xdotool` inside that desktop. Like ADB, this
+places input in the environment that owns the application instead of trying to
+deliver a background mouse event through an unrelated macOS host window.
+
+This is the common reliable pattern for VM, container, and mobile targets:
+inject through the guest/control plane when one exists; use host global input
+only when deliberately operating the visible foreground desktop.
+
+## Implemented AUV slice
+
+The owner approved and the follow-up implemented this narrow bug fix:
+
+1. Click `ForegroundPreferred` now attempts foreground first, matching
+   its name and the scroll policy.
+2. Foreground activation addresses the owning process by PID before falling
+   back to bundle ID or application name, so bundleless QEMU processes can
+   participate.
+3. `InputActionResult` now persists `verified`. Raw input producers return
+   `verified: false`; only a producer with post-action read-back may set it to
+   `true`.
+4. The driver does not automatically retry foreground after every
+   API-successful background
+   click inside the low-level driver: without semantic evidence it would cause
+   duplicate clicks on applications where the first click worked. Let a
+   verification-aware operation or caller select the next rung.
+5. A typed Android/ADB capability remains a separate, owner-approved feature;
+   do not hard-code a QEMU exception into the generic macOS mouse driver.
+
+The post-fix live run used the same text and window:
+
+```text
+run_id: 019fb970-d397-74f1-971d-ca8f93422129
+selected_path: foreground_system_events
+attempts: [{ path: foreground_system_events, succeeded: true }]
+verified: false
+focus_disturbance: foreground
+Android UIAutomator: tap 4 -> tap 5
+```
+
+This is direct evidence that foreground delivery reached this Android guest.
+It remains intentionally unverified in the driver result because UIAutomator
+was an external test assertion, not an observation performed by the click
+operation itself. A planned repeat could not run because the emulator process
+and ADB device exited after the first confirmed run; that later environment
+loss does not change the captured `tap 4 -> tap 5` result.
+
+## Sources
+
+- [CUA macOS click tool](https://github.com/trycua/cua/blob/main/libs/cua-driver/rust/crates/platform-macos/src/tools/click.rs)
+- [CUA macOS mouse transport](https://github.com/trycua/cua/blob/main/libs/cua-driver/rust/crates/platform-macos/src/input/mouse.rs)
+- [CUA macOS foreground helper](https://github.com/trycua/cua/blob/main/libs/cua-driver/rust/crates/platform-macos/src/input/skylight.rs)
+- [CUA Android ADB transport](https://github.com/trycua/cua/blob/main/libs/python/cua-sandbox/cua_sandbox/transport/adb.py)
+- [KWWK computer-use actions](https://github.com/EYHN/kwwk-computer-use-core/blob/main/Sources/KWWKComputerUseCore/ComputerUseActions.swift)
+- [KWWK background input dispatcher](https://github.com/EYHN/kwwk-computer-use-core/blob/main/Sources/KWWKComputerUseCore/BackgroundInputDispatcher.swift)
+- [KWWK background activation session](https://github.com/EYHN/kwwk-computer-use-core/blob/main/Sources/KWWKComputerUseCore/BackgroundActivationSession.swift)
+- [QEMU stable Cocoa frontend](https://gitlab.com/qemu-project/qemu/-/blob/stable-6.1/ui/cocoa.m)
+- [QEMU current Cocoa frontend](https://gitlab.com/qemu-project/qemu/-/blob/master/ui/cocoa.m)
+- [Anthropic computer-use reference tool](https://github.com/anthropics/claude-quickstarts/blob/main/computer-use-demo/computer_use_demo/tools/computer.py)

--- a/docs/ai/references/driver/INDEX.md
+++ b/docs/ai/references/driver/INDEX.md
@@ -2,7 +2,7 @@
 
 Platform drivers, input, window, capture, permissions
 
-Count: **22**
+Count: **23**
 
 - [`2026-05-20-macos-driver-namespace-after-window-screen-design.md`](2026-05-20-macos-driver-namespace-after-window-screen-design.md)
 - [`2026-05-20-macos-osascript-backend-design.md`](2026-05-20-macos-osascript-backend-design.md)
@@ -28,6 +28,7 @@ Count: **22**
 - [`2026-06-18-driver-windows-v0-implementation.md`](2026-06-18-driver-windows-v0-implementation.md)
 - [`2026-07-19-error-chain-inventory.md`](2026-07-19-error-chain-inventory.md)
 - [`2026-07-30-overlay-interface-and-debug-commands-handoff.md`](2026-07-30-overlay-interface-and-debug-commands-handoff.md)
+- [`2026-08-01-qemu-window-input-framework-research.md`](2026-08-01-qemu-window-input-framework-research.md)
 
 ## Related
 


### PR DESCRIPTION
## Summary

- make macOS click delivery honor `ForegroundPreferred` by activating the target process and using the global HID path first
- activate bundleless windows such as Android Emulator's `qemu-system-aarch64` by owner PID
- add `InputActionResult.verified` so dispatch-only success is not presented as semantic verification
- document the QEMU boundary and add regression coverage across the shared driver result producers

## Root cause

The pid-targeted CGEvent path can return success even when a focus-sensitive QEMU window does not forward the click into the Android guest. Click handling treated that transport success as terminal, so `ForegroundPreferred` never reached its foreground path. Bundleless QEMU processes also could not be activated through the existing application-id/name AppleScript route.

## Impact

`window.clickText --input-policy foreground-preferred` now reaches Android Emulator through foreground system events. Dispatch-only results explicitly report `verified: false`; only a producer with post-action read-back may set it to true.

## Validation

- `cargo fmt --all --check`
- `cargo check`
- `cargo test`
- `git diff --check`
- live Android Emulator verification: UIAutomator count changed from `tap 4` to `tap 5`
  - run id: `019fb970-d397-74f1-971d-ca8f93422129`
  - selected path: `foreground_system_events`
  - driver verification: `false` (the UIAutomator assertion was external to the operation)
