### PR TITLE
refactor(auv-netease-music): use typed runner client

### DIFF
--- a/supported/apps/auv-netease-music/src/cli.rs
+++ b/supported/apps/auv-netease-music/src/cli.rs
@@ -858,12 +858,12 @@ async fn remote_now_playing(context: auv::AuvContext, app_id: &str) -> Result<au
   let run = auv.run(Default::default()).await.map_err(|error| format!("resolve inherited NetEase Run failed: {error}"))?;
   let runner = run
     .runner(auv::client::RunnerOptions {
-      runner_class: "auv.app.netease_music".to_string(),
+      runner_class: "auv.app.netease_music".parse().expect("the NetEase RunnerClass ID is valid"),
       ..Default::default()
     })
     .await
     .map_err(|error| format!("construct NetEase Runner route failed: {error}"))?;
-  let transport = runner.transport().map_err(|status| status.to_string())?;
+  let transport = runner.extension_transport().map_err(|error| error.to_string())?;
   let mut service = crate::api::v1::netease_music_service_client::NeteaseMusicServiceClient::new(transport);
   let result = service
     .get_now_playing(crate::api::v1::GetNowPlayingRequest {

--- a/supported/apps/auv-netease-music/tests/custom_runner_e2e.rs
+++ b/supported/apps/auv-netease-music/tests/custom_runner_e2e.rs
@@ -1,8 +1,8 @@
 #![cfg(all(unix, target_os = "macos"))]
 
 use auv_api_proto::auv::api::daemon::v1 as daemon_proto;
-use auv_api_server::runner_provider::{ExecutableRunnerRuntime, RunnerProviderConfig, RunnerRuntime};
-use auv_api_server::server::{ListenEndpoint, Server, ServerConfig};
+use auv_daemon::runner_provider::{ExecutableRunnerRuntime, RunnerProviderConfig, RunnerRuntime};
+use auv_daemon::{Config, ListenEndpoint, Server};
 
 #[tokio::test]
 async fn daemon_supervises_and_aggregates_the_netease_runner() {
@@ -12,12 +12,13 @@ async fn daemon_supervises_and_aggregates_the_netease_runner() {
   let mut runner_environment = std::collections::BTreeMap::new();
   runner_environment.insert("AUV_RUNNER_TEST_CONTEXT".to_string(), child_context_path.display().to_string());
   runner_environment.insert("AUV_RUNNER_TEST_BINARY".to_string(), env!("CARGO_BIN_EXE_auv-runner-netease-music").to_string());
-  let bound = Server::bind(ServerConfig {
+  let bound = Server::bind(Config {
     pairing_store: None,
-    listen: ListenEndpoint::Unix {
+    listeners: vec![ListenEndpoint::Unix {
       path: socket.clone(),
-    },
-    additional_listeners: Vec::new(),
+    }],
+    discovery_file: None,
+    publish_discovery: false,
     store_root: directory.path().join("store"),
     runner_providers: vec![RunnerProviderConfig {
       runner_class: "auv.app.netease_music".to_string(),


### PR DESCRIPTION
## Summary

- parse the NetEase runner class through the typed RunnerClass contract
- use the extension transport exposed by the shared runner client
- update the custom-runner integration test to the current daemon server API

## Why

The NetEase command still used the retired stringly transport access path and stale server construction types.

## Impact

NetEase now follows the same typed runner boundary as other command frontends without changing user-facing command behavior.

## Dependency

Stacked on #159, which owns the shared typed runner client API.

## Validation

- `cargo check -p auv-netease-music`
- `git diff --check`

The focused check passes with existing unrelated dead-code warnings in the transport module.