### PR TITLE
feat(auv-api-server): add daemon API server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,6 +180,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.19",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,6 +386,42 @@ dependencies = [
  "tonic",
  "tonic-prost",
  "tonic-prost-build",
+]
+
+[[package]]
+name = "auv-api-server"
+version = "0.0.1"
+dependencies = [
+ "auv-api-client",
+ "auv-api-proto",
+ "axum",
+ "fs2",
+ "getrandom 0.3.4",
+ "hex",
+ "http",
+ "http-body",
+ "hyper-util",
+ "libc",
+ "prost",
+ "prost-types",
+ "rcgen",
+ "reqwest",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "subtle",
+ "tempfile",
+ "thiserror 2.0.19",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tonic",
+ "tonic-health",
+ "tonic-reflection",
+ "tower",
+ "uuid",
 ]
 
 [[package]]
@@ -867,10 +942,13 @@ checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http",
  "http-body",
  "http-body-util",
+ "hyper",
+ "hyper-util",
  "itoa",
  "matchit",
  "memchr",
@@ -878,10 +956,15 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
  "sync_wrapper",
+ "tokio",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -900,6 +983,7 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -973,6 +1057,15 @@ dependencies = [
  "rustc-hash 2.1.3",
  "shlex 1.3.0",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1619,6 +1712,20 @@ checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
 dependencies = [
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -4014,6 +4121,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4204,6 +4320,16 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
 
 [[package]]
 name = "pem-rfc7468"
@@ -4884,6 +5010,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "reborrow"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5129,6 +5269,15 @@ dependencies = [
  "primal-check",
  "strength_reduce",
  "transpose",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -5430,6 +5579,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -6052,6 +6212,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -6200,6 +6361,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-health"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcfab99db777fba2802f0dfa861d1628d1ae916fb199d29819941f139ae85082"
+dependencies = [
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
 name = "tonic-prost"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6224,6 +6398,20 @@ dependencies = [
  "syn 2.0.119",
  "tempfile",
  "tonic-build",
+]
+
+[[package]]
+name = "tonic-reflection"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acccd136a4bf19810a1fde9c74edc6129b42a66b44d0c1c8aaa67aeb49a146a7"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-prost",
 ]
 
 [[package]]
@@ -6281,6 +6469,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -7465,6 +7654,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom 7.1.3",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.19",
+ "time",
+]
+
+[[package]]
 name = "xcap"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7673,6 +7880,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe5c30ade05e61656247b2e334a031dfd0cc466fadef865bdcdea8d537951bf1"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec",
+ "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "supported/apps/auv-apple-notes",
   "supported/apps/auv-apple-textedit",
   "crates/auv-api-proto",
+  "crates/auv-api-server",
   "crates/auv-api-client",
   "crates/auv-cli-invoke-macros",
   "crates/auv-cli-invoke",

--- a/crates/auv-api-server/Cargo.toml
+++ b/crates/auv-api-server/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+name = "auv-api-server"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+readme.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "AUV daemon control and capability API server"
+documentation.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+auv-api-proto = { path = "../auv-api-proto" }
+axum = "0.8"
+fs2.workspace = true
+getrandom = "0.3"
+hex.workspace = true
+prost = "0.14"
+prost-types = "0.14"
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
+rustls-pki-types = "1"
+serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
+subtle = "2"
+tokio = { version = "1", features = ["macros", "net", "process", "rt-multi-thread", "sync", "time"] }
+tokio-stream = { version = "0.1", features = ["net"] }
+tokio-util = { version = "0.7", features = ["rt"] }
+tonic = { version = "0.14", features = ["transport", "tls-ring"] }
+tonic-health = "0.14"
+hyper-util = { version = "0.1", features = ["tokio"] }
+http = "1"
+http-body = "1"
+tower = { version = "0.5", features = ["util"] }
+libc = "0.2"
+thiserror.workspace = true
+uuid.workspace = true
+
+[dev-dependencies]
+auv-api-client = { path = "../auv-api-client" }
+rcgen = "0.14"
+reqwest = { version = "0.13", default-features = false, features = ["http2", "rustls-no-provider"] }
+tempfile.workspace = true
+tonic-reflection = "0.14"

--- a/crates/auv-api-server/src/auth/mod.rs
+++ b/crates/auv-api-server/src/auth/mod.rs
@@ -1,0 +1,24 @@
+//! Request authentication and durable paired-Device credentials.
+
+mod pairing;
+mod persistence;
+
+pub use pairing::{CredentialState, DeviceCredential, PairedDeviceEnrollment, PairingError, PairingRecord, PairingStore, PairingToken};
+
+/// Stable identity of the authenticated caller used for resource admission.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct CallerId(String);
+
+impl CallerId {
+  pub fn local_owner() -> Self {
+    Self("local-owner".to_string())
+  }
+
+  pub(crate) fn paired_device(pair_id: &str) -> Self {
+    Self(format!("paired-device:{pair_id}"))
+  }
+
+  pub fn as_str(&self) -> &str {
+    &self.0
+  }
+}

--- a/crates/auv-api-server/src/auth/pairing.rs
+++ b/crates/auv-api-server/src/auth/pairing.rs
@@ -1,0 +1,302 @@
+//! Paired-Device enrollment, credentials, and authentication.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use sha2::{Digest, Sha256};
+use subtle::ConstantTimeEq as _;
+
+use super::CallerId;
+use super::persistence::{FileStore, PairingTokenRecord, StoreFile};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CredentialState {
+  Active,
+  Revoked,
+}
+
+/// Stable paired-Device identity with revocable opaque bearer digests.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+pub struct PairingRecord {
+  pub pair_id: String,
+  pub label: String,
+  pub enabled: bool,
+  #[serde(default)]
+  pub device_credentials: Vec<DeviceCredential>,
+}
+
+/// Persisted digest of one opaque long-lived bearer credential.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+pub struct DeviceCredential {
+  pub credential_sha256: String,
+  pub state: CredentialState,
+}
+
+/// A short-lived enrollment token. The plaintext is returned only by
+/// [`PairingStore::issue_token`] and is never persisted or included in store
+/// listings.
+pub struct PairingToken(String);
+
+impl PairingToken {
+  pub fn expose_once(self) -> String {
+    self.0
+  }
+}
+
+/// Result of consuming a bootstrap token. The bearer plaintext is returned
+/// once while only its digest is persisted.
+pub struct PairedDeviceEnrollment {
+  pub device: PairingRecord,
+  credential: String,
+}
+
+impl PairedDeviceEnrollment {
+  pub fn expose_credential_once(self) -> String {
+    self.credential
+  }
+}
+
+impl std::fmt::Debug for PairedDeviceEnrollment {
+  fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    formatter.debug_struct("PairedDeviceEnrollment").field("device", &self.device).field("credential", &"[REDACTED]").finish()
+  }
+}
+
+impl std::fmt::Debug for PairingToken {
+  fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    formatter.write_str("PairingToken([REDACTED])")
+  }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum PairingError {
+  #[error("pair_id must not be empty")]
+  EmptyPairId,
+  #[error("pairing token lifetime must be greater than zero")]
+  InvalidTokenLifetime,
+  #[error("pairing token is invalid, expired, or has already been consumed")]
+  InvalidPairingToken,
+  #[error("system clock cannot represent a pairing token deadline")]
+  InvalidTokenClock,
+  #[error("failed to generate a secure pairing token: {0}")]
+  TokenGeneration(String),
+  #[error("paired device was not found: {0}")]
+  UnknownPair(String),
+  #[error("Device credential was not found")]
+  UnknownCredential,
+  #[error("Device credential is not paired or has been revoked")]
+  Unauthenticated,
+  #[error("duplicate paired-device ID: {0}")]
+  DuplicatePairId(String),
+  #[error("Device credential digest is already assigned to paired Device {0}")]
+  DuplicateCredential(String),
+  #[error("failed to read pairing store {path}: {source}")]
+  Read {
+    path: PathBuf,
+    #[source]
+    source: std::io::Error,
+  },
+  #[error("invalid pairing store {path}: {source}")]
+  Decode {
+    path: PathBuf,
+    #[source]
+    source: serde_json::Error,
+  },
+  #[error("unsupported pairing store version {version} in {path}")]
+  UnsupportedVersion { version: u32, path: PathBuf },
+  #[error("failed to update pairing store {path}: {message}")]
+  Update { path: PathBuf, message: String },
+  #[error("pairing store revision {revision} committed, but directory durability could not be confirmed: {message}")]
+  CommittedButDurabilityUnknown { revision: u64, message: String },
+}
+
+/// Process-owned pairing store with in-memory authentication reads.
+#[derive(Clone)]
+pub struct PairingStore {
+  inner: Arc<FileStore>,
+}
+
+impl PairingStore {
+  pub fn open(path: PathBuf) -> Result<Self, PairingError> {
+    Ok(Self {
+      inner: Arc::new(FileStore::open(path)?),
+    })
+  }
+
+  pub fn path(&self) -> &Path {
+    self.inner.path()
+  }
+
+  pub fn revision(&self) -> u64 {
+    self.inner.revision()
+  }
+
+  pub fn list(&self) -> Vec<PairingRecord> {
+    self.inner.devices()
+  }
+
+  /// Creates a cryptographically random, short-lived, one-time enrollment
+  /// token. Only its SHA-256 digest is persisted.
+  pub fn issue_token(&self, lifetime: Option<Duration>) -> Result<PairingToken, PairingError> {
+    self.issue_token_at(lifetime, SystemTime::now())
+  }
+
+  fn issue_token_at(&self, lifetime: Option<Duration>, now: SystemTime) -> Result<PairingToken, PairingError> {
+    if lifetime.is_some_and(|lifetime| lifetime.is_zero()) {
+      return Err(PairingError::InvalidTokenLifetime);
+    }
+    let expires_at = lifetime
+      .map(|lifetime| {
+        now
+          .duration_since(UNIX_EPOCH)
+          .ok()
+          .and_then(|now| now.checked_add(lifetime))
+          .map(|deadline| deadline.as_secs())
+          .ok_or(PairingError::InvalidTokenClock)
+      })
+      .transpose()?;
+    let mut secret = [0_u8; 16];
+    getrandom::fill(&mut secret).map_err(|error| PairingError::TokenGeneration(error.to_string()))?;
+    let plaintext = hex::encode(secret);
+    let digest = token_digest(&plaintext);
+    self.update(|store| {
+      store.tokens.push(PairingTokenRecord { digest, expires_at });
+      Ok(())
+    })?;
+    Ok(PairingToken(plaintext))
+  }
+
+  /// Atomically consumes one enrollment token and creates the stable paired
+  /// Device identity. Reusing the same token always fails.
+  pub fn consume_token(&self, token: &str, pair_id: String, label: String) -> Result<PairedDeviceEnrollment, PairingError> {
+    self.consume_token_at(token, pair_id, label, SystemTime::now())
+  }
+
+  fn consume_token_at(&self, token: &str, pair_id: String, label: String, now: SystemTime) -> Result<PairedDeviceEnrollment, PairingError> {
+    let now = now.duration_since(UNIX_EPOCH).map_err(|_| PairingError::InvalidTokenClock)?.as_secs();
+    let digest = token_digest(token);
+    let mut paired = None;
+    let mut credential_bytes = [0_u8; 32];
+    getrandom::fill(&mut credential_bytes).map_err(|error| PairingError::TokenGeneration(error.to_string()))?;
+    let credential = hex::encode(credential_bytes);
+    let credential_sha256 = token_digest(&credential);
+    self.update(|store| {
+      let index =
+        store.tokens.iter().position(|candidate| digest_matches(&candidate.digest, &digest)).ok_or(PairingError::InvalidPairingToken)?;
+      if store.tokens[index].expires_at.is_some_and(|deadline| deadline <= now) {
+        return Err(PairingError::InvalidPairingToken);
+      }
+      if store.devices.iter().any(|device| device.pair_id == pair_id) {
+        return Err(PairingError::DuplicatePairId(pair_id.clone()));
+      }
+      store.tokens.remove(index);
+      let record = PairingRecord {
+        pair_id: pair_id.clone(),
+        label: label.clone(),
+        enabled: true,
+        device_credentials: vec![DeviceCredential {
+          credential_sha256,
+          state: CredentialState::Active,
+        }],
+      };
+      store.devices.push(record.clone());
+      paired = Some(record);
+      Ok(())
+    })?;
+    Ok(PairedDeviceEnrollment {
+      device: paired.expect("successful token consumption creates a paired Device"),
+      credential,
+    })
+  }
+
+  /// Resolves a long-lived bearer against the current immutable snapshot so
+  /// disable/revoke mutations affect the next RPC without a CRL or cache TTL.
+  pub fn authenticate_bearer(&self, credential: &str) -> Result<CallerId, PairingError> {
+    let digest = token_digest(credential);
+    self.inner.with_snapshot(|snapshot| {
+      let record = snapshot
+        .devices
+        .iter()
+        .find(|record| record.device_credentials.iter().any(|candidate| digest_matches(&candidate.credential_sha256, &digest)))
+        .ok_or(PairingError::Unauthenticated)?;
+      let credential = record
+        .device_credentials
+        .iter()
+        .find(|candidate| digest_matches(&candidate.credential_sha256, &digest))
+        .expect("matched credential exists");
+      if !record.enabled || credential.state != CredentialState::Active {
+        return Err(PairingError::Unauthenticated);
+      }
+      Ok(CallerId::paired_device(&record.pair_id))
+    })
+  }
+
+  pub fn revoke_bearer(&self, credential: &str) -> Result<(), PairingError> {
+    let digest = token_digest(credential);
+    self.update(|store| {
+      let credential = store
+        .devices
+        .iter_mut()
+        .flat_map(|record| &mut record.device_credentials)
+        .find(|candidate| digest_matches(&candidate.credential_sha256, &digest))
+        .ok_or(PairingError::UnknownCredential)?;
+      credential.state = CredentialState::Revoked;
+      Ok(())
+    })
+  }
+
+  /// Revokes every long-lived bearer owned by one stable paired Device.
+  pub fn revoke_device_credentials(&self, pair_id: &str) -> Result<bool, PairingError> {
+    self.update(|store| {
+      let record =
+        store.devices.iter_mut().find(|record| record.pair_id == pair_id).ok_or_else(|| PairingError::UnknownPair(pair_id.into()))?;
+      let mut changed = false;
+      for credential in &mut record.device_credentials {
+        changed |= credential.state != CredentialState::Revoked;
+        credential.state = CredentialState::Revoked;
+      }
+      if !changed {
+        return Err(PairingError::UnknownCredential);
+      }
+      Ok(())
+    })?;
+    Ok(true)
+  }
+
+  pub fn set_enabled(&self, pair_id: &str, enabled: bool) -> Result<(), PairingError> {
+    self.update(|store| {
+      let record =
+        store.devices.iter_mut().find(|record| record.pair_id == pair_id).ok_or_else(|| PairingError::UnknownPair(pair_id.to_string()))?;
+      record.enabled = enabled;
+      Ok(())
+    })
+  }
+
+  /// Removes one paired Device and all credentials owned by its stable ID.
+  pub fn remove_pair(&self, pair_id: &str) -> Result<(), PairingError> {
+    self.update(|store| {
+      let index =
+        store.devices.iter().position(|record| record.pair_id == pair_id).ok_or_else(|| PairingError::UnknownPair(pair_id.to_string()))?;
+      store.devices.remove(index);
+      Ok(())
+    })
+  }
+
+  fn update(&self, mutate: impl FnOnce(&mut StoreFile) -> Result<(), PairingError>) -> Result<(), PairingError> {
+    self.inner.update(mutate)
+  }
+}
+
+fn token_digest(token: &str) -> String {
+  hex::encode(Sha256::digest(token.as_bytes()))
+}
+
+fn digest_matches(stored_hex: &str, candidate_hex: &str) -> bool {
+  stored_hex.len() == candidate_hex.len() && bool::from(stored_hex.as_bytes().ct_eq(candidate_hex.as_bytes()))
+}
+
+#[cfg(test)]
+#[path = "tests.rs"]
+mod tests;

