### PR TITLE
fix(auv-driver-linux): stabilize Wayland capture and portal reuse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,10 +476,12 @@ name = "auv-driver-linux"
 version = "0.0.1"
 dependencies = [
  "auv-driver-common",
+ "fs2",
  "image",
  "leptess",
  "pipewire",
  "serde",
+ "tempfile",
  "wayland-client 0.31.14",
  "wayland-protocols 0.32.12",
  "zbus",
@@ -2032,6 +2034,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/crates/auv-driver-linux/Cargo.toml
+++ b/crates/auv-driver-linux/Cargo.toml
@@ -23,8 +23,12 @@ image.workspace = true
 serde.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
+fs2.workspace = true
 leptess.workspace = true
 pipewire = "0.8"
 wayland-client = "0.31"
 wayland-protocols = { version = "0.32", features = ["client", "unstable"] }
 zbus.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/auv-driver-linux/src/capture.rs
+++ b/crates/auv-driver-linux/src/capture.rs
@@ -139,7 +139,8 @@ fn capture_monitor_frame_for_session(
 ) -> DriverResult<ScreenCastFrame> {
   let mut state = state.lock().expect("linux driver session state poisoned");
   if state.screencast_session.is_none() {
-    state.screencast_session = Some(ScreenCastSession::open_monitor()?);
+    let restore_tokens = state.restore_tokens.clone();
+    state.screencast_session = Some(ScreenCastSession::open_monitor(restore_tokens.as_ref())?);
   }
   state.screencast_session.as_mut().expect("screencast session was just initialized").capture_monitor_frame(target_bounds)
 }

--- a/crates/auv-driver-linux/src/driver.rs
+++ b/crates/auv-driver-linux/src/driver.rs
@@ -1,16 +1,25 @@
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use auv_driver_common::{Driver, DriverDescriptor, DriverResult, DriverSession};
 
 use crate::descriptor::{LinuxDriverDescriptor, linux_driver_descriptor};
-use crate::native::portal::{ClipboardSession, InputSession, ScreenCastSession};
+use crate::native::portal::{ClipboardSession, InputSession, RestoreTokenStore, ScreenCastSession};
 
-#[derive(Clone, Copy, Debug, Default)]
-pub struct LinuxDriver;
+#[derive(Clone, Debug, Default)]
+pub struct LinuxDriver {
+  portal_state_root: Option<PathBuf>,
+}
 
 impl LinuxDriver {
   pub fn new() -> Self {
-    Self
+    Self::default()
+  }
+
+  /// Persists opaque portal restore tokens below a daemon-owned state root.
+  pub fn with_portal_state_root(mut self, root: PathBuf) -> Self {
+    self.portal_state_root = Some(root);
+    self
   }
 
   pub fn linux_descriptor(&self) -> LinuxDriverDescriptor {
@@ -30,9 +39,13 @@ pub(crate) struct LinuxDriverSessionState {
   // permissions separately. Merge only after an owner-approved slice defines
   // combined RequestClipboard/SelectDevices/Start and clipboard transfer
   // thread ownership.
+  // TODO(linux-portal-clipboard-restore): persistent clipboard authorization
+  // is deferred with that shared-session slice because GNOME currently hangs
+  // when the standalone clipboard session calls SelectDevices with no devices.
   pub(crate) clipboard_session: Option<ClipboardSession>,
   pub(crate) input_session: Option<InputSession>,
   pub(crate) screencast_session: Option<ScreenCastSession>,
+  pub(crate) restore_tokens: Option<RestoreTokenStore>,
 }
 
 impl LinuxDriverSession {
@@ -50,7 +63,10 @@ impl Driver for LinuxDriver {
 
   fn open_local(&self) -> DriverResult<Self::Session> {
     Ok(LinuxDriverSession {
-      state: Arc::new(Mutex::new(LinuxDriverSessionState::default())),
+      state: Arc::new(Mutex::new(LinuxDriverSessionState {
+        restore_tokens: self.portal_state_root.clone().map(RestoreTokenStore::new),
+        ..Default::default()
+      })),
     })
   }
 }

--- a/crates/auv-driver-linux/src/input.rs
+++ b/crates/auv-driver-linux/src/input.rs
@@ -130,7 +130,8 @@ fn with_input_session<T>(
 ) -> DriverResult<T> {
   let mut state = state.lock().expect("linux driver session state poisoned");
   if state.input_session.is_none() {
-    state.input_session = Some(PortalInput::open()?);
+    let restore_tokens = state.restore_tokens.clone();
+    state.input_session = Some(PortalInput::open(restore_tokens.as_ref())?);
   }
   operation(state.input_session.as_mut().expect("input session was just initialized"))
 }

--- a/crates/auv-driver-linux/src/native.rs
+++ b/crates/auv-driver-linux/src/native.rs
@@ -38,8 +38,17 @@ pub mod portal {
   pub struct PortalInput;
 
   impl PortalInput {
-    pub fn open() -> DriverResult<InputSession> {
+    pub fn open(_restore_tokens: Option<&RestoreTokenStore>) -> DriverResult<InputSession> {
       Err(DriverError::unsupported("linux.portal.input"))
+    }
+  }
+
+  #[derive(Clone, Debug, Default)]
+  pub struct RestoreTokenStore;
+
+  impl RestoreTokenStore {
+    pub(crate) fn new(_root: std::path::PathBuf) -> Self {
+      Self
     }
   }
 
@@ -72,7 +81,7 @@ pub mod portal {
   pub struct ScreenCastSession;
 
   impl ScreenCastSession {
-    pub fn open_monitor() -> DriverResult<Self> {
+    pub fn open_monitor(_restore_tokens: Option<&RestoreTokenStore>) -> DriverResult<Self> {
       Err(DriverError::unsupported("linux.portal.screencast"))
     }
   }

--- a/crates/auv-driver-linux/src/native/portal/input.rs
+++ b/crates/auv-driver-linux/src/native/portal/input.rs
@@ -11,12 +11,17 @@ use zbus::zvariant::{OwnedObjectPath, OwnedValue, Value};
 use crate::capture::list_displays;
 use crate::error::{backend, invalid_input};
 
-use super::request::{close_session, create_remote_desktop_session, portal_proxy, session_connection, session_request};
+use super::persistence::{RestoreTokenKind, RestoreTokenStore};
+use super::request::{
+  close_session, create_remote_desktop_session, interface_version, portal_proxy, restore_token, session_connection, session_request,
+};
 use super::{ScreenCastStream, decode_streams, select_monitor_sources};
 
 const REMOTE_DESKTOP_INTERFACE: &str = "org.freedesktop.portal.RemoteDesktop";
 const DEVICE_KEYBOARD: u32 = 1;
 const DEVICE_POINTER: u32 = 2;
+const PERSIST_UNTIL_REVOKED: u32 = 2;
+const PERSISTENCE_INTERFACE_VERSION: u32 = 2;
 const STATE_RELEASED: u32 = 0;
 const STATE_PRESSED: u32 = 1;
 const BUTTON_LEFT: i32 = 0x110;
@@ -26,8 +31,8 @@ const BUTTON_MIDDLE: i32 = 0x112;
 pub struct PortalInput;
 
 impl PortalInput {
-  pub fn open() -> DriverResult<InputSession> {
-    InputSession::open()
+  pub fn open(restore_tokens: Option<&RestoreTokenStore>) -> DriverResult<InputSession> {
+    InputSession::open(restore_tokens)
   }
 }
 
@@ -52,30 +57,52 @@ impl std::fmt::Debug for InputSession {
 }
 
 impl InputSession {
-  fn open() -> DriverResult<Self> {
+  fn open(restore_tokens: Option<&RestoreTokenStore>) -> DriverResult<Self> {
     let connection = session_connection()?;
     let session_handle = create_remote_desktop_session(&connection)?;
-    let mut options = HashMap::new();
-    options.insert("types", Value::from(DEVICE_KEYBOARD | DEVICE_POINTER));
-    session_request(&connection, REMOTE_DESKTOP_INTERFACE, "SelectDevices", &session_handle, options)?;
-    select_monitor_sources(&connection, &session_handle)?;
-    let results = start_remote_desktop(&connection, &session_handle)?;
-    let streams = decode_streams(&results)?;
-    if streams.is_empty() {
-      return Err(backend("remote desktop portal started without screencast streams"));
+    let result = (|| {
+      let persistent =
+        restore_tokens.is_some() && interface_version(&connection, REMOTE_DESKTOP_INTERFACE)? >= PERSISTENCE_INTERFACE_VERSION;
+      let results = if let Some(restore_tokens) = restore_tokens.filter(|_| persistent) {
+        restore_tokens.rotate(RestoreTokenKind::RemoteDesktopInput, |current| {
+          select_input_devices(&connection, &session_handle, current, true)?;
+          select_monitor_sources(&connection, &session_handle)?;
+          let results = start_remote_desktop(&connection, &session_handle)?;
+          let replacement = restore_token(&results, REMOTE_DESKTOP_INTERFACE)?;
+          Ok((results, replacement))
+        })?
+      } else {
+        select_input_devices(&connection, &session_handle, None, false)?;
+        select_monitor_sources(&connection, &session_handle)?;
+        start_remote_desktop(&connection, &session_handle)?
+      };
+      let streams = decode_streams(&results)?;
+      if streams.is_empty() {
+        return Err(backend("remote desktop portal started without screencast streams"));
+      }
+      let devices = results.get("devices").and_then(|value| u32::try_from(value).ok()).unwrap_or(0);
+      if devices & DEVICE_KEYBOARD == 0 && devices & DEVICE_POINTER == 0 {
+        return Err(backend("remote desktop portal started without keyboard or pointer access"));
+      }
+      let output_mappings = remote_desktop_output_mappings(&streams).unwrap_or_default();
+      Ok((devices, streams, output_mappings))
+    })();
+    match result {
+      Ok((devices, streams, output_mappings)) => Ok(Self {
+        connection,
+        session_handle,
+        devices,
+        streams,
+        output_mappings,
+      }),
+      Err(error) => {
+        let close_result = close_session(&connection, &session_handle);
+        match close_result {
+          Ok(()) => Err(error),
+          Err(close_error) => Err(backend(format!("{error}; also failed to close remote desktop portal session: {close_error}"))),
+        }
+      }
     }
-    let devices = results.get("devices").and_then(|value| u32::try_from(value).ok()).unwrap_or(0);
-    if devices & DEVICE_KEYBOARD == 0 && devices & DEVICE_POINTER == 0 {
-      return Err(backend("remote desktop portal started without keyboard or pointer access"));
-    }
-    let output_mappings = remote_desktop_output_mappings(&streams).unwrap_or_default();
-    Ok(Self {
-      connection,
-      session_handle,
-      devices,
-      streams,
-      output_mappings,
-    })
   }
 
   pub fn key_press(&mut self, keysym: i32) -> DriverResult<()> {
@@ -219,6 +246,24 @@ impl InputSession {
       .find(|mapping| rect_contains_point(mapping.logical_rect, point))
       .map(|mapping| mapping.to_motion_target(point))
   }
+}
+
+fn select_input_devices(
+  connection: &Connection,
+  session_handle: &OwnedObjectPath,
+  restore: Option<&str>,
+  persistent: bool,
+) -> DriverResult<()> {
+  let mut options = HashMap::new();
+  options.insert("types", Value::from(DEVICE_KEYBOARD | DEVICE_POINTER));
+  if persistent {
+    options.insert("persist_mode", Value::from(PERSIST_UNTIL_REVOKED));
+    if let Some(restore) = restore {
+      options.insert("restore_token", Value::from(restore));
+    }
+  }
+  session_request(connection, REMOTE_DESKTOP_INTERFACE, "SelectDevices", session_handle, options)?;
+  Ok(())
 }
 
 impl Drop for InputSession {

--- a/crates/auv-driver-linux/src/native/portal/mod.rs
+++ b/crates/auv-driver-linux/src/native/portal/mod.rs
@@ -1,8 +1,10 @@
 mod clipboard;
 mod input;
+mod persistence;
 mod request;
 mod screencast;
 
 pub use clipboard::{ClipboardSession, PortalClipboard};
 pub use input::{InputSession, PortalInput};
-pub use screencast::{ScreenCastFrame, ScreenCastSession, ScreenCastStream, capture_window_frame, decode_streams, select_monitor_sources};
+pub(crate) use persistence::RestoreTokenStore;
+pub use screencast::{ScreenCastFrame, ScreenCastSession, ScreenCastStream, decode_streams, select_monitor_sources};

--- a/crates/auv-driver-linux/src/native/portal/persistence.rs
+++ b/crates/auv-driver-linux/src/native/portal/persistence.rs
@@ -1,0 +1,197 @@
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use auv_driver_common::error::DriverResult;
+use fs2::FileExt;
+
+use crate::error::backend;
+
+static TEMPORARY_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum RestoreTokenKind {
+  ScreenCast,
+  RemoteDesktopInput,
+}
+
+impl RestoreTokenKind {
+  fn file_name(self) -> &'static str {
+    match self {
+      Self::ScreenCast => "screencast-token",
+      Self::RemoteDesktopInput => "remote-desktop-input-token",
+    }
+  }
+}
+
+/// Serializes one portal restore-token use and publishes the replacement token
+/// atomically. Portal tokens are single-use, so the lock intentionally spans
+/// the restore request and the durable rotation.
+#[derive(Clone, Debug)]
+pub(crate) struct RestoreTokenStore {
+  root: PathBuf,
+}
+
+impl RestoreTokenStore {
+  pub(crate) fn new(root: PathBuf) -> Self {
+    Self { root }
+  }
+
+  pub(super) fn rotate<T>(
+    &self,
+    kind: RestoreTokenKind,
+    operation: impl FnOnce(Option<&str>) -> DriverResult<(T, Option<String>)>,
+  ) -> DriverResult<T> {
+    create_private_directory(&self.root)?;
+    let lock_path = self.root.join(format!("{}.lock", kind.file_name()));
+    let lock = OpenOptions::new()
+      .create(true)
+      .truncate(false)
+      .read(true)
+      .write(true)
+      .open(&lock_path)
+      .map_err(|error| backend(format!("failed to open portal restore-token lock {}: {error}", lock_path.display())))?;
+    set_private_file(&lock_path)?;
+    lock.lock_exclusive().map_err(|error| backend(format!("failed to lock portal restore-token store {}: {error}", lock_path.display())))?;
+
+    let token_path = self.root.join(kind.file_name());
+    let current = read_token(&token_path)?;
+    let result = operation(current.as_deref());
+    let result = match result {
+      Ok((value, replacement)) => {
+        replace_token(&token_path, replacement.as_deref())?;
+        Ok(value)
+      }
+      Err(error) => Err(error),
+    };
+    let unlock = FileExt::unlock(&lock)
+      .map_err(|error| backend(format!("failed to unlock portal restore-token store {}: {error}", lock_path.display())));
+    match (result, unlock) {
+      (Ok(value), Ok(())) => Ok(value),
+      (Err(error), Ok(())) => Err(error),
+      (Ok(_), Err(error)) => Err(error),
+      (Err(error), Err(unlock_error)) => Err(backend(format!("{error}; additionally {unlock_error}"))),
+    }
+  }
+}
+
+fn read_token(path: &Path) -> DriverResult<Option<String>> {
+  match fs::read_to_string(path) {
+    Ok(token) if token.is_empty() => Err(backend(format!("portal restore-token file {} is empty", path.display()))),
+    Ok(token) => Ok(Some(token)),
+    Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+    Err(error) => Err(backend(format!("failed to read portal restore token {}: {error}", path.display()))),
+  }
+}
+
+fn replace_token(path: &Path, replacement: Option<&str>) -> DriverResult<()> {
+  let Some(replacement) = replacement else {
+    return match fs::remove_file(path) {
+      Ok(()) => Ok(()),
+      Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+      Err(error) => Err(backend(format!("failed to remove consumed portal restore token {}: {error}", path.display()))),
+    };
+  };
+  if replacement.is_empty() {
+    return Err(backend("portal returned an empty restore token"));
+  }
+  let sequence = TEMPORARY_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+  let temporary = path.with_extension(format!("tmp-{}-{sequence}", std::process::id()));
+  let write_result = (|| {
+    let mut file = OpenOptions::new()
+      .write(true)
+      .create_new(true)
+      .open(&temporary)
+      .map_err(|error| backend(format!("failed to create portal restore-token temporary file {}: {error}", temporary.display())))?;
+    set_private_file(&temporary)?;
+    file
+      .write_all(replacement.as_bytes())
+      .map_err(|error| backend(format!("failed to write portal restore-token temporary file {}: {error}", temporary.display())))?;
+    file
+      .sync_all()
+      .map_err(|error| backend(format!("failed to sync portal restore-token temporary file {}: {error}", temporary.display())))?;
+    fs::rename(&temporary, path).map_err(|error| backend(format!("failed to publish portal restore token {}: {error}", path.display())))?;
+    Ok(())
+  })();
+  if write_result.is_err() {
+    let _ = fs::remove_file(&temporary);
+  }
+  write_result
+}
+
+#[cfg(unix)]
+fn create_private_directory(path: &Path) -> DriverResult<()> {
+  use std::os::unix::fs::PermissionsExt;
+
+  fs::create_dir_all(path).map_err(|error| backend(format!("failed to create portal state directory {}: {error}", path.display())))?;
+  fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+    .map_err(|error| backend(format!("failed to protect portal state directory {}: {error}", path.display())))
+}
+
+#[cfg(unix)]
+fn set_private_file(path: &Path) -> DriverResult<()> {
+  use std::os::unix::fs::PermissionsExt;
+
+  fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+    .map_err(|error| backend(format!("failed to protect portal state file {}: {error}", path.display())))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn successful_restore_rotates_the_single_use_token_without_a_version_wrapper() {
+    let temporary = tempfile::tempdir().expect("temporary directory");
+    let store = RestoreTokenStore::new(temporary.path().to_path_buf());
+
+    store
+      .rotate(RestoreTokenKind::ScreenCast, |current| {
+        assert_eq!(current, None);
+        Ok(((), Some("first-opaque-token".to_string())))
+      })
+      .expect("first authorization token");
+    store
+      .rotate(RestoreTokenKind::ScreenCast, |current| {
+        assert_eq!(current, Some("first-opaque-token"));
+        Ok(((), Some("replacement-opaque-token".to_string())))
+      })
+      .expect("restored authorization token");
+
+    assert_eq!(fs::read_to_string(temporary.path().join("screencast-token")).unwrap(), "replacement-opaque-token");
+  }
+
+  #[test]
+  fn failed_restore_keeps_the_previous_token_for_a_later_retry() {
+    let temporary = tempfile::tempdir().expect("temporary directory");
+    let store = RestoreTokenStore::new(temporary.path().to_path_buf());
+    store.rotate(RestoreTokenKind::RemoteDesktopInput, |_| Ok(((), Some("input-token".to_string())))).expect("initial token");
+
+    let error = store
+      .rotate::<()>(RestoreTokenKind::RemoteDesktopInput, |current| {
+        assert_eq!(current, Some("input-token"));
+        Err(backend("portal request failed"))
+      })
+      .expect_err("failed portal request");
+
+    assert!(error.to_string().contains("portal request failed"));
+    assert_eq!(fs::read_to_string(temporary.path().join("remote-desktop-input-token")).unwrap(), "input-token");
+  }
+
+  #[test]
+  fn successful_start_without_a_replacement_removes_a_consumed_token() {
+    let temporary = tempfile::tempdir().expect("temporary directory");
+    let store = RestoreTokenStore::new(temporary.path().to_path_buf());
+    store.rotate(RestoreTokenKind::ScreenCast, |_| Ok(((), Some("old-token".to_string())))).unwrap();
+
+    store
+      .rotate(RestoreTokenKind::ScreenCast, |current| {
+        assert_eq!(current, Some("old-token"));
+        Ok(((), None))
+      })
+      .expect("successful non-persistent start");
+
+    assert!(!temporary.path().join("screencast-token").exists());
+  }
+}

--- a/crates/auv-driver-linux/src/native/portal/request.rs
+++ b/crates/auv-driver-linux/src/native/portal/request.rs
@@ -19,6 +19,21 @@ pub(super) fn portal_proxy<'a>(connection: &'a Connection, interface: &'static s
     .map_err(|error| backend(format!("failed to create {interface} proxy: {error}")))
 }
 
+pub(super) fn interface_version(connection: &Connection, interface: &'static str) -> DriverResult<u32> {
+  portal_proxy(connection, interface)?
+    .get_property("version")
+    .map_err(|error| backend(format!("failed to read {interface}.version: {error}")))
+}
+
+pub(super) fn restore_token(results: &HashMap<String, OwnedValue>, interface: &'static str) -> DriverResult<Option<String>> {
+  let Some(value) = results.get("restore_token") else {
+    return Ok(None);
+  };
+  <&str>::try_from(value)
+    .map(|value| Some(value.to_string()))
+    .map_err(|error| backend(format!("failed to decode {interface} restore token: {error}")))
+}
+
 pub(super) fn call_request(
   connection: &Connection,
   interface: &'static str,

--- a/crates/auv-driver-linux/src/native/portal/screencast.rs
+++ b/crates/auv-driver-linux/src/native/portal/screencast.rs
@@ -15,12 +15,17 @@ use zbus::zvariant::{DeserializeDict, OwnedFd as ZbusOwnedFd, OwnedObjectPath, O
 
 use crate::error::{backend, invalid_input};
 
-use super::request::{close_session, create_session, portal_proxy, response_signal, session_connection, session_request, wait_response};
+use super::persistence::{RestoreTokenKind, RestoreTokenStore};
+use super::request::{
+  close_session, create_session, interface_version, portal_proxy, response_signal, restore_token, session_connection, session_request,
+  wait_response,
+};
 
 const SCREENCAST_INTERFACE: &str = "org.freedesktop.portal.ScreenCast";
 const SOURCE_MONITOR: u32 = 1;
-const SOURCE_WINDOW: u32 = 2;
 const CURSOR_HIDDEN: u32 = 1;
+const PERSIST_UNTIL_REVOKED: u32 = 2;
+const PERSISTENCE_INTERFACE_VERSION: u32 = 4;
 const PIPEWIRE_FRAME_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Debug)]
@@ -80,20 +85,28 @@ struct StartStreamProperties {
 }
 
 pub fn select_monitor_sources(connection: &Connection, session_handle: &OwnedObjectPath) -> DriverResult<()> {
-  select_sources(connection, session_handle, SOURCE_MONITOR, true)?;
+  select_sources(connection, session_handle, SOURCE_MONITOR, true, None, false)?;
   Ok(())
 }
 
-pub fn select_window_sources(connection: &Connection, session_handle: &OwnedObjectPath) -> DriverResult<()> {
-  select_sources(connection, session_handle, SOURCE_WINDOW, false)?;
-  Ok(())
-}
-
-fn select_sources(connection: &Connection, session_handle: &OwnedObjectPath, source_type: u32, multiple: bool) -> DriverResult<()> {
+fn select_sources(
+  connection: &Connection,
+  session_handle: &OwnedObjectPath,
+  source_type: u32,
+  multiple: bool,
+  restore: Option<&str>,
+  persistent: bool,
+) -> DriverResult<()> {
   let mut options = HashMap::new();
   options.insert("types", Value::from(source_type));
   options.insert("multiple", Value::from(multiple));
   options.insert("cursor_mode", Value::from(CURSOR_HIDDEN));
+  if persistent {
+    options.insert("persist_mode", Value::from(PERSIST_UNTIL_REVOKED));
+    if let Some(restore) = restore {
+      options.insert("restore_token", Value::from(restore));
+    }
+  }
   session_request(connection, SCREENCAST_INTERFACE, "SelectSources", session_handle, options)?;
   Ok(())
 }
@@ -129,33 +142,14 @@ pub struct ScreenCastSession {
 }
 
 impl ScreenCastSession {
-  pub fn open_monitor() -> DriverResult<Self> {
+  pub fn open_monitor(restore_tokens: Option<&RestoreTokenStore>) -> DriverResult<Self> {
     let connection = session_connection()?;
     let session_handle = create_session(&connection, SCREENCAST_INTERFACE)?;
-    match start_session(connection, session_handle, select_monitor_sources) {
-      Ok(session) => Ok(session),
-      Err(error) => Err(error),
-    }
-  }
-
-  pub fn open_window() -> DriverResult<Self> {
-    let connection = session_connection()?;
-    let session_handle = create_session(&connection, SCREENCAST_INTERFACE)?;
-    match start_session(connection, session_handle, select_window_sources) {
-      Ok(session) => Ok(session),
-      Err(error) => Err(error),
-    }
+    start_session(connection, session_handle, restore_tokens)
   }
 
   pub fn capture_monitor_frame(&mut self, target_bounds: Option<Rect>) -> DriverResult<ScreenCastFrame> {
     let stream = select_stream(&self.streams, target_bounds)?.clone();
-    let fd = open_pipewire_remote(&self.connection, &self.session_handle)?;
-    let image = read_pipewire_frame(fd.into(), stream.id)?;
-    Ok(ScreenCastFrame { stream, image })
-  }
-
-  pub fn capture_window_frame(&mut self) -> DriverResult<ScreenCastFrame> {
-    let stream = select_window_stream(&self.streams)?.clone();
     let fd = open_pipewire_remote(&self.connection, &self.session_handle)?;
     let image = read_pipewire_frame(fd.into(), stream.id)?;
     Ok(ScreenCastFrame { stream, image })
@@ -171,11 +165,23 @@ impl Drop for ScreenCastSession {
 fn start_session(
   connection: Connection,
   session_handle: OwnedObjectPath,
-  select_sources: fn(&Connection, &OwnedObjectPath) -> DriverResult<()>,
+  restore_tokens: Option<&RestoreTokenStore>,
 ) -> DriverResult<ScreenCastSession> {
-  let result = select_sources(&connection, &session_handle)
-    .and_then(|()| start_screencast(&connection, &session_handle))
-    .and_then(|results| decode_streams(&results));
+  let result = (|| {
+    let persistent = restore_tokens.is_some() && interface_version(&connection, SCREENCAST_INTERFACE)? >= PERSISTENCE_INTERFACE_VERSION;
+    let results = if let Some(restore_tokens) = restore_tokens.filter(|_| persistent) {
+      restore_tokens.rotate(RestoreTokenKind::ScreenCast, |current| {
+        select_sources(&connection, &session_handle, SOURCE_MONITOR, true, current, true)?;
+        let results = start_screencast(&connection, &session_handle)?;
+        let replacement = restore_token(&results, SCREENCAST_INTERFACE)?;
+        Ok((results, replacement))
+      })?
+    } else {
+      select_monitor_sources(&connection, &session_handle)?;
+      start_screencast(&connection, &session_handle)?
+    };
+    decode_streams(&results)
+  })();
   let streams = match result {
     Ok(streams) => streams,
     Err(error) => {
@@ -195,11 +201,6 @@ fn start_session(
     session_handle,
     streams,
   })
-}
-
-pub fn capture_window_frame() -> DriverResult<ScreenCastFrame> {
-  let mut session = ScreenCastSession::open_window()?;
-  session.capture_window_frame()
 }
 
 fn start_screencast(connection: &Connection, session_handle: &OwnedObjectPath) -> DriverResult<HashMap<String, OwnedValue>> {
@@ -231,14 +232,6 @@ fn select_stream<'a>(streams: &'a [ScreenCastStream], target_bounds: Option<Rect
       .ok_or_else(|| backend(format!("no screencast stream contains target bounds {:?}; streams={streams:?}", target_bounds)));
   }
   streams.first().ok_or_else(|| backend("screencast start response contained no streams"))
-}
-
-fn select_window_stream(streams: &[ScreenCastStream]) -> DriverResult<&ScreenCastStream> {
-  streams
-    .iter()
-    .find(|stream| stream.source_type == Some(SOURCE_WINDOW))
-    .or_else(|| streams.first())
-    .ok_or_else(|| backend("screencast window source response contained no streams"))
 }
 
 fn rect_contains_rect(container: Rect, candidate: Rect) -> bool {

--- a/crates/auv-driver-linux/src/native/portal/screencast_test.rs
+++ b/crates/auv-driver-linux/src/native/portal/screencast_test.rs
@@ -47,28 +47,3 @@ fn xrgb_pixel_converts_to_rgba() {
 
   assert_eq!(dest, [1, 2, 3, 255]);
 }
-
-#[test]
-fn window_stream_prefers_window_source_type() {
-  let monitor = ScreenCastStream {
-    id: 1,
-    position: None,
-    size: None,
-    source_type: Some(SOURCE_MONITOR),
-    mapping_id: None,
-    pipewire_serial: None,
-  };
-  let window = ScreenCastStream {
-    id: 2,
-    position: None,
-    size: None,
-    source_type: Some(SOURCE_WINDOW),
-    mapping_id: None,
-    pipewire_serial: None,
-  };
-
-  let streams = [monitor, window];
-  let selected = select_window_stream(&streams).expect("stream selected");
-
-  assert_eq!(selected.id, 2);
-}

--- a/crates/auv-driver-linux/src/ocr.rs
+++ b/crates/auv-driver-linux/src/ocr.rs
@@ -8,7 +8,7 @@
 use std::fmt;
 
 use auv_driver_common::geometry::Rect;
-use auv_driver_common::vision::{RecognizedText, TextRecognition, TextRecognitionOptions};
+use auv_driver_common::vision::{OcrMatch, OcrMatches, RecognizedText, TextRecognition, TextRecognitionOptions};
 #[cfg(target_os = "linux")]
 use image::ImageEncoder;
 
@@ -35,8 +35,9 @@ impl fmt::Display for OcrError {
 
 impl std::error::Error for OcrError {}
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 struct Word {
+  text: String,
   left: f64,
   top: f64,
   width: f64,
@@ -57,6 +58,24 @@ struct Line {
 /// to Tesseract language ids and joined with `+`; the default is `eng`.
 #[cfg(target_os = "linux")]
 pub fn recognize_text_in_rgba(rgba: &[u8], width: u32, height: u32, options: &TextRecognitionOptions) -> Result<TextRecognition, OcrError> {
+  let tsv = tesseract_tsv_from_rgba(rgba, width, height, options)?;
+  Ok(text_recognition_from_tsv(&tsv))
+}
+
+#[cfg(target_os = "linux")]
+pub(crate) fn find_text_in_rgba(
+  rgba: &[u8],
+  width: u32,
+  height: u32,
+  query: &str,
+  options: &TextRecognitionOptions,
+) -> Result<OcrMatches, OcrError> {
+  let tsv = tesseract_tsv_from_rgba(rgba, width, height, options)?;
+  Ok(text_matches_from_tsv(&tsv, query))
+}
+
+#[cfg(target_os = "linux")]
+fn tesseract_tsv_from_rgba(rgba: &[u8], width: u32, height: u32, options: &TextRecognitionOptions) -> Result<String, OcrError> {
   let expected = (width as usize) * (height as usize) * 4;
   if rgba.len() != expected {
     return Err(OcrError::InvalidImage {
@@ -82,9 +101,7 @@ pub fn recognize_text_in_rgba(rgba: &[u8], width: u32, height: u32, options: &Te
   // weighting is deferred until an owner-approved OCR-quality slice needs it.
   tess.set_image_from_mem(&png).map_err(|error| OcrError::Runtime(format!("failed to load image into Tesseract: {error}")))?;
   tess.set_source_resolution(144);
-  let tsv = tess.get_tsv_text(0).map_err(|error| OcrError::Runtime(format!("failed to read Tesseract TSV: {error}")))?;
-
-  Ok(text_recognition_from_tsv(&tsv))
+  tess.get_tsv_text(0).map_err(|error| OcrError::Runtime(format!("failed to read Tesseract TSV: {error}")))
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -94,6 +111,17 @@ pub fn recognize_text_in_rgba(
   _height: u32,
   _options: &TextRecognitionOptions,
 ) -> Result<TextRecognition, OcrError> {
+  Err(OcrError::Unsupported)
+}
+
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn find_text_in_rgba(
+  _rgba: &[u8],
+  _width: u32,
+  _height: u32,
+  _query: &str,
+  _options: &TextRecognitionOptions,
+) -> Result<OcrMatches, OcrError> {
   Err(OcrError::Unsupported)
 }
 
@@ -136,6 +164,54 @@ fn text_recognition_from_tsv(tsv: &str) -> TextRecognition {
   }
 }
 
+fn text_matches_from_tsv(tsv: &str, query: &str) -> OcrMatches {
+  let normalized_query = normalize_match_text(query);
+  if normalized_query.is_empty() {
+    return OcrMatches::default();
+  }
+
+  let mut matches = Vec::new();
+  for line in parse_tsv_lines(tsv) {
+    for start in 0..line.words.len() {
+      let mut candidate = String::new();
+      for end in start..line.words.len() {
+        if !candidate.is_empty() {
+          candidate.push(' ');
+        }
+        candidate.push_str(&line.words[end].text);
+        if !normalize_match_text(&candidate).contains(&normalized_query) {
+          continue;
+        }
+        let words = &line.words[start..=end];
+        let Some(bounds) = union_words(words) else {
+          break;
+        };
+        matches.push(OcrMatch {
+          text: candidate,
+          confidence: mean_confidence(words).unwrap_or_default() as f64,
+          bounds,
+        });
+        break;
+      }
+    }
+  }
+  let candidates = matches.clone();
+  matches.retain(|candidate| !candidates.iter().any(|other| candidate != other && rect_strictly_contains(candidate.bounds, other.bounds)));
+  OcrMatches { matches }
+}
+
+fn rect_strictly_contains(container: Rect, candidate: Rect) -> bool {
+  let contains = candidate.origin.x >= container.origin.x
+    && candidate.origin.y >= container.origin.y
+    && candidate.origin.x + candidate.size.width <= container.origin.x + container.size.width
+    && candidate.origin.y + candidate.size.height <= container.origin.y + container.size.height;
+  contains && candidate.size.width * candidate.size.height < container.size.width * container.size.height
+}
+
+fn normalize_match_text(text: &str) -> String {
+  text.split_whitespace().collect::<Vec<_>>().join(" ").to_lowercase()
+}
+
 fn parse_tsv_lines(tsv: &str) -> Vec<Line> {
   let mut lines = Vec::<((String, String, String), Line)>::new();
   for row in tsv.lines().skip(1) {
@@ -147,7 +223,7 @@ fn parse_tsv_lines(tsv: &str) -> Vec<Line> {
     if text.is_empty() {
       continue;
     }
-    let Some(word) = parse_word(&columns) else {
+    let Some(word) = parse_word(&columns, text.clone()) else {
       continue;
     };
     let key = (columns[2].to_string(), columns[3].to_string(), columns[4].to_string());
@@ -170,8 +246,9 @@ fn parse_tsv_lines(tsv: &str) -> Vec<Line> {
   lines.into_iter().map(|(_, line)| line).collect()
 }
 
-fn parse_word(columns: &[&str]) -> Option<Word> {
+fn parse_word(columns: &[&str], text: String) -> Option<Word> {
   Some(Word {
+    text,
     left: columns.get(6)?.parse().ok()?,
     top: columns.get(7)?.parse().ok()?,
     width: columns.get(8)?.parse().ok()?,

--- a/crates/auv-driver-linux/src/ocr_test.rs
+++ b/crates/auv-driver-linux/src/ocr_test.rs
@@ -3,6 +3,7 @@ use auv_driver_common::geometry::Rect;
 use super::*;
 
 #[test]
+#[cfg(target_os = "linux")]
 fn rejects_buffer_with_mismatched_length() {
   let result = recognize_text_in_rgba(&[0u8; 7], 2, 2, &TextRecognitionOptions::default());
 
@@ -32,6 +33,31 @@ level\tpage_num\tblock_num\tpar_num\tline_num\tword_num\tleft\ttop\twidth\theigh
   assert_eq!(recognition.regions[0].bounds, Rect::new(10.0, 18.0, 60.0, 14.0));
   assert_eq!(recognition.regions[0].confidence, Some(0.88));
   assert_eq!(recognition.regions[1].confidence, None);
+}
+
+#[test]
+fn query_match_uses_word_span_instead_of_entire_tesseract_line() {
+  // ROOT CAUSE:
+  //
+  // If Tesseract placed sidebar text and editor text on one TSV line, AUV
+  // merged every word into one region and clicked the center of that entire
+  // line instead of the queried word.
+  //
+  // Before the fix, `AGENTS.md` inherited a 2486-pixel-wide line bound. The fix
+  // retains the minimal contiguous word span that contains the query.
+  let tsv = "\
+level\tpage_num\tblock_num\tpar_num\tline_num\tword_num\tleft\ttop\twidth\theight\tconf\ttext
+5\t1\t1\t1\t1\t1\t74\t705\t20\t33\t20.0\t(@
+5\t1\t1\t1\t1\t2\t101\t705\t70\t33\t94.0\tAGENTS.md
+5\t1\t1\t1\t1\t3\t400\t705\t2160\t33\t80.0\tREADME-content
+";
+
+  let matches = text_matches_from_tsv(tsv, "AGENTS.md");
+
+  assert_eq!(matches.matches.len(), 1);
+  assert_eq!(matches.matches[0].text, "AGENTS.md");
+  assert_eq!(matches.matches[0].bounds, Rect::new(101.0, 705.0, 70.0, 33.0));
+  assert!((matches.matches[0].confidence - 0.94).abs() < 0.000_001);
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/auv-driver-linux/src/vision.rs
+++ b/crates/auv-driver-linux/src/vision.rs
@@ -11,7 +11,7 @@ pub use auv_driver_common::vision::{OcrMatch, OcrMatches};
 use auv_driver_common::vision::{RecognizedText, TextRecognition, TextRecognitionOptions};
 
 use crate::error::backend;
-use crate::ocr::recognize_text_in_rgba;
+use crate::ocr::{find_text_in_rgba, recognize_text_in_rgba};
 
 pub fn recognize_text_in_capture(capture: &Capture, region: RatioRect, options: &TextRecognitionOptions) -> DriverResult<TextRecognition> {
   let crop = crop_pixels(capture, region);
@@ -30,8 +30,13 @@ pub fn find_text_in_capture(
   region: RatioRect,
   options: &TextRecognitionOptions,
 ) -> DriverResult<OcrMatches> {
-  let recognition = recognize_text_in_capture(capture, region, options)?;
-  Ok(ocr_matches_from_recognition(&recognition, query))
+  let crop = crop_pixels(capture, region);
+  if crop.width == 0 || crop.height == 0 {
+    return Ok(OcrMatches::default());
+  }
+  let cropped = image::imageops::crop_imm(&capture.image, crop.x, crop.y, crop.width, crop.height).to_image();
+  let matches = find_text_in_rgba(cropped.as_raw(), crop.width, crop.height, query, options).map_err(|error| backend(error.to_string()))?;
+  Ok(map_matches_to_capture(&matches, capture, crop))
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -65,6 +70,36 @@ fn ratio_to_pixel(ratio: f64, extent: u32) -> u32 {
 }
 
 fn map_recognition_to_capture(recognition: &TextRecognition, capture: &Capture, crop: CropPixels) -> TextRecognition {
+  let regions = recognition
+    .regions
+    .iter()
+    .map(|region| RecognizedText {
+      text: region.text.clone(),
+      confidence: region.confidence,
+      bounds: map_rect_to_capture(region.bounds, capture, crop),
+    })
+    .collect::<Vec<_>>();
+  TextRecognition {
+    text: regions.iter().map(|region| region.text.as_str()).collect::<Vec<_>>().join("\n"),
+    regions,
+  }
+}
+
+fn map_matches_to_capture(matches: &OcrMatches, capture: &Capture, crop: CropPixels) -> OcrMatches {
+  OcrMatches {
+    matches: matches
+      .matches
+      .iter()
+      .map(|matched| OcrMatch {
+        text: matched.text.clone(),
+        confidence: matched.confidence,
+        bounds: map_rect_to_capture(matched.bounds, capture, crop),
+      })
+      .collect(),
+  }
+}
+
+fn map_rect_to_capture(bounds: Rect, capture: &Capture, crop: CropPixels) -> Rect {
   let x_scale = if capture.bounds.size.width > 0.0 {
     f64::from(capture.image.width()) / capture.bounds.size.width
   } else {
@@ -75,30 +110,17 @@ fn map_recognition_to_capture(recognition: &TextRecognition, capture: &Capture, 
   } else {
     1.0
   };
-  let regions = recognition
-    .regions
-    .iter()
-    .map(|region| {
-      let full_x = region.bounds.origin.x + f64::from(crop.x);
-      let full_y = region.bounds.origin.y + f64::from(crop.y);
-      RecognizedText {
-        text: region.text.clone(),
-        confidence: region.confidence,
-        bounds: Rect::new(
-          capture.bounds.origin.x + full_x / x_scale,
-          capture.bounds.origin.y + full_y / y_scale,
-          region.bounds.size.width / x_scale,
-          region.bounds.size.height / y_scale,
-        ),
-      }
-    })
-    .collect::<Vec<_>>();
-  TextRecognition {
-    text: regions.iter().map(|region| region.text.as_str()).collect::<Vec<_>>().join("\n"),
-    regions,
-  }
+  let full_x = bounds.origin.x + f64::from(crop.x);
+  let full_y = bounds.origin.y + f64::from(crop.y);
+  Rect::new(
+    capture.bounds.origin.x + full_x / x_scale,
+    capture.bounds.origin.y + full_y / y_scale,
+    bounds.size.width / x_scale,
+    bounds.size.height / y_scale,
+  )
 }
 
+#[cfg(test)]
 fn ocr_matches_from_recognition(recognition: &TextRecognition, query: &str) -> OcrMatches {
   let matches = recognition
     .find_contains(query)

--- a/crates/auv-driver-linux/src/window.rs
+++ b/crates/auv-driver-linux/src/window.rs
@@ -8,8 +8,6 @@ use crate::capture::capture_display;
 #[cfg(target_os = "linux")]
 use crate::driver::LinuxDriverSessionState;
 use crate::error::{invalid_input, not_found};
-#[cfg(target_os = "linux")]
-use crate::native::portal::capture_window_frame;
 use auv_driver_common::capture::Capture;
 use auv_driver_common::error::DriverResult;
 #[cfg(any(target_os = "linux", test))]
@@ -35,21 +33,20 @@ pub fn resolve_window(selector: &WindowSelector) -> DriverResult<Window> {
 #[cfg(target_os = "linux")]
 pub fn capture_window(state: &Arc<Mutex<LinuxDriverSessionState>>, window: &Window) -> DriverResult<Capture> {
   atspi::ObjectRef::decode(&window.reference.id)?;
-  match capture_window_from_source(window) {
-    Ok(capture) => return Ok(capture),
-    Err(error) => {
-      validate_display_crop_fallback(window, &error.to_string())?;
-      let display = capture_display(state, None)?;
-      let crop = crop_capture_to_window(&display.capture, window.frame)?;
-      return Ok(Capture {
-        image: crop,
-        bounds: window.frame,
-        scale_factor: display.capture.scale_factor,
-        backend: format!("atspi.extents+{}.crop", display.capture.backend),
-        fallback_reason: Some(window_capture_fallback_reason(&error.to_string(), display.capture.fallback_reason)),
-      });
-    }
-  }
+  // TODO(linux-window-source-target-binding): XDG portal WINDOW capture is
+  // picker-driven and does not expose a stable mapping to an AT-SPI WindowRef.
+  // Re-enable it only when the selected portal source can be proven to identify
+  // this exact window; geometry similarity alone is insufficient for input.
+  validate_display_crop_fallback(window, "portal WINDOW source is not identity-bound to the requested AT-SPI WindowRef")?;
+  let display = capture_display(state, None)?;
+  let crop = crop_capture_to_window(&display.capture, window.frame)?;
+  Ok(Capture {
+    image: crop,
+    bounds: window.frame,
+    scale_factor: display.capture.scale_factor,
+    backend: format!("atspi.extents+{}.crop", display.capture.backend),
+    fallback_reason: Some(display_crop_reason(display.capture.fallback_reason)),
+  })
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -66,6 +63,7 @@ fn resolve_from_windows(windows: &[Window], selector: &WindowSelector) -> Driver
   if selector.main_visible {
     matches.sort_by_key(|window| {
       std::cmp::Reverse((
+        !is_desktop_shell_surface(window),
         window.is_main,
         window.title.as_ref().is_some_and(|title| !title.trim().is_empty()),
         (window.frame.size.width * window.frame.size.height).round() as i64,
@@ -101,7 +99,11 @@ fn matches_window_selector_except_main_visible(window: &Window, selector: &Windo
 
 fn matches_app_selector(window: &Window, selector: &AppSelector) -> bool {
   if selector.frontmost {
-    return window.is_main;
+    // GNOME Shell can expose its focused stage as the first/main AT-SPI
+    // surface even while a normal application window is foreground. Keep all
+    // applications eligible here and let main-visible ranking reject desktop
+    // shell surfaces before considering AT-SPI's main hint.
+    return true;
   }
   if let Some(pid) = selector.process_id
     && window.process_id != Some(pid)
@@ -127,6 +129,11 @@ fn matches_app_selector(window: &Window, selector: &AppSelector) -> bool {
   true
 }
 
+fn is_desktop_shell_surface(window: &Window) -> bool {
+  matches!(window.app_name.as_deref(), Some("gnome-shell" | "plasmashell"))
+    || matches!(window.app_bundle_id.as_deref(), Some("org.gnome.Shell" | "org.kde.plasmashell"))
+}
+
 fn matches_text(value: &str, matcher: &TextMatcher) -> bool {
   match matcher {
     TextMatcher::Exact(expected) => value == expected,
@@ -149,96 +156,10 @@ fn crop_capture_to_window(capture: &Capture, frame: Rect) -> DriverResult<image:
 }
 
 #[cfg(target_os = "linux")]
-fn capture_window_from_source(window: &Window) -> DriverResult<Capture> {
-  let frame = capture_window_frame()?;
-  let (image, scale_factor) = normalize_window_source_image(frame.image, window.frame)?;
-  Ok(Capture {
-    image,
-    bounds: window.frame,
-    scale_factor,
-    backend: "atspi.extents+xdg-desktop-portal.screencast.window.pipewire".to_string(),
-    fallback_reason: Some(
-      "portal window source is user-selected; Linux Wayland backend cannot yet verify it matches the AT-SPI window reference".to_string(),
-    ),
-  })
-}
-
-#[cfg(any(target_os = "linux", test))]
-fn normalize_window_source_image(image: image::RgbaImage, bounds: Rect) -> DriverResult<(image::RgbaImage, f64)> {
-  match window_source_scale_factor(&image, bounds) {
-    Ok(scale_factor) => Ok((image, scale_factor)),
-    Err(original_error) => {
-      let Some(trimmed) = trim_portal_window_padding(&image) else {
-        return Err(original_error);
-      };
-      match window_source_scale_factor(&trimmed, bounds) {
-        Ok(scale_factor) => Ok((trimmed, scale_factor)),
-        Err(_) => Err(original_error),
-      }
-    }
-  }
-}
-
-#[cfg(any(target_os = "linux", test))]
-fn window_source_scale_factor(image: &image::RgbaImage, bounds: Rect) -> DriverResult<f64> {
-  if bounds.size.width <= 0.0 || bounds.size.height <= 0.0 {
-    return Err(invalid_input("window bounds must be positive"));
-  }
-  let scale_x = f64::from(image.width()) / bounds.size.width;
-  let scale_y = f64::from(image.height()) / bounds.size.height;
-  let ratio = scale_x / scale_y;
-  if !(0.8..=1.25).contains(&ratio) {
-    return Err(invalid_input(format!(
-      "portal WINDOW stream size {}x{} is not consistent with AT-SPI window bounds {:?}",
-      image.width(),
-      image.height(),
-      bounds
-    )));
-  }
-  Ok(scale_x)
-}
-
-#[cfg(any(target_os = "linux", test))]
-fn trim_portal_window_padding(image: &image::RgbaImage) -> Option<image::RgbaImage> {
-  let mut min_x = image.width();
-  let mut min_y = image.height();
-  let mut max_x = 0;
-  let mut max_y = 0;
-  for (x, y, pixel) in image.enumerate_pixels() {
-    if is_window_source_content(*pixel) {
-      min_x = min_x.min(x);
-      min_y = min_y.min(y);
-      max_x = max_x.max(x);
-      max_y = max_y.max(y);
-    }
-  }
-  if min_x > max_x || min_y > max_y {
-    return None;
-  }
-  if min_x == 0 && min_y == 0 && max_x + 1 == image.width() && max_y + 1 == image.height() {
-    return None;
-  }
-  Some(image::imageops::crop_imm(image, min_x, min_y, max_x - min_x + 1, max_y - min_y + 1).to_image())
-}
-
-#[cfg(any(target_os = "linux", test))]
-fn is_window_source_content(pixel: image::Rgba<u8>) -> bool {
-  pixel[3] != 0 && (pixel[0] > 8 || pixel[1] > 8 || pixel[2] > 8)
-}
-
-#[cfg(target_os = "linux")]
-fn window_capture_fallback_reason(window_source_error: &str, display_fallback_reason: Option<String>) -> String {
-  // TODO(linux-window-source-target-binding): XDG portal WINDOW capture is
-  // picker-driven, and this slice does not have a compositor-independent way to
-  // bind the returned stream to the AT-SPI window ref. Revisit when a portal or
-  // compositor exposes stable window mapping metadata we can verify.
+fn display_crop_reason(display_fallback_reason: Option<String>) -> String {
   match display_fallback_reason {
-    Some(reason) => format!(
-      "xdg-desktop-portal.screencast WINDOW source failed ({window_source_error}); {reason}; window pixels were cropped from display capture using AT-SPI window extents"
-    ),
-    None => format!(
-      "xdg-desktop-portal.screencast WINDOW source failed ({window_source_error}); window pixels were cropped from display capture using AT-SPI window extents"
-    ),
+    Some(reason) => format!("{reason}; window pixels were cropped from display capture using AT-SPI screen extents"),
+    None => "window pixels were cropped from display capture using AT-SPI screen extents".to_string(),
   }
 }
 

--- a/crates/auv-driver-linux/src/window_test.rs
+++ b/crates/auv-driver-linux/src/window_test.rs
@@ -75,6 +75,57 @@ fn resolve_from_windows_matches_app_name_contains_case_insensitive() {
 }
 
 #[test]
+fn main_visible_prefers_application_window_over_desktop_shell_surface() {
+  // ROOT CAUSE:
+  //
+  // If AT-SPI enumerated GNOME Shell before the active application, the shell
+  // surface was marked main and won the default selector even though it was not
+  // the application window the user could operate.
+  //
+  // Before the fix, `window.findText` captured the shell surface and projected
+  // OCR coordinates through its unrelated bounds. The fix excludes desktop
+  // shell surfaces while normal application windows are available.
+  let shell = Window {
+    reference: WindowRef {
+      id: "shell".to_string(),
+    },
+    title: Some("Main stage".to_string()),
+    app_name: Some("gnome-shell".to_string()),
+    app_bundle_id: Some("org.gnome.Shell".to_string()),
+    process_id: None,
+    frame: Rect::new(0.0, 55.0, 100.0, 56.0),
+    coordinate_space: CoordinateSpace::Screen,
+    is_main: true,
+    is_visible: true,
+  };
+  let application = Window {
+    reference: WindowRef {
+      id: "code".to_string(),
+    },
+    title: Some("AGENTS.md - Visual Studio Code".to_string()),
+    app_name: Some("code".to_string()),
+    app_bundle_id: None,
+    process_id: None,
+    frame: Rect::new(0.0, 32.0, 2560.0, 1408.0),
+    coordinate_space: CoordinateSpace::Screen,
+    is_main: false,
+    is_visible: true,
+  };
+  let selector = WindowSelector {
+    app: Some(AppSelector {
+      frontmost: true,
+      ..AppSelector::default()
+    }),
+    main_visible: true,
+    ..WindowSelector::default()
+  };
+
+  let resolved = resolve_from_windows(&[shell, application.clone()], &selector).expect("application window resolves");
+
+  assert_eq!(resolved, application);
+}
+
+#[test]
 fn crop_capture_to_window_uses_window_extents_inside_display_capture() {
   let mut image = image::RgbaImage::new(10, 10);
   image.put_pixel(3, 4, image::Rgba([1, 2, 3, 4]));
@@ -91,30 +142,4 @@ fn crop_capture_to_window_uses_window_extents_inside_display_capture() {
   assert_eq!(cropped.width(), 2);
   assert_eq!(cropped.height(), 2);
   assert_eq!(*cropped.get_pixel(0, 0), image::Rgba([1, 2, 3, 4]));
-}
-
-#[test]
-fn window_source_scale_rejects_unmatched_stream_bounds() {
-  let image = image::RgbaImage::new(5504, 2304);
-
-  let error = window_source_scale_factor(&image, Rect::new(0.0, 0.0, 1505.0, 1077.0)).expect_err("non-uniform scale should be rejected");
-
-  assert!(error.to_string().contains("not consistent with AT-SPI window bounds"));
-}
-
-#[test]
-fn window_source_normalization_trims_black_portal_padding() {
-  let mut image = image::RgbaImage::new(11, 6);
-  for y in 1..4 {
-    for x in 1..5 {
-      image.put_pixel(x, y, image::Rgba([20, 20, 20, 255]));
-    }
-  }
-
-  let (normalized, scale) =
-    normalize_window_source_image(image, Rect::new(0.0, 0.0, 2.0, 1.5)).expect("black padding trims to target aspect");
-
-  assert_eq!(normalized.width(), 4);
-  assert_eq!(normalized.height(), 3);
-  assert_eq!(scale, 2.0);
 }

--- a/crates/auv-driver/src/lib.rs
+++ b/crates/auv-driver/src/lib.rs
@@ -29,6 +29,12 @@ impl LocalDriver {
       inner: auv_driver_windows::WindowsDriver::new(),
     }
   }
+
+  #[cfg(target_os = "linux")]
+  pub fn with_linux_portal_state_root(mut self, root: std::path::PathBuf) -> Self {
+    self.inner = self.inner.with_portal_state_root(root);
+    self
+  }
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
## Summary

- correct Linux Wayland window OCR bounds by matching word spans and mapping crop pixels through the capture coordinate space
- prefer normal application windows over GNOME/KDE shell surfaces when resolving a main visible window
- stop treating a user-selected portal window stream as proof that it matches an AT-SPI `WindowRef`; crop the verified display capture by AT-SPI extents instead
- add opt-in persistent ScreenCast and RemoteDesktop authorization to `auv-driver-linux`
- serialize single-use restore-token consumption and atomically publish replacement tokens

## Root cause

Linux OCR matching previously promoted an entire Tesseract line to one match and mixed cropped pixel coordinates with logical screen coordinates. That could produce bounds and click points far from the requested text. Window resolution could also select the GNOME Shell stage ahead of the foreground application.

Portal capture had a second identity problem: the ScreenCast window picker does not provide a compositor-independent mapping back to an AT-SPI window reference. Treating the selected stream as the requested window made subsequent input unsafe. The revised path uses display capture plus the requested window's AT-SPI extents.

Finally, each local driver session discarded the portal `restore_token`. New Runner processes therefore prompted again even after a successful authorization. The driver can now receive a daemon-owned state directory, request persistent authorization when the portal version supports it, and rotate the opaque single-use token after every successful restore.

## Integration boundary

This PR intentionally contains only the Linux driver and its cross-platform `LocalDriver` configuration entrypoint. A host opts in with `LocalDriver::with_linux_portal_state_root(...)`. Wiring that directory to the daemon store remains in the separate control-plane/API work, which is not yet present on `main`.

ScreenCast and RemoteDesktop input remain separate portal authorization chains. Clipboard persistence is explicitly deferred until a shared RemoteDesktop session policy is approved.

## Validation

- `cargo test -p auv-driver-linux` on macOS: 27 passed
- `cargo test -p auv-driver`: 4 passed
- `cargo check -p auv-driver-linux -p auv-driver`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `cargo +1.95.0 test -p auv-driver-linux` on `neko-gpu-1` at commit `0718da8f`: 54 passed