--- a/crates/auv-api-server/src/auth/persistence.rs
+++ b/crates/auv-api-server/src/auth/persistence.rs
@@ -1,0 +1,236 @@
+//! Private persistence implementation for paired-Device authentication data.
+
+use std::collections::{HashMap, HashSet};
+use std::fs::{self, File, OpenOptions};
+use std::io::{ErrorKind, Write};
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, RwLock};
+
+use fs2::FileExt;
+
+use super::pairing::{PairingError, PairingRecord};
+
+const STORE_VERSION: u32 = 1;
+
+pub(super) struct FileStore {
+  path: PathBuf,
+  _lifetime_lock: File,
+  snapshot: RwLock<StoreFile>,
+  mutation: Mutex<()>,
+}
+
+impl FileStore {
+  pub(super) fn open(path: PathBuf) -> Result<Self, PairingError> {
+    let parent = path.parent().ok_or_else(|| update_error(&path, "pairing store path has no parent"))?;
+    fs::create_dir_all(parent).map_err(|error| update_error(&path, format!("failed to create parent directory: {error}")))?;
+    set_private_directory(parent)?;
+    let lock_path = path.with_extension("lock");
+    let lock = OpenOptions::new()
+      .create(true)
+      .truncate(false)
+      .read(true)
+      .write(true)
+      .open(&lock_path)
+      .map_err(|error| update_error(&path, format!("failed to open lock {}: {error}", lock_path.display())))?;
+    set_private_file(&lock_path)?;
+    lock
+      .try_lock_exclusive()
+      .map_err(|error| update_error(&path, format!("another pairing-store owner holds {}: {error}", lock_path.display())))?;
+    let snapshot = read_store(&path)?;
+    Ok(Self {
+      path,
+      _lifetime_lock: lock,
+      snapshot: RwLock::new(snapshot),
+      mutation: Mutex::new(()),
+    })
+  }
+
+  pub(super) fn path(&self) -> &Path {
+    &self.path
+  }
+
+  pub(super) fn revision(&self) -> u64 {
+    self.snapshot.read().expect("pairing snapshot lock poisoned").revision
+  }
+
+  pub(super) fn devices(&self) -> Vec<PairingRecord> {
+    self.snapshot.read().expect("pairing snapshot lock poisoned").devices.clone()
+  }
+
+  pub(super) fn with_snapshot<T>(&self, read: impl FnOnce(&StoreFile) -> T) -> T {
+    read(&self.snapshot.read().expect("pairing snapshot lock poisoned"))
+  }
+
+  pub(super) fn update(&self, mutate: impl FnOnce(&mut StoreFile) -> Result<(), PairingError>) -> Result<(), PairingError> {
+    let _mutation = self.mutation.lock().expect("pairing mutation lock poisoned");
+    let mut next = self.snapshot.read().expect("pairing snapshot lock poisoned").clone();
+    mutate(&mut next)?;
+    next.revision = next.revision.checked_add(1).ok_or_else(|| update_error(&self.path, "pairing store revision overflow"))?;
+    validate_store(&next)?;
+    let persistence = write_store(&self.path, &next);
+    if persistence.is_ok() || matches!(persistence, Err(PairingError::CommittedButDurabilityUnknown { .. })) {
+      *self.snapshot.write().expect("pairing snapshot lock poisoned") = next;
+    }
+    persistence
+  }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+pub(super) struct StoreFile {
+  version: u32,
+  pub(super) revision: u64,
+  pub(super) devices: Vec<PairingRecord>,
+  #[serde(default)]
+  pub(super) tokens: Vec<PairingTokenRecord>,
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+pub(super) struct PairingTokenRecord {
+  pub(super) digest: String,
+  pub(super) expires_at: Option<u64>,
+}
+
+impl Default for StoreFile {
+  fn default() -> Self {
+    Self {
+      version: STORE_VERSION,
+      revision: 0,
+      devices: Vec::new(),
+      tokens: Vec::new(),
+    }
+  }
+}
+
+fn validate_store(store: &StoreFile) -> Result<(), PairingError> {
+  if store.version != STORE_VERSION {
+    return Err(PairingError::UnsupportedVersion {
+      version: store.version,
+      path: PathBuf::from("<pairing-store>"),
+    });
+  }
+  let mut pair_ids = HashSet::new();
+  let mut credential_digests = HashMap::new();
+  for record in &store.devices {
+    if record.pair_id.trim().is_empty() {
+      return Err(PairingError::EmptyPairId);
+    }
+    if !pair_ids.insert(record.pair_id.clone()) {
+      return Err(PairingError::DuplicatePairId(record.pair_id.clone()));
+    }
+    for credential in &record.device_credentials {
+      if credential.credential_sha256.len() != 64 || !credential.credential_sha256.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(update_error(Path::new("<pairing-store>"), "invalid Device credential digest"));
+      }
+      if let Some(existing) = credential_digests.insert(credential.credential_sha256.clone(), record.pair_id.clone()) {
+        return Err(PairingError::DuplicateCredential(existing));
+      }
+    }
+  }
+  let mut token_digests = HashSet::new();
+  for token in &store.tokens {
+    if token.digest.len() != 64 || !token.digest.bytes().all(|byte| byte.is_ascii_hexdigit()) || !token_digests.insert(token.digest.clone())
+    {
+      return Err(update_error(Path::new("<pairing-store>"), "invalid or duplicate pairing token digest"));
+    }
+  }
+  Ok(())
+}
+
+fn read_store(path: &Path) -> Result<StoreFile, PairingError> {
+  let bytes = match fs::read(path) {
+    Ok(bytes) => bytes,
+    Err(source) if source.kind() == ErrorKind::NotFound => return Ok(StoreFile::default()),
+    Err(source) => {
+      return Err(PairingError::Read {
+        path: path.to_path_buf(),
+        source,
+      });
+    }
+  };
+  let store = serde_json::from_slice::<StoreFile>(&bytes).map_err(|source| PairingError::Decode {
+    path: path.to_path_buf(),
+    source,
+  })?;
+  if store.version != STORE_VERSION {
+    return Err(PairingError::UnsupportedVersion {
+      version: store.version,
+      path: path.to_path_buf(),
+    });
+  }
+  validate_store(&store)?;
+  Ok(store)
+}
+
+fn write_store(path: &Path, store: &StoreFile) -> Result<(), PairingError> {
+  let temporary_path = path.with_extension(format!("tmp-{}", uuid::Uuid::now_v7()));
+  let mut temporary = TemporaryStore::new(temporary_path.clone());
+  let mut file = OpenOptions::new()
+    .write(true)
+    .create_new(true)
+    .open(&temporary_path)
+    .map_err(|error| update_error(path, format!("failed to create temporary store: {error}")))?;
+  set_private_file(&temporary_path)?;
+  serde_json::to_writer_pretty(&mut file, store).map_err(|error| update_error(path, format!("failed to encode store: {error}")))?;
+  file.write_all(b"\n").and_then(|_| file.sync_all()).map_err(|error| update_error(path, format!("failed to sync store: {error}")))?;
+  drop(file);
+  fs::rename(&temporary_path, path).map_err(|error| update_error(path, format!("failed to publish store: {error}")))?;
+  temporary.committed = true;
+  let parent = path.parent().expect("validated pairing-store parent");
+  File::open(parent).and_then(|directory| directory.sync_all()).map_err(|error| PairingError::CommittedButDurabilityUnknown {
+    revision: store.revision,
+    message: error.to_string(),
+  })
+}
+
+struct TemporaryStore {
+  path: PathBuf,
+  committed: bool,
+}
+
+impl TemporaryStore {
+  fn new(path: PathBuf) -> Self {
+    Self {
+      path,
+      committed: false,
+    }
+  }
+}
+
+impl Drop for TemporaryStore {
+  fn drop(&mut self) {
+    if !self.committed {
+      let _ = fs::remove_file(&self.path);
+    }
+  }
+}
+
+fn update_error(path: &Path, message: impl Into<String>) -> PairingError {
+  PairingError::Update {
+    path: path.to_path_buf(),
+    message: message.into(),
+  }
+}
+
+#[cfg(unix)]
+fn set_private_directory(path: &Path) -> Result<(), PairingError> {
+  use std::os::unix::fs::PermissionsExt;
+  fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+    .map_err(|error| update_error(path, format!("failed to set directory permissions: {error}")))
+}
+
+#[cfg(not(unix))]
+fn set_private_directory(_path: &Path) -> Result<(), PairingError> {
+  Ok(())
+}
+
+#[cfg(unix)]
+fn set_private_file(path: &Path) -> Result<(), PairingError> {
+  use std::os::unix::fs::PermissionsExt;
+  fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+    .map_err(|error| update_error(path, format!("failed to set file permissions: {error}")))
+}
+
+#[cfg(not(unix))]
+fn set_private_file(_path: &Path) -> Result<(), PairingError> {
+  Ok(())
+}

--- a/crates/auv-api-server/src/auth/tests.rs
+++ b/crates/auv-api-server/src/auth/tests.rs
@@ -1,0 +1,64 @@
+use std::fs;
+use std::time::{Duration, UNIX_EPOCH};
+
+use super::{PairingError, PairingStore};
+
+#[test]
+fn bootstrap_token_is_one_time_and_plaintexts_are_never_persisted() {
+  let directory = tempfile::tempdir().unwrap();
+  let path = directory.path().join("pairs.json");
+  let store = PairingStore::open(path.clone()).unwrap();
+  let token = store.issue_token(None).unwrap().expose_once();
+  assert_eq!(token.len(), 32);
+  assert!(token.bytes().all(|byte| byte.is_ascii_hexdigit()));
+  let persisted = fs::read_to_string(&path).unwrap();
+  assert!(!persisted.contains(&token));
+  assert_eq!(serde_json::from_str::<serde_json::Value>(&persisted).unwrap()["version"], 1);
+
+  let enrollment = store.consume_token(&token, "tablet".to_string(), "Tablet".to_string()).unwrap();
+  let bearer = enrollment.expose_credential_once();
+  assert_eq!(bearer.len(), 64);
+  assert!(bearer.bytes().all(|byte| byte.is_ascii_hexdigit()));
+  assert!(!fs::read_to_string(&path).unwrap().contains(&bearer));
+  assert_eq!(store.authenticate_bearer(&bearer).unwrap().as_str(), "paired-device:tablet");
+  assert!(matches!(store.consume_token(&token, "other".to_string(), "Other".to_string()), Err(PairingError::InvalidPairingToken)));
+
+  assert!(PairingStore::open(path.clone()).is_err(), "one process owns the pairing store lock");
+  store.revoke_device_credentials("tablet").unwrap();
+  assert!(matches!(store.authenticate_bearer(&bearer), Err(PairingError::Unauthenticated)));
+  drop(store);
+  let reopened = PairingStore::open(path).unwrap();
+  assert!(matches!(reopened.authenticate_bearer(&bearer), Err(PairingError::Unauthenticated)));
+}
+
+#[test]
+fn bootstrap_token_expires_only_when_a_ttl_was_requested() {
+  let directory = tempfile::tempdir().unwrap();
+  let store = PairingStore::open(directory.path().join("pairs.json")).unwrap();
+  let issued_at = UNIX_EPOCH + Duration::from_secs(100);
+  let expiring = store.issue_token_at(Some(Duration::from_secs(30)), issued_at).unwrap().expose_once();
+  assert!(matches!(
+    store.consume_token_at(&expiring, "late".to_string(), "Late".to_string(), UNIX_EPOCH + Duration::from_secs(130)),
+    Err(PairingError::InvalidPairingToken)
+  ));
+
+  let persistent = store.issue_token_at(None, issued_at).unwrap().expose_once();
+  store
+    .consume_token_at(&persistent, "later".to_string(), "Later".to_string(), UNIX_EPOCH + Duration::from_secs(10_000))
+    .expect("token without explicit TTL remains valid");
+}
+
+#[test]
+fn disable_and_remove_apply_to_the_next_bearer_lookup() {
+  let directory = tempfile::tempdir().unwrap();
+  let store = PairingStore::open(directory.path().join("pairs.json")).unwrap();
+  let token = store.issue_token(None).unwrap().expose_once();
+  let bearer = store.consume_token(&token, "tablet".to_string(), "Tablet".to_string()).unwrap().expose_credential_once();
+
+  store.set_enabled("tablet", false).unwrap();
+  assert!(matches!(store.authenticate_bearer(&bearer), Err(PairingError::Unauthenticated)));
+  store.set_enabled("tablet", true).unwrap();
+  assert!(store.authenticate_bearer(&bearer).is_ok());
+  store.remove_pair("tablet").unwrap();
+  assert!(matches!(store.authenticate_bearer(&bearer), Err(PairingError::Unauthenticated)));
+}

--- a/crates/auv-api-server/src/daemon/mod.rs
+++ b/crates/auv-api-server/src/daemon/mod.rs
@@ -1,0 +1,540 @@
+//! Long-lived Device, Run, and Runner state owned by one daemon.
+
+mod runner;
+pub mod runner_provider;
+
+use std::collections::HashMap;
+use std::fs::{self, OpenOptions};
+use std::io::{ErrorKind, Write};
+use std::path::Path;
+use std::sync::Mutex;
+
+use auv_api_proto::auv::api::daemon::v1 as proto;
+use tonic::transport::Channel;
+
+use self::runner::RunnerSupervisor;
+use crate::auth::CallerId;
+
+const LOCAL_DEVICE_ID_FILE: &str = "device-id";
+
+/// Process-local view of durable control-plane identity and live resources.
+pub(crate) struct Daemon {
+  local_device: proto::Device,
+  // TODO(distributed-run-authority): Runs are daemon-memory resources until a
+  // coordinator/storage slice defines cross-daemon ownership, recovery, and
+  // terminal append semantics in the accepted architecture document.
+  runs: Mutex<HashMap<String, OwnedRun>>,
+  runner_affinities: Mutex<HashMap<RunnerAffinityKey, String>>,
+  runner_affinity_locks: tokio::sync::Mutex<HashMap<RunnerAffinityKey, std::sync::Arc<tokio::sync::Mutex<()>>>>,
+  runners: RunnerSupervisor,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct RunnerAffinityKey {
+  caller: CallerId,
+  run_id: String,
+  device_id: String,
+  runner_class: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct RunnerRoute {
+  pub(crate) device_id: Option<String>,
+  pub(crate) run_id: Option<String>,
+  pub(crate) runner_class: String,
+}
+
+struct OwnedRun {
+  caller: CallerId,
+  run: proto::Run,
+}
+
+pub(crate) struct OperationPermit {
+  _runner: runner::OperationPermit,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum DaemonError {
+  #[error("failed to generate control-plane identity: {0}")]
+  Identity(String),
+  #[error("invalid control-plane argument: {0}")]
+  InvalidArgument(&'static str),
+  #[error("unknown Device: {0}")]
+  UnknownDevice(String),
+  #[error("unknown Run: {0}")]
+  UnknownRun(String),
+  #[error("unknown Runner: {0}")]
+  UnknownRunner(String),
+  #[error("no RunnerProvider is registered for RunnerClass: {0}")]
+  RunnerProviderUnavailable(String),
+  #[error("Runner operation failed: {0}")]
+  RunnerOperation(String),
+}
+
+impl Daemon {
+  #[cfg(test)]
+  pub(crate) fn open(store_root: &Path) -> Result<Self, String> {
+    Self::open_with_runner_providers_and_parent_endpoint(store_root, None, runner_provider::FirstPartyRunnerRuntimes::default(), Vec::new())
+  }
+
+  pub(super) fn open_with_runner_providers_and_parent_endpoint(
+    store_root: &Path,
+    parent_endpoint: Option<String>,
+    first_party_runners: runner_provider::FirstPartyRunnerRuntimes,
+    runner_providers: Vec<runner_provider::RunnerProviderConfig>,
+  ) -> Result<Self, String> {
+    let control_root = store_root.join("control");
+    fs::create_dir_all(&control_root)
+      .map_err(|error| format!("failed to create control-plane directory {}: {error}", control_root.display()))?;
+    set_private_directory(&control_root)?;
+    let device_id = load_or_create_local_device_id(&control_root.join(LOCAL_DEVICE_ID_FILE))?;
+    let platform = local_platform();
+    let mut labels = HashMap::new();
+    labels.insert("auv.dev/platform".to_string(), proto::DevicePlatform::try_from(platform).unwrap_or_default().as_str_name().to_string());
+    let local_device = proto::Device {
+      r#ref: Some(proto::DeviceRef { device_id }),
+      name: std::env::var("HOSTNAME").unwrap_or_default(),
+      platform,
+      local: true,
+      labels,
+    };
+    let runners = RunnerSupervisor::with_providers(
+      local_device.r#ref.clone().expect("local Device always has a ref"),
+      parent_endpoint,
+      first_party_runners,
+      runner_providers,
+    )?;
+    Ok(Self {
+      local_device,
+      runs: Mutex::new(HashMap::new()),
+      runner_affinities: Mutex::new(HashMap::new()),
+      runner_affinity_locks: tokio::sync::Mutex::new(HashMap::new()),
+      runners,
+    })
+  }
+
+  pub fn list_devices(&self) -> proto::ListDevicesResponse {
+    proto::ListDevicesResponse {
+      devices: vec![self.local_device.clone()],
+    }
+  }
+
+  pub fn get_device(&self, device_id: &str) -> Option<proto::Device> {
+    self.local_device.r#ref.as_ref().is_some_and(|device| device.device_id == device_id).then(|| self.local_device.clone())
+  }
+
+  pub(crate) fn create_run(&self, caller: &CallerId, request: proto::CreateRunRequest) -> Result<proto::CreateRunResponse, DaemonError> {
+    let mut runs = self.runs.lock().expect("Run registry lock poisoned");
+    let devices = if request.devices.is_empty() {
+      vec![self.local_device.r#ref.clone().expect("local Device always has a ref")]
+    } else {
+      let mut devices = Vec::with_capacity(request.devices.len());
+      for device in request.devices {
+        // TODO(distributed-run-authority): remote Device membership requires
+        // the owner/participant contract in the accepted aggregated API design.
+        if self.get_device(&device.device_id).is_none() {
+          return Err(DaemonError::UnknownDevice(device.device_id));
+        }
+        if !devices.iter().any(|existing: &proto::DeviceRef| existing.device_id == device.device_id) {
+          devices.push(device);
+        }
+      }
+      devices
+    };
+    let run_id = crate::resource_id::generate_run().map_err(DaemonError::Identity)?;
+    let run = proto::Run {
+      r#ref: Some(proto::RunRef {
+        run_id: run_id.clone(),
+      }),
+      phase: proto::RunPhase::Running as i32,
+      devices,
+      labels: request.labels,
+      created_at: Some(timestamp_now()),
+      completed_at: None,
+    };
+    runs.insert(
+      run_id,
+      OwnedRun {
+        caller: caller.clone(),
+        run: run.clone(),
+      },
+    );
+    Ok(proto::CreateRunResponse { run: Some(run) })
+  }
+
+  pub async fn stop_run(&self, caller: &CallerId, run_id: &str, outcome: proto::RunOutcome) -> Result<proto::StopRunResponse, DaemonError> {
+    let terminal_phase = match outcome {
+      proto::RunOutcome::Succeeded => proto::RunPhase::Succeeded,
+      proto::RunOutcome::Failed => proto::RunPhase::Failed,
+      proto::RunOutcome::Canceled => proto::RunPhase::Canceled,
+      proto::RunOutcome::Unspecified => return Err(DaemonError::InvalidArgument("terminal Run outcome is required")),
+    };
+    let run = {
+      let mut runs = self.runs.lock().expect("Run registry lock poisoned");
+      let owned = runs.get_mut(run_id).filter(|owned| &owned.caller == caller).ok_or_else(|| DaemonError::UnknownRun(run_id.to_string()))?;
+      if owned.run.phase == proto::RunPhase::Running as i32 || owned.run.phase == proto::RunPhase::Pending as i32 {
+        owned.run.phase = terminal_phase as i32;
+        owned.run.completed_at = Some(timestamp_now());
+      } else if owned.run.phase != terminal_phase as i32 {
+        return Err(DaemonError::InvalidArgument("Run already stopped with a different outcome"));
+      }
+      owned.run.clone()
+    };
+    let runner_ids = {
+      let mut affinities = self.runner_affinities.lock().expect("Runner affinity registry lock poisoned");
+      let keys = affinities.keys().filter(|key| &key.caller == caller && key.run_id == run_id).cloned().collect::<Vec<_>>();
+      keys.into_iter().filter_map(|key| affinities.remove(&key)).collect::<Vec<_>>()
+    };
+    self.runner_affinity_locks.lock().await.retain(|key, _| &key.caller != caller || key.run_id != run_id);
+    for runner_id in runner_ids {
+      self.runners.release_run_affinity(&runner_id).await?;
+    }
+    Ok(proto::StopRunResponse { run: Some(run) })
+  }
+
+  pub fn list_runs(&self, caller: &CallerId) -> proto::ListRunsResponse {
+    let mut runs = self
+      .runs
+      .lock()
+      .expect("Run registry lock poisoned")
+      .values()
+      .filter(|owned| &owned.caller == caller)
+      .map(|owned| owned.run.clone())
+      .collect::<Vec<_>>();
+    runs.sort_by(|left, right| run_id(left).cmp(run_id(right)));
+    proto::ListRunsResponse { runs }
+  }
+
+  pub(crate) fn get_run(&self, caller: &CallerId, run_id: &str) -> Result<proto::GetRunResponse, DaemonError> {
+    self
+      .runs
+      .lock()
+      .expect("Run registry lock poisoned")
+      .get(run_id)
+      .filter(|owned| &owned.caller == caller)
+      .map(|owned| proto::GetRunResponse {
+        run: Some(owned.run.clone()),
+      })
+      .ok_or_else(|| DaemonError::UnknownRun(run_id.to_string()))
+  }
+
+  pub fn list_runners(&self) -> proto::ListRunnersResponse {
+    self.runners.list()
+  }
+
+  pub(crate) async fn create_runner(&self, request: proto::CreateRunnerRequest) -> Result<proto::CreateRunnerResponse, DaemonError> {
+    let device_id = request
+      .device
+      .as_ref()
+      .or(self.local_device.r#ref.as_ref())
+      .map(|device| device.device_id.as_str())
+      .expect("local Device always has a ref");
+    if self.get_device(device_id).is_none() {
+      return Err(DaemonError::UnknownDevice(device_id.to_string()));
+    }
+    if request.runner_class.as_ref().is_none_or(|runner_class| runner_class.runner_class.trim().is_empty()) {
+      return Err(DaemonError::InvalidArgument("runner_class is required"));
+    }
+    self.runners.create(request, 0).await.map_err(Into::into)
+  }
+
+  pub(crate) fn get_runner(&self, runner_id: &str) -> Result<proto::GetRunnerResponse, DaemonError> {
+    self.runners.get(runner_id).map_err(Into::into)
+  }
+
+  pub(crate) fn list_runner_classes(&self, device_id: Option<&str>) -> Result<proto::ListRunnerClassesResponse, DaemonError> {
+    self.validate_local_device(device_id)?;
+    Ok(self.runners.list_classes())
+  }
+
+  pub(crate) fn get_runner_class(&self, device_id: Option<&str>, runner_class: &str) -> Result<proto::GetRunnerClassResponse, DaemonError> {
+    self.validate_local_device(device_id)?;
+    self.runners.get_class(runner_class).map_err(Into::into)
+  }
+
+  pub async fn delete_runner(
+    &self,
+    runner_id: &str,
+    grace_period: Option<prost_types::Duration>,
+    force: bool,
+  ) -> Result<proto::DeleteRunnerResponse, DaemonError> {
+    self.runners.delete(runner_id, grace_period, force).await.map_err(Into::into)
+  }
+
+  pub(crate) async fn admit_routed_channel(
+    &self,
+    caller: &CallerId,
+    route: RunnerRoute,
+    service: &str,
+    method: &str,
+  ) -> Result<(Channel, OperationPermit), DaemonError> {
+    if route.runner_class.trim().is_empty() {
+      return Err(DaemonError::InvalidArgument("runner_class routing metadata is required"));
+    }
+    let device_id = route
+      .device_id
+      .as_deref()
+      .or_else(|| self.local_device.r#ref.as_ref().map(|device| device.device_id.as_str()))
+      .expect("local Device always has a ref")
+      .to_string();
+    self.validate_local_device(Some(&device_id))?;
+
+    let affinity = match route.run_id.as_deref() {
+      Some(run_id) => {
+        let run = self.get_run(caller, run_id)?.run.expect("GetRun always returns a Run");
+        if run.phase != proto::RunPhase::Running as i32 {
+          return Err(DaemonError::InvalidArgument("capability routing requires a running Run"));
+        }
+        if !run.devices.iter().any(|device| device.device_id == device_id) {
+          return Err(DaemonError::InvalidArgument("routed Device is not attached to the Run"));
+        }
+        Some(RunnerAffinityKey {
+          caller: caller.clone(),
+          run_id: run_id.to_string(),
+          device_id: device_id.clone(),
+          runner_class: route.runner_class.clone(),
+        })
+      }
+      None => None,
+    };
+
+    // Only calls for the same Run/Device/RunnerClass serialize while a Runner
+    // starts. An unhealthy provider must not block unrelated routing or Run
+    // shutdown across the daemon.
+    let affinity_lock = match &affinity {
+      Some(key) => Some(
+        self
+          .runner_affinity_locks
+          .lock()
+          .await
+          .entry(key.clone())
+          .or_insert_with(|| std::sync::Arc::new(tokio::sync::Mutex::new(())))
+          .clone(),
+      ),
+      None => None,
+    };
+    let _affinity_resolution = match &affinity_lock {
+      Some(lock) => Some(lock.lock().await),
+      None => None,
+    };
+    let existing_affinity =
+      affinity.as_ref().and_then(|key| self.runner_affinities.lock().expect("Runner affinity registry lock poisoned").get(key).cloned());
+    let mut runner = existing_affinity
+      .as_deref()
+      .and_then(|runner_id| self.runners.get(runner_id).ok().and_then(|response| response.runner))
+      .filter(|runner| runner.phase == proto::RunnerPhase::Ready as i32);
+    if runner.is_none()
+      && existing_affinity.is_some()
+      && let Some(key) = &affinity
+    {
+      self.runner_affinities.lock().expect("Runner affinity registry lock poisoned").remove(key);
+      if let Some(stale_runner_id) = existing_affinity.as_deref()
+        && self.runners.get(stale_runner_id).is_ok()
+      {
+        self.runners.release_run_affinity(stale_runner_id).await?;
+      }
+    }
+    let mut attach_to_run = false;
+    let mut created_runner = false;
+    if runner.is_none() {
+      runner = self.runners.find_routable(&device_id, &route.runner_class);
+      attach_to_run = runner.is_some() && affinity.is_some();
+      if runner.is_none() {
+        runner = self
+          .runners
+          .create(
+            proto::CreateRunnerRequest {
+              device: Some(proto::DeviceRef {
+                device_id: device_id.clone(),
+              }),
+              runner_class: Some(proto::RunnerClassRef {
+                runner_class: route.runner_class.clone(),
+              }),
+              labels: HashMap::new(),
+              lifecycle: if affinity.is_some() {
+                proto::RunnerLifecycle::UnlessShutdown as i32
+              } else {
+                proto::RunnerLifecycle::Ephemeral as i32
+              },
+              idle_timeout: None,
+            },
+            0,
+          )
+          .await?
+          .runner;
+        attach_to_run = affinity.is_some();
+        created_runner = true;
+      }
+    }
+    let runner_id = runner
+      .as_ref()
+      .map(runner_id)
+      .filter(|id| !id.is_empty())
+      .ok_or(DaemonError::RunnerOperation("resolved Runner omitted its canonical ID".to_string()))?;
+    let mut attached_to_run = false;
+    let admission = if let Some(key) = &affinity {
+      // StopRun changes the Run phase under this same lock. Revalidate after
+      // the potentially slow spawn, then publish the affinity and admit the
+      // operation atomically with respect to a terminal transition.
+      let runs = self.runs.lock().expect("Run registry lock poisoned");
+      (|| {
+        let run =
+          runs.get(&key.run_id).filter(|owned| &owned.caller == caller).ok_or_else(|| DaemonError::UnknownRun(key.run_id.clone()))?;
+        if run.run.phase != proto::RunPhase::Running as i32 {
+          return Err(DaemonError::InvalidArgument("capability routing requires a running Run"));
+        }
+        if attach_to_run {
+          self.runners.attach_run(runner_id)?;
+          attached_to_run = true;
+        }
+        self.runner_affinities.lock().expect("Runner affinity registry lock poisoned").insert(key.clone(), runner_id.to_string());
+        match self.runners.begin_external_operation(runner_id, service, method) {
+          Ok(admission) => Ok(admission),
+          Err(error) => {
+            self.runner_affinities.lock().expect("Runner affinity registry lock poisoned").remove(key);
+            Err(error.into())
+          }
+        }
+      })()
+    } else {
+      self.runners.begin_external_operation(runner_id, service, method).map_err(Into::into)
+    };
+    let (channel, permit) = match admission {
+      Ok(admission) => admission,
+      Err(error) => {
+        if attached_to_run {
+          self.runners.release_run_affinity(runner_id).await?;
+        }
+        if created_runner {
+          self.runners.delete(runner_id, None, true).await?;
+        }
+        return Err(error);
+      }
+    };
+    Ok((channel, OperationPermit { _runner: permit }))
+  }
+
+  pub async fn shutdown(&self) {
+    self.runners.shutdown().await;
+  }
+
+  pub fn has_live_runners(&self) -> bool {
+    self.runners.has_live()
+  }
+
+  fn validate_local_device(&self, device_id: Option<&str>) -> Result<(), DaemonError> {
+    if let Some(device_id) = device_id
+      && self.get_device(device_id).is_none()
+    {
+      return Err(DaemonError::UnknownDevice(device_id.to_string()));
+    }
+    Ok(())
+  }
+}
+
+impl From<runner::RunnerError> for DaemonError {
+  fn from(error: runner::RunnerError) -> Self {
+    match error {
+      runner::RunnerError::InvalidArgument(message) => Self::InvalidArgument(message),
+      runner::RunnerError::ProviderUnavailable(class) => Self::RunnerProviderUnavailable(class),
+      runner::RunnerError::Unknown(id) => Self::UnknownRunner(id),
+      error => Self::RunnerOperation(error.to_string()),
+    }
+  }
+}
+
+fn run_id(run: &proto::Run) -> &str {
+  run.r#ref.as_ref().map(|run| run.run_id.as_str()).unwrap_or_default()
+}
+
+fn runner_id(runner: &proto::Runner) -> &str {
+  runner.r#ref.as_ref().map(|runner| runner.runner_id.as_str()).unwrap_or_default()
+}
+
+fn timestamp_now() -> prost_types::Timestamp {
+  let duration = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap_or_default();
+  prost_types::Timestamp {
+    seconds: i64::try_from(duration.as_secs()).unwrap_or(i64::MAX),
+    nanos: i32::try_from(duration.subsec_nanos()).expect("nanoseconds fit i32"),
+  }
+}
+
+fn load_or_create_local_device_id(path: &Path) -> Result<String, String> {
+  match fs::read_to_string(path) {
+    Ok(value) => validate_device_id(path, value.trim()),
+    Err(error) if error.kind() == ErrorKind::NotFound => create_local_device_id(path),
+    Err(error) => Err(format!("failed to read local Device ID {}: {error}", path.display())),
+  }
+}
+
+fn create_local_device_id(path: &Path) -> Result<String, String> {
+  let device_id = crate::resource_id::generate()?;
+  match OpenOptions::new().write(true).create_new(true).open(path) {
+    Ok(mut file) => {
+      set_private_file(path)?;
+      writeln!(file, "{device_id}").map_err(|error| format!("failed to write local Device ID {}: {error}", path.display()))?;
+      file.sync_all().map_err(|error| format!("failed to sync local Device ID {}: {error}", path.display()))?;
+      Ok(device_id)
+    }
+    Err(error) if error.kind() == ErrorKind::AlreadyExists => {
+      let value =
+        fs::read_to_string(path).map_err(|error| format!("failed to read concurrently created Device ID {}: {error}", path.display()))?;
+      validate_device_id(path, value.trim())
+    }
+    Err(error) => Err(format!("failed to create local Device ID {}: {error}", path.display())),
+  }
+}
+
+fn validate_device_id(path: &Path, value: &str) -> Result<String, String> {
+  // TODO(resource-id-migration): Accept the previously persisted
+  // `device_<UUID>` shape until Device stores have an explicit migration.
+  // New identities are always opaque 256-bit hexadecimal values.
+  let legacy = value.strip_prefix("device_").is_some_and(|value| uuid::Uuid::parse_str(value).is_ok());
+  (crate::resource_id::validate(value) || legacy)
+    .then(|| value.to_string())
+    .ok_or_else(|| format!("invalid local Device ID in {}", path.display()))
+}
+
+#[cfg(target_os = "linux")]
+fn local_platform() -> i32 {
+  proto::DevicePlatform::Linux as i32
+}
+
+#[cfg(target_os = "macos")]
+fn local_platform() -> i32 {
+  proto::DevicePlatform::Macos as i32
+}
+
+#[cfg(target_os = "windows")]
+fn local_platform() -> i32 {
+  proto::DevicePlatform::Windows as i32
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+fn local_platform() -> i32 {
+  proto::DevicePlatform::Unspecified as i32
+}
+
+#[cfg(unix)]
+fn set_private_directory(path: &Path) -> Result<(), String> {
+  use std::os::unix::fs::PermissionsExt;
+  fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+    .map_err(|error| format!("failed to set private control-plane directory permissions on {}: {error}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn set_private_directory(_path: &Path) -> Result<(), String> {
+  Ok(())
+}
+
+#[cfg(unix)]
+fn set_private_file(path: &Path) -> Result<(), String> {
+  use std::os::unix::fs::PermissionsExt;
+  fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+    .map_err(|error| format!("failed to set private local Device ID permissions on {}: {error}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn set_private_file(_path: &Path) -> Result<(), String> {
+  Ok(())
+}

--- a/crates/auv-api-server/src/daemon/runner.rs
+++ b/crates/auv-api-server/src/daemon/runner.rs
@@ -1,0 +1,670 @@
+//! Daemon-owned process Runner supervision and private Unix gRPC routing.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use auv_api_proto::auv::api::daemon::v1 as daemon_proto;
+use tokio::process::Child;
+use tokio::sync::Notify;
+use tonic::transport::{Channel, Endpoint};
+
+use super::runner_provider::{
+  FirstPartyRunnerRuntimes, RegisteredRunnerProvider, RunnerProviderConfig, RunnerProviderRegistry, RunnerRuntime,
+};
+
+const RUNNER_HEALTH_CHECK_TIMEOUT: Duration = Duration::from_secs(10);
+
+pub(crate) struct RunnerSupervisor {
+  providers: RunnerProviderRegistry,
+  local_device: daemon_proto::DeviceRef,
+  parent_context: Option<String>,
+  runners: Arc<Mutex<HashMap<String, ManagedRunner>>>,
+  activity_changed: Arc<Notify>,
+}
+
+struct ManagedRunner {
+  record: daemon_proto::Runner,
+  runtime: ManagedRunnerRuntime,
+  channel: Channel,
+  display_name: String,
+  run_affinities: u64,
+}
+
+enum ManagedRunnerRuntime {
+  Executable { child: Child },
+  RemoteGrpc,
+}
+
+struct ReadyRunner {
+  runtime: ManagedRunnerRuntime,
+  channel: Channel,
+  display_name: String,
+  labels: HashMap<String, String>,
+  process_id: u32,
+}
+
+pub(crate) struct OperationPermit {
+  runners: Arc<Mutex<HashMap<String, ManagedRunner>>>,
+  activity_changed: Arc<Notify>,
+  runner_id: String,
+}
+
+impl Drop for OperationPermit {
+  fn drop(&mut self) {
+    let (stop_now, schedule) = match decrement_activity_locked(&self.runners, &self.runner_id, false) {
+      Ok(transition) => transition,
+      Err(RunnerError::Unknown(_)) => return,
+      Err(_) => {
+        debug_assert!(false, "admitted Runner operation accounting must remain balanced");
+        return;
+      }
+    };
+    self.activity_changed.notify_waiters();
+    if let Some(managed) = stop_now {
+      tokio::spawn(async move {
+        let _ = stop_managed(managed).await;
+      });
+    }
+    if let Some((deadline, timeout)) = schedule {
+      schedule_idle_stop(self.runners.clone(), self.runner_id.clone(), deadline, timeout);
+    }
+  }
+}
+
+impl RunnerSupervisor {
+  pub(crate) fn with_providers(
+    local_device: daemon_proto::DeviceRef,
+    parent_endpoint: Option<String>,
+    first_party: FirstPartyRunnerRuntimes,
+    custom: Vec<RunnerProviderConfig>,
+  ) -> Result<Self, String> {
+    let parent_context = parent_endpoint
+      .map(|daemon_endpoint| {
+        serde_json::to_string(&serde_json::json!({
+          "device_id": local_device.device_id.clone(),
+          "daemon_endpoint": daemon_endpoint,
+        }))
+      })
+      .transpose()
+      .map_err(|error| format!("failed to encode Runner parent AUV_CONTEXT: {error}"))?;
+    Ok(Self {
+      providers: RunnerProviderRegistry::build_with_first_party(first_party.local_driver, custom).map_err(|error| error.to_string())?,
+      local_device,
+      parent_context,
+      runners: Arc::new(Mutex::new(HashMap::new())),
+      activity_changed: Arc::new(Notify::new()),
+    })
+  }
+
+  pub(crate) async fn create(
+    &self,
+    request: daemon_proto::CreateRunnerRequest,
+    initial_run_affinities: u64,
+  ) -> Result<daemon_proto::CreateRunnerResponse, RunnerError> {
+    let runner_class = request
+      .runner_class
+      .as_ref()
+      .map(|runner_class| runner_class.runner_class.as_str())
+      .filter(|runner_class| !runner_class.is_empty())
+      .ok_or(RunnerError::InvalidArgument("runner_class is required"))?;
+    let provider = self.providers.get(runner_class).cloned().ok_or_else(|| RunnerError::ProviderUnavailable(runner_class.to_string()))?;
+    let lifecycle =
+      daemon_proto::RunnerLifecycle::try_from(request.lifecycle).map_err(|_| RunnerError::InvalidArgument("runner lifecycle is unknown"))?;
+    match lifecycle {
+      daemon_proto::RunnerLifecycle::Ephemeral | daemon_proto::RunnerLifecycle::UnlessShutdown => {}
+      daemon_proto::RunnerLifecycle::UnlessIdle => {
+        validate_idle_timeout(request.idle_timeout.as_ref())?;
+      }
+      daemon_proto::RunnerLifecycle::Unspecified => return Err(RunnerError::InvalidArgument("runner lifecycle is required")),
+    }
+    let runner_id = crate::resource_id::generate().map_err(RunnerError::Start)?;
+    let ready = match spawn_ready(&provider, self.parent_context.as_deref()).await {
+      Ok(ready) => ready,
+      Err(error) => return Err(error),
+    };
+    let mut labels = ready.labels.clone();
+    labels.extend(request.labels);
+    let record = daemon_proto::Runner {
+      r#ref: Some(daemon_proto::RunnerRef {
+        runner_id: runner_id.clone(),
+      }),
+      device: Some(self.local_device.clone()),
+      runner_class: request.runner_class,
+      labels,
+      lifecycle: request.lifecycle,
+      idle_timeout: request.idle_timeout,
+      phase: daemon_proto::RunnerPhase::Ready as i32,
+      created_at: Some(timestamp_from_system_time(std::time::SystemTime::now())),
+      process_id: ready.process_id,
+      active_operations: 0,
+      idle_deadline: None,
+    };
+    let managed = ManagedRunner {
+      record: record.clone(),
+      runtime: ready.runtime,
+      channel: ready.channel,
+      display_name: ready.display_name,
+      run_affinities: initial_run_affinities,
+    };
+    self.runners.lock().expect("Runner registry lock poisoned").insert(runner_id, managed);
+    Ok(daemon_proto::CreateRunnerResponse {
+      runner: Some(record),
+    })
+  }
+
+  pub(crate) fn find_routable(&self, device_id: &str, runner_class: &str) -> Option<daemon_proto::Runner> {
+    let mut runners = self.runners.lock().expect("Runner registry lock poisoned");
+    refresh_exited(&mut runners);
+    runners.values().find_map(|managed| {
+      let record = &managed.record;
+      (record.phase == daemon_proto::RunnerPhase::Ready as i32
+        && record.device.as_ref().is_some_and(|device| device.device_id == device_id)
+        && record.runner_class.as_ref().is_some_and(|class| class.runner_class == runner_class))
+      .then(|| record.clone())
+    })
+  }
+
+  pub(crate) fn attach_run(&self, runner_id: &str) -> Result<(), RunnerError> {
+    let mut runners = self.runners.lock().expect("Runner registry lock poisoned");
+    refresh_exited(&mut runners);
+    let managed = runners.get_mut(runner_id).ok_or_else(|| RunnerError::Unknown(runner_id.to_string()))?;
+    managed.run_affinities = managed.run_affinities.saturating_add(1);
+    managed.record.idle_deadline = None;
+    Ok(())
+  }
+
+  pub(crate) async fn release_run_affinity(&self, runner_id: &str) -> Result<(), RunnerError> {
+    self.decrement_activity(runner_id, true).await
+  }
+
+  pub(crate) fn begin_external_operation(
+    &self,
+    runner_id: &str,
+    service: &str,
+    method: &str,
+  ) -> Result<(Channel, OperationPermit), RunnerError> {
+    self.begin_operation_inner(runner_id, service, method)
+  }
+
+  fn begin_operation_inner(&self, runner_id: &str, service: &str, method: &str) -> Result<(Channel, OperationPermit), RunnerError> {
+    let mut runners = self.runners.lock().expect("Runner registry lock poisoned");
+    refresh_exited(&mut runners);
+    let managed = runners.get_mut(runner_id).ok_or_else(|| RunnerError::Unknown(runner_id.to_string()))?;
+    if managed.record.phase != daemon_proto::RunnerPhase::Ready as i32 {
+      return Err(RunnerError::Call("Runner is not ready for operation admission".to_string()));
+    }
+    // Registration approves the complete endpoint. The daemon routes the
+    // original gRPC path without parsing descriptors or maintaining a
+    // per-service/method allowlist.
+    let _ = (service, method);
+    managed.record.active_operations = managed.record.active_operations.saturating_add(1);
+    managed.record.idle_deadline = None;
+    Ok((
+      managed.channel.clone(),
+      OperationPermit {
+        runners: self.runners.clone(),
+        activity_changed: self.activity_changed.clone(),
+        runner_id: runner_id.to_string(),
+      },
+    ))
+  }
+
+  async fn decrement_activity(&self, runner_id: &str, run_affinity: bool) -> Result<(), RunnerError> {
+    let (stop_now, schedule) = decrement_activity_locked(&self.runners, runner_id, run_affinity)?;
+    self.activity_changed.notify_waiters();
+    if let Some(managed) = stop_now {
+      stop_managed(managed).await?;
+    }
+    if let Some((deadline, timeout)) = schedule {
+      schedule_idle_stop(self.runners.clone(), runner_id.to_string(), deadline, timeout);
+    }
+    Ok(())
+  }
+
+  pub(crate) fn list_classes(&self) -> daemon_proto::ListRunnerClassesResponse {
+    let runners = self.runners.lock().expect("Runner registry lock poisoned");
+    daemon_proto::ListRunnerClassesResponse {
+      runner_classes: self
+        .providers
+        .values()
+        .map(|provider| runner_class_record(provider, self.local_device.clone(), runners.values()))
+        .collect(),
+    }
+  }
+
+  pub(crate) fn get_class(&self, runner_class: &str) -> Result<daemon_proto::GetRunnerClassResponse, RunnerError> {
+    let provider = self.providers.get(runner_class).ok_or_else(|| RunnerError::ProviderUnavailable(runner_class.to_string()))?;
+    let runners = self.runners.lock().expect("Runner registry lock poisoned");
+    Ok(daemon_proto::GetRunnerClassResponse {
+      runner_class: Some(runner_class_record(provider, self.local_device.clone(), runners.values())),
+    })
+  }
+
+  pub(crate) fn list(&self) -> daemon_proto::ListRunnersResponse {
+    let mut runners = self.runners.lock().expect("Runner registry lock poisoned");
+    refresh_exited(&mut runners);
+    let mut records = runners.values().map(|runner| runner.record.clone()).collect::<Vec<_>>();
+    records.sort_by(|left, right| runner_id(left).cmp(runner_id(right)));
+    daemon_proto::ListRunnersResponse { runners: records }
+  }
+
+  pub(crate) fn get(&self, runner_id: &str) -> Result<daemon_proto::GetRunnerResponse, RunnerError> {
+    let mut runners = self.runners.lock().expect("Runner registry lock poisoned");
+    refresh_exited(&mut runners);
+    runners
+      .get(runner_id)
+      .map(|runner| daemon_proto::GetRunnerResponse {
+        runner: Some(runner.record.clone()),
+      })
+      .ok_or_else(|| RunnerError::Unknown(runner_id.to_string()))
+  }
+
+  pub(crate) fn has_live(&self) -> bool {
+    let mut runners = self.runners.lock().expect("Runner registry lock poisoned");
+    refresh_exited(&mut runners);
+    runners.values().any(|runner| runner.record.phase == daemon_proto::RunnerPhase::Ready as i32)
+  }
+
+  pub(crate) async fn delete(
+    &self,
+    runner_id: &str,
+    grace_period: Option<prost_types::Duration>,
+    force: bool,
+  ) -> Result<daemon_proto::DeleteRunnerResponse, RunnerError> {
+    let grace_period = grace_period.map(validate_grace_period).transpose()?;
+    {
+      let mut runners = self.runners.lock().expect("Runner registry lock poisoned");
+      let managed = runners.get_mut(runner_id).ok_or_else(|| RunnerError::Unknown(runner_id.to_string()))?;
+      managed.record.phase = daemon_proto::RunnerPhase::Draining as i32;
+      managed.run_affinities = 0;
+      managed.record.idle_deadline = None;
+    }
+    let deadline = grace_period.map(|grace| tokio::time::Instant::now() + grace);
+    let is_remote = self
+      .runners
+      .lock()
+      .expect("Runner registry lock poisoned")
+      .get(runner_id)
+      .is_some_and(|managed| matches!(&managed.runtime, ManagedRunnerRuntime::RemoteGrpc));
+    if is_remote && !force {
+      loop {
+        let changed = self.activity_changed.notified();
+        let drained = self
+          .runners
+          .lock()
+          .expect("Runner registry lock poisoned")
+          .get(runner_id)
+          .is_some_and(|managed| managed.record.active_operations == 0);
+        if drained {
+          break;
+        }
+        match deadline {
+          Some(deadline) => {
+            if tokio::time::timeout_at(deadline, changed).await.is_err() {
+              break;
+            }
+          }
+          None => changed.await,
+        }
+      }
+    }
+    let mut managed =
+      self.runners.lock().expect("Runner registry lock poisoned").remove(runner_id).expect("draining Runner remains registered");
+    stop_managed_in_place(&mut managed, deadline, force).await?;
+    Ok(daemon_proto::DeleteRunnerResponse {
+      runner: Some(managed.record),
+    })
+  }
+
+  pub(crate) async fn shutdown(&self) {
+    let runners = std::mem::take(&mut *self.runners.lock().expect("Runner registry lock poisoned"));
+    for (_, managed) in runners {
+      let _ = stop_managed(managed).await;
+    }
+  }
+}
+
+fn runner_class_record<'a>(
+  provider: &RegisteredRunnerProvider,
+  device: daemon_proto::DeviceRef,
+  runners: impl Iterator<Item = &'a ManagedRunner>,
+) -> daemon_proto::RunnerClass {
+  let observed = runners.filter(|runner| {
+    runner.record.runner_class.as_ref().is_some_and(|class| class.runner_class == provider.runner_class)
+      && runner.record.phase == daemon_proto::RunnerPhase::Ready as i32
+  });
+  let mut display_name = provider.runner_class.clone();
+  for runner in observed {
+    display_name = runner.display_name.clone();
+  }
+  daemon_proto::RunnerClass {
+    r#ref: Some(daemon_proto::RunnerClassRef {
+      runner_class: provider.runner_class.clone(),
+    }),
+    device: Some(device),
+    display_name,
+    supported_lifecycles: vec![
+      daemon_proto::RunnerLifecycle::Ephemeral as i32,
+      daemon_proto::RunnerLifecycle::UnlessIdle as i32,
+      daemon_proto::RunnerLifecycle::UnlessShutdown as i32,
+    ],
+    available: true,
+  }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum RunnerError {
+  #[error("invalid Runner argument: {0}")]
+  InvalidArgument(&'static str),
+  #[error("no RunnerProvider is registered for RunnerClass: {0}")]
+  ProviderUnavailable(String),
+  #[error("unknown Runner: {0}")]
+  Unknown(String),
+  #[error("failed to start Runner: {0}")]
+  Start(String),
+  #[error("failed to stop Runner: {0}")]
+  Stop(String),
+  #[error("Runner call failed: {0}")]
+  Call(String),
+}
+
+fn validate_idle_timeout(value: Option<&prost_types::Duration>) -> Result<Duration, RunnerError> {
+  let value = value.ok_or(RunnerError::InvalidArgument("idle_timeout is required for unless-idle"))?;
+  if value.seconds < 0 || value.nanos < 0 || value.nanos >= 1_000_000_000 || (value.seconds == 0 && value.nanos == 0) {
+    return Err(RunnerError::InvalidArgument("idle_timeout must be positive"));
+  }
+  Ok(Duration::new(
+    u64::try_from(value.seconds).map_err(|_| RunnerError::InvalidArgument("idle_timeout is too large"))?,
+    u32::try_from(value.nanos).map_err(|_| RunnerError::InvalidArgument("idle_timeout is invalid"))?,
+  ))
+}
+
+fn validate_grace_period(value: prost_types::Duration) -> Result<Duration, RunnerError> {
+  if value.seconds < 0 || value.nanos < 0 || value.nanos >= 1_000_000_000 {
+    return Err(RunnerError::InvalidArgument("grace_period must be a non-negative protobuf duration"));
+  }
+  Ok(Duration::new(value.seconds as u64, value.nanos as u32))
+}
+
+type IdleTransition = (Option<ManagedRunner>, Option<(std::time::SystemTime, Duration)>);
+
+fn decrement_activity_locked(
+  runners: &Arc<Mutex<HashMap<String, ManagedRunner>>>,
+  runner_id: &str,
+  run_affinity: bool,
+) -> Result<IdleTransition, RunnerError> {
+  let mut runners = runners.lock().expect("Runner registry lock poisoned");
+  let managed = runners.get_mut(runner_id).ok_or_else(|| RunnerError::Unknown(runner_id.to_string()))?;
+  if run_affinity {
+    managed.run_affinities =
+      managed.run_affinities.checked_sub(1).ok_or_else(|| RunnerError::Call("Runner affinity accounting underflow".to_string()))?;
+  } else {
+    managed.record.active_operations = managed
+      .record
+      .active_operations
+      .checked_sub(1)
+      .ok_or_else(|| RunnerError::Call("Runner operation accounting underflow".to_string()))?;
+  }
+  if managed.run_affinities != 0 || managed.record.active_operations != 0 {
+    return Ok((None, None));
+  }
+  match daemon_proto::RunnerLifecycle::try_from(managed.record.lifecycle).unwrap_or_default() {
+    daemon_proto::RunnerLifecycle::Ephemeral => Ok((runners.remove(runner_id), None)),
+    daemon_proto::RunnerLifecycle::UnlessIdle => {
+      let timeout = validate_idle_timeout(managed.record.idle_timeout.as_ref())?;
+      let deadline = std::time::SystemTime::now() + timeout;
+      managed.record.idle_deadline = Some(timestamp_from_system_time(deadline));
+      Ok((None, Some((deadline, timeout))))
+    }
+    _ => Ok((None, None)),
+  }
+}
+
+fn schedule_idle_stop(
+  runners: Arc<Mutex<HashMap<String, ManagedRunner>>>,
+  runner_id: String,
+  deadline: std::time::SystemTime,
+  timeout: Duration,
+) {
+  tokio::spawn(async move {
+    tokio::time::sleep(timeout).await;
+    let managed = {
+      let mut runners = runners.lock().expect("Runner registry lock poisoned");
+      let should_stop = runners.get(&runner_id).is_some_and(|managed| {
+        managed.run_affinities == 0
+          && managed.record.active_operations == 0
+          && managed.record.idle_deadline.as_ref() == Some(&timestamp_from_system_time(deadline))
+      });
+      should_stop.then(|| runners.remove(&runner_id)).flatten()
+    };
+    if let Some(managed) = managed {
+      let _ = stop_managed(managed).await;
+    }
+  });
+}
+
+async fn stop_managed(mut managed: ManagedRunner) -> Result<(), RunnerError> {
+  stop_managed_in_place(&mut managed, None, false).await
+}
+
+async fn stop_managed_in_place(managed: &mut ManagedRunner, deadline: Option<tokio::time::Instant>, force: bool) -> Result<(), RunnerError> {
+  managed.record.phase = daemon_proto::RunnerPhase::Draining as i32;
+  let channel = std::mem::replace(&mut managed.channel, Channel::from_static("http://[::]:1").connect_lazy());
+  match &mut managed.runtime {
+    ManagedRunnerRuntime::RemoteGrpc => {
+      // A RemoteGrpc runtime may be shared infrastructure. Deleting the local
+      // Runner detaches its Channel but never drains or terminates the remote
+      // endpoint itself.
+      drop(channel);
+    }
+    ManagedRunnerRuntime::Executable { child } => {
+      if force {
+        drop(channel);
+        terminate_child(child).await?;
+      } else {
+        drop(channel);
+        match deadline {
+          Some(deadline) => match tokio::time::timeout_at(deadline, child.wait()).await {
+            Ok(Ok(_)) => {}
+            Ok(Err(error)) => return Err(RunnerError::Stop(error.to_string())),
+            Err(_) => terminate_child(child).await?,
+          },
+          None => {
+            child.wait().await.map_err(|error| RunnerError::Stop(error.to_string()))?;
+          }
+        }
+      }
+    }
+  }
+  managed.record.phase = daemon_proto::RunnerPhase::Stopped as i32;
+  Ok(())
+}
+
+async fn terminate_child(child: &mut Child) -> Result<(), RunnerError> {
+  if child.try_wait().map_err(|error| RunnerError::Stop(error.to_string()))?.is_none() {
+    child.kill().await.map_err(|error| RunnerError::Stop(error.to_string()))?;
+  }
+  child.wait().await.map_err(|error| RunnerError::Stop(error.to_string()))?;
+  Ok(())
+}
+
+#[cfg(unix)]
+async fn spawn_ready(provider: &RegisteredRunnerProvider, parent_context: Option<&str>) -> Result<ReadyRunner, RunnerError> {
+  match &provider.runtime {
+    RunnerRuntime::Executable(runtime) => spawn_executable_ready(provider, runtime, parent_context).await,
+    RunnerRuntime::RemoteGrpc(runtime) => connect_remote_ready(provider, runtime).await,
+  }
+}
+
+#[cfg(unix)]
+async fn spawn_executable_ready(
+  provider: &RegisteredRunnerProvider,
+  runtime: &super::runner_provider::ExecutableRunnerRuntime,
+  parent_context: Option<&str>,
+) -> Result<ReadyRunner, RunnerError> {
+  use std::os::fd::AsRawFd;
+
+  let (parent, child_stream) = std::os::unix::net::UnixStream::pair().map_err(|error| RunnerError::Start(error.to_string()))?;
+  parent.set_nonblocking(true).map_err(|error| RunnerError::Start(error.to_string()))?;
+  let inherited_fd = child_stream.as_raw_fd();
+  let mut command = tokio::process::Command::new(&runtime.executable);
+  command
+    .args(&runtime.arguments)
+    // Runner children inherit the daemon environment so platform launch
+    // context such as XDG, Wayland, DBus, dynamic-loader, and GPU variables
+    // remains available without rebuilding AUV for every new integration.
+    .envs(&runtime.environment)
+    // The daemon owns this value. Never let a stale context inherited by the
+    // daemon or supplied by a provider manifest redirect child delegation.
+    .env_remove("AUV_CONTEXT")
+    .env("AUV_RUNNER_IPC_FD", "3")
+    .stdin(std::process::Stdio::null())
+    .stdout(std::process::Stdio::null())
+    .stderr(std::process::Stdio::inherit());
+  if let Some(parent_context) = parent_context {
+    command.env("AUV_CONTEXT", parent_context);
+  }
+  if let Some(working_directory) = &runtime.working_directory {
+    command.current_dir(working_directory);
+  }
+  // SAFETY: this closure uses only async-signal-safe libc calls between fork
+  // and exec, copies one already-open socket to a fixed descriptor, and
+  // reports failures through io::Error.
+  unsafe {
+    command.pre_exec(move || {
+      if inherited_fd != 3 && libc::dup2(inherited_fd, 3) == -1 {
+        return Err(std::io::Error::last_os_error());
+      }
+      if libc::fcntl(3, libc::F_SETFD, 0) == -1 {
+        return Err(std::io::Error::last_os_error());
+      }
+      Ok(())
+    });
+  }
+  let mut child = command.spawn().map_err(|error| RunnerError::Start(error.to_string()))?;
+  drop(child_stream);
+  let stream = tokio::net::UnixStream::from_std(parent).map_err(|error| RunnerError::Start(error.to_string()))?;
+  let once = std::sync::Arc::new(tokio::sync::Mutex::new(Some(stream)));
+  let endpoint = Endpoint::from_static("http://[::]:50051");
+  let connect = endpoint.connect_with_connector(tower::service_fn(move |_: http::Uri| {
+    let once = once.clone();
+    async move {
+      once
+        .lock()
+        .await
+        .take()
+        .map(hyper_util::rt::TokioIo::new)
+        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotConnected, "Runner IPC stream already consumed"))
+    }
+  }));
+  let channel = match connect.await {
+    Ok(channel) => channel,
+    Err(error) => {
+      let _ = child.kill().await;
+      let _ = child.wait().await;
+      return Err(RunnerError::Start(error.to_string()));
+    }
+  };
+  let reflected = match validate_ready(channel.clone(), provider).await {
+    Ok(reflected) => reflected,
+    Err(error) => {
+      let _ = child.kill().await;
+      let _ = child.wait().await;
+      return Err(error);
+    }
+  };
+  let process_id = child.id().ok_or_else(|| RunnerError::Start("Runner process omitted its PID".to_string()))?;
+  Ok(ReadyRunner {
+    runtime: ManagedRunnerRuntime::Executable { child },
+    channel,
+    display_name: reflected.display_name,
+    labels: reflected.labels,
+    process_id,
+  })
+}
+
+#[cfg(not(unix))]
+async fn spawn_ready(provider: &RegisteredRunnerProvider, _parent_context: Option<&str>) -> Result<ReadyRunner, RunnerError> {
+  match &provider.runtime {
+    RunnerRuntime::Executable(_) => Err(RunnerError::Start("inherited-stream Runner IPC requires Unix".to_string())),
+    RunnerRuntime::RemoteGrpc(runtime) => connect_remote_ready(provider, runtime).await,
+  }
+}
+
+async fn connect_remote_ready(
+  provider: &RegisteredRunnerProvider,
+  runtime: &super::runner_provider::RemoteGrpcRunnerRuntime,
+) -> Result<ReadyRunner, RunnerError> {
+  let endpoint = Endpoint::from_shared(runtime.endpoint.clone()).map_err(|error| RunnerError::Start(error.to_string()))?;
+  let channel = endpoint.connect().await.map_err(|error| RunnerError::Start(error.to_string()))?;
+  let reflected = validate_ready(channel.clone(), provider).await?;
+  Ok(ReadyRunner {
+    runtime: ManagedRunnerRuntime::RemoteGrpc,
+    channel,
+    display_name: reflected.display_name,
+    labels: reflected.labels,
+    process_id: 0,
+  })
+}
+
+struct ReflectedRuntime {
+  display_name: String,
+  labels: HashMap<String, String>,
+}
+
+async fn validate_ready(channel: Channel, provider: &RegisteredRunnerProvider) -> Result<ReflectedRuntime, RunnerError> {
+  let mut health = tonic_health::pb::health_client::HealthClient::new(channel.clone());
+  let response = tokio::time::timeout(
+    RUNNER_HEALTH_CHECK_TIMEOUT,
+    health.check(tonic_health::pb::HealthCheckRequest {
+      service: String::new(),
+    }),
+  )
+  .await
+  .map_err(|_| RunnerError::Start(format!("Runner health check timed out after {}s", RUNNER_HEALTH_CHECK_TIMEOUT.as_secs())))?
+  .map_err(|status| RunnerError::Start(format!("Runner health check failed: {status}")))?
+  .into_inner();
+  if response.status != tonic_health::pb::health_check_response::ServingStatus::Serving as i32 {
+    return Err(RunnerError::Start("Runner endpoint is not serving".to_string()));
+  }
+  Ok(ReflectedRuntime {
+    display_name: provider.runner_class.clone(),
+    labels: Default::default(),
+  })
+}
+
+fn refresh_exited(runners: &mut HashMap<String, ManagedRunner>) {
+  for managed in runners.values_mut() {
+    let exited = match &mut managed.runtime {
+      ManagedRunnerRuntime::Executable { child } => child.try_wait().ok().flatten().is_some(),
+      // TODO(remote-runner-watch-status): consume WatchStatus and health
+      // transitions once retry/backoff and failure evidence semantics are
+      // approved. Ordinary RPCs already surface endpoint unavailability.
+      ManagedRunnerRuntime::RemoteGrpc => false,
+    };
+    if managed.record.phase == daemon_proto::RunnerPhase::Ready as i32 && exited {
+      // TODO(runner-restart-policy): crashed children are retained as FAILED
+      // evidence and a later routed request may create a replacement.
+      // Automatic restart/backoff is deferred until the owner approves
+      // attempt limits, crash-loop visibility, and Run-affinity reassignment.
+      managed.record.phase = daemon_proto::RunnerPhase::Failed as i32;
+    }
+  }
+}
+
+fn runner_id(runner: &daemon_proto::Runner) -> &str {
+  runner.r#ref.as_ref().map(|runner| runner.runner_id.as_str()).unwrap_or_default()
+}
+
+fn timestamp_from_system_time(value: std::time::SystemTime) -> prost_types::Timestamp {
+  let duration = value.duration_since(std::time::UNIX_EPOCH).unwrap_or_default();
+  prost_types::Timestamp {
+    seconds: i64::try_from(duration.as_secs()).unwrap_or(i64::MAX),
+    nanos: i32::try_from(duration.subsec_nanos()).expect("nanoseconds fit i32"),
+  }
+}
+
+#[cfg(test)]
+#[path = "runner_test.rs"]
+mod tests;

--- a/crates/auv-api-server/src/daemon/runner_provider.rs
+++ b/crates/auv-api-server/src/daemon/runner_provider.rs
@@ -1,0 +1,209 @@
+//! Daemon-side selection of Runner providers.
+//!
+//! A provider manifest selects how the daemon reaches a RunnerClass. Runtime
+//! business services belong to the running endpoint and are deliberately not
+//! duplicated or pinned in this configuration.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+const LOCAL_RUNNER_CLASS: &str = "auv.core.local";
+
+/// Experimental daemon-side selection of one RunnerClass provider.
+///
+/// `runner_class` is the stable selector known before connecting. Display
+/// Registration supplies identity and process configuration. Standard gRPC
+/// Health reports endpoint readiness; Reflection remains available to callers
+/// through the opaque route.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+pub struct RunnerProviderConfig {
+  pub runner_class: String,
+  pub runtime: RunnerRuntime,
+}
+
+/// Daemon-side transport used to realize one Runner provider.
+///
+/// This is a Rust/configuration enum. Compatible runtimes expose the same
+/// the same standard gRPC service contract; the transport choice is
+/// intentionally absent from the protobuf resource model.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[serde(tag = "type", content = "config", rename_all = "kebab-case")]
+pub enum RunnerRuntime {
+  Executable(ExecutableRunnerRuntime),
+  RemoteGrpc(RemoteGrpcRunnerRuntime),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+pub struct ExecutableRunnerRuntime {
+  /// Program passed to the operating system at spawn time.
+  ///
+  /// A bare name uses normal `PATH` lookup. A relative path containing a
+  /// directory is resolved relative to the provider manifest by `load_json`.
+  /// Absolute paths remain unchanged.
+  pub executable: PathBuf,
+  #[serde(default)]
+  pub arguments: Vec<String>,
+  /// Optional child working directory. A relative directory is resolved from
+  /// the provider manifest directory by `load_json`.
+  pub working_directory: Option<PathBuf>,
+  /// Environment entries overlaid on the daemon's inherited environment.
+  ///
+  /// This is intentionally not an allowlist and does not request that the
+  /// daemon clear unrelated variables before spawning the child.
+  #[serde(default)]
+  pub environment: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+pub struct RemoteGrpcRunnerRuntime {
+  pub endpoint: String,
+  // TODO(remote-runner-credentials): add a typed daemon-owned credential
+  // reference when authenticated outbound Runner connections are approved;
+  // caller Authorization must never be forwarded to a provider endpoint.
+}
+
+/// First-party runtimes supplied by the process that embeds the API server.
+#[derive(Clone, Debug, Default)]
+pub struct FirstPartyRunnerRuntimes {
+  pub local_driver: Option<RunnerRuntime>,
+}
+
+impl RunnerProviderConfig {
+  /// Loads one JSON provider configuration.
+  ///
+  /// The manifest selects a program or endpoint; it is not a filesystem trust
+  /// boundary. Executable existence, permissions, symlinks, ownership, and
+  /// `PATH` resolution are therefore left to the operating system at spawn.
+  pub fn load_json(path: impl AsRef<Path>) -> Result<Self, RunnerProviderConfigError> {
+    let path = path.as_ref();
+    let bytes = std::fs::read(path).map_err(|source| RunnerProviderConfigError::FileRead {
+      path: path.to_path_buf(),
+      source,
+    })?;
+    let mut config: Self = serde_json::from_slice(&bytes).map_err(|source| RunnerProviderConfigError::Json {
+      path: path.to_path_buf(),
+      source,
+    })?;
+    config.resolve_manifest_relative_executable(path);
+    Ok(config)
+  }
+
+  fn resolve_manifest_relative_executable(&mut self, manifest_path: &Path) {
+    let RunnerRuntime::Executable(runtime) = &mut self.runtime else {
+      return;
+    };
+    let directory = manifest_path.parent().unwrap_or_else(|| Path::new(""));
+    if runtime.executable.is_absolute() || is_bare_executable_name(&runtime.executable) {
+      // Bare executable names retain normal operating-system PATH lookup.
+    } else {
+      runtime.executable = directory.join(&runtime.executable);
+    }
+    if let Some(working_directory) = &mut runtime.working_directory
+      && !working_directory.is_absolute()
+    {
+      *working_directory = directory.join(&*working_directory);
+    }
+  }
+}
+
+fn is_bare_executable_name(path: &Path) -> bool {
+  path.parent().is_none_or(|parent| parent.as_os_str().is_empty())
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RunnerProviderConfigError {
+  #[error("failed to read Runner provider config {path}: {source}")]
+  FileRead {
+    path: PathBuf,
+    #[source]
+    source: std::io::Error,
+  },
+  #[error("invalid Runner provider JSON {path}: {source}")]
+  Json {
+    path: PathBuf,
+    #[source]
+    source: serde_json::Error,
+  },
+  #[error("invalid RunnerClass identity: {0}")]
+  InvalidRunnerClass(String),
+  #[error("RunnerClass {0} is reserved by the daemon")]
+  ReservedRunnerClass(String),
+  #[error("RunnerClass is configured more than once: {0}")]
+  DuplicateRunnerClass(String),
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct RegisteredRunnerProvider {
+  pub(crate) runner_class: String,
+  pub(crate) runtime: RunnerRuntime,
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct RunnerProviderRegistry {
+  providers: BTreeMap<String, RegisteredRunnerProvider>,
+}
+
+impl RunnerProviderRegistry {
+  pub(crate) fn build_with_first_party(
+    local_runtime: Option<RunnerRuntime>,
+    custom: Vec<RunnerProviderConfig>,
+  ) -> Result<Self, RunnerProviderConfigError> {
+    let mut registry = Self::default();
+    if let Some(runtime) = local_runtime {
+      registry.insert(first_party_provider(LOCAL_RUNNER_CLASS, runtime))?;
+    }
+    for config in custom {
+      registry.insert(register_custom(config)?)?;
+    }
+    Ok(registry)
+  }
+
+  fn insert(&mut self, provider: RegisteredRunnerProvider) -> Result<(), RunnerProviderConfigError> {
+    if self.providers.contains_key(&provider.runner_class) {
+      return Err(RunnerProviderConfigError::DuplicateRunnerClass(provider.runner_class));
+    }
+    self.providers.insert(provider.runner_class.clone(), provider);
+    Ok(())
+  }
+
+  pub(crate) fn get(&self, runner_class: &str) -> Option<&RegisteredRunnerProvider> {
+    self.providers.get(runner_class)
+  }
+
+  pub(crate) fn values(&self) -> impl Iterator<Item = &RegisteredRunnerProvider> {
+    self.providers.values()
+  }
+}
+
+fn first_party_provider(runner_class: &str, runtime: RunnerRuntime) -> RegisteredRunnerProvider {
+  RegisteredRunnerProvider {
+    runner_class: runner_class.to_string(),
+    runtime,
+  }
+}
+
+fn register_custom(config: RunnerProviderConfig) -> Result<RegisteredRunnerProvider, RunnerProviderConfigError> {
+  validate_class_identity(&config.runner_class)?;
+  if is_reserved_runner_class(&config.runner_class) {
+    return Err(RunnerProviderConfigError::ReservedRunnerClass(config.runner_class));
+  }
+  Ok(RegisteredRunnerProvider {
+    runner_class: config.runner_class,
+    runtime: config.runtime,
+  })
+}
+
+fn validate_class_identity(value: &str) -> Result<(), RunnerProviderConfigError> {
+  if value.is_empty() {
+    return Err(RunnerProviderConfigError::InvalidRunnerClass(value.to_string()));
+  }
+  Ok(())
+}
+
+fn is_reserved_runner_class(value: &str) -> bool {
+  value == LOCAL_RUNNER_CLASS
+}
+
+#[cfg(test)]
+#[path = "runner_provider_test.rs"]
+mod tests;

--- a/crates/auv-api-server/src/daemon/runner_provider_test.rs
+++ b/crates/auv-api-server/src/daemon/runner_provider_test.rs
@@ -1,0 +1,148 @@
+use super::*;
+
+fn executable(path: impl Into<PathBuf>) -> RunnerRuntime {
+  RunnerRuntime::Executable(ExecutableRunnerRuntime {
+    executable: path.into(),
+    arguments: vec!["serve-runner".to_string()],
+    working_directory: None,
+    environment: BTreeMap::new(),
+  })
+}
+
+fn custom_config(runtime: RunnerRuntime) -> RunnerProviderConfig {
+  RunnerProviderConfig {
+    runner_class: "example.runner.music".to_string(),
+    runtime,
+  }
+}
+
+fn write_config(directory: &Path, name: &str, config: &serde_json::Value) -> PathBuf {
+  let path = directory.join(name);
+  std::fs::write(&path, serde_json::to_vec_pretty(config).expect("encode provider config")).expect("write provider config");
+  path
+}
+
+#[test]
+fn load_json_preserves_bare_and_absolute_executables() {
+  let directory = tempfile::tempdir().expect("provider fixture directory");
+  let bare = custom_config(executable("runner-on-path"));
+  let bare_path = write_config(directory.path(), "bare.json", &serde_json::to_value(&bare).unwrap());
+  assert_eq!(RunnerProviderConfig::load_json(bare_path).unwrap(), bare);
+
+  let absolute_path = directory.path().join("not-required-to-exist");
+  let absolute = custom_config(executable(absolute_path));
+  let absolute_config = write_config(directory.path(), "absolute.json", &serde_json::to_value(&absolute).unwrap());
+  assert_eq!(RunnerProviderConfig::load_json(absolute_config).unwrap(), absolute);
+}
+
+#[test]
+fn load_json_resolves_relative_executable_from_manifest_directory_without_admission() {
+  let directory = tempfile::tempdir().expect("provider fixture directory");
+  let config = custom_config(executable("bin/custom-runner"));
+  let mut config = config;
+  let RunnerRuntime::Executable(runtime) = &mut config.runtime else {
+    panic!("fixture uses executable runtime")
+  };
+  runtime.working_directory = Some(PathBuf::from("runner-work"));
+  runtime.environment.insert("RUNNER_MODE".to_string(), "test".to_string());
+  let config_path = write_config(directory.path(), "provider.json", &serde_json::to_value(&config).unwrap());
+
+  let loaded = RunnerProviderConfig::load_json(config_path).expect("load relative provider");
+  let RunnerRuntime::Executable(runtime) = loaded.runtime else {
+    panic!("fixture uses executable runtime")
+  };
+  assert_eq!(runtime.executable, directory.path().join("bin/custom-runner"));
+  assert_eq!(runtime.arguments, ["serve-runner"]);
+  assert_eq!(runtime.working_directory, Some(directory.path().join("runner-work")));
+  assert_eq!(runtime.environment.get("RUNNER_MODE").map(String::as_str), Some("test"));
+}
+
+#[test]
+fn config_accepts_forward_compatible_unknown_fields() {
+  let directory = tempfile::tempdir().expect("provider fixture directory");
+  let config_path = write_config(
+    directory.path(),
+    "provider.json",
+    &serde_json::json!({
+      "runner_class": "example.runner.music",
+      "future_provider_field": true,
+      "runtime": {
+        "type": "executable",
+        "config": {
+          "executable": "runner-on-path",
+          "arguments": [],
+          "future_runtime_field": "accepted"
+        }
+      }
+    }),
+  );
+
+  let loaded = RunnerProviderConfig::load_json(config_path).expect("unknown fields are ignored by serde");
+  assert_eq!(loaded.runner_class, "example.runner.music");
+  assert_eq!(loaded.runtime, executable("runner-on-path").with_arguments(Vec::new()));
+}
+
+#[test]
+fn registry_keeps_runtime_selection_without_preflighting_it() {
+  let executable_config = custom_config(executable("missing-runner-on-path"));
+  let remote_config = RunnerProviderConfig {
+    runner_class: "example.runner.remote".to_string(),
+    runtime: RunnerRuntime::RemoteGrpc(RemoteGrpcRunnerRuntime {
+      endpoint: "not prevalidated until connect".to_string(),
+    }),
+  };
+
+  let registry =
+    RunnerProviderRegistry::build_with_first_party(None, vec![executable_config, remote_config]).expect("selection does not perform IO");
+  assert!(matches!(registry.get("example.runner.music").unwrap().runtime, RunnerRuntime::Executable(_)));
+  assert!(matches!(registry.get("example.runner.remote").unwrap().runtime, RunnerRuntime::RemoteGrpc(_)));
+}
+
+#[test]
+fn registry_rejects_invalid_reserved_and_duplicate_runner_classes() {
+  let invalid = RunnerProviderConfig {
+    runner_class: String::new(),
+    runtime: executable("runner"),
+  };
+  assert!(matches!(
+    RunnerProviderRegistry::build_with_first_party(None, vec![invalid]),
+    Err(RunnerProviderConfigError::InvalidRunnerClass(_))
+  ));
+
+  let reserved = RunnerProviderConfig {
+    runner_class: LOCAL_RUNNER_CLASS.to_string(),
+    runtime: executable("runner"),
+  };
+  assert!(matches!(
+    RunnerProviderRegistry::build_with_first_party(None, vec![reserved]),
+    Err(RunnerProviderConfigError::ReservedRunnerClass(class)) if class == LOCAL_RUNNER_CLASS
+  ));
+
+  let first = custom_config(executable("first"));
+  let duplicate = custom_config(executable("second"));
+  assert!(matches!(
+    RunnerProviderRegistry::build_with_first_party(None, vec![first, duplicate]),
+    Err(RunnerProviderConfigError::DuplicateRunnerClass(class)) if class == "example.runner.music"
+  ));
+}
+
+#[test]
+fn first_party_runtimes_are_registered_under_daemon_owned_classes() {
+  let registry = RunnerProviderRegistry::build_with_first_party(Some(executable("auv")), Vec::new()).unwrap();
+  assert!(registry.get(LOCAL_RUNNER_CLASS).is_some());
+  assert_eq!(registry.values().count(), 1);
+}
+
+trait RuntimeTestExt {
+  fn with_arguments(self, arguments: Vec<String>) -> Self;
+}
+
+impl RuntimeTestExt for RunnerRuntime {
+  fn with_arguments(mut self, arguments: Vec<String>) -> Self {
+    let RunnerRuntime::Executable(runtime) = &mut self else {
+      panic!("test helper requires executable runtime")
+    };
+    runtime.arguments = arguments;
+    self
+  }
+}

--- a/crates/auv-api-server/src/daemon/runner_test.rs
+++ b/crates/auv-api-server/src/daemon/runner_test.rs
@@ -1,0 +1,168 @@
+use super::*;
+use auv_api_proto::auv::api::driver::v1 as driver_proto;
+use auv_api_proto::auv::api::driver::v1::display_service_client::DisplayServiceClient;
+
+const DISPLAY_SERVICE: &str = "auv.api.driver.v1.DisplayService";
+
+impl RunnerSupervisor {
+  fn new(local_device: daemon_proto::DeviceRef) -> Self {
+    Self::with_providers(local_device, None, FirstPartyRunnerRuntimes::default(), Vec::new())
+      .expect("empty RunnerProvider configuration is valid")
+  }
+}
+
+#[derive(Default)]
+struct RemoteDisplayFixture;
+
+#[tonic::async_trait]
+impl driver_proto::display_service_server::DisplayService for RemoteDisplayFixture {
+  async fn list_displays(
+    &self,
+    _request: tonic::Request<driver_proto::ListDisplaysRequest>,
+  ) -> Result<tonic::Response<driver_proto::ListDisplaysResponse>, tonic::Status> {
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    Ok(tonic::Response::new(driver_proto::ListDisplaysResponse::default()))
+  }
+}
+
+#[tokio::test]
+async fn remote_grpc_runtime_connects_without_owning_the_endpoint_process() {
+  use driver_proto::display_service_server::DisplayServiceServer;
+  use tokio_stream::wrappers::TcpListenerStream;
+
+  let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("bind remote Runner fixture");
+  let address = listener.local_addr().expect("remote Runner fixture address");
+  let display = DisplayServiceServer::new(RemoteDisplayFixture);
+  let (health_reporter, health) = tonic_health::server::health_reporter();
+  health_reporter.set_serving::<DisplayServiceServer<RemoteDisplayFixture>>().await;
+  let descriptor = auv_api_proto::descriptor_set_for_service(DISPLAY_SERVICE).expect("remote Runner descriptor");
+  let reflection = tonic_reflection::server::Builder::configure()
+    .register_encoded_file_descriptor_set(&descriptor)
+    .build_v1()
+    .expect("remote Runner reflection");
+  let server = tokio::spawn(async move {
+    tonic::transport::Server::builder()
+      .add_service(health)
+      .add_service(reflection)
+      .add_service(display)
+      .serve_with_incoming(TcpListenerStream::new(listener))
+      .await
+  });
+
+  let registry = RunnerProviderRegistry::build_with_first_party(
+    None,
+    vec![RunnerProviderConfig {
+      runner_class: "example.runner.remote".to_string(),
+      runtime: RunnerRuntime::RemoteGrpc(crate::runner_provider::RemoteGrpcRunnerRuntime {
+        endpoint: format!("http://{address}"),
+      }),
+    }],
+  )
+  .expect("remote provider");
+  let provider = registry.get("example.runner.remote").expect("remote provider").clone();
+
+  let ready = spawn_ready(&provider, None).await.expect("connect remote Runner");
+  assert_eq!(ready.process_id, 0);
+  let operation_channel = ready.channel.clone();
+  let operation =
+    tokio::spawn(async move { DisplayServiceClient::new(operation_channel).list_displays(driver_proto::ListDisplaysRequest {}).await });
+  operation.await.expect("join business RPC").expect("business RPC");
+  let mut managed = ManagedRunner {
+    record: daemon_proto::Runner::default(),
+    runtime: ready.runtime,
+    channel: ready.channel,
+    display_name: ready.display_name,
+    run_affinities: 0,
+  };
+  stop_managed_in_place(&mut managed, None, false).await.expect("detach remote Runner");
+
+  let channel = tonic::transport::Endpoint::from_shared(format!("http://{address}"))
+    .expect("remote endpoint")
+    .connect()
+    .await
+    .expect("remote endpoint remains reachable after detach");
+  let mut client = tonic_health::pb::health_client::HealthClient::new(channel);
+  assert!(client.check(tonic_health::pb::HealthCheckRequest::default()).await.is_ok());
+  server.abort();
+}
+
+#[cfg(unix)]
+async fn managed_runner(lifecycle: daemon_proto::RunnerLifecycle, run_affinities: u64) -> ManagedRunner {
+  let child = tokio::process::Command::new("/bin/sleep").arg("10").spawn().expect("spawn inert test child");
+  ManagedRunner {
+    record: daemon_proto::Runner {
+      r#ref: Some(daemon_proto::RunnerRef {
+        runner_id: "runner_test".to_string(),
+      }),
+      lifecycle: lifecycle as i32,
+      idle_timeout: Some(prost_types::Duration {
+        seconds: 0,
+        nanos: 50_000_000,
+      }),
+      phase: daemon_proto::RunnerPhase::Ready as i32,
+      ..daemon_proto::Runner::default()
+    },
+    runtime: ManagedRunnerRuntime::Executable { child },
+    channel: Channel::from_static("http://[::]:1").connect_lazy(),
+    display_name: "test Runner".to_string(),
+    run_affinities,
+  }
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn dropped_operation_permit_balances_cancellation_safe_accounting() {
+  let supervisor = RunnerSupervisor::new(daemon_proto::DeviceRef {
+    device_id: "device_test".to_string(),
+  });
+  let managed = managed_runner(daemon_proto::RunnerLifecycle::UnlessShutdown, 0).await;
+  supervisor.runners.lock().expect("registry").insert("runner_test".to_string(), managed);
+
+  let (_channel, permit) = supervisor.begin_external_operation("runner_test", DISPLAY_SERVICE, "ListDisplays").expect("admit operation");
+  assert_eq!(supervisor.get("runner_test").expect("Runner").runner.expect("record").active_operations, 1);
+  drop(permit);
+  assert_eq!(supervisor.get("runner_test").expect("Runner").runner.expect("record").active_operations, 0);
+
+  let managed = supervisor.runners.lock().expect("registry").remove("runner_test").expect("managed Runner");
+  let mut managed = managed;
+  stop_managed_in_place(&mut managed, None, true).await.expect("stop test Runner");
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn aggregated_admission_routes_the_registered_endpoint_without_a_method_allowlist() {
+  let supervisor = RunnerSupervisor::new(daemon_proto::DeviceRef {
+    device_id: "device_test".to_string(),
+  });
+  let managed = managed_runner(daemon_proto::RunnerLifecycle::UnlessShutdown, 0).await;
+  supervisor.runners.lock().expect("registry").insert("runner_test".to_string(), managed);
+
+  let (_channel, permit) =
+    supervisor.begin_external_operation("runner_test", DISPLAY_SERVICE, "ListDisplays").expect("registered endpoint is externally routable");
+  drop(permit);
+  let managed = supervisor.runners.lock().expect("registry").remove("runner_test").expect("managed Runner");
+  let mut managed = managed;
+  stop_managed_in_place(&mut managed, None, true).await.expect("stop test Runner");
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn final_activity_selects_ephemeral_stop_or_unless_idle_deadline() {
+  let runners = Arc::new(Mutex::new(HashMap::new()));
+  let managed = managed_runner(daemon_proto::RunnerLifecycle::Ephemeral, 1).await;
+  runners.lock().expect("registry").insert("runner_test".to_string(), managed);
+  let (ephemeral, deadline) = decrement_activity_locked(&runners, "runner_test", true).expect("release ephemeral affinity");
+  assert!(deadline.is_none());
+  let mut ephemeral = ephemeral.expect("ephemeral Runner stops immediately");
+  stop_managed_in_place(&mut ephemeral, None, true).await.expect("stop ephemeral test Runner");
+
+  let managed = managed_runner(daemon_proto::RunnerLifecycle::UnlessIdle, 1).await;
+  runners.lock().expect("registry").insert("runner_test".to_string(), managed);
+  let (stopped, deadline) = decrement_activity_locked(&runners, "runner_test", true).expect("release idle affinity");
+  assert!(stopped.is_none());
+  assert!(deadline.is_some());
+  assert!(runners.lock().expect("registry").get("runner_test").expect("idle Runner remains registered").record.idle_deadline.is_some());
+  let managed = runners.lock().expect("registry").remove("runner_test").expect("managed Runner");
+  let mut managed = managed;
+  stop_managed_in_place(&mut managed, None, true).await.expect("stop idle test Runner");
+}

--- a/crates/auv-api-server/src/lib.rs
+++ b/crates/auv-api-server/src/lib.rs
@@ -1,0 +1,20 @@
+//! AUV daemon control APIs and transparent capability routing.
+//!
+//! Modules:
+//! - `daemon`: long-lived Device, Run, and Runner ownership.
+//! - `server`: listener binding, request serving, and daemon-owned routing.
+//! - `runner_transport`: inherited private IPC for daemon-owned Runners.
+//! - `test_fixtures` (tests only): shared run/artifact staging helpers.
+
+pub mod auth;
+mod daemon;
+mod protocol;
+mod resource_id;
+mod rest;
+pub mod runner_transport;
+pub mod server;
+
+pub use daemon::runner_provider;
+
+#[cfg(test)]
+pub(crate) mod test_fixtures;

--- a/crates/auv-api-server/src/protocol/grpc/daemon/mod.rs
+++ b/crates/auv-api-server/src/protocol/grpc/daemon/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod v1;

--- a/crates/auv-api-server/src/protocol/grpc/daemon/v1/device.rs
+++ b/crates/auv-api-server/src/protocol/grpc/daemon/v1/device.rs
@@ -1,0 +1,40 @@
+//! Device service adapter.
+
+use std::sync::Arc;
+
+use auv_api_proto::auv::api::daemon::v1 as proto;
+use auv_api_proto::auv::api::daemon::v1::device_service_server::DeviceService;
+use tonic::{Request, Response, Status};
+
+use crate::daemon::Daemon;
+
+#[derive(Clone)]
+pub(crate) struct DeviceServiceGrpc {
+  daemon: Arc<Daemon>,
+}
+
+impl DeviceServiceGrpc {
+  pub(crate) fn new(daemon: Arc<Daemon>) -> Self {
+    Self { daemon }
+  }
+}
+
+#[tonic::async_trait]
+impl DeviceService for DeviceServiceGrpc {
+  async fn list_devices(&self, _request: Request<proto::ListDevicesRequest>) -> Result<Response<proto::ListDevicesResponse>, Status> {
+    Ok(Response::new(self.daemon.list_devices()))
+  }
+
+  async fn get_device(&self, request: Request<proto::GetDeviceRequest>) -> Result<Response<proto::GetDeviceResponse>, Status> {
+    let device_id = request
+      .into_inner()
+      .device
+      .map(|device| device.device_id)
+      .filter(|device_id| !device_id.is_empty())
+      .ok_or_else(|| Status::invalid_argument("device is required"))?;
+    let device = self.daemon.get_device(&device_id).ok_or_else(|| Status::not_found(format!("unknown Device: {device_id}")))?;
+    Ok(Response::new(proto::GetDeviceResponse {
+      device: Some(device),
+    }))
+  }
+}

--- a/crates/auv-api-server/src/protocol/grpc/daemon/v1/discovery.rs
+++ b/crates/auv-api-server/src/protocol/grpc/daemon/v1/discovery.rs
@@ -1,0 +1,103 @@
+//! API discovery service adapter.
+
+use auv_api_proto::auv::api::daemon::v1 as proto;
+use auv_api_proto::auv::api::daemon::v1::discovery_service_server::DiscoveryService;
+use tonic::{Request, Response, Status};
+
+#[derive(Clone)]
+pub(crate) struct DiscoveryServiceGrpc;
+
+impl DiscoveryServiceGrpc {
+  pub(crate) fn new() -> Self {
+    Self
+  }
+}
+
+#[tonic::async_trait]
+impl DiscoveryService for DiscoveryServiceGrpc {
+  async fn list_api_namespaces(
+    &self,
+    _request: Request<proto::ListApiNamespacesRequest>,
+  ) -> Result<Response<proto::ListApiNamespacesResponse>, Status> {
+    Ok(Response::new(proto::ListApiNamespacesResponse {
+      namespaces: vec![proto::ApiNamespace {
+        name: "auv".to_string(),
+      }],
+    }))
+  }
+
+  async fn get_api_namespace(
+    &self,
+    request: Request<proto::GetApiNamespaceRequest>,
+  ) -> Result<Response<proto::GetApiNamespaceResponse>, Status> {
+    if request.get_ref().namespace != "auv" {
+      return Err(Status::not_found("unknown API namespace"));
+    }
+    Ok(Response::new(proto::GetApiNamespaceResponse {
+      namespace: "auv".to_string(),
+      groups: vec![
+        proto::ApiGroup {
+          name: "daemon".to_string(),
+          versions: vec!["v1".to_string()],
+        },
+        proto::ApiGroup {
+          name: "runtime".to_string(),
+          versions: vec!["v1".to_string()],
+        },
+      ],
+    }))
+  }
+
+  async fn get_api_group_version(
+    &self,
+    request: Request<proto::GetApiGroupVersionRequest>,
+  ) -> Result<Response<proto::GetApiGroupVersionResponse>, Status> {
+    let request = request.into_inner();
+    if request.namespace != "auv" {
+      return Err(Status::not_found("unknown API namespace"));
+    }
+    let resources = match (request.group.as_str(), request.version.as_str()) {
+      ("daemon", "v1") => vec![api_resource(
+        "devices",
+        "Device",
+        &[
+          proto::ApiResourceOperation::List,
+          proto::ApiResourceOperation::Get,
+        ],
+      )],
+      ("runtime", "v1") => {
+        let read = [
+          proto::ApiResourceOperation::List,
+          proto::ApiResourceOperation::Get,
+        ];
+        let mut runners = read.to_vec();
+        let mut runs = read.to_vec();
+        runners.extend([
+          proto::ApiResourceOperation::Create,
+          proto::ApiResourceOperation::Delete,
+        ]);
+        runs.push(proto::ApiResourceOperation::Create);
+        vec![
+          api_resource("runners", "Runner", &runners),
+          api_resource("runnerclasses", "RunnerClass", &read),
+          api_resource("runs", "Run", &runs),
+        ]
+      }
+      _ => return Err(Status::not_found("unknown AUV API group or version")),
+    };
+    Ok(Response::new(proto::GetApiGroupVersionResponse {
+      namespace: request.namespace,
+      group: request.group,
+      version: request.version,
+      resources,
+    }))
+  }
+}
+
+fn api_resource(name: &str, kind: &str, operations: &[proto::ApiResourceOperation]) -> proto::ApiResource {
+  proto::ApiResource {
+    name: name.to_string(),
+    kind: kind.to_string(),
+    operations: operations.iter().map(|operation| *operation as i32).collect(),
+  }
+}

--- a/crates/auv-api-server/src/protocol/grpc/daemon/v1/mod.rs
+++ b/crates/auv-api-server/src/protocol/grpc/daemon/v1/mod.rs
@@ -1,0 +1,23 @@
+//! gRPC adapters for daemon-owned `auv.api.daemon.v1` services.
+
+mod device;
+mod discovery;
+mod pairing;
+mod run;
+mod runner;
+mod runner_class;
+
+pub(crate) use device::DeviceServiceGrpc;
+pub(crate) use discovery::DiscoveryServiceGrpc;
+pub(crate) use pairing::PairingServiceGrpc;
+pub(crate) use run::RunServiceGrpc;
+pub(crate) use runner::RunnerServiceGrpc;
+pub(crate) use runner_class::RunnerClassServiceGrpc;
+
+fn caller<T>(request: &tonic::Request<T>) -> Result<crate::auth::CallerId, tonic::Status> {
+  request
+    .extensions()
+    .get::<crate::auth::CallerId>()
+    .cloned()
+    .ok_or_else(|| tonic::Status::internal("gRPC authentication interceptor omitted CallerId"))
+}

--- a/crates/auv-api-server/src/protocol/grpc/daemon/v1/pairing.rs
+++ b/crates/auv-api-server/src/protocol/grpc/daemon/v1/pairing.rs
@@ -1,0 +1,93 @@
+//! Pairing service adapter.
+
+use auv_api_proto::auv::api::daemon::v1 as proto;
+use auv_api_proto::auv::api::daemon::v1::pairing_service_server::PairingService;
+use tonic::{Request, Response, Status};
+
+use crate::server::RequestAuth;
+
+#[derive(Clone)]
+pub(crate) struct PairingServiceGrpc {
+  auth: RequestAuth,
+}
+
+impl PairingServiceGrpc {
+  pub(crate) fn new(auth: RequestAuth) -> Self {
+    Self { auth }
+  }
+
+  fn store(&self) -> Result<crate::auth::PairingStore, Status> {
+    self.auth.pairing_store().ok_or_else(|| Status::failed_precondition("pairing store is not configured"))
+  }
+}
+
+#[tonic::async_trait]
+impl PairingService for PairingServiceGrpc {
+  async fn create_pairing_token(
+    &self,
+    request: Request<proto::CreatePairingTokenRequest>,
+  ) -> Result<Response<proto::CreatePairingTokenResponse>, Status> {
+    self.auth.authenticate(&request)?;
+    let request = request.into_inner();
+    let lifetime = request.ttl.as_ref().map(proto_duration).transpose()?;
+    let token = self.store()?.issue_token(lifetime).map_err(pairing_status)?;
+    let expires_at = lifetime.map(|lifetime| {
+      let deadline = std::time::SystemTime::now() + lifetime;
+      let duration = deadline.duration_since(std::time::UNIX_EPOCH).expect("current time is after Unix epoch");
+      prost_types::Timestamp {
+        seconds: i64::try_from(duration.as_secs()).unwrap_or(i64::MAX),
+        nanos: i32::try_from(duration.subsec_nanos()).expect("nanoseconds fit i32"),
+      }
+    });
+    Ok(Response::new(proto::CreatePairingTokenResponse {
+      token: token.expose_once(),
+      expires_at,
+    }))
+  }
+
+  async fn pair_device(&self, request: Request<proto::PairDeviceRequest>) -> Result<Response<proto::PairDeviceResponse>, Status> {
+    let request = request.into_inner();
+    if request.token.is_empty() || request.device_id.is_empty() {
+      return Err(Status::invalid_argument("token and device_id are required"));
+    }
+    let enrollment = self.store()?.consume_token(&request.token, request.device_id.clone(), request.label).map_err(pairing_status)?;
+    Ok(Response::new(proto::PairDeviceResponse {
+      device_id: request.device_id,
+      device_credential: enrollment.expose_credential_once(),
+    }))
+  }
+
+  async fn revoke_device_credential(
+    &self,
+    request: Request<proto::RevokeDeviceCredentialRequest>,
+  ) -> Result<Response<proto::RevokeDeviceCredentialResponse>, Status> {
+    self.auth.authenticate(&request)?;
+    let device_id = request.into_inner().device_id;
+    if device_id.is_empty() {
+      return Err(Status::invalid_argument("device_id is required"));
+    }
+    let revoked = self.store()?.revoke_device_credentials(&device_id).map_err(pairing_status)?;
+    Ok(Response::new(proto::RevokeDeviceCredentialResponse { revoked }))
+  }
+}
+
+fn proto_duration(value: &prost_types::Duration) -> Result<std::time::Duration, Status> {
+  if value.seconds < 0 || value.nanos < 0 || value.nanos >= 1_000_000_000 {
+    return Err(Status::invalid_argument("ttl must be a non-negative protobuf Duration"));
+  }
+  Ok(std::time::Duration::new(
+    u64::try_from(value.seconds).expect("non-negative seconds fit u64"),
+    u32::try_from(value.nanos).expect("validated nanos fit u32"),
+  ))
+}
+
+fn pairing_status(error: crate::auth::PairingError) -> Status {
+  match error {
+    crate::auth::PairingError::InvalidPairingToken => Status::unauthenticated(error.to_string()),
+    crate::auth::PairingError::InvalidTokenLifetime
+    | crate::auth::PairingError::EmptyPairId
+    | crate::auth::PairingError::DuplicatePairId(_) => Status::invalid_argument(error.to_string()),
+    crate::auth::PairingError::UnknownPair(_) | crate::auth::PairingError::UnknownCredential => Status::not_found(error.to_string()),
+    _ => Status::internal(error.to_string()),
+  }
+}

--- a/crates/auv-api-server/src/protocol/grpc/daemon/v1/run.rs
+++ b/crates/auv-api-server/src/protocol/grpc/daemon/v1/run.rs
@@ -1,0 +1,52 @@
+//! Run service adapter.
+
+use std::sync::Arc;
+
+use auv_api_proto::auv::api::daemon::v1 as proto;
+use auv_api_proto::auv::api::daemon::v1::run_service_server::RunService;
+use tonic::{Request, Response, Status};
+
+use super::caller;
+use crate::daemon::Daemon;
+use crate::protocol::grpc::status::map_control_error;
+
+#[derive(Clone)]
+pub(crate) struct RunServiceGrpc {
+  daemon: Arc<Daemon>,
+}
+
+impl RunServiceGrpc {
+  pub(crate) fn new(daemon: Arc<Daemon>) -> Self {
+    Self { daemon }
+  }
+}
+
+#[tonic::async_trait]
+impl RunService for RunServiceGrpc {
+  async fn create_run(&self, request: Request<proto::CreateRunRequest>) -> Result<Response<proto::CreateRunResponse>, Status> {
+    let caller = caller(&request)?;
+    self.daemon.create_run(&caller, request.into_inner()).map(Response::new).map_err(map_control_error)
+  }
+
+  async fn list_runs(&self, request: Request<proto::ListRunsRequest>) -> Result<Response<proto::ListRunsResponse>, Status> {
+    let caller = caller(&request)?;
+    Ok(Response::new(self.daemon.list_runs(&caller)))
+  }
+
+  async fn get_run(&self, request: Request<proto::GetRunRequest>) -> Result<Response<proto::GetRunResponse>, Status> {
+    let caller = caller(&request)?;
+    let request = request.into_inner();
+    let run_id =
+      request.run.map(|run| run.run_id).filter(|run_id| !run_id.is_empty()).ok_or_else(|| Status::invalid_argument("run is required"))?;
+    self.daemon.get_run(&caller, &run_id).map(Response::new).map_err(map_control_error)
+  }
+
+  async fn stop_run(&self, request: Request<proto::StopRunRequest>) -> Result<Response<proto::StopRunResponse>, Status> {
+    let caller = caller(&request)?;
+    let request = request.into_inner();
+    let outcome = proto::RunOutcome::try_from(request.outcome).map_err(|_| Status::invalid_argument("Run outcome is unknown"))?;
+    let run_id =
+      request.run.map(|run| run.run_id).filter(|run_id| !run_id.is_empty()).ok_or_else(|| Status::invalid_argument("run is required"))?;
+    self.daemon.stop_run(&caller, &run_id, outcome).await.map(Response::new).map_err(map_control_error)
+  }
+}

--- a/crates/auv-api-server/src/protocol/grpc/daemon/v1/runner.rs
+++ b/crates/auv-api-server/src/protocol/grpc/daemon/v1/runner.rs
@@ -1,0 +1,52 @@
+//! Runner service adapter.
+
+use std::sync::Arc;
+
+use auv_api_proto::auv::api::daemon::v1 as proto;
+use auv_api_proto::auv::api::daemon::v1::runner_service_server::RunnerService;
+use tonic::{Request, Response, Status};
+
+use crate::daemon::Daemon;
+use crate::protocol::grpc::status::map_control_error;
+
+#[derive(Clone)]
+pub(crate) struct RunnerServiceGrpc {
+  daemon: Arc<Daemon>,
+}
+
+impl RunnerServiceGrpc {
+  pub(crate) fn new(daemon: Arc<Daemon>) -> Self {
+    Self { daemon }
+  }
+}
+
+#[tonic::async_trait]
+impl RunnerService for RunnerServiceGrpc {
+  async fn create_runner(&self, request: Request<proto::CreateRunnerRequest>) -> Result<Response<proto::CreateRunnerResponse>, Status> {
+    self.daemon.create_runner(request.into_inner()).await.map(Response::new).map_err(map_control_error)
+  }
+
+  async fn list_runners(&self, _request: Request<proto::ListRunnersRequest>) -> Result<Response<proto::ListRunnersResponse>, Status> {
+    Ok(Response::new(self.daemon.list_runners()))
+  }
+
+  async fn get_runner(&self, request: Request<proto::GetRunnerRequest>) -> Result<Response<proto::GetRunnerResponse>, Status> {
+    let runner_id = request
+      .into_inner()
+      .runner
+      .map(|runner| runner.runner_id)
+      .filter(|runner_id| !runner_id.is_empty())
+      .ok_or_else(|| Status::invalid_argument("runner is required"))?;
+    self.daemon.get_runner(&runner_id).map(Response::new).map_err(map_control_error)
+  }
+
+  async fn delete_runner(&self, request: Request<proto::DeleteRunnerRequest>) -> Result<Response<proto::DeleteRunnerResponse>, Status> {
+    let request = request.into_inner();
+    let runner_id = request
+      .runner
+      .map(|runner| runner.runner_id)
+      .filter(|runner_id| !runner_id.is_empty())
+      .ok_or_else(|| Status::invalid_argument("runner is required"))?;
+    self.daemon.delete_runner(&runner_id, request.grace_period, request.force).await.map(Response::new).map_err(map_control_error)
+  }
+}

--- a/crates/auv-api-server/src/protocol/grpc/daemon/v1/runner_class.rs
+++ b/crates/auv-api-server/src/protocol/grpc/daemon/v1/runner_class.rs
@@ -1,0 +1,47 @@
+//! Runner class service adapter.
+
+use std::sync::Arc;
+
+use auv_api_proto::auv::api::daemon::v1 as proto;
+use auv_api_proto::auv::api::daemon::v1::runner_class_service_server::RunnerClassService;
+use tonic::{Request, Response, Status};
+
+use crate::daemon::Daemon;
+use crate::protocol::grpc::status::map_control_error;
+
+#[derive(Clone)]
+pub(crate) struct RunnerClassServiceGrpc {
+  daemon: Arc<Daemon>,
+}
+
+impl RunnerClassServiceGrpc {
+  pub(crate) fn new(daemon: Arc<Daemon>) -> Self {
+    Self { daemon }
+  }
+}
+
+#[tonic::async_trait]
+impl RunnerClassService for RunnerClassServiceGrpc {
+  async fn list_runner_classes(
+    &self,
+    request: Request<proto::ListRunnerClassesRequest>,
+  ) -> Result<Response<proto::ListRunnerClassesResponse>, Status> {
+    let device_id = request.get_ref().device.as_ref().map(|device| device.device_id.as_str());
+    self.daemon.list_runner_classes(device_id).map(Response::new).map_err(map_control_error)
+  }
+
+  async fn get_runner_class(
+    &self,
+    request: Request<proto::GetRunnerClassRequest>,
+  ) -> Result<Response<proto::GetRunnerClassResponse>, Status> {
+    let request = request.into_inner();
+    let device_id = request.device.as_ref().map(|device| device.device_id.as_str());
+    let runner_class = request
+      .runner_class
+      .as_ref()
+      .map(|runner_class| runner_class.runner_class.as_str())
+      .filter(|runner_class| !runner_class.is_empty())
+      .ok_or_else(|| Status::invalid_argument("runner_class is required"))?;
+    self.daemon.get_runner_class(device_id, runner_class).map(Response::new).map_err(map_control_error)
+  }
+}

--- a/crates/auv-api-server/src/protocol/grpc/mod.rs
+++ b/crates/auv-api-server/src/protocol/grpc/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod daemon;
+pub(crate) mod status;

--- a/crates/auv-api-server/src/protocol/grpc/status.rs
+++ b/crates/auv-api-server/src/protocol/grpc/status.rs
@@ -1,0 +1,14 @@
+//! Shared translation from server-domain failures to gRPC status codes.
+
+use tonic::Status;
+
+pub(crate) fn map_control_error(error: crate::daemon::DaemonError) -> Status {
+  use crate::daemon::DaemonError;
+  match error {
+    DaemonError::Identity(_) => Status::internal(error.to_string()),
+    DaemonError::InvalidArgument(_) | DaemonError::UnknownDevice(_) => Status::invalid_argument(error.to_string()),
+    DaemonError::UnknownRun(_) | DaemonError::UnknownRunner(_) => Status::not_found(error.to_string()),
+    DaemonError::RunnerProviderUnavailable(_) => Status::unimplemented(error.to_string()),
+    DaemonError::RunnerOperation(_) => Status::unavailable(error.to_string()),
+  }
+}

--- a/crates/auv-api-server/src/protocol/mod.rs
+++ b/crates/auv-api-server/src/protocol/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod grpc;

--- a/crates/auv-api-server/src/resource_id.rs
+++ b/crates/auv-api-server/src/resource_id.rs
@@ -1,0 +1,19 @@
+//! Opaque daemon resource identity generation.
+
+/// Generates a Docker-style full random identifier.
+pub(crate) fn generate() -> Result<String, String> {
+  let mut bytes = [0_u8; 32];
+  getrandom::fill(&mut bytes).map_err(|error| format!("failed to generate resource ID: {error}"))?;
+  Ok(hex::encode(bytes))
+}
+
+/// Generates the compact 128-bit identity shared with tracing Run records.
+pub(crate) fn generate_run() -> Result<String, String> {
+  let mut bytes = [0_u8; 16];
+  getrandom::fill(&mut bytes).map_err(|error| format!("failed to generate resource ID: {error}"))?;
+  Ok(hex::encode(bytes))
+}
+
+pub(crate) fn validate(value: &str) -> bool {
+  value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}

--- a/crates/auv-api-server/src/rest.rs
+++ b/crates/auv-api-server/src/rest.rs
@@ -1,0 +1,347 @@
+//! Protobuf-over-HTTP resource routes backed by the shared control plane.
+
+use std::sync::Arc;
+
+use auv_api_proto::auv::api::daemon::v1 as daemon_proto;
+use axum::Router;
+use axum::body::{Body, to_bytes};
+use axum::extract::{Path, State};
+use axum::http::{HeaderValue, Request, StatusCode, header};
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, post};
+use prost::Message;
+use tonic::{Code, Status};
+
+use crate::auth::CallerId;
+use crate::daemon::{Daemon, DaemonError};
+use crate::server::RequestAuth;
+
+const PROTOBUF_CONTENT_TYPE: &str = "application/protobuf";
+
+#[derive(Clone)]
+struct RestState {
+  daemon: Arc<Daemon>,
+  auth: RequestAuth,
+}
+
+pub(crate) fn router(daemon: Arc<Daemon>, auth: RequestAuth) -> Router {
+  // TODO(rest-transcoding-v1): these handwritten routes map canonical protobuf
+  // messages without creating a second Rust domain model. Replace the mapping
+  // with google.api.http + Protovalidate + OpenAPI generation when that Buf
+  // dependency/toolchain slice is owner-approved.
+  // TODO(websocket-events): no WebSocket route is exposed until a concrete
+  // non-video event consumer defines ordering, cursor, gap recovery, and
+  // cancellation semantics. Video/frame streaming is a separate future slice.
+  Router::new()
+    .route("/apis", get(list_api_namespaces))
+    .route("/apis/auv", get(get_auv_api_namespace))
+    .route("/apis/auv/{group}/{version}", get(get_auv_api_group_version))
+    .route("/apis/auv/daemon/v1/devices", get(list_devices))
+    .route("/apis/auv/daemon/v1/devices/{device_id}", get(get_device))
+    .route("/apis/auv/runtime/v1/runs", post(create_run).get(list_runs))
+    .route("/apis/auv/runtime/v1/runs/{run_id}", get(get_run))
+    .route("/apis/auv/runtime/v1/runs/{run_id}/stop", post(stop_run))
+    .route("/apis/auv/runtime/v1/runners", post(create_runner).get(list_runners))
+    .route("/apis/auv/runtime/v1/runners/{runner_id}", get(get_runner).delete(delete_runner))
+    .route("/apis/auv/runtime/v1/runnerclasses", get(list_runner_classes))
+    .route("/apis/auv/runtime/v1/runnerclasses/{runner_class}", get(get_runner_class))
+    .with_state(RestState { daemon, auth })
+}
+
+async fn list_api_namespaces(
+  State(state): State<RestState>,
+  request: Request<Body>,
+) -> Result<Protobuf<daemon_proto::ListApiNamespacesResponse>, RestError> {
+  let _caller = authenticate(&state, &request)?;
+  Ok(Protobuf(daemon_proto::ListApiNamespacesResponse {
+    namespaces: vec![daemon_proto::ApiNamespace {
+      name: "auv".to_string(),
+    }],
+  }))
+}
+
+async fn get_auv_api_namespace(
+  State(state): State<RestState>,
+  request: Request<Body>,
+) -> Result<Protobuf<daemon_proto::GetApiNamespaceResponse>, RestError> {
+  let _caller = authenticate(&state, &request)?;
+  Ok(Protobuf(daemon_proto::GetApiNamespaceResponse {
+    namespace: "auv".to_string(),
+    groups: vec![
+      daemon_proto::ApiGroup {
+        name: "daemon".to_string(),
+        versions: vec!["v1".to_string()],
+      },
+      daemon_proto::ApiGroup {
+        name: "runtime".to_string(),
+        versions: vec!["v1".to_string()],
+      },
+    ],
+  }))
+}
+
+async fn get_auv_api_group_version(
+  State(state): State<RestState>,
+  Path((group, version)): Path<(String, String)>,
+  request: Request<Body>,
+) -> Result<Protobuf<daemon_proto::GetApiGroupVersionResponse>, RestError> {
+  let _caller = authenticate(&state, &request)?;
+  let resources = match (group.as_str(), version.as_str()) {
+    ("daemon", "v1") => vec![api_resource(
+      "devices",
+      "Device",
+      &[
+        daemon_proto::ApiResourceOperation::List,
+        daemon_proto::ApiResourceOperation::Get,
+      ],
+    )],
+    ("runtime", "v1") => {
+      let mut runner_operations = vec![
+        daemon_proto::ApiResourceOperation::List,
+        daemon_proto::ApiResourceOperation::Get,
+      ];
+      if !state.daemon.list_runner_classes(None)?.runner_classes.is_empty() {
+        runner_operations.extend([
+          daemon_proto::ApiResourceOperation::Create,
+          daemon_proto::ApiResourceOperation::Delete,
+        ]);
+      }
+      let mut run_operations = vec![
+        daemon_proto::ApiResourceOperation::List,
+        daemon_proto::ApiResourceOperation::Get,
+      ];
+      run_operations.extend([
+        daemon_proto::ApiResourceOperation::Create,
+        daemon_proto::ApiResourceOperation::Delete,
+      ]);
+      vec![
+        api_resource("runners", "Runner", &runner_operations),
+        api_resource(
+          "runnerclasses",
+          "RunnerClass",
+          &[
+            daemon_proto::ApiResourceOperation::List,
+            daemon_proto::ApiResourceOperation::Get,
+          ],
+        ),
+        api_resource("runs", "Run", &run_operations),
+      ]
+    }
+    _ => return Err(RestError::new(StatusCode::NOT_FOUND, "not_found", "unknown AUV API group or version")),
+  };
+  Ok(Protobuf(daemon_proto::GetApiGroupVersionResponse {
+    namespace: "auv".to_string(),
+    group,
+    version,
+    resources,
+  }))
+}
+
+fn api_resource(name: &str, kind: &str, operations: &[daemon_proto::ApiResourceOperation]) -> daemon_proto::ApiResource {
+  daemon_proto::ApiResource {
+    name: name.to_string(),
+    kind: kind.to_string(),
+    operations: operations.iter().map(|operation| *operation as i32).collect(),
+  }
+}
+
+async fn list_devices(
+  State(state): State<RestState>,
+  request: Request<Body>,
+) -> Result<Protobuf<daemon_proto::ListDevicesResponse>, RestError> {
+  let _caller = authenticate(&state, &request)?;
+  Ok(Protobuf(state.daemon.list_devices()))
+}
+
+async fn get_device(
+  State(state): State<RestState>,
+  Path(device_id): Path<String>,
+  request: Request<Body>,
+) -> Result<Protobuf<daemon_proto::GetDeviceResponse>, RestError> {
+  let _caller = authenticate(&state, &request)?;
+  let device = state
+    .daemon
+    .get_device(&device_id)
+    .ok_or_else(|| RestError::new(StatusCode::NOT_FOUND, "not_found", format!("unknown Device: {device_id}")))?;
+  Ok(Protobuf(daemon_proto::GetDeviceResponse {
+    device: Some(device),
+  }))
+}
+
+async fn create_run(State(state): State<RestState>, request: Request<Body>) -> Result<Protobuf<daemon_proto::CreateRunResponse>, RestError> {
+  let caller = authenticate(&state, &request)?;
+  let request = decode_protobuf_body(request).await?;
+  state.daemon.create_run(&caller, request).map(Protobuf).map_err(RestError::from)
+}
+
+async fn list_runs(State(state): State<RestState>, request: Request<Body>) -> Result<Protobuf<daemon_proto::ListRunsResponse>, RestError> {
+  let caller = authenticate(&state, &request)?;
+  Ok(Protobuf(state.daemon.list_runs(&caller)))
+}
+
+async fn get_run(
+  State(state): State<RestState>,
+  Path(run_id): Path<String>,
+  request: Request<Body>,
+) -> Result<Protobuf<daemon_proto::GetRunResponse>, RestError> {
+  let caller = authenticate(&state, &request)?;
+  state.daemon.get_run(&caller, &run_id).map(Protobuf).map_err(RestError::from)
+}
+
+async fn stop_run(
+  State(state): State<RestState>,
+  Path(run_id): Path<String>,
+  request: Request<Body>,
+) -> Result<Protobuf<daemon_proto::StopRunResponse>, RestError> {
+  let caller = authenticate(&state, &request)?;
+  let request = decode_protobuf_body::<daemon_proto::StopRunRequest>(request).await?;
+  if request.run.as_ref().is_some_and(|run| run.run_id != run_id) {
+    return Err(RestError::new(StatusCode::BAD_REQUEST, "invalid_argument", "path Run and request Run differ"));
+  }
+  let outcome = daemon_proto::RunOutcome::try_from(request.outcome)
+    .map_err(|_| RestError::new(StatusCode::BAD_REQUEST, "invalid_argument", "Run outcome is unknown"))?;
+  state.daemon.stop_run(&caller, &run_id, outcome).await.map(Protobuf).map_err(RestError::from)
+}
+
+async fn create_runner(
+  State(state): State<RestState>,
+  request: Request<Body>,
+) -> Result<Protobuf<daemon_proto::CreateRunnerResponse>, RestError> {
+  let _caller = authenticate(&state, &request)?;
+  let request = decode_protobuf_body(request).await?;
+  state.daemon.create_runner(request).await.map(Protobuf).map_err(RestError::from)
+}
+
+async fn list_runners(
+  State(state): State<RestState>,
+  request: Request<Body>,
+) -> Result<Protobuf<daemon_proto::ListRunnersResponse>, RestError> {
+  let _caller = authenticate(&state, &request)?;
+  Ok(Protobuf(state.daemon.list_runners()))
+}
+
+async fn list_runner_classes(
+  State(state): State<RestState>,
+  request: Request<Body>,
+) -> Result<Protobuf<daemon_proto::ListRunnerClassesResponse>, RestError> {
+  let _caller = authenticate(&state, &request)?;
+  state.daemon.list_runner_classes(None).map(Protobuf).map_err(RestError::from)
+}
+
+async fn get_runner_class(
+  State(state): State<RestState>,
+  Path(runner_class): Path<String>,
+  request: Request<Body>,
+) -> Result<Protobuf<daemon_proto::GetRunnerClassResponse>, RestError> {
+  let _caller = authenticate(&state, &request)?;
+  state.daemon.get_runner_class(None, &runner_class).map(Protobuf).map_err(RestError::from)
+}
+
+async fn get_runner(
+  State(state): State<RestState>,
+  Path(runner_id): Path<String>,
+  request: Request<Body>,
+) -> Result<Protobuf<daemon_proto::GetRunnerResponse>, RestError> {
+  let _caller = authenticate(&state, &request)?;
+  state.daemon.get_runner(&runner_id).map(Protobuf).map_err(RestError::from)
+}
+
+async fn delete_runner(
+  State(state): State<RestState>,
+  Path(runner_id): Path<String>,
+  request: Request<Body>,
+) -> Result<Protobuf<daemon_proto::DeleteRunnerResponse>, RestError> {
+  let _caller = authenticate(&state, &request)?;
+  state.daemon.delete_runner(&runner_id, None, false).await.map(Protobuf).map_err(RestError::from)
+}
+
+fn authenticate(state: &RestState, request: &Request<Body>) -> Result<CallerId, RestError> {
+  state.auth.authenticate_http(request).map_err(RestError::from)
+}
+
+async fn decode_protobuf_body<M: Message + Default>(request: Request<Body>) -> Result<M, RestError> {
+  let content_type = request.headers().get(header::CONTENT_TYPE).and_then(|value| value.to_str().ok()).unwrap_or_default();
+  if content_type.split(';').next() != Some(PROTOBUF_CONTENT_TYPE) {
+    return Err(RestError::new(StatusCode::UNSUPPORTED_MEDIA_TYPE, "unsupported_media_type", "request body must use application/protobuf"));
+  }
+  // No AUV-specific request ceiling is imposed here. Listener operators may
+  // add a transport policy when they actually need one; otherwise allocation
+  // and transport failures surface from Axum/the operating system.
+  let bytes = to_bytes(request.into_body(), usize::MAX)
+    .await
+    .map_err(|error| RestError::new(StatusCode::BAD_REQUEST, "invalid_body", error.to_string()))?;
+  M::decode(bytes).map_err(|error| RestError::new(StatusCode::BAD_REQUEST, "invalid_protobuf", error.to_string()))
+}
+
+struct Protobuf<M>(M);
+
+impl<M: Message> IntoResponse for Protobuf<M> {
+  fn into_response(self) -> Response {
+    let mut response = self.0.encode_to_vec().into_response();
+    response.headers_mut().insert(header::CONTENT_TYPE, HeaderValue::from_static(PROTOBUF_CONTENT_TYPE));
+    response
+  }
+}
+
+struct RestError {
+  status: StatusCode,
+  code: &'static str,
+  detail: String,
+}
+
+impl RestError {
+  fn new(status: StatusCode, code: &'static str, detail: impl Into<String>) -> Self {
+    Self {
+      status,
+      code,
+      detail: detail.into(),
+    }
+  }
+}
+
+impl From<Status> for RestError {
+  fn from(status: Status) -> Self {
+    let (http_status, code) = match status.code() {
+      Code::InvalidArgument => (StatusCode::BAD_REQUEST, "invalid_argument"),
+      Code::Unauthenticated => (StatusCode::UNAUTHORIZED, "unauthenticated"),
+      Code::PermissionDenied => (StatusCode::FORBIDDEN, "permission_denied"),
+      Code::NotFound => (StatusCode::NOT_FOUND, "not_found"),
+      Code::FailedPrecondition => (StatusCode::CONFLICT, "failed_precondition"),
+      Code::ResourceExhausted => (StatusCode::TOO_MANY_REQUESTS, "resource_exhausted"),
+      Code::Unimplemented => (StatusCode::NOT_IMPLEMENTED, "unimplemented"),
+      Code::Cancelled => (StatusCode::from_u16(499).expect("valid client-closed status"), "cancelled"),
+      _ => (StatusCode::INTERNAL_SERVER_ERROR, "internal"),
+    };
+    Self::new(http_status, code, status.message())
+  }
+}
+
+impl From<DaemonError> for RestError {
+  fn from(error: DaemonError) -> Self {
+    match error {
+      DaemonError::Identity(_) => Self::new(StatusCode::INTERNAL_SERVER_ERROR, "internal", error.to_string()),
+      DaemonError::InvalidArgument(_) => Self::new(StatusCode::BAD_REQUEST, "invalid_argument", error.to_string()),
+      DaemonError::UnknownDevice(_) => Self::new(StatusCode::BAD_REQUEST, "invalid_argument", error.to_string()),
+      DaemonError::UnknownRun(_) => Self::new(StatusCode::NOT_FOUND, "not_found", error.to_string()),
+      DaemonError::UnknownRunner(_) => Self::new(StatusCode::NOT_FOUND, "not_found", error.to_string()),
+      DaemonError::RunnerProviderUnavailable(_) => Self::new(StatusCode::NOT_IMPLEMENTED, "unimplemented", error.to_string()),
+      DaemonError::RunnerOperation(_) => Self::new(StatusCode::SERVICE_UNAVAILABLE, "unavailable", error.to_string()),
+    }
+  }
+}
+
+impl IntoResponse for RestError {
+  fn into_response(self) -> Response {
+    let body = serde_json::json!({
+      "type": format!("urn:auv:error:{}", self.code),
+      "title": self.code,
+      "status": self.status.as_u16(),
+      "detail": self.detail,
+    });
+    (self.status, [(header::CONTENT_TYPE, HeaderValue::from_static("application/problem+json"))], body.to_string()).into_response()
+  }
+}
+
+#[cfg(test)]
+#[path = "rest_test.rs"]
+mod tests;

--- a/crates/auv-api-server/src/rest_test.rs
+++ b/crates/auv-api-server/src/rest_test.rs
@@ -1,0 +1,25 @@
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+use crate::daemon::Daemon;
+use crate::server::RequestAuth;
+
+use super::router;
+
+#[tokio::test]
+async fn generic_invoke_rest_path_is_not_registered() {
+  let store = tempfile::tempdir().expect("temporary API store");
+  let daemon = Arc::new(Daemon::open(store.path()).expect("daemon"));
+  let auth = RequestAuth::local(
+    #[cfg(unix)]
+    None,
+    None,
+  );
+  let response =
+    router(daemon, auth).oneshot(Request::post("/v1/operations:invoke").body(Body::empty()).expect("request")).await.expect("REST response");
+
+  assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}

--- a/crates/auv-api-server/src/runner_transport.rs
+++ b/crates/auv-api-server/src/runner_transport.rs
@@ -1,0 +1,123 @@
+//! Inherited local transport for daemon-owned AUV Runner processes.
+//!
+//! This crate deliberately does not define a private Runner control protocol.
+//! A Runner serves its own gRPC services plus standard Health and Reflection;
+//! the daemon owns routing, admission, process lifetime, and active-call
+//! accounting.
+
+use std::future::Future;
+#[cfg(unix)]
+use std::os::fd::{FromRawFd as _, RawFd};
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+#[cfg(unix)]
+use tokio_stream::StreamExt as _;
+
+pub const RUNNER_IPC_FD_ENV: &str = "AUV_RUNNER_IPC_FD";
+#[cfg(unix)]
+pub const RUNNER_IPC_FD: RawFd = 3;
+
+#[cfg(unix)]
+pub struct InheritedStream {
+  inner: tokio::net::UnixStream,
+  disconnected: Option<tokio::sync::oneshot::Sender<()>>,
+}
+
+#[cfg(unix)]
+impl tokio::io::AsyncRead for InheritedStream {
+  fn poll_read(mut self: Pin<&mut Self>, context: &mut Context<'_>, buffer: &mut tokio::io::ReadBuf<'_>) -> Poll<std::io::Result<()>> {
+    Pin::new(&mut self.inner).poll_read(context, buffer)
+  }
+}
+
+#[cfg(unix)]
+impl tokio::io::AsyncWrite for InheritedStream {
+  fn poll_write(mut self: Pin<&mut Self>, context: &mut Context<'_>, buffer: &[u8]) -> Poll<Result<usize, std::io::Error>> {
+    Pin::new(&mut self.inner).poll_write(context, buffer)
+  }
+
+  fn poll_flush(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
+    Pin::new(&mut self.inner).poll_flush(context)
+  }
+
+  fn poll_shutdown(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
+    Pin::new(&mut self.inner).poll_shutdown(context)
+  }
+}
+
+#[cfg(unix)]
+impl Drop for InheritedStream {
+  fn drop(&mut self) {
+    if let Some(disconnected) = self.disconnected.take() {
+      let _ = disconnected.send(());
+    }
+  }
+}
+
+#[cfg(unix)]
+impl tonic::transport::server::Connected for InheritedStream {
+  type ConnectInfo = ();
+
+  fn connect_info(&self) -> Self::ConnectInfo {}
+}
+
+/// One adopted daemon connection and a shutdown signal that resolves when the
+/// parent side disconnects.
+#[cfg(unix)]
+pub struct InheritedTransport {
+  stream: InheritedStream,
+  parent_disconnected: tokio::sync::oneshot::Receiver<()>,
+}
+
+#[cfg(unix)]
+impl InheritedTransport {
+  pub fn into_parts(
+    self,
+  ) -> (impl tokio_stream::Stream<Item = Result<InheritedStream, std::io::Error>> + Send + 'static, impl Future<Output = ()> + Send + 'static)
+  {
+    let incoming = tokio_stream::iter([Ok::<_, std::io::Error>(self.stream)]).chain(tokio_stream::pending());
+    let shutdown = async move {
+      let _ = self.parent_disconnected.await;
+    };
+    (incoming, shutdown)
+  }
+}
+
+/// Adopts the connected local stream supplied by the parent daemon.
+#[cfg(unix)]
+pub fn inherited_transport() -> Result<InheritedTransport, String> {
+  let fd = std::env::var(RUNNER_IPC_FD_ENV)
+    .map_err(|_| format!("{RUNNER_IPC_FD_ENV} is required"))?
+    .parse::<RawFd>()
+    .map_err(|error| format!("invalid {RUNNER_IPC_FD_ENV}: {error}"))?;
+  if fd != RUNNER_IPC_FD {
+    return Err(format!("{RUNNER_IPC_FD_ENV} must name inherited descriptor {RUNNER_IPC_FD}"));
+  }
+  // SAFETY: dup returns a new descriptor owned by this call. The original
+  // inherited descriptor remains owned by the process bootstrap contract.
+  let owned_fd = unsafe { libc::dup(fd) };
+  if owned_fd == -1 {
+    return Err(format!("failed to duplicate inherited Runner descriptor: {}", std::io::Error::last_os_error()));
+  }
+  // SAFETY: owned_fd is the fresh descriptor returned by dup and has not been
+  // transferred elsewhere.
+  let stream = unsafe { std::os::unix::net::UnixStream::from_raw_fd(owned_fd) };
+  stream.set_nonblocking(true).map_err(|error| format!("failed to configure inherited Runner stream: {error}"))?;
+  let stream = tokio::net::UnixStream::from_std(stream).map_err(|error| format!("failed to adopt inherited Runner stream: {error}"))?;
+  let (disconnected, parent_disconnected) = tokio::sync::oneshot::channel();
+  Ok(InheritedTransport {
+    stream: InheritedStream {
+      inner: stream,
+      disconnected: Some(disconnected),
+    },
+    parent_disconnected,
+  })
+}
+
+#[cfg(not(unix))]
+pub fn inherited_transport() -> Result<(), String> {
+  // TODO(runner-named-pipe-v1): add the Windows inherited named-pipe/handle
+  // transport when daemon-owned Windows custom Runners are implemented.
+  Err("the inherited Runner transport currently requires Unix".to_string())
+}

--- a/crates/auv-api-server/src/server.rs
+++ b/crates/auv-api-server/src/server.rs
@@ -1,0 +1,565 @@
+//! AUV daemon API server lifecycle and listener orchestration.
+
+mod runner_grpc_proxy;
+
+use std::fmt;
+use std::net::{IpAddr, SocketAddr};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use auv_api_proto::auv::api::daemon::v1::device_service_server::DeviceServiceServer;
+use auv_api_proto::auv::api::daemon::v1::discovery_service_server::DiscoveryServiceServer;
+use auv_api_proto::auv::api::daemon::v1::pairing_service_server::PairingServiceServer;
+use auv_api_proto::auv::api::daemon::v1::run_service_server::RunServiceServer;
+use auv_api_proto::auv::api::daemon::v1::runner_class_service_server::RunnerClassServiceServer;
+use auv_api_proto::auv::api::daemon::v1::runner_service_server::RunnerServiceServer;
+use tokio::net::TcpListener;
+#[cfg(unix)]
+use tokio::net::UnixListener;
+use tokio_stream::wrappers::TcpListenerStream;
+#[cfg(unix)]
+use tokio_stream::wrappers::UnixListenerStream;
+use tokio_util::sync::CancellationToken;
+use tonic::{Request, Status};
+
+use crate::auth::{CallerId, PairingError, PairingStore};
+use crate::daemon::Daemon;
+use crate::protocol::grpc::daemon::v1::{
+  DeviceServiceGrpc, DiscoveryServiceGrpc, PairingServiceGrpc, RunServiceGrpc, RunnerClassServiceGrpc, RunnerServiceGrpc,
+};
+
+pub const DEFAULT_API_HOST: &str = "127.0.0.1";
+pub const DEFAULT_API_PORT: u16 = 9847;
+
+/// Server-side endpoint on which the API accepts gRPC connections.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ListenEndpoint {
+  /// Loopback-only TCP. Paired remote TCP uses the separate bearer-authorized
+  /// variant.
+  // TODO(local-tcp-authentication): loopback is not user identity on a multi-user
+  // host. Add a descriptor-delivered local credential before treating TCP as
+  // equivalent to owner-checked Unix transport outside development use.
+  Tcp { host: String, port: u16 },
+  /// Paired gRPC authenticated by an opaque Device bearer.
+  ///
+  Remote { host: String, port: u16 },
+  /// Local gRPC over a Unix domain socket.
+  #[cfg(unix)]
+  Unix { path: PathBuf },
+}
+
+impl Default for ListenEndpoint {
+  fn default() -> Self {
+    Self::Tcp {
+      host: DEFAULT_API_HOST.to_string(),
+      port: DEFAULT_API_PORT,
+    }
+  }
+}
+
+/// Configuration for one AUV API server instance.
+#[derive(Clone, Debug, Default)]
+pub struct ServerConfig {
+  /// Primary listener retained as the single-listener convenience.
+  pub listen: ListenEndpoint,
+  /// Additional listeners sharing the same daemon control plane and Runner
+  /// supervisor. Each listener retains its own authentication mode.
+  pub additional_listeners: Vec<ListenEndpoint>,
+  pub store_root: PathBuf,
+  /// Durable short-token and Device-bearer authentication store shared by local
+  /// administration and remote listeners.
+  pub pairing_store: Option<PathBuf>,
+  /// Operator-trusted custom Runner providers registered before serving.
+  ///
+  /// This experimental configuration is loaded before any child is started.
+  pub runner_providers: Vec<crate::runner_provider::RunnerProviderConfig>,
+  /// Built-in Runner implementations explicitly hosted by this process.
+  pub first_party_runners: crate::runner_provider::FirstPartyRunnerRuntimes,
+  /// Optional process-level idle timeout. Live Runners keep the daemon alive.
+  pub daemon_idle_timeout: Option<std::time::Duration>,
+}
+
+/// Resolved endpoint of a bound server.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum BoundEndpoint {
+  Tcp(SocketAddr),
+  Remote(SocketAddr),
+  #[cfg(unix)]
+  Unix(PathBuf),
+}
+
+impl fmt::Display for BoundEndpoint {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match self {
+      Self::Tcp(address) => write!(f, "http://{address}"),
+      Self::Remote(address) => write!(f, "http://{address}"),
+      #[cfg(unix)]
+      Self::Unix(path) => write!(f, "unix://{}", path.display()),
+    }
+  }
+}
+
+enum BoundListener {
+  Tcp(TcpListener),
+  #[cfg(unix)]
+  Unix {
+    listener: UnixListener,
+    cleanup: UnixSocketCleanup,
+  },
+}
+
+/// Bound server whose endpoint is observable before serving begins.
+// TODO(server-handle): a cloneable running-server control handle is deferred
+// because current callers only need pre-serve endpoint inspection and injected
+// cancellation; add it when an owner-approved runtime status, reload, or
+// pause/resume operation needs that interface.
+pub struct Server {
+  endpoints: Vec<BoundEndpoint>,
+  listeners: Vec<BoundListenerState>,
+  daemon: Arc<Daemon>,
+  daemon_idle_timeout: Option<std::time::Duration>,
+}
+
+struct BoundListenerState {
+  listener: BoundListener,
+  auth: RequestAuth,
+}
+
+impl Server {
+  /// Primary endpoint, retained for callers that configure one listener.
+  pub fn endpoint(&self) -> &BoundEndpoint {
+    self.endpoints.first().expect("bind always produces a primary endpoint")
+  }
+
+  /// Every endpoint that was bound atomically before readiness.
+  pub fn endpoints(&self) -> &[BoundEndpoint] {
+    &self.endpoints
+  }
+
+  /// Endpoint safe for caller-local discovery, preferring Unix over loopback
+  /// TCP and never returning a credential-dependent remote endpoint.
+  pub fn discovery_endpoint(&self) -> Option<&BoundEndpoint> {
+    #[cfg(unix)]
+    if let Some(endpoint) = self.endpoints.iter().find(|endpoint| matches!(endpoint, BoundEndpoint::Unix(_))) {
+      return Some(endpoint);
+    }
+    self.endpoints.iter().find(|endpoint| matches!(endpoint, BoundEndpoint::Tcp(_)))
+  }
+
+  /// Serves every listener until cancellation or one listener fails. One
+  /// unexpected listener failure cancels the complete daemon instance.
+  pub async fn serve(self, shutdown: CancellationToken) -> Result<(), String> {
+    let daemon = self.daemon;
+    let idle_shutdown =
+      self.daemon_idle_timeout.map(|timeout| tokio::spawn(shutdown_when_daemon_idle(Arc::clone(&daemon), shutdown.clone(), timeout)));
+    let mut servers = tokio::task::JoinSet::new();
+    for listener in self.listeners {
+      let daemon = Arc::clone(&daemon);
+      let listener_shutdown = shutdown.clone();
+      servers.spawn(async move { serve_listener(listener, daemon, listener_shutdown).await });
+    }
+
+    let mut errors = Vec::new();
+    while let Some(result) = servers.join_next().await {
+      match result {
+        Ok(Ok(())) if !shutdown.is_cancelled() => {
+          errors.push("API listener stopped before daemon shutdown".to_string());
+          shutdown.cancel();
+        }
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => {
+          errors.push(error);
+          shutdown.cancel();
+        }
+        Err(error) => {
+          errors.push(format!("API listener task failed: {error}"));
+          shutdown.cancel();
+        }
+      }
+    }
+    shutdown.cancel();
+    daemon.shutdown().await;
+    if let Some(idle_shutdown) = idle_shutdown
+      && let Err(error) = idle_shutdown.await
+    {
+      errors.push(format!("daemon idle task failed: {error}"));
+    }
+    if errors.is_empty() {
+      Ok(())
+    } else {
+      Err(errors.join("; "))
+    }
+  }
+}
+
+async fn serve_listener(listener: BoundListenerState, daemon: Arc<Daemon>, shutdown: CancellationToken) -> Result<(), String> {
+  let pairing_service = PairingServiceGrpc::new(listener.auth.clone());
+  let discovery_service = DiscoveryServiceGrpc::new();
+  let device_service = DeviceServiceGrpc::new(Arc::clone(&daemon));
+  let runner_service = RunnerServiceGrpc::new(Arc::clone(&daemon));
+  let runner_class_service = RunnerClassServiceGrpc::new(Arc::clone(&daemon));
+  let run_service = RunServiceGrpc::new(Arc::clone(&daemon));
+  let mut server = tonic::transport::Server::builder();
+  // PairDevice is the token-authenticated enrollment operation. The two
+  // administrative pairing RPCs authenticate inside their handlers, so this
+  // service intentionally cannot share the listener-wide bearer interceptor.
+  let grpc_routes = tonic::service::Routes::new(PairingServiceServer::new(pairing_service))
+    .add_service(DiscoveryServiceServer::with_interceptor(discovery_service, listener.auth.clone()))
+    .add_service(DeviceServiceServer::with_interceptor(device_service, listener.auth.clone()))
+    .add_service(RunnerServiceServer::with_interceptor(runner_service, listener.auth.clone()))
+    .add_service(RunnerClassServiceServer::with_interceptor(runner_class_service, listener.auth.clone()))
+    .add_service(RunServiceServer::with_interceptor(run_service, listener.auth.clone()))
+    .into_axum_router()
+    .fallback({
+      let proxy = runner_grpc_proxy::RunnerGrpcProxy::new(Arc::clone(&daemon), listener.auth.clone());
+      move |request| {
+        let proxy = proxy.clone();
+        async move { proxy.forward(request).await }
+      }
+    });
+  let routes = crate::rest::router(Arc::clone(&daemon), listener.auth).fallback_service(grpc_routes);
+  match listener.listener {
+    BoundListener::Tcp(listener) => server
+      .add_routes(routes.into())
+      .serve_with_incoming_shutdown(TcpListenerStream::new(listener), shutdown.cancelled_owned())
+      .await
+      .map_err(|error| format!("API server failed: {error}")),
+    #[cfg(unix)]
+    BoundListener::Unix {
+      listener,
+      cleanup: _cleanup,
+    } => server
+      .add_routes(routes.into())
+      .serve_with_incoming_shutdown(UnixListenerStream::new(listener), shutdown.cancelled_owned())
+      .await
+      .map_err(|error| format!("API server failed: {error}")),
+  }
+}
+
+async fn shutdown_when_daemon_idle(daemon: Arc<Daemon>, shutdown: CancellationToken, timeout: std::time::Duration) {
+  let poll_interval = timeout.min(std::time::Duration::from_secs(1));
+  let mut interval = tokio::time::interval(poll_interval);
+  interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+  let mut idle_since = tokio::time::Instant::now();
+  loop {
+    tokio::select! {
+      _ = shutdown.cancelled() => return,
+      _ = interval.tick() => {
+        if daemon.has_live_runners() {
+          idle_since = tokio::time::Instant::now();
+        } else if idle_since.elapsed() >= timeout {
+          shutdown.cancel();
+          return;
+        }
+      }
+    }
+  }
+}
+
+impl Server {
+  /// Binds without starting request processing so a process supervisor can
+  /// publish readiness only after the endpoint actually exists.
+  pub async fn bind(config: ServerConfig) -> Result<Self, String> {
+    let ServerConfig {
+      listen,
+      additional_listeners,
+      store_root,
+      pairing_store,
+      runner_providers,
+      first_party_runners,
+      daemon_idle_timeout,
+    } = config;
+    let pairing_store =
+      pairing_store.map(PairingStore::open).transpose().map_err(|error| format!("failed to open pairing store: {error}"))?;
+    let mut configured = Vec::with_capacity(1 + additional_listeners.len());
+    configured.push(listen);
+    configured.extend(additional_listeners);
+    let mut endpoints = Vec::with_capacity(configured.len());
+    let mut listeners = Vec::with_capacity(configured.len());
+    for endpoint in configured {
+      let (listener, endpoint, auth) = bind_listener(endpoint, pairing_store.clone()).await?;
+      endpoints.push(endpoint);
+      listeners.push(BoundListenerState { listener, auth });
+    }
+    let mut parent_endpoint = endpoints
+      .iter()
+      .find(|endpoint| matches!(endpoint, BoundEndpoint::Unix(_)))
+      .or_else(|| endpoints.iter().find(|endpoint| matches!(endpoint, BoundEndpoint::Tcp(_))))
+      .map(ToString::to_string);
+    let executable_runner_requires_parent =
+      runner_providers.iter().any(|provider| matches!(provider.runtime, crate::runner_provider::RunnerRuntime::Executable(_)))
+        || [&first_party_runners.local_driver]
+          .into_iter()
+          .flatten()
+          .any(|runtime| matches!(runtime, crate::runner_provider::RunnerRuntime::Executable(_)));
+    if parent_endpoint.is_none() && executable_runner_requires_parent {
+      #[cfg(unix)]
+      let internal_endpoint = ListenEndpoint::Unix {
+        path: internal_runner_parent_socket(&store_root),
+      };
+      #[cfg(not(unix))]
+      let internal_endpoint = ListenEndpoint::Tcp {
+        host: DEFAULT_API_HOST.to_string(),
+        port: 0,
+      };
+      let (listener, endpoint, auth) = bind_listener(internal_endpoint, pairing_store.clone()).await?;
+      parent_endpoint = Some(endpoint.to_string());
+      endpoints.push(endpoint);
+      listeners.push(BoundListenerState { listener, auth });
+    }
+    // Build daemon state after listeners have concrete addresses so executable
+    // Runners receive a parent context pointing back to this daemon instance.
+    let daemon =
+      Arc::new(Daemon::open_with_runner_providers_and_parent_endpoint(&store_root, parent_endpoint, first_party_runners, runner_providers)?);
+    Ok(Self {
+      endpoints,
+      listeners,
+      daemon,
+      daemon_idle_timeout,
+    })
+  }
+}
+
+#[cfg(unix)]
+fn internal_runner_parent_socket(store_root: &Path) -> PathBuf {
+  use std::hash::{Hash as _, Hasher as _};
+
+  // NOTICE: Unix socket paths have a small platform limit (104 bytes on
+  // macOS), so a socket nested under a long temporary store path can fail to
+  // bind. Keep only a stable per-store hash in the platform temp directory.
+  let mut hash = std::collections::hash_map::DefaultHasher::new();
+  store_root.hash(&mut hash);
+  std::env::temp_dir().join(format!("auv-parent-{}-{:x}.sock", std::process::id(), hash.finish()))
+}
+
+async fn bind_listener(
+  endpoint: ListenEndpoint,
+  pairing_store: Option<PairingStore>,
+) -> Result<(BoundListener, BoundEndpoint, RequestAuth), String> {
+  Ok(match endpoint {
+    ListenEndpoint::Tcp { host, port } => {
+      let bind_addr = resolve_loopback_bind_addr(&host, port).await?;
+      let listener = TcpListener::bind(bind_addr).await.map_err(|error| format!("failed to bind API server {bind_addr}: {error}"))?;
+      let local_address = listener.local_addr().map_err(|error| format!("failed to read API server address: {error}"))?;
+      assert_socket_addr_is_loopback(local_address)?;
+      (
+        BoundListener::Tcp(listener),
+        BoundEndpoint::Tcp(local_address),
+        RequestAuth::local(
+          #[cfg(unix)]
+          None,
+          pairing_store,
+        ),
+      )
+    }
+    ListenEndpoint::Remote { host, port } => {
+      let bind_addr = resolve_remote_bind_addr(&host, port)?;
+      let listener = TcpListener::bind(bind_addr).await.map_err(|error| format!("failed to bind remote API server {bind_addr}: {error}"))?;
+      let local_address = listener.local_addr().map_err(|error| format!("failed to read remote API server address: {error}"))?;
+      let store = pairing_store.ok_or_else(|| "remote API listener requires --pairing-store".to_string())?;
+      (BoundListener::Tcp(listener), BoundEndpoint::Remote(local_address), RequestAuth::paired_bearer(store))
+    }
+    #[cfg(unix)]
+    ListenEndpoint::Unix { path } => {
+      let (listener, cleanup) = bind_unix(&path)?;
+      let owner_uid = cleanup.owner_uid;
+      (BoundListener::Unix { listener, cleanup }, BoundEndpoint::Unix(path), RequestAuth::local(Some(owner_uid), pairing_store))
+    }
+  })
+}
+
+fn resolve_remote_bind_addr(host: &str, port: u16) -> Result<SocketAddr, String> {
+  let ip = host.parse::<IpAddr>().map_err(|error| format!("remote listen host must be an explicit IP address, got {host:?}: {error}"))?;
+  Ok(SocketAddr::new(ip, port))
+}
+
+/// Rejects host strings that are not allowed loopback listen targets.
+pub fn assert_loopback_host(host: &str) -> Result<(), String> {
+  if host.eq_ignore_ascii_case("localhost") {
+    return Ok(());
+  }
+  match host.parse::<IpAddr>() {
+    Ok(ip) if ip.is_loopback() => Ok(()),
+    Ok(_) => Err(format!("API server refuses non-loopback host: {host}")),
+    Err(_) => Err(format!("API server refuses unrecognized host: {host}")),
+  }
+}
+
+/// Verifies a bound socket address is loopback-only.
+pub fn assert_socket_addr_is_loopback(addr: SocketAddr) -> Result<(), String> {
+  if addr.ip().is_loopback() {
+    return Ok(());
+  }
+  Err(format!("API server refused non-loopback bind address: {addr}"))
+}
+
+async fn resolve_loopback_bind_addr(host: &str, port: u16) -> Result<SocketAddr, String> {
+  assert_loopback_host(host)?;
+  if host.eq_ignore_ascii_case("localhost") {
+    let mut addresses =
+      tokio::net::lookup_host((host, port)).await.map_err(|error| format!("failed to resolve localhost for API server: {error}"))?;
+    return addresses
+      .find(|address| address.ip().is_loopback())
+      .ok_or_else(|| "localhost did not resolve to a loopback address".to_string());
+  }
+  let ip = host.parse::<IpAddr>().map_err(|error| format!("failed to parse API host {host}: {error}"))?;
+  Ok(SocketAddr::new(ip, port))
+}
+
+#[cfg(unix)]
+fn bind_unix(path: &Path) -> Result<(UnixListener, UnixSocketCleanup), String> {
+  if path.exists() {
+    return Err(format!("API Unix socket path already exists: {}", path.display()));
+  }
+  if let Some(parent) = path.parent() {
+    std::fs::create_dir_all(parent).map_err(|error| format!("failed to create API socket directory {}: {error}", parent.display()))?;
+  }
+  let listener = UnixListener::bind(path).map_err(|error| format!("failed to bind API Unix socket {}: {error}", path.display()))?;
+  // Local transport skips pairing, so the socket itself must not grant access
+  // to group/other users while peer-caller projection remains deferred.
+  use std::os::unix::fs::PermissionsExt;
+  std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+    .map_err(|error| format!("failed to protect API Unix socket {}: {error}", path.display()))?;
+  let cleanup = UnixSocketCleanup::new(path)?;
+  Ok((listener, cleanup))
+}
+
+#[cfg(unix)]
+struct UnixSocketCleanup {
+  path: PathBuf,
+  device: u64,
+  inode: u64,
+  owner_uid: u32,
+}
+
+#[cfg(unix)]
+impl UnixSocketCleanup {
+  fn new(path: &Path) -> Result<Self, String> {
+    use std::os::unix::fs::MetadataExt;
+    let metadata =
+      std::fs::symlink_metadata(path).map_err(|error| format!("failed to inspect API Unix socket {}: {error}", path.display()))?;
+    Ok(Self {
+      path: path.to_path_buf(),
+      device: metadata.dev(),
+      inode: metadata.ino(),
+      owner_uid: metadata.uid(),
+    })
+  }
+}
+
+#[cfg(unix)]
+impl Drop for UnixSocketCleanup {
+  fn drop(&mut self) {
+    use std::os::unix::fs::MetadataExt;
+    let Ok(metadata) = std::fs::symlink_metadata(&self.path) else {
+      return;
+    };
+    // NOTICE(unix-socket-cleanup): only unlink the exact filesystem object we
+    // bound; another process may have replaced the path while shutdown raced.
+    if metadata.dev() == self.device && metadata.ino() == self.inode {
+      let _ = std::fs::remove_file(&self.path);
+    }
+  }
+}
+
+/// Authentication mode attached to a listener. Remote requests can never fall
+/// through to local-owner authentication.
+#[derive(Clone)]
+pub enum RequestAuth {
+  Local {
+    #[cfg(unix)]
+    allowed_unix_uid: Option<u32>,
+    pairing_store: Option<PairingStore>,
+  },
+  PairedBearer {
+    store: PairingStore,
+  },
+}
+
+impl RequestAuth {
+  pub fn local(#[cfg(unix)] allowed_unix_uid: Option<u32>, pairing_store: Option<PairingStore>) -> Self {
+    Self::Local {
+      #[cfg(unix)]
+      allowed_unix_uid,
+      pairing_store,
+    }
+  }
+
+  pub fn paired_bearer(store: PairingStore) -> Self {
+    Self::PairedBearer { store }
+  }
+
+  pub(crate) fn authenticate<T>(&self, request: &Request<T>) -> Result<CallerId, Status> {
+    match self {
+      Self::Local { .. } => self.authenticate_extensions(request.extensions()),
+      Self::PairedBearer { store } => {
+        authenticate_bearer(store, request.metadata().get("authorization").and_then(|value| value.to_str().ok()))
+      }
+    }
+  }
+
+  pub(crate) fn authenticate_extensions(&self, extensions: &axum::http::Extensions) -> Result<CallerId, Status> {
+    match self {
+      Self::Local {
+        #[cfg(unix)]
+        allowed_unix_uid,
+        pairing_store: _,
+      } => {
+        #[cfg(unix)]
+        if let Some(allowed_uid) = allowed_unix_uid {
+          let peer_uid = extensions
+            .get::<tonic::transport::server::UdsConnectInfo>()
+            .and_then(|info| info.peer_cred.as_ref())
+            .map(tokio::net::unix::UCred::uid);
+          if peer_uid != Some(*allowed_uid) {
+            return Err(Status::permission_denied("Unix peer credentials do not match the API server owner"));
+          }
+        }
+        Ok(CallerId::local_owner())
+      }
+      Self::PairedBearer { .. } => Err(Status::unauthenticated("paired Device bearer required")),
+    }
+  }
+
+  pub(crate) fn authenticate_http<T>(&self, request: &axum::http::Request<T>) -> Result<CallerId, Status> {
+    match self {
+      Self::Local { .. } => self.authenticate_extensions(request.extensions()),
+      Self::PairedBearer { store } => {
+        authenticate_bearer(store, request.headers().get(axum::http::header::AUTHORIZATION).and_then(|value| value.to_str().ok()))
+      }
+    }
+  }
+
+  pub(crate) fn pairing_store(&self) -> Option<PairingStore> {
+    match self {
+      Self::Local { pairing_store, .. } => pairing_store.clone(),
+      Self::PairedBearer { store } => Some(store.clone()),
+    }
+  }
+}
+
+impl tonic::service::Interceptor for RequestAuth {
+  fn call(&mut self, mut request: Request<()>) -> Result<Request<()>, Status> {
+    let caller = self.authenticate(&request)?;
+    request.extensions_mut().insert(caller);
+    Ok(request)
+  }
+}
+
+fn authenticate_bearer(store: &PairingStore, authorization: Option<&str>) -> Result<CallerId, Status> {
+  let credential = authorization
+    .and_then(|value| value.strip_prefix("Bearer "))
+    .filter(|value| !value.is_empty())
+    .ok_or_else(|| Status::unauthenticated("paired Device bearer required"))?;
+  store.authenticate_bearer(credential).map_err(map_pairing_auth_error)
+}
+
+fn map_pairing_auth_error(error: PairingError) -> Status {
+  match error {
+    PairingError::Unauthenticated => Status::unauthenticated("Device bearer is not an active paired credential"),
+    _ => Status::internal("paired-device authentication store failed"),
+  }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/auv-api-server/src/server/runner_grpc_proxy.rs
+++ b/crates/auv-api-server/src/server/runner_grpc_proxy.rs
@@ -1,0 +1,153 @@
+//! Raw gRPC proxying for daemon-owned custom Runner services.
+//!
+//! The daemon owns authentication, route admission, and routing. It does not
+//! decode application-owned protobuf messages: after validating the concrete
+//! service/method and AUV routing metadata, it streams standard gRPC bodies
+//! and trailers between the public connection and private IPC.
+
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use axum::body::Body as AxumBody;
+use axum::http::{Method, Request, Response, header};
+use tonic::body::Body as TonicBody;
+use tonic::{Code, Status};
+use tower::ServiceExt as _;
+
+use super::RequestAuth;
+use crate::daemon::{Daemon, RunnerRoute};
+use crate::protocol::grpc::status::map_control_error;
+
+pub(crate) const ROUTE_DEVICE_METADATA: &str = "auv-device-id";
+pub(crate) const ROUTE_RUN_METADATA: &str = "auv-run-id";
+pub(crate) const ROUTE_RUNNER_CLASS_METADATA: &str = "auv-runner-class";
+
+#[derive(Clone)]
+pub(crate) struct RunnerGrpcProxy {
+  daemon: Arc<Daemon>,
+  auth: RequestAuth,
+}
+
+impl RunnerGrpcProxy {
+  pub(crate) fn new(daemon: Arc<Daemon>, auth: RequestAuth) -> Self {
+    Self { daemon, auth }
+  }
+
+  pub(crate) async fn forward(&self, mut request: Request<AxumBody>) -> Response<TonicBody> {
+    match self.try_forward(&mut request).await {
+      Ok(response) => response,
+      Err(status) => status.into_http(),
+    }
+  }
+
+  async fn try_forward(&self, request: &mut Request<AxumBody>) -> Result<Response<TonicBody>, Status> {
+    require_grpc_request(request)?;
+    let (service, method) = grpc_method(request.uri().path())?;
+    reject_daemon_namespace(service)?;
+    let caller = self.auth.authenticate_http(&request)?;
+    let route = runner_route(request.headers())?;
+    let (channel, permit) = self.daemon.admit_routed_channel(&caller, route, service, method).await.map_err(map_control_error)?;
+
+    // Route fields are daemon input rather than application metadata.
+    request.headers_mut().remove(ROUTE_DEVICE_METADATA);
+    request.headers_mut().remove(ROUTE_RUN_METADATA);
+    request.headers_mut().remove(ROUTE_RUNNER_CLASS_METADATA);
+
+    let forwarded = std::mem::replace(request, Request::new(AxumBody::empty())).map(TonicBody::new);
+    let response = channel.oneshot(forwarded).await.map_err(|error| Status::unavailable(format!("Runner transport failed: {error}")))?;
+    Ok(response.map(|body| TonicBody::new(PermitBody::new(body, permit))))
+  }
+}
+
+struct PermitBody {
+  inner: TonicBody,
+  permit: Option<crate::daemon::OperationPermit>,
+}
+
+impl PermitBody {
+  fn new(inner: TonicBody, permit: crate::daemon::OperationPermit) -> Self {
+    Self {
+      inner,
+      permit: Some(permit),
+    }
+  }
+}
+
+impl http_body::Body for PermitBody {
+  type Data = <TonicBody as http_body::Body>::Data;
+  type Error = Status;
+
+  fn poll_frame(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Option<Result<http_body::Frame<Self::Data>, Self::Error>>> {
+    let poll = Pin::new(&mut self.inner).poll_frame(context);
+    if matches!(poll, Poll::Ready(None) | Poll::Ready(Some(Err(_)))) {
+      self.permit.take();
+    }
+    poll
+  }
+
+  fn is_end_stream(&self) -> bool {
+    self.inner.is_end_stream()
+  }
+
+  fn size_hint(&self) -> http_body::SizeHint {
+    self.inner.size_hint()
+  }
+}
+
+fn require_grpc_request(request: &Request<AxumBody>) -> Result<(), Status> {
+  if request.method() != Method::POST {
+    return Err(Status::unimplemented("proxied Runner gRPC methods require POST"));
+  }
+  let content_type = request.headers().get(header::CONTENT_TYPE).and_then(|value| value.to_str().ok()).unwrap_or_default();
+  if !content_type.starts_with("application/grpc") {
+    return Err(Status::new(Code::Unimplemented, "unknown HTTP resource"));
+  }
+  if request.uri().query().is_some() {
+    return Err(Status::unimplemented("proxied Runner gRPC method paths do not accept a query"));
+  }
+  Ok(())
+}
+
+fn grpc_method(path: &str) -> Result<(&str, &str), Status> {
+  let mut segments = path.strip_prefix('/').unwrap_or(path).split('/');
+  let service = segments.next().unwrap_or_default();
+  let method = segments.next().unwrap_or_default();
+  if service.is_empty() || method.is_empty() || segments.next().is_some() {
+    return Err(Status::unimplemented("unknown gRPC method path"));
+  }
+  Ok((service, method))
+}
+
+fn reject_daemon_namespace(service: &str) -> Result<(), Status> {
+  if service.starts_with("auv.api.daemon.") {
+    return Err(Status::unimplemented("unknown daemon gRPC method"));
+  }
+  Ok(())
+}
+
+fn runner_route(headers: &http::HeaderMap) -> Result<RunnerRoute, Status> {
+  let value = |name: &'static str, required: bool| -> Result<Option<String>, Status> {
+    let mut values = headers.get_all(name).iter();
+    let first = values.next();
+    if values.next().is_some() {
+      return Err(Status::invalid_argument(format!("{name} metadata must appear at most once")));
+    }
+    let value = first
+      .map(|value| value.to_str().map(str::to_string).map_err(|_| Status::invalid_argument(format!("{name} metadata is not valid ASCII"))))
+      .transpose()?;
+    if required && value.as_deref().is_none_or(str::is_empty) {
+      return Err(Status::invalid_argument(format!("{name} metadata is required")));
+    }
+    Ok(value.filter(|value| !value.is_empty()))
+  };
+  Ok(RunnerRoute {
+    device_id: value(ROUTE_DEVICE_METADATA, false)?,
+    run_id: value(ROUTE_RUN_METADATA, false)?,
+    runner_class: value(ROUTE_RUNNER_CLASS_METADATA, true)?.expect("required route metadata was checked"),
+  })
+}
+
+#[cfg(test)]
+#[path = "runner_grpc_proxy_test.rs"]
+mod tests;

--- a/crates/auv-api-server/src/server/runner_grpc_proxy_test.rs
+++ b/crates/auv-api-server/src/server/runner_grpc_proxy_test.rs
@@ -1,0 +1,44 @@
+//! Tests for raw Runner gRPC proxy routing inputs.
+
+use super::*;
+
+#[test]
+fn parses_exact_grpc_method_path() {
+  assert_eq!(grpc_method("/auv.example.v1.ExampleService/Get").unwrap(), ("auv.example.v1.ExampleService", "Get"));
+  assert!(grpc_method("/auv.example.v1.ExampleService").is_err());
+  assert!(grpc_method("/auv.example.v1.ExampleService/Get/extra").is_err());
+}
+
+#[test]
+fn opaque_forwarding_cannot_shadow_daemon_services() {
+  assert_eq!(reject_daemon_namespace("auv.api.daemon.v1.FutureService").unwrap_err().code(), Code::Unimplemented);
+  assert_eq!(reject_daemon_namespace("auv.api.daemon.v1.FutureService").unwrap_err().code(), Code::Unimplemented);
+  assert!(reject_daemon_namespace("auv.netease_music.v1.SongService").is_ok());
+  assert!(reject_daemon_namespace("grpc.health.v1.Health").is_ok());
+  assert!(reject_daemon_namespace("grpc.reflection.v1.ServerReflection").is_ok());
+}
+
+#[test]
+fn routing_metadata_is_parsed_without_a_protobuf_envelope() {
+  let mut headers = http::HeaderMap::new();
+  headers.insert(ROUTE_DEVICE_METADATA, "device_local".parse().unwrap());
+  headers.insert(ROUTE_RUN_METADATA, "run_test".parse().unwrap());
+  headers.insert(ROUTE_RUNNER_CLASS_METADATA, "netease-music.personal".parse().unwrap());
+  assert_eq!(
+    runner_route(&headers).unwrap(),
+    RunnerRoute {
+      device_id: Some("device_local".to_string()),
+      run_id: Some("run_test".to_string()),
+      runner_class: "netease-music.personal".to_string(),
+    }
+  );
+}
+
+#[test]
+fn route_metadata_requires_exactly_one_runner_class() {
+  assert_eq!(runner_route(&http::HeaderMap::new()).unwrap_err().code(), Code::InvalidArgument);
+  let mut headers = http::HeaderMap::new();
+  headers.append(ROUTE_RUNNER_CLASS_METADATA, "one".parse().unwrap());
+  headers.append(ROUTE_RUNNER_CLASS_METADATA, "two".parse().unwrap());
+  assert_eq!(runner_route(&headers).unwrap_err().code(), Code::InvalidArgument);
+}

--- a/crates/auv-api-server/src/server/tests.rs
+++ b/crates/auv-api-server/src/server/tests.rs
@@ -1,0 +1,555 @@
+//! Server lifecycle and end-to-end transport tests.
+
+use auv_api_client::ConnectEndpoint;
+use auv_api_client::protocol::grpc::Client as GrpcClient;
+use auv_api_proto::auv::api::daemon::v1 as daemon_proto;
+use prost::Message as _;
+
+use crate::test_fixtures::api_temp_store_root;
+
+use super::*;
+
+fn test_http_client_builder() -> reqwest::ClientBuilder {
+  let _ = rustls::crypto::ring::default_provider().install_default();
+  reqwest::Client::builder()
+}
+
+#[test]
+fn loopback_policy_rejects_remote_tcp() {
+  assert!(assert_loopback_host("127.0.0.1").is_ok());
+  assert!(assert_loopback_host("::1").is_ok());
+  assert!(assert_loopback_host("0.0.0.0").is_err());
+  assert!(assert_loopback_host("192.168.1.1").is_err());
+}
+
+#[tokio::test]
+async fn remote_only_daemon_adds_a_local_executable_runner_parent_listener() {
+  let root = api_temp_store_root("runner-parent-listener");
+  let bound = Server::bind(ServerConfig {
+    listen: ListenEndpoint::Remote {
+      host: "127.0.0.1".to_string(),
+      port: 0,
+    },
+    pairing_store: Some(root.join("pairings.json")),
+    store_root: root,
+    runner_providers: vec![crate::runner_provider::RunnerProviderConfig {
+      runner_class: "example.runner".to_string(),
+      runtime: crate::runner_provider::RunnerRuntime::Executable(crate::runner_provider::ExecutableRunnerRuntime {
+        executable: "example-runner".into(),
+        arguments: Vec::new(),
+        working_directory: None,
+        environment: Default::default(),
+      }),
+    }],
+    ..Default::default()
+  })
+  .await
+  .expect("bind paired listener plus internal Runner parent listener");
+  #[cfg(unix)]
+  assert!(bound.endpoints().iter().any(|endpoint| matches!(endpoint, BoundEndpoint::Unix(_))));
+  #[cfg(not(unix))]
+  assert!(bound.endpoints().iter().any(|endpoint| matches!(endpoint, BoundEndpoint::Tcp(_))));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn multi_listener_bind_is_atomic_and_cleans_up_bound_unix_sockets() {
+  let directory = tempfile::tempdir().expect("temporary multi-listener directory");
+  let socket_path = directory.path().join("auv.sock");
+  let result = Server::bind(ServerConfig {
+    pairing_store: None,
+    listen: ListenEndpoint::Unix {
+      path: socket_path.clone(),
+    },
+    additional_listeners: vec![ListenEndpoint::Unix {
+      path: socket_path.clone(),
+    }],
+    store_root: directory.path().join("runs"),
+    daemon_idle_timeout: None,
+    runner_providers: Vec::new(),
+    first_party_runners: Default::default(),
+  })
+  .await;
+  let error = match result {
+    Ok(_) => panic!("all listeners must bind before readiness"),
+    Err(error) => error,
+  };
+
+  assert!(error.contains("already exists"));
+  assert!(!socket_path.exists(), "failed multi-listener bind removes sockets bound earlier in the same attempt");
+}
+
+#[tokio::test]
+async fn tcp_client_reaches_typed_control_services() {
+  let config = ServerConfig {
+    pairing_store: None,
+    listen: ListenEndpoint::Tcp {
+      host: DEFAULT_API_HOST.to_string(),
+      port: 0,
+    },
+    additional_listeners: Vec::new(),
+    store_root: api_temp_store_root("tcp"),
+    daemon_idle_timeout: None,
+    runner_providers: Vec::new(),
+    first_party_runners: Default::default(),
+  };
+  let bound = Server::bind(config).await.expect("bind TCP server");
+  let BoundEndpoint::Tcp(address) = bound.endpoint().clone() else {
+    panic!("TCP endpoint");
+  };
+  let shutdown = CancellationToken::new();
+  let server = tokio::spawn(bound.serve(shutdown.clone()));
+  let endpoint = format!("http://{address}").parse().expect("valid loopback endpoint");
+  let client = GrpcClient::connect(endpoint).await.expect("connect TCP client");
+  let devices = client.devices().list_devices().await.expect("list Devices through gRPC");
+  assert_eq!(devices.len(), 1);
+  assert!(devices[0].local);
+  shutdown.cancel();
+  server.await.expect("join server").expect("serve TCP");
+}
+
+#[tokio::test]
+async fn rest_discovery_lists_the_auv_api_namespace() {
+  let config = ServerConfig {
+    pairing_store: None,
+    listen: ListenEndpoint::Tcp {
+      host: DEFAULT_API_HOST.to_string(),
+      port: 0,
+    },
+    additional_listeners: Vec::new(),
+    store_root: api_temp_store_root("rest-discovery"),
+    daemon_idle_timeout: None,
+    runner_providers: Vec::new(),
+    first_party_runners: Default::default(),
+  };
+  let bound = Server::bind(config).await.expect("bind TCP server");
+  let BoundEndpoint::Tcp(address) = bound.endpoint().clone() else {
+    panic!("TCP endpoint");
+  };
+  let shutdown = CancellationToken::new();
+  let server = tokio::spawn(bound.serve(shutdown.clone()));
+  let client = test_http_client_builder().http2_prior_knowledge().build().expect("build REST test client");
+
+  let response = client.get(format!("http://{address}/apis")).send().await.expect("request API discovery");
+  assert_eq!(response.status(), reqwest::StatusCode::OK);
+  assert_eq!(response.headers().get("content-type").and_then(|value| value.to_str().ok()), Some("application/protobuf"));
+  let discovery =
+    daemon_proto::ListApiNamespacesResponse::decode(response.bytes().await.expect("read API discovery")).expect("decode API discovery");
+  assert_eq!(
+    discovery.namespaces,
+    vec![daemon_proto::ApiNamespace {
+      name: "auv".to_string(),
+    }]
+  );
+
+  shutdown.cancel();
+  server.await.expect("join server").expect("serve TCP");
+}
+
+#[tokio::test]
+async fn rest_discovery_lists_auv_groups_versions_and_resources() {
+  let config = ServerConfig {
+    pairing_store: None,
+    listen: ListenEndpoint::Tcp {
+      host: DEFAULT_API_HOST.to_string(),
+      port: 0,
+    },
+    additional_listeners: Vec::new(),
+    store_root: api_temp_store_root("rest-resource-discovery"),
+    daemon_idle_timeout: None,
+    runner_providers: Vec::new(),
+    first_party_runners: Default::default(),
+  };
+  let bound = Server::bind(config).await.expect("bind TCP server");
+  let BoundEndpoint::Tcp(address) = bound.endpoint().clone() else {
+    panic!("TCP endpoint");
+  };
+  let shutdown = CancellationToken::new();
+  let server = tokio::spawn(bound.serve(shutdown.clone()));
+  let client = test_http_client_builder().http2_prior_knowledge().build().expect("build REST test client");
+
+  let namespace = client.get(format!("http://{address}/apis/auv")).send().await.expect("request AUV namespace discovery");
+  assert_eq!(namespace.status(), reqwest::StatusCode::OK);
+  let namespace = daemon_proto::GetApiNamespaceResponse::decode(namespace.bytes().await.expect("read namespace discovery"))
+    .expect("decode namespace discovery");
+  assert_eq!(namespace.namespace, "auv");
+  assert_eq!(
+    namespace.groups,
+    vec![
+      daemon_proto::ApiGroup {
+        name: "daemon".to_string(),
+        versions: vec!["v1".to_string()],
+      },
+      daemon_proto::ApiGroup {
+        name: "runtime".to_string(),
+        versions: vec!["v1".to_string()],
+      },
+    ]
+  );
+
+  let daemon = client.get(format!("http://{address}/apis/auv/daemon/v1")).send().await.expect("request daemon discovery");
+  assert_eq!(daemon.status(), reqwest::StatusCode::OK);
+  let daemon =
+    daemon_proto::GetApiGroupVersionResponse::decode(daemon.bytes().await.expect("read daemon discovery")).expect("decode daemon discovery");
+  assert_eq!(daemon.group, "daemon");
+  assert_eq!(daemon.version, "v1");
+  assert_eq!(daemon.resources.len(), 1);
+  assert_eq!(daemon.resources[0].name, "devices");
+  assert_eq!(
+    daemon.resources[0].operations,
+    vec![
+      daemon_proto::ApiResourceOperation::List as i32,
+      daemon_proto::ApiResourceOperation::Get as i32
+    ]
+  );
+  let runtime = client.get(format!("http://{address}/apis/auv/runtime/v1")).send().await.expect("request runtime discovery");
+  assert_eq!(runtime.status(), reqwest::StatusCode::OK);
+  let runtime = daemon_proto::GetApiGroupVersionResponse::decode(runtime.bytes().await.expect("read runtime discovery"))
+    .expect("decode runtime discovery");
+  assert_eq!(runtime.resources.iter().map(|resource| resource.name.as_str()).collect::<Vec<_>>(), vec!["runners", "runnerclasses", "runs"]);
+  assert_eq!(
+    runtime.resources[0].operations,
+    vec![
+      daemon_proto::ApiResourceOperation::List as i32,
+      daemon_proto::ApiResourceOperation::Get as i32,
+    ],
+    "Runner mutations are not discoverable until a provider exists"
+  );
+  assert_eq!(
+    runtime.resources[1].operations,
+    vec![
+      daemon_proto::ApiResourceOperation::List as i32,
+      daemon_proto::ApiResourceOperation::Get as i32,
+    ]
+  );
+  assert_eq!(
+    runtime.resources[2].operations,
+    vec![
+      daemon_proto::ApiResourceOperation::List as i32,
+      daemon_proto::ApiResourceOperation::Get as i32,
+      daemon_proto::ApiResourceOperation::Create as i32,
+      daemon_proto::ApiResourceOperation::Delete as i32,
+    ],
+    "Run lifecycle operations are advertised without scope-based hiding"
+  );
+
+  shutdown.cancel();
+  server.await.expect("join server").expect("serve TCP");
+}
+
+#[tokio::test]
+async fn rest_devices_list_and_get_the_persistent_local_device() {
+  let store_root = api_temp_store_root("rest-devices");
+  let (first_id, first_server) = {
+    let bound = Server::bind(ServerConfig {
+      pairing_store: None,
+      listen: ListenEndpoint::Tcp {
+        host: DEFAULT_API_HOST.to_string(),
+        port: 0,
+      },
+      additional_listeners: Vec::new(),
+      store_root: store_root.clone(),
+      daemon_idle_timeout: None,
+      runner_providers: Vec::new(),
+      first_party_runners: Default::default(),
+    })
+    .await
+    .expect("bind first server");
+    let BoundEndpoint::Tcp(address) = bound.endpoint().clone() else {
+      panic!("TCP endpoint");
+    };
+    let shutdown = CancellationToken::new();
+    let server = tokio::spawn(bound.serve(shutdown.clone()));
+    let client = test_http_client_builder().http2_prior_knowledge().build().expect("build REST test client");
+    let response = client.get(format!("http://{address}/apis/auv/daemon/v1/devices")).send().await.expect("list devices");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    let response = daemon_proto::ListDevicesResponse::decode(response.bytes().await.expect("read devices")).expect("decode devices");
+    assert_eq!(response.devices.len(), 1);
+    let device = response.devices.into_iter().next().expect("local device");
+    assert!(device.local);
+    let device_id = device.r#ref.as_ref().expect("device ref").device_id.clone();
+    assert_eq!(device_id.len(), 64);
+    assert!(device_id.bytes().all(|byte| byte.is_ascii_hexdigit()));
+
+    let get = client.get(format!("http://{address}/apis/auv/daemon/v1/devices/{device_id}")).send().await.expect("get device");
+    assert_eq!(get.status(), reqwest::StatusCode::OK);
+    let get = daemon_proto::GetDeviceResponse::decode(get.bytes().await.expect("read device")).expect("decode device");
+    assert_eq!(get.device, Some(device));
+    shutdown.cancel();
+    (device_id, server)
+  };
+  first_server.await.expect("join first server").expect("serve first server");
+
+  let bound = Server::bind(ServerConfig {
+    pairing_store: None,
+    listen: ListenEndpoint::Tcp {
+      host: DEFAULT_API_HOST.to_string(),
+      port: 0,
+    },
+    additional_listeners: Vec::new(),
+    store_root,
+    daemon_idle_timeout: None,
+    runner_providers: Vec::new(),
+    first_party_runners: Default::default(),
+  })
+  .await
+  .expect("bind restarted server");
+  let BoundEndpoint::Tcp(address) = bound.endpoint().clone() else {
+    panic!("TCP endpoint");
+  };
+  let shutdown = CancellationToken::new();
+  let server = tokio::spawn(bound.serve(shutdown.clone()));
+  let client = test_http_client_builder().http2_prior_knowledge().build().expect("build restarted REST test client");
+  let response =
+    client.get(format!("http://{address}/apis/auv/daemon/v1/devices/{first_id}")).send().await.expect("get persistent local device");
+  assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+  shutdown.cancel();
+  server.await.expect("join restarted server").expect("serve restarted server");
+}
+
+#[tokio::test]
+async fn rest_runs_create_list_and_get_under_the_local_device() {
+  let bound = Server::bind(ServerConfig {
+    pairing_store: None,
+    listen: ListenEndpoint::Tcp {
+      host: DEFAULT_API_HOST.to_string(),
+      port: 0,
+    },
+    additional_listeners: Vec::new(),
+    store_root: api_temp_store_root("rest-runs"),
+    daemon_idle_timeout: None,
+    runner_providers: Vec::new(),
+    first_party_runners: Default::default(),
+  })
+  .await
+  .expect("bind server");
+  let BoundEndpoint::Tcp(address) = bound.endpoint().clone() else {
+    panic!("TCP endpoint");
+  };
+  let shutdown = CancellationToken::new();
+  let server = tokio::spawn(bound.serve(shutdown.clone()));
+  let client = test_http_client_builder().http2_prior_knowledge().build().expect("build REST test client");
+
+  let create = client
+    .post(format!("http://{address}/apis/auv/runtime/v1/runs"))
+    .header("content-type", "application/protobuf")
+    .body(
+      daemon_proto::CreateRunRequest {
+        labels: std::collections::HashMap::from([("purpose".to_string(), "test".to_string())]),
+        devices: Vec::new(),
+      }
+      .encode_to_vec(),
+    )
+    .send()
+    .await
+    .expect("create Run");
+  assert_eq!(create.status(), reqwest::StatusCode::OK);
+  let created = daemon_proto::CreateRunResponse::decode(create.bytes().await.expect("read created Run")).expect("decode created Run");
+  let run = created.run.expect("created Run");
+  let run_id = run.r#ref.as_ref().expect("Run ref").run_id.clone();
+  assert_eq!(run_id.len(), 32);
+  assert!(run_id.bytes().all(|byte| byte.is_ascii_hexdigit()));
+  assert_eq!(run.phase, daemon_proto::RunPhase::Running as i32);
+  assert_eq!(run.devices.len(), 1);
+  assert_eq!(run.labels.get("purpose").map(String::as_str), Some("test"));
+
+  let list = client.get(format!("http://{address}/apis/auv/runtime/v1/runs")).send().await.expect("list Runs");
+  assert_eq!(list.status(), reqwest::StatusCode::OK);
+  let list = daemon_proto::ListRunsResponse::decode(list.bytes().await.expect("read Runs")).expect("decode Runs");
+  assert_eq!(list.runs, vec![run.clone()]);
+
+  let get = client.get(format!("http://{address}/apis/auv/runtime/v1/runs/{run_id}")).send().await.expect("get Run");
+  assert_eq!(get.status(), reqwest::StatusCode::OK);
+  let get = daemon_proto::GetRunResponse::decode(get.bytes().await.expect("read Run")).expect("decode Run");
+  assert_eq!(get.run, Some(run));
+
+  shutdown.cancel();
+  server.await.expect("join server").expect("serve server");
+}
+
+#[tokio::test]
+async fn rest_runners_are_empty_and_creation_fails_without_a_provider() {
+  let bound = Server::bind(ServerConfig {
+    pairing_store: None,
+    listen: ListenEndpoint::Tcp {
+      host: DEFAULT_API_HOST.to_string(),
+      port: 0,
+    },
+    additional_listeners: Vec::new(),
+    store_root: api_temp_store_root("rest-runners"),
+    daemon_idle_timeout: None,
+    runner_providers: Vec::new(),
+    first_party_runners: Default::default(),
+  })
+  .await
+  .expect("bind server");
+  let BoundEndpoint::Tcp(address) = bound.endpoint().clone() else {
+    panic!("TCP endpoint");
+  };
+  let shutdown = CancellationToken::new();
+  let server = tokio::spawn(bound.serve(shutdown.clone()));
+  let client = test_http_client_builder().http2_prior_knowledge().build().expect("build REST test client");
+
+  let list = client.get(format!("http://{address}/apis/auv/runtime/v1/runners")).send().await.expect("list Runners");
+  assert_eq!(list.status(), reqwest::StatusCode::OK);
+  let list = daemon_proto::ListRunnersResponse::decode(list.bytes().await.expect("read Runners")).expect("decode Runners");
+  assert!(list.runners.is_empty());
+
+  let create = client
+    .post(format!("http://{address}/apis/auv/runtime/v1/runners"))
+    .header("content-type", "application/protobuf")
+    .body(
+      daemon_proto::CreateRunnerRequest {
+        device: None,
+        runner_class: Some(daemon_proto::RunnerClassRef {
+          runner_class: "auv.core.local".to_string(),
+        }),
+        labels: std::collections::HashMap::new(),
+        lifecycle: daemon_proto::RunnerLifecycle::UnlessShutdown as i32,
+        idle_timeout: None,
+      }
+      .encode_to_vec(),
+    )
+    .send()
+    .await
+    .expect("create Runner without provider");
+  assert_eq!(create.status(), reqwest::StatusCode::NOT_IMPLEMENTED);
+  assert_eq!(create.headers().get("content-type").and_then(|value| value.to_str().ok()), Some("application/problem+json"));
+
+  shutdown.cancel();
+  server.await.expect("join server").expect("serve server");
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn short_token_pairing_issues_live_revocable_bearer() {
+  let directory = tempfile::tempdir().expect("pairing test directory");
+  let socket_path = directory.path().join("auv.sock");
+  let pairing_path = directory.path().join("pairings.json");
+  let bound = Server::bind(ServerConfig {
+    pairing_store: Some(pairing_path),
+    listen: ListenEndpoint::Unix {
+      path: socket_path.clone(),
+    },
+    additional_listeners: vec![ListenEndpoint::Remote {
+      host: "127.0.0.1".to_string(),
+      port: 0,
+    }],
+    store_root: api_temp_store_root("short-token-pairing"),
+    daemon_idle_timeout: None,
+    runner_providers: Vec::new(),
+    first_party_runners: Default::default(),
+  })
+  .await
+  .expect("bind local administration and remote bearer listeners");
+  let remote = bound
+    .endpoints()
+    .iter()
+    .find_map(|endpoint| match endpoint {
+      BoundEndpoint::Remote(address) => Some(*address),
+      _ => None,
+    })
+    .expect("remote endpoint");
+  let shutdown = CancellationToken::new();
+  let server = tokio::spawn(bound.serve(shutdown.clone()));
+
+  let local = GrpcClient::connect(ConnectEndpoint::Unix(socket_path)).await.expect("connect owner Unix client");
+  let token =
+    local.pairing().create_pairing_token(daemon_proto::CreatePairingTokenRequest { ttl: None }).await.expect("create one-time token").token;
+  let endpoint = format!("http://{remote}").parse::<http::Uri>().expect("remote URI");
+  let enrollment = auv_api_client::protocol::grpc::clients::daemon::v1::pairing::Client::pair_device(
+    endpoint.clone(),
+    daemon_proto::PairDeviceRequest {
+      token: token.clone(),
+      device_id: "device_remote_test".to_string(),
+      label: "Remote test".to_string(),
+    },
+  )
+  .await
+  .expect("consume token");
+  let reused = auv_api_client::protocol::grpc::clients::daemon::v1::pairing::Client::pair_device(
+    endpoint.clone(),
+    daemon_proto::PairDeviceRequest {
+      token,
+      device_id: "device_reuse".to_string(),
+      label: String::new(),
+    },
+  )
+  .await
+  .expect_err("pairing token is one-time");
+  assert_eq!(reused.code(), tonic::Code::Unauthenticated);
+
+  let remote_client = GrpcClient::connect_paired(auv_api_client::PairedConnectConfig {
+    endpoint,
+    device_credential: enrollment.device_credential,
+  })
+  .await
+  .expect("connect paired Device");
+  assert_eq!(remote_client.devices().list_devices().await.expect("inspect through bearer").len(), 1);
+  assert!(local.pairing().revoke_device_credential("device_remote_test").await.expect("revoke bearer"));
+  let revoked = remote_client.devices().list_devices().await.expect_err("revocation is checked on every request");
+  assert_eq!(revoked.code(), tonic::Code::Unauthenticated);
+
+  shutdown.cancel();
+  server.await.expect("join pairing server").expect("serve pairing test");
+}
+
+#[tokio::test]
+async fn remote_bearer_listener_is_not_published_as_local_discovery() {
+  let directory = tempfile::tempdir().expect("pairing test directory");
+  let bound = Server::bind(ServerConfig {
+    pairing_store: Some(directory.path().join("pairings.json")),
+    listen: ListenEndpoint::Remote {
+      host: "127.0.0.1".to_string(),
+      port: 0,
+    },
+    additional_listeners: Vec::new(),
+    store_root: api_temp_store_root("remote-not-local-discovery"),
+    daemon_idle_timeout: None,
+    runner_providers: Vec::new(),
+    first_party_runners: Default::default(),
+  })
+  .await
+  .expect("bind remote bearer listener");
+
+  assert!(bound.discovery_endpoint().is_none());
+}
+
+#[tokio::test]
+async fn unix_client_uses_typed_services_and_cleans_up_socket() {
+  let directory = tempfile::tempdir().expect("temporary Unix socket directory");
+  let socket_path = directory.path().join("auv.sock");
+  let config = ServerConfig {
+    pairing_store: None,
+    listen: ListenEndpoint::Unix {
+      path: socket_path.clone(),
+    },
+    additional_listeners: Vec::new(),
+    store_root: api_temp_store_root("unix"),
+    daemon_idle_timeout: None,
+    runner_providers: Vec::new(),
+    first_party_runners: Default::default(),
+  };
+  let bound = Server::bind(config).await.expect("bind Unix server");
+  assert!(socket_path.exists());
+  use std::os::unix::fs::PermissionsExt;
+  assert_eq!(std::fs::metadata(&socket_path).unwrap().permissions().mode() & 0o777, 0o600);
+  let shutdown = CancellationToken::new();
+  let server = tokio::spawn(bound.serve(shutdown.clone()));
+  let client = GrpcClient::connect(ConnectEndpoint::Unix(socket_path.clone())).await.expect("connect Unix client");
+  let implicit = client.runs().create_run(daemon_proto::CreateRunRequest::default()).await.expect("create implicit local Run");
+  let implicit_id = implicit.r#ref.as_ref().expect("Run ref").run_id.clone();
+  let implicit_device_id = implicit.devices.first().expect("implicit local Device ref").device_id.clone();
+  assert!(client.devices().get_device(implicit_device_id).await.expect("implicit local Device").local);
+  let completed = client.runs().stop_run(implicit_id.clone(), daemon_proto::RunOutcome::Succeeded).await.expect("finish implicit local Run");
+  assert_eq!(completed.phase, daemon_proto::RunPhase::Succeeded as i32);
+  assert_eq!(
+    client.runs().get_run(implicit_id).await.expect("completed Run remains queryable").phase,
+    daemon_proto::RunPhase::Succeeded as i32
+  );
+
+  shutdown.cancel();
+  server.await.expect("join server").expect("serve Unix");
+  assert!(!socket_path.exists());
+}

--- a/crates/auv-api-server/src/test_fixtures.rs
+++ b/crates/auv-api-server/src/test_fixtures.rs
@@ -1,0 +1,13 @@
+use std::fs;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static FIXTURE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+pub fn api_temp_store_root(label: &str) -> PathBuf {
+  let unique = FIXTURE_COUNTER.fetch_add(1, Ordering::Relaxed);
+  let path = std::env::temp_dir().join(format!("auv-api-{label}-{}-{unique}", uuid::Uuid::now_v7()));
+  let _ = fs::remove_dir_all(&path);
+  fs::create_dir_all(&path).expect("API fixture directory");
+  path
+}


### PR DESCRIPTION
## Summary

- add the `auv-api-server` crate as the daemon-owned control and capability server
- provide pairing, persistent device identity, Run and Runner lifecycle handling, REST discovery, and typed gRPC routing
- keep the dependency direction one-way: the server uses `auv-api-proto`, while server integration tests use the transport-level `auv-api-client` and do not depend on the higher-level `auv` facade

## Why

This establishes the server-side half of the shared typed execution seam without routing daemon behavior through CLI-owned code or an aggregate runtime crate.

## Impact

Consumers can embed and bind the API server over local Unix or TCP listeners, use typed daemon services, and route capability calls to registered Runner providers. The higher-level `auv` client facade remains a separate follow-up slice.

## Validation

- `cargo check -p auv-api-server`
- `cargo test -p auv-api-server` (30 passed)
- `cargo fmt --check`
- `git diff --cached --check`
