### PR TITLE
feat(auv-game-balatro): read card attributes

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -8,6 +8,8 @@ words:
   - antfu
   - apalis
   - apeira
+  - Balatro
+  - bbox
   - clippy
   - conv
   - cust
@@ -47,6 +49,7 @@ words:
   - serde
   - sonarjs
   - sqlx
+  - ultralytics
   - utoipa
   - uuidv
   - vchord

--- a/docs/ai/references/apps/balatro/2026-08-04-balatro-ground-truth-dataset-evidence.md
+++ b/docs/ai/references/apps/balatro/2026-08-04-balatro-ground-truth-dataset-evidence.md
@@ -1,0 +1,402 @@
+# Balatro Ground-Truth Dataset Evidence
+
+Date: 2026-08-04
+
+## Evidence level
+
+This note records live behavior on one development host. It proves that an
+AUV-owned Balatro mod can stage exact card identities, capture synchronized
+labels and frames, restore the original hand, and align those labels with a
+separate `auv-driver-linux` screen capture. It is not a production support,
+recognition-accuracy, or cross-environment claim.
+
+The prototype source and generated corpus are local scratch material under
+`docs/notes/neko/balatro-dataset-mod-prototype/`. They are intentionally not
+committed as durable project source or redistributable game assets.
+
+## Live environment
+
+- Host: `neko-gpu-1`, Debian with Flatpak Steam and Proton.
+- Balatro: `1.0.1o-FULL`.
+- Lovely: `0.9.0`; installed `version.dll` SHA-256
+  `ccfed59e4d245b7802c684fc86708e0a937f584d6e07d1ecc11e8eae22f9fc1a`.
+- Steamodded: release `1.0.0~BETA-1814a-STEAMODDED`.
+- BalatroBot: [`coder/balatrobot` commit
+  `e7c6db8a9ad88318f6e4128eefd6e61aafc94885`](https://github.com/coder/balatrobot/tree/e7c6db8a9ad88318f6e4128eefd6e61aafc94885).
+- AUV dataset mod: `0.3.0-prototype`, an independent Steamodded extension that
+  uses BalatroBot only for its loopback JSON-RPC dispatcher.
+- Steam per-application launch option:
+  `WINEDLLOVERRIDES="version=n,b" %command%`.
+
+Before installation, the entire Balatro save/profile directory and Steam's
+per-user configuration were copied to:
+
+```text
+/home/neko/.local/state/auv-balatro-dataset-backups/20260804-205646/
+```
+
+The existing unreleased Steamodded checkout was preserved in the same backup.
+
+## Prototype boundary
+
+The mod registers seven narrow methods:
+
+- `dataset.health` reports versions, state, render dimensions, and readiness.
+- `dataset.catalog` reports the exact vanilla enhancements, editions, seals,
+  facings, contrast modes, and deck backs that the current game exposes.
+- `dataset.status` reports the current typed stage and signature for settlement
+  polling.
+- `dataset.stage_cards` validates and stages typed per-card identity and visual
+  fields.
+- `dataset.stage` saves the visible hand and replaces its card bases with an
+  exact requested sequence; it remains the base-card convenience endpoint.
+- `dataset.capture` freezes `love.update`, captures the framebuffer, and reads
+  labels inside the `love.graphics.captureScreenshot` callback.
+- `dataset.restore` restores the saved card bases, including on collector
+  cleanup.
+
+Each card record includes rank, suit, card key, instance IDs, face direction,
+highlight/debuff state, seal, edition, enhancement, target transform `T`, and
+visible transform `VT`, and identity visibility. Version 0.3 accepts exact
+vanilla enhancement, edition, seal, debuff, highlight, facing, contrast, and
+deck-back fields. Each sample also records game/mod versions, render
+dimensions, tile/canvas scale, room transform, and language.
+
+Deck-back staging is visual-only at the card-instance boundary: the mod updates
+the existing back Sprite position and never calls `Back:change_to` or mutates
+`G.GAME.selected_back`. Negative edition is likewise staged as a visual-only
+shader record because the normal playing-card API changes hand capacity.
+Blind updates can recalculate debuff state, so status and capture entrypoints
+re-enforce the validated instance-bound visual spec before signing a frame.
+
+Frame paths are constrained beneath `auv-dataset/frames`; sidecar manifests
+are written beneath `auv-dataset/manifests`. The prototype exposes no arbitrary
+Lua execution and does not copy upstream endpoint or gameplay code.
+
+## Generated samples
+
+The first live run used seed `AUVTRAIN`, red deck, white stake, and a stable
+eight-card hand in `SELECTING_HAND`.
+
+| Session | Frames | Card records | Unique rank/suit faces | Position coverage | Hidden cards |
+| --- | ---: | ---: | ---: | --- | ---: |
+| `base-52-live-20260804` | 7 | 56 | 52 | Ordered proof pass | 0 |
+| `base-52-shuffled-r4-20260804` | 28 | 224 | 52 | Each face in 2-5 screen positions | 0 |
+| `base-52-shuffled-r40-20260804` | 280 | 2,240 | 52 | Forty independently shuffled rounds | 0 |
+
+The shuffled corpus contains at least four examples of every base face. Some
+faces occur six times because each 52-card round must fill the last eight-card
+frame. All internal captures were `2043x1126`; the shuffled local corpus is
+approximately 8.8 MiB.
+
+Visual inspection of the first ordered frame confirmed that the rendered hand
+matched its labels (`H2` through `H9`). After collection, `dataset.restore`
+reported eight restored cards, and `dataset.health` reported no active staged
+hand or pending capture.
+
+## Project AIRI-compatible dataset export
+
+The 40-round capture was exported inside the existing Linux checkout at:
+
+```text
+/home/neko/Git/github.com/proj-airi/game-playing-ai-balatro/
+  data/datasets/games-balatro-2024-mod-ground-truth-prototype/
+```
+
+The independent exporter prototype is
+`cli/prototypes/export_mod_ground_truth.py` in that checkout. Its output is
+approximately 221 MiB and contains:
+
+- 280 hand-region YOLO images with 2,240 `poker_card_front` objects, preserving
+  the existing Project AIRI entity class ID `6`.
+- 2,080 rectified full-card crops and 2,080 top-left rank/suit crops.
+- Exact 52-class labels, with 40 balanced samples for every rank/suit identity.
+- Full source frames, frame hashes, stage-token hashes, game/Mod/render
+  versions, source and ROI geometry, quadrilaterals, axis-aligned boxes, and
+  modifier fields.
+- Deterministic complete-round splits: 28 train groups / 1,456 card crops, six
+  validation groups / 312 crops, and six test groups / 312 crops.
+
+The four cards repeated to fill the final eight-card frame in each round stay
+in object detection but are excluded from classification, producing exact
+class balance. Complete rounds are the split unit, so frames, crops, and these
+padding duplicates cannot cross train/validation/test boundaries.
+
+Full frames contain other visible entities for which the current Mod does not
+produce labels. The primary YOLO view therefore crops to the exact union of
+the eight annotated hand-card quadrilaterals. Full frames remain as provenance,
+but are not presented as completely annotated detector inputs. This prevents
+unlabelled deck, stack, or tooltip entities from becoming false-negative
+training examples.
+
+Validation completed with the repository's Pixi environment:
+
+- Ruff formatting and lint passed for the exporter.
+- Ultralytics resolved all train, validation, and test paths with ten class
+  names from both the embedded-repository and standalone YAML configurations.
+- Every detector image has one label file and every crop has one metadata row.
+- All 2,240 YOLO rows use class ID `6` and valid normalized coordinates.
+- Every split contains all 52 card classes with equal per-class counts.
+- Visual overlays align the Mod `VT` quadrilaterals with the rendered card
+  borders; sampled full-card and corner crops retain the expected identity.
+
+Three superseded local exports were moved, not deleted, to:
+
+```text
+/home/neko/.local/state/auv-balatro-dataset-prototypes/20260804/
+```
+
+They record why full-frame partial labels, padded hand regions, and a
+repository-root path ambiguity were rejected.
+
+## Playing-card visual-variant dataset
+
+Mod 0.3 generated a separate card-specialized raw session:
+
+```text
+/home/neko/.var/app/com.valvesoftware.Steam/.local/share/Steam/steamapps/
+  compatdata/2379780/pfx/drive_c/users/steamuser/AppData/Roaming/Balatro/
+  auv-dataset/collections/card-variants-v3-20260804.jsonl
+```
+
+It contains 819 synchronized frames, 6,552 card records, 117 complete-round
+groups, and 47 profiles. Every single-axis profile uses three independently
+shuffled complete 52-card rounds, one per split. The exact vanilla axes are:
+
+- all 52 rank/suit identities;
+- base plus eight enhancements;
+- four editions and four seals;
+- debuff, highlight, front/back, and both contrast settings;
+- all fifteen vanilla deck backs.
+
+Twelve additional deterministic pairwise profiles exercise modifier
+interactions. This is not a full Cartesian product; the omission is explicit
+in the collector because exhaustive combinations would be mostly duplicate
+framebuffer data without an error-analysis trigger.
+
+The separate exported dataset is:
+
+```text
+/home/neko/Git/github.com/proj-airi/game-playing-ai-balatro/
+  data/datasets/games-balatro-2024-playing-card-ground-truth-prototype/
+```
+
+The 1.3 GiB output has 18,421 files. Each split has 39 round groups, 273
+detector frames, 2,184 typed objects, and 2,184 rectified all-variant crops.
+The detector projection contains 1,344 `poker_card_front` and 840
+`poker_card_back` instances per split. Separate views contain:
+
+| Split | Visible identity crops | Corner crops | Deck-back crops |
+| --- | ---: | ---: | ---: |
+| train | 1,172 | 1,172 | 780 |
+| validation | 1,173 | 1,173 | 780 |
+| test | 1,173 | 1,173 | 780 |
+
+Every split has all 52 visible identity classes with 21-23 samples per class,
+and exactly 52 non-padding crops for each of the fifteen deck-back classes.
+Stone and face-down instances stay in detection and the all-variant view but
+have `identity_visible=false`; they are excluded from identity and corner
+supervision.
+
+The exporter is
+`cli/prototypes/export_card_variants.py` in the Project AIRI checkout. Ruff
+formatting and lint passed. Both repository-embedded and standalone
+Ultralytics YAML files resolved train/validation/test successfully. Automated
+checks also proved:
+
+- one image, label file, and metadata row per detector frame;
+- one metadata row per crop in all four derived views;
+- valid normalized YOLO coordinates using only existing entity IDs 4 and 6;
+- no round-group overlap across splits;
+- every one-axis profile present in every split;
+- exact fifteen-way back-label balance and complete 52-class identity presence.
+
+Visual inspection covered the geometry overlay and a 35-profile single-axis
+contact sheet. All enhancements, editions, seals, debuff, contrast, highlight,
+and deck-back pixels matched their typed labels.
+
+Two earlier raw sessions remain as evidence but are excluded from the final
+dataset: `card-variants-v1-20260804` stopped at 357 frames when status exposed
+blind-recalculated debuffs, and `card-variants-v2-20260804` completed 525
+frames before deck-back staging existed. The v2 export was moved intact to:
+
+```text
+/home/neko/.local/state/auv-balatro-dataset-prototypes/20260804/
+  card-variants-v2-without-all-backs/
+```
+
+The first edition implementation also exposed why normal negative-edition
+staging is invalid for corpus generation: it changed hand capacity and dealt a
+ninth card. The final Mod uses visual-only negative shader state, re-enforces
+debuff at status/capture boundaries, and restores the original eight-card hand.
+
+## Card-detector training probe
+
+The Project AIRI training entrypoint was changed from a hard-coded experiment
+to a parameterized CLI while retaining its previous defaults. Focused tests
+cover default compatibility, argument overrides, and automatic device
+selection. Ruff formatting/lint and the three tests passed in the repository's
+Pixi environment.
+
+The existing Balatro entity detector was fine-tuned on the card-specialized
+dataset rather than starting from generic YOLO11n weights. The deterministic
+run used image size 640, batch 64, seed `20260804`, and early-stopping patience
+20 on an RTX 4080 SUPER. It stopped after epoch 63 and selected epoch 43. The
+packaged local artifacts are:
+
+```text
+/home/neko/Git/github.com/proj-airi/game-playing-ai-balatro/
+  models/games-balatro-2024-yolo-card-detection-mod-ground-truth/
+```
+
+On the group-held-out 273-image / 2,184-object test split, the source model had
+precision `0.608135`, recall `0.533036`, `mAP50=0.617639`, and
+`mAP50-95=0.400004`. The fine-tuned model had precision `0.999943`, recall
+`1.0`, `mAP50=0.995`, and `mAP50-95=0.994965`. Both supervised classes,
+`poker_card_back` and `poker_card_front`, were approximately `0.995` mAP50-95.
+
+This high score is an in-session dataset result, not deployment accuracy. The
+groups do not overlap, but every split came from the same game session and
+render setup. A full-frame visual probe found all eight hand cards and the deck
+back but also five false-positive front-card boxes on the left-side blind/score
+UI at confidence `0.25`; multiple false positives remained above `0.8`. This
+matches the dataset contract: its detector projection contains fully annotated
+hand-region crops, while full frames retain incompletely labelled UI entities
+only as provenance. The model therefore requires a hand-region crop today.
+Full-frame use needs a separate owner-approved corpus with complete UI labels
+or explicit hard-negative supervision.
+
+The fixed-shape opset-19 ONNX export passed `onnx.checker` and ONNX Runtime CPU
+inference. On a held-out card-back image, PyTorch and ONNX both returned the
+same eight class-4 detections. Model hashes and exact metrics are recorded in
+the package's `metrics.json`. Dataset/source-weight/game-asset redistribution
+licensing remains unreviewed, so the package is local experimental evidence.
+
+The dataset and model were subsequently uploaded as private Hugging Face
+repositories, preserving that licensing boundary:
+
+- `proj-airi/games-balatro-2024-playing-card-ground-truth`
+- `proj-airi/games-balatro-2024-yolo-card-detection-mod-ground-truth`
+
+AUV now accepts an opt-in `--cards-model` ONNX path. This does not replace the
+global entities detector: observation runs the specialized model only on the
+normalized hand band, maps detections back to source-frame pixels, and uses
+them as the hand-slot source while retaining global entity/UI results for all
+other state. The initial no-crop integration reproduced the expected failure
+on a 2043x1126 full frame: thirteen hand slots were emitted from eight hand
+cards, the deck back, and four UI false positives. With the specialized crop,
+the same AUV observation emitted exactly eight left-to-right hand slots at
+confidence `0.9613-0.9731`; global entities still supplied phase evidence.
+Focused crop/remapping and source-selection regression tests passed together
+with all 22 library tests.
+
+A later Linux live probe exposed a second coordinate boundary: window capture
+was unavailable, so the portal returned a `2560x1440` full display containing a
+roughly `2048x1129` Balatro viewport offset from the desktop origin. Applying
+the hand percentages to the display produced eleven slots. The observation
+crop now downsamples boundary samples, converts them to grayscale, thresholds
+edge contrast, and combines the two long-edge scores with the corpus viewport
+aspect ratio before deriving the hand band. On the recorded live frame it
+resolved `viewport=(512,311,2048,1129)` and
+`hand=(1054,898,1127,361)`. The same remote detector invocation then emitted
+exactly eight hand slots at confidence `0.9659-0.9723`. A synthetic offset-
+viewport regression, including a stronger internal panel edge, passed with all
+23 library tests. Arbitrary floating-window recovery remains explicitly
+deferred at the detector call site; this evidence covers the reproduced
+right/bottom-clipped display fallback.
+
+Temporary stage timing on one live invocation attributed the approximately
+29-second wall time as follows: class-asset resolution `4.22s`, window resolve
+plus portal capture `7.46s`, OCR `8.44s`, entities RPC `4.39s`, cropped card RPC
+and crop `0.15s`, and UI RPC `2.86s`. Two fixed-frame warm probes put the full-
+frame entities/UI RPCs at `3.76-5.15s` and `3.70-6.99s`, while the cropped card
+path remained `0.12-0.16s`. The card model and viewport preprocessing are not
+the latency bottleneck; serial OCR plus repeated uncompressed full-frame RPCs
+are.
+
+A follow-up optimization tested concurrent full-frame OCR and detection first.
+That reduced one occluded live invocation only from `29.03s` to `26.26s`
+because the large RPCs competed for the same remote transport. The accepted
+path instead waits for UI detection, skips OCR when no numeric UI was detected,
+and otherwise derives one padded numeric-UI crop on the caller. It updates the
+derived `Capture.bounds` before RPC delivery, preserving screen-coordinate
+projection while avoiding a second full-display RGBA transfer. On a visible
+live frame this sent a `456x856` crop instead of `2560x1440` and reduced the OCR
+stage from `8.44s` to `0.62s`. Observed end-to-end time was `17.25-21.88s`; the
+spread came primarily from portal capture, which reached `9.80s` in the slower
+probe. Remaining measured costs were class-asset resolution `2.15s` and the
+three detector RPCs `4.85s`.
+
+Linux OCR is Tesseract through `leptess`. The driver currently PNG-encodes each
+request and constructs a new language-configured engine. Engine reuse was not
+added in this slice: the complete cropped OCR RPC is now about `0.62s`, while
+portal capture and full-frame entities/UI transport are materially larger. A
+driver-owned reuse cache also needs a thread/concurrency lifecycle rather than
+an observation-local mutex.
+
+## Independent driver-domain alignment
+
+To check that game-internal labels describe what AUV sees through its actual
+Linux display driver, the mod staged:
+
+```text
+S_A, H_K, C_Q, D_J, S_T, H_9, C_8, D_7
+```
+
+Without changing that stage token, `auv-driver-linux` captured the external
+portal display:
+
+- Run: `fbfeb64f-6dbc-a6dc-6ab3-cc93a86cf9e1`.
+- Artifact:
+  `auv://runs/fbfeb64f-6dbc-a6dc-6ab3-cc93a86cf9e1/artifacts/019fcce8-33a0-7cc2-90bd-644bb254fcd9`.
+- PNG SHA-256:
+  `cd4667e652fdb41e6519cebb55835f4ab27b9c425b1f79e75aab01cb6c8e5bcb`.
+- Capture backend and dimensions: portal, `2560x1440`.
+
+Visual inspection showed exactly A-spades, K-hearts, Q-clubs, J-diamonds,
+10-spades, 9-hearts, 8-clubs, and 7-diamonds. The current AUV visual state
+reader found eight `poker_card_front` regions with confidence from about
+`0.9397` to `0.9578` and no diagnostics. A subsequent same-token internal
+capture returned the same eight exact labels, after which restoration
+succeeded.
+
+This proves alignment for that staged hand. It does not yet measure exact
+rank/suit classification accuracy: the current visual result identifies card
+front regions, while the Mod supplies the exact ground truth.
+
+## Installation findings
+
+- Use the official per-game Steam launch option for Proton injection. A global
+  Wine registry override has broader effects than this development tool needs.
+- When transferring mod archives from macOS, suppress AppleDouble metadata.
+  `._*.toml` files were treated as Lovely patch files and failed UTF-8 parsing.
+  The generated metadata files were removed from the target after their exact
+  paths were enumerated.
+- The Lovely console is visible in the external full-display screenshot. It
+  does not overlap the staged cards, but future driver-domain collection should
+  hide it or capture/crop the Balatro window explicitly.
+
+## Known boundaries and next slice
+
+- Both the 280-frame base corpus and 819-frame visual-variant corpus use the
+  Mod's same-callback framebuffer capture. The external-driver check is one
+  proof frame, not yet the collection transport.
+- There is no durable `prepare -> external capture -> commit` protocol yet.
+  That handshake must freeze a stage, carry a shared sample ID into the AUV run
+  artifact, verify the unchanged stage signature, and then restore/unfreeze.
+- The specialized corpus exhausts each supported vanilla card axis separately,
+  but interaction coverage is pairwise rather than Cartesian. It still uses
+  one resolution, language, game version, run, hand layout, and background
+  family. Motion phases, deliberate overlap variation, multiple display
+  scales, localization variants, and modded card assets remain outside this
+  prototype.
+- The current split is grouped by complete shuffled round, but all rounds still
+  share one game run, seed, language, resolution, and background family. Final
+  evaluation must reserve independent sessions and driver-domain captures.
+- Redistribution of rendered game assets or derived weights needs a separate
+  rights review; upstream source licenses do not decide game-asset rights.
+
+The smallest useful follow-up is an AUV-owned external capture handshake and
+independent-session collection. The crop/manifest exporter now exists; moving
+its input to the production driver domain would make a real rank/suit accuracy
+evaluation possible.

--- a/docs/ai/references/apps/balatro/2026-08-04-balatro-mod-dataset-api-research.md
+++ b/docs/ai/references/apps/balatro/2026-08-04-balatro-mod-dataset-api-research.md
@@ -1,0 +1,395 @@
+# Balatro Mod Dataset API Research
+
+Date: 2026-08-04
+
+## Question
+
+What can AUV reuse conceptually from `coder/balatrollm`,
+`FFFishes7/blinddeck`, `abhinavuppala/BalatroBotLearning`, and
+`alesha-pro/evalatro` to inject a development-only Balatro mod and generate
+ground-truth card-recognition training data?
+
+This is a source review, not an implementation decision. All repositories were
+cloned into a temporary directory outside the AUV worktree. No upstream code
+was copied into AUV.
+
+## Evidence snapshot
+
+| Repository | Inspected commit | Declared license | Relevant role |
+| --- | --- | --- | --- |
+| [`coder/balatrollm`](https://github.com/coder/balatrollm/tree/6269c592ac4d4534934701f42773256342457b69) | `6269c592ac4d4534934701f42773256342457b69` | MIT | BalatroBot HTTP client, run loop, delayed screenshot collection |
+| [`FFFishes7/blinddeck`](https://github.com/FFFishes7/blinddeck/tree/8015c448d0a97e4f9d180ae6f1192412cc308871) | `8015c448d0a97e4f9d180ae6f1192412cc308871` | MIT | Current Steamodded mod, state extraction, screenshot endpoint, stable-action waits |
+| [`abhinavuppala/BalatroBotLearning`](https://github.com/abhinavuppala/BalatroBotLearning/tree/2a39dd3eabb3df6e0773d6d14b7230e8bafc1c8d) | `2a39dd3eabb3df6e0773d6d14b7230e8bafc1c8d` | No repository license found | Older UDP API and simulation-speed experiments |
+| [`alesha-pro/evalatro`](https://github.com/alesha-pro/evalatro/tree/2f82617b646f88944111f91d1f8c92b05d1f6f58) | `2f82617b646f88944111f91d1f8c92b05d1f6f58` | ISC declared in `package.json`; no license file found | Cross-platform installer, isolated profile, JSONL/SQLite provenance |
+| [`coder/balatrobot`](https://github.com/coder/balatrobot/tree/e7c6db8a9ad88318f6e4128eefd6e61aafc94885) | `e7c6db8a9ad88318f6e4128eefd6e61aafc94885` | MIT | Direct dependency/source of truth used by BalatroLLM and Evalatro |
+| [`Steamodded/smods`](https://github.com/Steamodded/smods/tree/c7e8eb2f6daadb05ee89d72c8edfbf5094ed1eb6) | `c7e8eb2f6daadb05ee89d72c8edfbf5094ed1eb6` | GPL-3.0 | Primary source for current JSON mod metadata loading |
+
+Repository license and game-asset rights are separate. Before publishing a
+dataset or trained weights containing knowledge derived from Balatro renders,
+the owner should review the distribution boundary. This note makes no claim
+that an upstream code license grants rights to redistribute game assets.
+
+## Executive conclusion
+
+The useful seam is not any project's agent or strategy code. It is the proven
+game-side integration pattern:
+
+```text
+Lovely injects into Balatro/LÖVE
+  -> Steamodded loads a narrowly scoped Lua mod
+  -> the mod reads card identity from G.*
+  -> a localhost request stages or captures one sample
+  -> the capture response returns the image identity and same-frame labels
+  -> AUV records the sample as an artifact and validates it before training
+```
+
+AUV should write a small, development-only Steamodded extension mod of its own.
+For the first spike it can depend on BalatroBot's server/dispatcher and register
+only AUV-owned dataset endpoints; it should not fork BalatroBot, expose general
+gameplay, or copy any upstream endpoint implementation. BlindDeck/BalatroBot's
+separate `gamestate` and `screenshot` calls do not provide the atomic
+image/label pairing required for a trustworthy training corpus.
+
+## Repository findings
+
+### `coder/balatrollm`
+
+BalatroLLM contains no game-side mod. It declares `balatrobot>=1.4.1` and uses
+BalatroBot's instance manager and an async JSON-RPC-over-HTTP client
+([dependency](https://github.com/coder/balatrollm/blob/6269c592ac4d4534934701f42773256342457b69/pyproject.toml#L7-L14),
+[client](https://github.com/coder/balatrollm/blob/6269c592ac4d4534934701f42773256342457b69/src/balatrollm/client.py#L21-L71)).
+The client posts JSON-RPC requests to `http://127.0.0.1:12346/` by default.
+
+The run loop polls named stable game states and executes typed method names such
+as `start`, `gamestate`, `play`, and `cash_out`
+([loop](https://github.com/coder/balatrollm/blob/6269c592ac4d4534934701f42773256342457b69/src/balatrollm/bot.py#L104-L215)).
+Its screenshot is requested only after the LLM response returns and through a
+separate `screenshot` call
+([capture call](https://github.com/coder/balatrollm/blob/6269c592ac4d4534934701f42773256342457b69/src/balatrollm/bot.py#L250-L284)).
+That is suitable for a run viewer, but the screenshot is not guaranteed to be
+the same rendered frame as the previously supplied state.
+
+Reusable ideas:
+
+- Monotonic request IDs and structured JSON-RPC errors.
+- One port per launched instance, allowing parallel data workers.
+- A durable run directory that associates requests, responses, screenshots,
+  and statistics.
+
+Not reusable for this slice:
+
+- The LLM strategy, prompt, and action loop.
+- Its delayed, separate screenshot/state pairing.
+
+### `FFFishes7/blinddeck`
+
+BlindDeck is a BalatroBot fork. Its mod manifest declares version `1.5.2`, mod
+ID `balatrobot`, and `Steamodded (>=1.~)` as its dependency
+([manifest](https://github.com/FFFishes7/blinddeck/blob/8015c448d0a97e4f9d180ae6f1192412cc308871/balatrobot.json#L1-L23)).
+Its installation path is the conventional stack: Lovely beside the game,
+Steamodded under Balatro's `Mods/smods`, and the mod under `Mods/balatrobot`
+([installation](https://github.com/FFFishes7/blinddeck/blob/8015c448d0a97e4f9d180ae6f1192412cc308871/README.md#L44-L76)).
+
+The main Lua file loads modules with `SMODS.load_file`, registers endpoints,
+initializes the server/dispatcher, and updates the non-blocking server from
+`love.update`
+([entrypoint](https://github.com/FFFishes7/blinddeck/blob/8015c448d0a97e4f9d180ae6f1192412cc308871/balatrobot.lua#L1-L103)).
+The server is a single-client HTTP/1.1 JSON-RPC server using LuaSocket; the
+dispatcher validates protocol shape, method schema, required game state, and
+then endpoint execution
+([server](https://github.com/FFFishes7/blinddeck/blob/8015c448d0a97e4f9d180ae6f1192412cc308871/src/lua/core/server.lua#L1-L118),
+[dispatcher](https://github.com/FFFishes7/blinddeck/blob/8015c448d0a97e4f9d180ae6f1192412cc308871/src/lua/core/dispatcher.lua#L112-L224)).
+
+The exact ground truth needed by AUV is already available inside the game:
+`card.config.card.suit` and `card.config.card.value` are normalized into four
+suits and thirteen ranks
+([normalization](https://github.com/FFFishes7/blinddeck/blob/8015c448d0a97e4f9d180ae6f1192412cc308871/src/lua/utils/gamestate.lua#L590-L633),
+[extraction](https://github.com/FFFishes7/blinddeck/blob/8015c448d0a97e4f9d180ae6f1192412cc308871/src/lua/utils/gamestate.lua#L858-L872)).
+The state serializer walks `G.hand`, `G.deck`, shop, and pack areas
+([areas](https://github.com/FFFishes7/blinddeck/blob/8015c448d0a97e4f9d180ae6f1192412cc308871/src/lua/utils/gamestate.lua#L1680-L1714)).
+It deliberately masks identity for face-down cards, which is the correct
+runtime behavior and should remain the default outside dataset staging
+([masking](https://github.com/FFFishes7/blinddeck/blob/8015c448d0a97e4f9d180ae6f1192412cc308871/src/lua/utils/gamestate.lua#L976-L1042)).
+
+The screenshot endpoint schedules `love.graphics.captureScreenshot`, encodes
+the callback's `ImageData` as PNG, writes through `nativefs`, and only then
+responds
+([endpoint](https://github.com/FFFishes7/blinddeck/blob/8015c448d0a97e4f9d180ae6f1192412cc308871/src/lua/endpoints/screenshot.lua#L20-L75)).
+However, that response contains only the output path. It does not extract
+labels inside the callback, so a separate `gamestate` request is not an atomic
+ground-truth pair.
+
+BlindDeck's strongest additional idea is its event-based settlement checks.
+Actions wait for meaningful conditions such as final state, complete UI,
+unlocked controller, and positioned cards before returning
+([play settlement](https://github.com/FFFishes7/blinddeck/blob/8015c448d0a97e4f9d180ae6f1192412cc308871/src/lua/endpoints/play.lua#L94-L179)).
+The dataset mod should use similarly explicit stability predicates instead of a
+fixed sleep.
+
+### `abhinavuppala/BalatroBotLearning`
+
+This repository embeds an older `Balatrobot-v0.3` mod using the old
+`SMODS.INIT`/`NFS.read` loading style
+([entrypoint](https://github.com/abhinavuppala/BalatroBotLearning/blob/2a39dd3eabb3df6e0773d6d14b7230e8bafc1c8d/balatrobot/main.lua#L1-L37)).
+It binds a UDP socket to `0.0.0.0`, responds to `HELLO` polls, and accepts a
+pipe-delimited action protocol
+([UDP API](https://github.com/abhinavuppala/BalatroBotLearning/blob/2a39dd3eabb3df6e0773d6d14b7230e8bafc1c8d/balatrobot/src/api.lua#L1-L105),
+[client](https://github.com/abhinavuppala/BalatroBotLearning/blob/2a39dd3eabb3df6e0773d6d14b7230e8bafc1c8d/balatro_connection.py#L57-L137)).
+The state reader directly exports `card.config.card.suit` and `.value`, but it
+does not mask face-down identities and has no screenshot endpoint
+([card extraction](https://github.com/abhinavuppala/BalatroBotLearning/blob/2a39dd3eabb3df6e0773d6d14b7230e8bafc1c8d/balatrobot/src/utils.lua#L4-L47)).
+
+Its only useful conceptual clue is the distinction between the target transform
+`T` and visible transform `VT`: its optional instant-move patch assigns
+`VT.x/y = T.x/y`
+([speed patch](https://github.com/abhinavuppala/BalatroBotLearning/blob/2a39dd3eabb3df6e0773d6d14b7230e8bafc1c8d/balatrobot/src/api.lua#L104-L179)).
+For visual annotations, AUV should record visible transforms rather than assume
+the target layout is what was rendered.
+
+Do not reuse this implementation: it has no repository license, uses an old mod
+API, exposes UDP beyond loopback, omits screenshot synchronization, and contains
+comments acknowledging stability problems when delays are disabled.
+
+### `alesha-pro/evalatro`
+
+Evalatro also delegates game access to BalatroBot. Its TypeScript client adds
+timeouts, retry/backoff, structured error handling, and one-line JSONL logging
+for every request/result pair
+([client](https://github.com/alesha-pro/evalatro/blob/2f82617b646f88944111f91d1f8c92b05d1f6f58/src/client/balatrobot.ts#L1-L90)).
+That provenance pattern is useful for dataset generation, though its exposed
+client has no screenshot method.
+
+Its installer identifies the required upstreams—Steamodded, BalatroBot, and a
+Lovely release—and has explicit macOS, Windows, and Linux/Proton layouts
+([dependencies](https://github.com/alesha-pro/evalatro/blob/2f82617b646f88944111f91d1f8c92b05d1f6f58/scripts/setup-local-lib.mjs#L1-L13),
+[layouts](https://github.com/alesha-pro/evalatro/blob/2f82617b646f88944111f91d1f8c92b05d1f6f58/scripts/setup-local-lib.mjs#L161-L235)).
+It clones the mods and installs Lovely rather than embedding game files
+([install execution](https://github.com/alesha-pro/evalatro/blob/2f82617b646f88944111f91d1f8c92b05d1f6f58/scripts/setup-local-lib.mjs#L627-L636)).
+
+The small `evalatro_unlock` mod is a good lifecycle precedent: it is gated by an
+environment variable, waits until `G` and the selected profile exist, applies
+once, and operates on a dedicated profile
+([unlock helper](https://github.com/alesha-pro/evalatro/blob/2f82617b646f88944111f91d1f8c92b05d1f6f58/assets/evalatro_unlock/evalatro_unlock.lua#L1-L75)).
+AUV's dataset mod should likewise require an explicit environment gate and a
+dedicated profile so normal saves are untouched.
+
+Evalatro launches BalatroBot with `--fast --no-shaders` for benchmark throughput
+([launcher](https://github.com/alesha-pro/evalatro/blob/2f82617b646f88944111f91d1f8c92b05d1f6f58/src/game/launch.ts#L15-L46)).
+Those options are unsuitable for the primary visual corpus because they change
+rendering and animation behavior. They may be useful only for a separately
+labeled ablation corpus.
+
+## Current BalatroBot details that affect AUV
+
+The current BalatroBot source supports a headed `render_on_api` mode, explicitly
+separate from headless mode. Headless mode disables rendering, while
+render-on-API only draws/presents when a request sets the render flag
+([settings](https://github.com/coder/balatrobot/blob/e7c6db8a9ad88318f6e4128eefd6e61aafc94885/src/lua/settings.lua#L46-L75),
+[headless](https://github.com/coder/balatrobot/blob/e7c6db8a9ad88318f6e4128eefd6e61aafc94885/src/lua/settings.lua#L119-L188),
+[render-on-API](https://github.com/coder/balatrobot/blob/e7c6db8a9ad88318f6e4128eefd6e61aafc94885/src/lua/settings.lua#L191-L220)).
+For deterministic collection, headed render-on-API plus normal shaders is the
+better starting point.
+
+On macOS, the launcher injects Lovely by setting `DYLD_INSERT_LIBRARIES` to
+`liblovely.dylib` and launches Balatro's bundled LÖVE executable
+([launcher](https://github.com/coder/balatrobot/blob/e7c6db8a9ad88318f6e4128eefd6e61aafc94885/src/balatrobot/platforms/macos.py#L10-L47)).
+That confirms an automated local launch is feasible without modifying the game
+bundle beyond installing Lovely and the Steamodded mods.
+
+## Recommended AUV-owned dataset seam
+
+### Scope classification
+
+This would be an approved feature only if the owner accepts a development-only
+Balatro data-generation surface. It should not become a gameplay dependency or
+a public AUV support claim. The output is training evidence, not proof that the
+production visual reader works.
+
+### Mod boundary
+
+Create a small Steamodded mod with its own ID and prefix, for example provisional
+`auv_dataset`. For the first integration spike, make BalatroBot `>=1.5.2` an
+explicit dependency and register AUV-owned endpoint tables through
+`BB_DISPATCHER.register`; the dispatcher supports post-initialization endpoint
+registration by name
+([registration](https://github.com/coder/balatrobot/blob/e7c6db8a9ad88318f6e4128eefd6e61aafc94885/src/lua/core/dispatcher.lua#L44-L72)).
+This reuses the MIT-licensed installed component without copying its server. A
+standalone AUV server should be a later, separately approved slice only if the
+dataset tool must run without BalatroBot.
+
+The mod should:
+
+- Depend on Steamodded and BalatroBot, but not on an agent/player project.
+- Load only when `AUV_BALATRO_DATASET=1`.
+- Bind only to `127.0.0.1` on a configurable port.
+- Refuse requests outside a dedicated profile and dataset mode.
+- Expose no arbitrary Lua evaluation, save mutation, money setting, or gameplay
+  actions.
+- Write only beneath a configured output root, rejecting traversal and absolute
+  paths outside that root.
+- Include `schema_version`, mod version, Balatro version, Steamodded version,
+  render settings, and run/sample IDs in every response.
+
+The current Steamodded loader requires JSON metadata fields `id`, `author`,
+`name`, `description`, `prefix`, and `main_file`. It validates the referenced
+main file before loading it
+([loader schema](https://github.com/Steamodded/smods/blob/c7e8eb2f6daadb05ee89d72c8edfbf5094ed1eb6/src/preflight/loader.lua#L135-L153),
+[main-file validation](https://github.com/Steamodded/smods/blob/c7e8eb2f6daadb05ee89d72c8edfbf5094ed1eb6/src/preflight/loader.lua#L301-L354)).
+A minimal AUV manifest should therefore have this shape:
+
+```json
+{
+  "id": "auv_dataset",
+  "name": "AUV Dataset Capture",
+  "author": ["moeru-ai"],
+  "description": "Development-only synchronized Balatro dataset capture.",
+  "prefix": "AUVD",
+  "main_file": "main.lua",
+  "version": "0.1.0",
+  "priority": 0,
+  "dependencies": ["Steamodded (>=1.~)", "balatrobot (>=1.5.2)"]
+}
+```
+
+Steamodded executes the referenced Lua file directly after config and
+dependency checks
+([load path](https://github.com/Steamodded/smods/blob/c7e8eb2f6daadb05ee89d72c8edfbf5094ed1eb6/src/preflight/loader.lua#L767-L780)).
+This is the current JSON-manifest path; the old `--- STEAMODDED HEADER` form in
+BalatroBotLearning should not be used.
+
+### Minimal API shape
+
+The exact names remain provisional until implementation review.
+
+```json
+{"jsonrpc":"2.0","method":"dataset.health","params":{},"id":1}
+```
+
+Returns versions, active profile, render settings, and whether capture is
+available.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "dataset.stage",
+  "params": {
+    "sample_id": "base-000001",
+    "cards": [
+      {"rank": "A", "suit": "S"},
+      {"rank": "2", "suit": "H"}
+    ],
+    "highlighted": [],
+    "layout_seed": 17
+  },
+  "id": 2
+}
+```
+
+Stages a bounded hand from typed rank/suit values using game-native card
+construction, then waits for explicit stability. It returns a `stage_token`,
+not an image.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "dataset.capture",
+  "params": {
+    "stage_token": "...",
+    "relative_path": "frames/base-000001.png"
+  },
+  "id": 3
+}
+```
+
+The capture response should be produced from the
+`love.graphics.captureScreenshot` callback and contain:
+
+```json
+{
+  "schema_version": 1,
+  "sample_id": "base-000001",
+  "stage_token": "...",
+  "frame_seq": 42,
+  "image": {"path": "frames/base-000001.png", "width": 1920, "height": 1080},
+  "state": "SELECTING_HAND",
+  "cards": [
+    {
+      "area": "hand",
+      "index": 0,
+      "instance_id": 123,
+      "rank": "A",
+      "suit": "S",
+      "hidden": false,
+      "highlighted": false,
+      "target_transform": {"x": 0, "y": 0, "w": 0, "h": 0},
+      "visible_transform": {"x": 0, "y": 0, "w": 0, "h": 0}
+    }
+  ]
+}
+```
+
+The mod should extract labels and visible transforms inside that callback, not
+in an earlier `gamestate` request. Pixel-coordinate conversion is intentionally
+deferred until it is validated against an overlay or known single-card fixture;
+raw `T`/`VT` values should not be called pixel bounds prematurely.
+
+`dataset.clear` may be added only if staging cannot replace the previous bounded
+hand atomically. Do not add a general-purpose `exec`, `set`, or `add` endpoint.
+
+### Stability and pairing rules
+
+A sample is accepted only when all applicable conditions hold:
+
+- Dataset mode and dedicated profile are active.
+- The staged token still matches the current hand.
+- `G.STATE_COMPLETE == true`.
+- `G.CONTROLLER.locked` is false.
+- The hand exists, is not removed, and every card has `T` and `VT` transforms.
+- The requested card count equals the returned label count.
+- The screenshot write succeeds and its dimensions are recorded.
+- The external AUV detector returns the same number of ordered card slots; if
+  order-to-slot association is used, any ambiguity rejects the sample.
+
+The runner should use a bounded retry/timeout and persist rejection reasons.
+Fixed sleeps are not evidence that the frame settled.
+
+### Balanced generation schedule
+
+The external AUV runner, not Lua, should own the schedule and manifest. A useful
+first corpus is:
+
+1. Balance all 52 `(rank, suit)` combinations exactly.
+2. Randomize order and neighboring cards so class and screen position are not
+   correlated.
+3. Cross controlled nuisance factors: window/render scale, 5–8 card overlap,
+   highlighted/unhighlighted, debuff, enhancement, edition, seal, and normal
+   shader effects.
+4. Keep clean base cards as a separately measurable stratum.
+5. Split train/validation/test by capture run and nuisance configuration, not by
+   adjacent crops from the same frame.
+6. Store a manifest row per crop with image hash, source-frame hash, label,
+   stage request, render settings, mod/source versions, detector association,
+   and rejection history.
+
+This makes every captured example fully labeled without pretending every
+possible modifier combination needs equal weight. Class balance and nuisance
+coverage should be explicit, reviewable distributions.
+
+## Recommended first slice
+
+1. Install/verify Lovely, Steamodded, and current BalatroBot using the current
+   machine's platform path, without installing or modifying any reviewed agent
+   project.
+2. Build the AUV-owned mod with only `dataset.health`, `dataset.stage`, and
+   atomic `dataset.capture`.
+3. Generate a 52-card clean corpus in small hands, normal shaders, and one fixed
+   resolution.
+4. Run AUV's existing card detector/corner cropper, reject count mismatches,
+   and write a manifest.
+5. Manually inspect a stratified sample and run schema/hash/inventory checks.
+6. Only after this gate, add controlled visual nuisances and train/evaluate the
+   existing Balatro corner classifier.
+
+The highest-risk issue is not card identity extraction; that is straightforward.
+It is proving that each crop, screenshot, and label refer to the same rendered
+frame and preserving that lineage in AUV's run artifacts.

--- a/docs/ai/references/apps/balatro/2026-08-04-card-face-recognition-options-note.md
+++ b/docs/ai/references/apps/balatro/2026-08-04-card-face-recognition-options-note.md
@@ -1,0 +1,104 @@
+# Balatro card-face recognition options
+
+Date: 2026-08-04
+
+Status: research note. This is not approval to add a new recognition surface.
+
+## Conclusion
+
+AUV should not start with a generic 52-class playing-card detector. The hand
+slots and card boxes are already localized, so the shortest path is to crop the
+Balatro corner index and classify **13 ranks plus 4 suits**, with rejection and
+temporal consensus.
+
+The strongest first candidate already exists: Project AIRI's
+[`games-balatro-2024-card-corner-classifier`](https://huggingface.co/proj-airi/games-balatro-2024-card-corner-classifier).
+It is Balatro-specific, MIT-licensed, exports a 2.77 MB ONNX model, and uses the
+same two-head shape that this task needs. Standard-card models remain useful as
+baselines or training-pipeline references, but their reported metrics do not
+transfer to Balatro.
+
+## Shortlist
+
+| Priority | Candidate | Evidence and fit | Decision |
+|---|---|---|---|
+| 1 | [Project AIRI Balatro card-corner classifier](https://huggingface.co/proj-airi/games-balatro-2024-card-corner-classifier) | Balatro crops; `float32[N,3,64,64]` input; 13-rank and 4-suit logits; ONNX; MIT. The model card reports rank/exact accuracy `0.8387` and suit accuracy `1.0` on its recovered local validation run. | Evaluate first on a frozen AUV Linux screenshot holdout. Do not promote the reported validation number to a live capability claim. |
+| 2 | [sroot/lgd-cards-gen3](https://huggingface.co/sroot/lgd-cards-gen3) | Current member of an actively documented YOLO11s family that detects 52 standard-card corner pips. The [gen4 card](https://huggingface.co/sroot/lgd-cards-gen4) identifies gen3 as the served model and reports roughly `0.85` normal-gameplay recall on its casino-video holdout. ONNX is available; AGPL-3.0. | Zero-shot comparison only. It solves full-frame physical-card detection, carries AGPL obligations, and has severe Balatro domain shift. |
+| 3 | Balatro-specific normalized templates | [EdjeElectronics' OpenCV detector](https://github.com/EdjeElectronics/OpenCV-Playing-Card-Detector) demonstrates corner isolation followed by separate rank/suit templates and explicitly recommends templates captured from the target deck. | Keep as an interpretable baseline, but reimplement the small algorithm if selected: that repository has no published license or metrics and targets isolated physical cards on dark backgrounds. |
+| 4 | BalatroBot as labeling oracle | [BalatroBot](https://github.com/coder/balatrobot) is an active MIT JSON-RPC mod exposing exact game state and controls. | Useful only to create or audit labeled screenshots if an owner approves a modded benchmark. It is not screenshot recognition and must not become evidence for the unmodified UI path. |
+
+## Existing AUV seam
+
+The repository already has a feature-gated ONNX adapter in
+`supported/games/auv-game-balatro/src/card_corner.rs` and names the Project AIRI
+model as the default asset in `config.rs`. The adapter's tensors and label
+order match the model card. It is not yet connected to the production card-read
+path: `cards read` still uses OCR, color-based suit inference, and diagnostic
+deck-template rank candidates. Consequently, the current `0/168` live complete
+card reads do **not** evaluate the new ONNX model.
+
+The upstream training implementation is also available in
+[`card_corner_classifier.py`](https://github.com/proj-airi/game-playing-ai-balatro/blob/main/src/ai_balatro/datasets/card_corner_classifier.py),
+with an [ONNX export utility](https://github.com/proj-airi/game-playing-ai-balatro/blob/main/cli/export-card-corner-classifier-onnx.py).
+The Hugging Face artifact is MIT, but the GitHub repository itself has no root
+license file, so source-code reuse should be reviewed separately from consuming
+the published model.
+
+## Why ordinary playing-card models are not direct solutions
+
+Ordinary-card datasets and detectors see printed physical decks, camera
+perspective, and casino tables. Balatro introduces a different font and suit
+rendering, overlapping animated cards, UI scaling, selected-card displacement,
+and editions/effects such as foil, holographic, polychrome, seals, enhancement,
+and debuff treatments. No standard-card model or dataset found in this review
+claims Balatro support.
+
+The limitation is visible even within the standard-card domain. The
+[`lgd-cards-gen4` model card](https://huggingface.co/sroot/lgd-cards-gen4)
+reports that it was reverted on the day of deployment after nested false reads
+and missed hole cards; on a shared 318-frame holdout it reports recall `0.786`
+and a precision proxy `0.752`. A
+[`Poker_Detection`](https://github.com/zinuoli/Poker_Detection) project reports
+YOLOv7 `mAP@0.5 = 0.959`, but its target is physical bridge cards and the root
+repository has no unified license. These are useful architecture references,
+not transferable Balatro accuracy claims.
+
+## Data and algorithm references
+
+- [`Lolitofdez55/playing-cards`](https://huggingface.co/datasets/Lolitofdez55/playing-cards)
+  is an MIT synthetic dataset with four sets of 10,000 images, rank/suit
+  concepts, class labels, and card-corner coordinates. It can bootstrap generic
+  augmentation experiments but uses ordinary ornate cards, not Balatro.
+- [`geaxgx/playing-card-detection`](https://github.com/geaxgx/playing-card-detection)
+  is an MIT synthetic-data generator that rotates, scales, and overlaps cards
+  while labeling the printed corners. Its augmentation pattern is reusable;
+  its ordinary-card assets and labels are not a Balatro training set.
+- [`masarunakajima/playing_card_detection`](https://github.com/masarunakajima/playing_card_detection)
+  applies the same corner-label idea to YOLOv7 and documents generation of
+  40,000 training and 2,000 validation images. It publishes neither weights,
+  metrics, nor a license, so it is reference material only.
+- The original [Project AIRI Balatro repository](https://github.com/proj-airi/game-playing-ai-balatro)
+  remains the only reviewed GitHub project with a Balatro-specific rank/suit
+  crop classifier and reproducible ONNX export path.
+
+## Recommended evaluation slice
+
+1. Freeze an offline holdout from AUV's recorded Linux frames and label exact
+   rank/suit per slot. Split by run or scene, never adjacent frames, to avoid
+   temporal leakage.
+2. Cover every rank and suit plus selected/unselected positions, overlap,
+   resolution/UI scale, and the supported visual effects. Report coverage
+   separately when rare effects are absent.
+3. Run the existing Project AIRI ONNX model on the already-known card-corner
+   crops. Measure rank, suit, exact-card accuracy, rejection coverage, and a
+   confusion matrix; keep `6/9`, `10`, and face-card confusions explicit.
+4. Calibrate separate rank/suit thresholds and require 3--5 stable frames to
+   agree before publishing a verified card. Preserve low-confidence logits as
+   diagnostics rather than promoting them to `rank` or `short_code`.
+5. If the first model misses the gate, fine-tune the same small two-head model
+   on AUV-labeled Balatro crops. Compare it against normalized edge/template
+   matching before considering a larger 52-class detector.
+
+This slice would answer the actual product question: exact-card accuracy on
+Balatro under AUV capture. It avoids conflating entity/slot detection,
+driver delivery, ordinary-card benchmarks, and verified card content.

--- a/docs/ai/references/apps/balatro/2026-08-04-proj-airi-entities-dataset-structure-research.md
+++ b/docs/ai/references/apps/balatro/2026-08-04-proj-airi-entities-dataset-structure-research.md
@@ -1,0 +1,269 @@
+# Project AIRI Balatro entities dataset structure research
+
+Date: 2026-08-04
+
+Status: primary-source review of the published dataset and its owning repository.
+This note describes the current artifact; it is not an AUV support claim and
+does not approve publishing Balatro screenshots.
+
+## Executive finding
+
+The existing Project AIRI dataset is useful as a compact distribution pattern:
+it keeps full-frame images, YOLO labels, a class list, and the original Label
+Studio export together, then pins the Hugging Face repository as a submodule of
+the owning project. It is **not** a card-face dataset: `poker_card_front` is one
+of ten broad entity classes, and the published labels do not contain rank,
+suit, edition, enhancement, or seal.
+
+An AUV Mod-ground-truth dataset should retain the useful packaging ideas but
+replace the identity, provenance, split, and annotation contracts. The most
+important reason is concrete: 335 Label Studio tasks collapse to 286 published
+images because the exporter flattens source paths to colliding basenames. That
+also reduces 2,697 source rectangles to 2,423 published boxes.
+
+## Reviewed revisions and ownership
+
+The current Hugging Face dataset revision is
+`a3fcce53757fc0ea0c10bd2a178f612c631a6173`. The owning
+[`proj-airi/game-playing-ai-balatro`](https://github.com/proj-airi/game-playing-ai-balatro)
+repository embeds that dataset at
+`data/datasets/games-balatro-2024-entities-detection`; its
+[`gitmodules`](https://github.com/proj-airi/game-playing-ai-balatro/blob/9654de554e68ea3367bffbb5574b84563423603d/.gitmodules)
+points directly to the Hugging Face Git repository. The local checkout reviewed
+for the owner-side tooling was commit
+`d23013f8e41e592b5964a1d7468e065bc6d008e1`; the relevant files are unchanged
+at remote `main` commit `9654de554e68ea3367bffbb5574b84563423603d`.
+
+The
+[`dataset card`](https://huggingface.co/datasets/proj-airi/games-balatro-2024-entities-detection/blob/a3fcce53757fc0ea0c10bd2a178f612c631a6173/README.md)
+names Neko Ayaka and RainbowBird as annotation creators, classifies the task as
+object detection, and declares CC BY-SA 4.0. There is no separate license file
+or per-image rights/provenance record in the dataset revision. In particular,
+the dataset-card declaration alone does not document the rights boundary for
+the underlying Balatro imagery, so AUV should treat publication of raw game
+screenshots as a separate review from internal data generation.
+
+## Exact published layout
+
+The pinned
+[`repository tree`](https://huggingface.co/datasets/proj-airi/games-balatro-2024-entities-detection/tree/a3fcce53757fc0ea0c10bd2a178f612c631a6173)
+contains:
+
+```text
+data/
+  train/
+    metadata.jsonl                 # 286 rows
+    yolo/
+      images/                      # 286 JPG images
+      labels/                      # 286 YOLO TXT files
+      classes.txt
+      notes.json
+      project.label-studio.json    # original annotation export
+  val/
+    yolo/
+      images/                      # 7 images, no labels or metadata.jsonl
+docs/
+  cover.png
+  example-1.png
+  example-2.png
+```
+
+Hugging Face's current
+[`datasets-server info`](https://datasets-server.huggingface.co/info?dataset=proj-airi%2Fgames-balatro-2024-entities-detection)
+loads the repository as `imagefolder` with only two features:
+
+```text
+image: Image
+label: string
+```
+
+It reports 286 train examples and zero validation examples. The seven files
+under `data/val/yolo/images` therefore do not form a usable published
+validation split. The train image dimensions in the pinned revision are:
+
+| Resolution | Images |
+| --- | ---: |
+| `1280 x 660` | 80 |
+| `1920 x 884` | 75 |
+| `2622 x 1206` | 131 |
+
+All seven unlabeled `val` files are `1280 x 660`.
+
+Each row of
+[`metadata.jsonl`](https://huggingface.co/datasets/proj-airi/games-balatro-2024-entities-detection/blob/a3fcce53757fc0ea0c10bd2a178f612c631a6173/data/train/metadata.jsonl)
+has this shape:
+
+```json
+{
+  "file_name": "yolo/images/out_00001.jpg",
+  "label": "6 0.5 0.4091737739 0.1022297013 0.2749582489"
+}
+```
+
+`label` is unparsed, possibly multiline YOLO text. Every annotation line is
+`class_id center_x center_y width height` with normalized coordinates. The
+published Hugging Face row does not carry structured boxes, image dimensions,
+source/session identity, hashes, annotation author, capture configuration, or
+game/mod versions. Seven train rows have an empty label string, so they are
+negative/empty-box examples rather than missing rows.
+
+## Classes and observed distribution
+
+The ten class IDs are defined consistently by
+[`classes.txt`](https://huggingface.co/datasets/proj-airi/games-balatro-2024-entities-detection/blob/a3fcce53757fc0ea0c10bd2a178f612c631a6173/data/train/yolo/classes.txt),
+[`notes.json`](https://huggingface.co/datasets/proj-airi/games-balatro-2024-entities-detection/blob/a3fcce53757fc0ea0c10bd2a178f612c631a6173/data/train/yolo/notes.json),
+and the owner's
+[`v2 entity configuration`](https://github.com/proj-airi/game-playing-ai-balatro/blob/9654de554e68ea3367bffbb5574b84563423603d/configs/v2-balatro-entities/dataset.yaml).
+Counts below were calculated from the pinned raw artifacts. “Source” means the
+Label Studio export; “published” means the 286 YOLO files and `metadata.jsonl`.
+
+| ID | Class | Published boxes | Images containing class | Source boxes |
+| ---: | --- | ---: | ---: | ---: |
+| 0 | `card_description` | 86 | 73 | 92 |
+| 1 | `card_pack` | 141 | 75 | 163 |
+| 2 | `joker_card` | 685 | 191 | 750 |
+| 3 | `planet_card` | 160 | 95 | 193 |
+| 4 | `poker_card_back` | 56 | 36 | 66 |
+| 5 | `poker_card_description` | 20 | 20 | 22 |
+| 6 | `poker_card_front` | 906 | 125 | 995 |
+| 7 | `poker_card_stack` | 252 | 248 | 298 |
+| 8 | `spectral_card` | 26 | 7 | 26 |
+| 9 | `tarot_card` | 91 | 53 | 92 |
+| | **Total** | **2,423** | | **2,697** |
+
+This distribution is strongly imbalanced. It can support a broad entity
+detector, but it cannot supervise exact card-face recognition because every
+visible playing card shares class 6.
+
+## Provenance recovered from the Label Studio export
+
+The retained
+[`project.label-studio.json`](https://huggingface.co/datasets/proj-airi/games-balatro-2024-entities-detection/blob/a3fcce53757fc0ea0c10bd2a178f612c631a6173/data/train/yolo/project.label-studio.json)
+contains 335 annotated tasks and 2,697 manual rectangle results. Their local
+source paths identify three capture cohorts:
+
+| Source cohort | Tasks |
+| --- | ---: |
+| `luoling8192-2025-09-17-23-02-diff` | 113 |
+| `luoling8192-2025-09-19-21-39-diff` | 147 |
+| `nekomeowww-2025-09-19-21-54-diff` | 75 |
+
+Those task paths preserve recorder/session hints inside an annotation-tool
+snapshot, but the published row schema discards them. It also exposes local
+directory names without turning them into a stable, documented provenance
+contract.
+
+### Reproduced basename collision
+
+The 335 tasks have exactly 286 unique source basenames. Forty-seven basenames
+occur more than once, accounting for 49 excess task rows. For example, multiple
+capture cohorts can each contain `out_00042.jpg`.
+
+The owner's
+[`Label Studio to YOLO exporter`](https://github.com/proj-airi/game-playing-ai-balatro/blob/9654de554e68ea3367bffbb5574b84563423603d/cli/label-studio/export-yolo.py)
+strips the source path to its basename and copies all images into one directory;
+it similarly strips converter prefixes when renaming labels. Colliding frames
+and labels can therefore overwrite each other. The published difference is:
+
+```text
+335 source tasks   - 49 colliding task rows = 286 published images
+2697 source boxes  - 274 overwritten boxes = 2423 published boxes
+```
+
+This is direct evidence that the next format needs globally stable sample IDs
+and collision rejection, not only prettier folder naming.
+
+## Existing owner-side toolchain
+
+The documented and implemented path is:
+
+```text
+game-record frame folders
+  -> Label Studio manual rectangles
+  -> cli/label-studio/export-yolo.py
+  -> images/ + labels/ + classes.txt
+  -> cli/export-datasets.py
+  -> data/<split>/yolo/* + metadata.jsonl
+  -> Hugging Face imagefolder repository
+```
+
+The owning repository says the model used fewer than 1,000 manually labeled
+images with YOLO11n as its base in its
+[`README`](https://github.com/proj-airi/game-playing-ai-balatro/blob/9654de554e68ea3367bffbb5574b84563423603d/README.md).
+The
+[`Hugging Face exporter`](https://github.com/proj-airi/game-playing-ai-balatro/blob/9654de554e68ea3367bffbb5574b84563423603d/cli/export-datasets.py)
+copies the YOLO layout and embeds each TXT file as one string; it does not
+validate duplicate IDs, image/label pairing, coordinates, class ranges,
+checksums, provenance, or split leakage.
+
+The checked-in
+[`v2 entity configuration`](https://github.com/proj-airi/game-playing-ai-balatro/blob/9654de554e68ea3367bffbb5574b84563423603d/configs/v2-balatro-entities/dataset.yaml)
+points both `train` and `val` at the same image directory. It explicitly marks
+that as temporary, so metrics produced with this configuration are not evidence
+from an independent holdout.
+
+## What AUV should reuse conceptually
+
+1. **Keep source and consumable projections together.** A canonical typed
+   manifest can coexist with generated YOLO files and Hugging Face-compatible
+   rows. YOLO should be an export projection, not the source of truth.
+2. **Keep full frames.** Full game frames are useful for entity detection,
+   context-dependent selection state, overlap, and false-positive negatives.
+   Card crops should link back to the immutable parent-frame ID.
+3. **Publish an explicit class list and stats.** Class IDs, counts by split,
+   negative samples, geometry validation, and discarded-sample reasons should
+   be machine-generated artifacts.
+4. **Pin datasets in the consumer repository.** The submodule pattern gives the
+   model code a reproducible dataset revision, although large generated corpora
+   may later prefer an immutable manifest revision over a full checkout.
+5. **Retain annotation evidence.** The existing project export is useful for
+   auditing manual labels. AUV's equivalent should retain Mod-ground-truth and
+   capture-handshake evidence instead of depending on an opaque YOLO TXT.
+
+## Contract AUV should replace it with
+
+The next dataset should separate two tasks that the existing repository blends
+under “entities”:
+
+- **Frame entity detection:** broad regions such as card front/back, joker,
+  pack, description, stack, tarot, planet, and spectral card.
+- **Visible card semantics:** linked card crops/quads with rank, suit, edition,
+  enhancement, seal, debuff, facing, and selection supervision masks.
+
+A minimum release layout could be:
+
+```text
+dataset.json                         # schema/version/taxonomy/license boundary
+splits.json                          # session/run groups, never crop-level random
+data/{train,val,test}/metadata.jsonl # one typed frame record per row
+frames/<sample_id>.png
+crops/<sample_id>/<card_id>.png
+exports/yolo/{train,val,test}/...
+stats/class-and-domain-coverage.json
+provenance/sessions/<session_id>.json
+```
+
+Required improvements over the reviewed dataset:
+
+- Use a UUID or content-addressed `sample_id`; preserve original capture name
+  only as metadata and reject duplicate IDs before writing.
+- Record `session_id`, `run_id`, seed, scenario, parent frame, capture backend,
+  frame SHA-256, Balatro/Lovely/Steamodded/Mod versions, language, resolution,
+  scale, and active visual Mods.
+- Make structured cards/boxes/quads canonical. Generate normalized YOLO lines
+  mechanically and verify the projection round trip.
+- Split by capture session/run/seed, keeping adjacent frames and all derived
+  crops in one split. Provide labeled `val` and `test` partitions.
+- Preserve visible-vs-hidden supervision: Mod knowledge must not label an
+  invisible rank/suit as a visual target.
+- Check class coverage across domains and balance rare effects intentionally;
+  do not infer quality from total frame count.
+- Fail generation on missing image/label pairs, duplicate IDs, bad class IDs,
+  out-of-range geometry, hash changes, or capture-signature mismatches.
+- Keep real `auv-driver-linux` frames for final evaluation while optionally
+  retaining clean Love framebuffer frames as a separately named source domain.
+
+This makes the Mod-generated corpus a strict superset of the useful parts of
+the Project AIRI dataset: it remains exportable to the same YOLO/imagefolder
+consumers, while adding exact card supervision, reproducible provenance, and a
+real evaluation boundary.

--- a/docs/ai/references/apps/balatro/2026-08-05-card-attribute-runner-integration.md
+++ b/docs/ai/references/apps/balatro/2026-08-05-card-attribute-runner-integration.md
@@ -1,0 +1,67 @@
+# Balatro card-attribute Runner integration
+
+Date: 2026-08-05
+
+## Current contract
+
+Balatro observation owns four full-frame card-attribute detectors in addition
+to the existing entities, optional hand-card, and UI detectors:
+
+- `balatro-card-identity`, input size 960
+- `balatro-card-enhancement`, input size 640
+- `balatro-card-edition`, input size 640
+- `balatro-card-seal`, input size 640
+
+The default assets are the corresponding published `proj-airi` Mod
+ground-truth ONNX model repositories. CLI model-path options override each
+asset independently. `--device` is translated into the Runner's typed
+`InferenceDevice`; no CUDA index is embedded in the operation. CUDA-capable
+Runner builds enable the crate's `cuda` feature. A CUDA request is rejected
+when that compile-time provider capability is absent, rather than silently
+running the detector set on CPU.
+
+The observation client sends one full-frame batch RPC. The Balatro Runner
+decodes that frame once and runs independent detectors concurrently. The
+optional normalized-hand detector remains a separate concurrent request because
+it consumes a different cropped frame. The Runner resolves a cache key from detector ID,
+model path, input size, thresholds, maximum detections, device, and class-name
+override. Its per-key `OnceLock` initializes an ONNX session once and returns
+the same `Arc` on later observations. Different keys initialize and infer
+independently; the cache-map mutex is not held during model loading.
+
+Identity detections enrich the existing hand-slot `reading`. Enhancement,
+edition, and seal detections enrich the typed `attributes` object. Association
+uses a greedy, descending-IoU one-to-one assignment with a minimum IoU of 0.2.
+One attribute detection therefore cannot read multiple overlapping hand slots.
+Raw evidence from every model remains available in `raw_entities` so incorrect
+associations can be diagnosed without treating the fused state as ground truth.
+
+## Evidence
+
+Focused unit coverage verifies:
+
+- trained input size and CUDA index survive protobuf construction;
+- rank/suit and three attribute results associate with the intended hand slot;
+- identical cache keys initialize once and return the same session;
+- distinct model keys can enter their loaders concurrently.
+- an empty detector batch is rejected before frame decoding;
+- one identity box cannot enrich two overlapping hand slots.
+
+On `neko-gpu-1` (RTX 4080 SUPER), CUDA activation required both the crate
+feature and CUDA 12 runtime libraries in `LD_LIBRARY_PATH`. `nvtop -s`, loaded
+library inspection, and `nvidia-smi` then showed the Runner using the CUDA
+provider; framebuffer memory rose from roughly 0.9 GiB to 2.2 GiB while the six
+sessions were resident. A 2198x562 fixed-frame hot observation measured
+2.00-2.16 seconds before batching and 2.03-2.14 seconds after batching. A
+2560x1440 live observation remained about 6.1 seconds when warm, showing that
+per-model resize/preprocessing and inference dominate over repeated gRPC frame
+decoding. Cold live observations measured roughly 9.7-12.6 seconds.
+
+Live evidence also showed that the identity model can emit several distinct
+`C_7` detections for cards in the generated overlay fixture. The one-to-one
+fusion fix prevents reuse of one box, but it cannot repair independent model
+misclassifications; test-set mAP is not yet a live-domain accuracy claim.
+
+TODO(card-attribute-association-fixtures): replace the provisional IoU threshold
+with fixture-derived matching policy after representative live frames include
+overlapping, highlighted, debuffed, and face-down hands.

--- a/docs/ai/references/apps/balatro/2026-08-05-linux-live-gameplay-evidence.md
+++ b/docs/ai/references/apps/balatro/2026-08-05-linux-live-gameplay-evidence.md
@@ -1,0 +1,128 @@
+# Balatro macOS-to-Linux live gameplay evidence
+
+Date: 2026-08-05
+
+## Scope and evidence level
+
+This is a live probe, not a support claim. The controller was the AUV CLI and
+app plugin on macOS. The selected remote Device was `neko-gpu-1`, where the
+daemon, Balatro Runner, screen capture, model inference, and input delivery ran
+on Linux/Wayland. The stable Device ID was
+`39734f5cd95c64682b0fba06045c37276a5a8c454040a03d4739d7decc356e1e`.
+
+Four blinds were played end to end across two runs. In the first run, the Small
+Blind was won after a 296-point straight and a three-ace hand; the Big Blind
+reached 448 of the required 450 points and lost by two. After the driver and
+action fixes were deployed, a fresh Yellow Deck run won the Small Blind 344/300
+and the Big Blind 472/450. The second run used typed blind selection, card play,
+discard, cash-out, and store next-round operations throughout. Card submissions
+were confirmed by score, hand-count, hands-left, or phase changes rather than
+input delivery or image fingerprints alone.
+
+A later routed run added a Business Card Joker and entered the next Boss Blind.
+`jokers ls` retained one Driver Runner while it hovered every unread owned
+Joker, captured the tooltip frame, and ran OCR. The live result identified
+`Business Card` and part of its “Played cards have ... give ... when scored”
+effect, changed the reading status to `read`, and cleared `needs_reading`.
+Four structurally confirmed hands were then played; the run lost to The Pillar
+and reached `game_over`. Most card identities were still null, so the gameplay
+policy could only blind-play the first five rank-sorted slots.
+
+Representative durable run evidence:
+
+- Game over after round 2: run `916b0823-f081-1863-9101-e6ddbba0ee8b`, artifact
+  `019fcee4-44fe-75c2-81e7-6c76acb6b716.png`.
+- First click on New Run changed hover but did not activate: run
+  `f54fab01-3e45-818f-fd16-5f14df5ae1d8`, artifact
+  `019fceee-4cd3-73b1-9591-75c757a65ea1.png`.
+- After adding pointer settle, one click on Play entered the run: run
+  `c4c62360-f27d-6d1e-dbc6-3d1be5dbb146`, artifact
+  `019fcef0-c034-7b93-938f-df27ff3848d6.png`.
+- Fresh-run blind selection: run `18e8c79f-452a-0279-62d2-8c30fb7d2889`,
+  artifact `019fcef1-11f2-7691-afdc-f5af5fcd1ead.png`.
+- Unobstructed eight-slot hand after clipped-edge filtering: run
+  `650bc024-3d83-e0e6-e973-82f11b7dc959`, artifact
+  `019fcf00-f506-7923-a2b9-274cb4bbd020.png`.
+- Helldivers crash dialog obscuring the live hand: run
+  `37f18eb9-c75a-7211-4f8c-d6fe70e828fa`, artifact
+  `019fcf00-7e44-76a1-a50f-9ecfa3b92eb6.png`.
+- Fresh-run Small Blind at 220/300 before the winning two-pair hand: run
+  `b8d7804f-fb6e-4925-9bf1-634674bd6a69`, artifact
+  `019fd12d-a9d7-7c13-8d9e-a402682db51e.png`.
+- Big Blind full-house result at 412/450: run
+  `dd1910a7-3573-ed7a-dacb-a2d03e1e0698`, artifact
+  `019fd133-dd88-7b12-bce8-c1e5934585fc.png`.
+- Big Blind cash-out at 472/450 with one hand remaining: run
+  `db313bcc-521c-aebb-fc19-69a7a573f01b`, artifact
+  `019fd136-b23c-7972-9c33-e39605893286.png`.
+
+## Findings and disposition
+
+| Finding | Evidence or root cause | Disposition |
+| --- | --- | --- |
+| `devices get "$ID"` reported no Device while `devices list` showed the remote Device | Without a root `--device-id`, `get` addressed the local daemon inventory rather than selecting B | Use `auv --device-id "$ID" devices get "$ID"`; CLI discoverability remains a candidate follow-up |
+| CUDA Runner crashed with a transport failure | `strace` showed `SIGBUS` loading a 155 MB incomplete uv/rattler temporary `libcublasLt.so.12`; `ldd` later exposed missing cuFFT and cuRAND | Daemon now uses complete stable archive paths for cuDNN, cuBLAS, CUDA runtime, cuFFT, and cuRAND |
+| A specialized full-screen card detector produced ten hand slots | A floating 2041x1125 Balatro viewport was being interpreted relative to the 2560x1440 desktop; a narrow duplicate and the deck stack entered the hand | Hand crop now resolves the game viewport from grayscale/polarized edge candidates and maps detections back to display coordinates; regression coverage includes an offset viewport |
+| The corrected crop could still expose a ninth `poker_card_back` | The remaining box was a 29x142 deck-stack sliver while complete live cards were approximately 173-197x236-250 | Specialized hand remapping now rejects boxes narrower than 0.30 of their height. The same unobstructed live hand then reported eight slots |
+| Play/Discard was sometimes absent even though the hand was playable | UI detector missed the commit button | A typed `PlayingHandLayout` fallback derives a conservative commit point from the two detected Sort Hand controls |
+| A delivered click often only established hover | The portal sent absolute motion and button press in the same scheduling slice; Balatro updated hover hit-testing on a later frame | Linux portal input now waits 20 ms after motion, then holds the button for 34 ms. A fresh target subsequently activated with one click |
+| `InputActionResult` said delivered when the UI had not changed | Delivery records input transport, not semantic activation; `verified` remained false | Kept the boundary explicit. Game operations perform a separate observation; the generic screen-point command does not claim activation |
+| A card play falsely succeeded on hand fingerprint change | Detector jitter and a missed commit control could change fingerprints even when the card remained in hand | Confirmation now requires phase, hand count, observed score, hands-left, or discards-left change. Fingerprint-only evidence becomes `unstable_visual_change` |
+| A successful card play was reported as `unstable_visual_change` and Play was clicked twice | The first post-submit capture started during the scoring animation. Inference exceeded the wall-clock settle deadline, so fingerprint evidence triggered a second submit before stable score OCR was observed | Remote card commit now waits before the first observation, permits one additional observation for partial visual evidence, and resubmits only after an explicit `no_hand_state_change`. A regression test and live pair-of-fives play confirmed one submit plus `round_score_changed` |
+| Rank/suit output repeated `C_7` across visibly distinct cards | Independent live-domain model misclassification, not association reuse | Unresolved model-quality gap; raw detections remain available and live accuracy must not be inferred from test mAP |
+| Non-playing phases exposed a false hand card | On blind-select and cash-out screens, the right-side deck stack was classified as one hand card (for example `H_K` with a negative edition) | Typed phase remained correct, but `hand` is not trustworthy outside `playing`. Phase/zone gating remains intentionally deferred |
+| Attribute models labeled the deck stack as glass/foil/red | Full-frame attribute boxes associated with a false hand candidate | Viewport/hand filtering reduces this case, but phase/zone gating remains intentionally deferred |
+| Pixel-font OCR missed Play/Discard and some counters | Tesseract did not reliably read Balatro's stylized font; examples included `round_score: "00"` and null hands/discards | Button detection and structural state changes are preferred. OCR replacement or game-state telemetry is a separate slice |
+| Plain `game state` output was a Rust debug dump | The app-owned human table has not been designed | JSON is the reliable current interface; table output is deferred at the CLI call site |
+| Updating the daemon did not update local orchestration behavior | The macOS `auv-game-balatro` plugin owns action orchestration while the Linux Runner owns observations/input; `cargo check` did not relink the local plugin | Rebuild both the local plugin and affected remote binaries when their respective responsibilities change |
+| Typed actions disagreed with an immediately preceding CUDA state command | Actions constructed default CPU configuration with no specialized hand model, producing different slot indices | Remote operation controls now accept `--cards-model` and `--device`; cash-out, restart, next-round, card commit, and blind selection pass that policy through every observation. Argument/config regression coverage is green; final live action replay was interrupted by the external OpenGL failure below |
+| A Helldivers crash dialog covered half the hand while Balatro was still visible | Full-display fallback has no typed foreground/occlusion fact; the detector returned only the visible cards | The probe preserved `unknown`/partial evidence instead of inventing covered cards. Foreground and occlusion diagnostics remain a separate contract slice |
+| The paired Device became offline although TCP port 19848 remained reachable | The local daemon's paired transport stopped reconnecting after repeated long operations | Restarting only the macOS daemon restored the Device immediately. Reconnect/backoff instrumentation remains a daemon follow-up |
+| `input.key alt+f2` was rejected | Linux key parsing omitted standard function-key keysyms | F1-F12 parsing and an Alt+F2 regression test were added. The deployed build then delivered Alt+F4 and closed the exclusive Helldivers window |
+| `input.key ctrl+alt+t` reported delivery but the terminal was not initially visible | The shortcut did open Ghostty, but behind Steam; `window.list` could enumerate it while neither `app.activate` nor window-targeted pointer delivery could foreground it | GNOME Overview recovered it manually. Linux window clicks now attempt AT-SPI root focus before portal pointer delivery; app-level activation remains unsupported |
+| `input.key super` was rejected | The parser recognized Super only as a shortcut modifier, even though GNOME uses a standalone Super press for Overview | Standalone Ctrl/Shift/Alt/Super parsing and a regression test were added and deployed |
+| Screen-point input crashed the runner after daemon restart | `strace` showed the crash immediately after portal motion mapping loaded X11; the service environment had Wayland/DBus variables but no XWayland `DISPLAY` or `XAUTHORITY` | The live daemon was relaunched with `DISPLAY=:0` and the active Mutter Xauthority file. AUV clicks then produced exact X11 ButtonPress/Release coordinates and no crash. A durable service launcher still needs to preserve this environment |
+| The new remote runner rejected `cuda:0` after deployment | The isolated Linux build omitted the crate's `cuda` feature; the daemon also retained the already-running non-CUDA runner after the binary was rebuilt | Rebuilt `auv-runner-balatro` with `--features cuda` and restarted the cached runner process. Subsequent typed actions used CUDA successfully |
+| Remote `jokers read` and `jokers ls` always returned unread objects | The non-macOS path stopped after entity detection; hover movement and OCR existed only in the local macOS branch | Added the typed `MoveMouse` Driver capability and routed batch hover, capture, and OCR. `jokers ls` now reads pending owned Jokers in one Runner session and returns the Joker list instead of the entire game state. |
+| Store Jokers appeared in owned `jokers` | Store products and owned inventory share the `joker_card` detector label | Owned-Joker promotion is now constrained to the upper inventory row; overlapping store class predictions are also deduplicated before slot assignment |
+| `store buy --slot store:2` selected different products across observations | Hover tooltips occluded products, and store slot indices are reconstructed from whichever detections survive each frame | Remote buy now clears hover before resolving its frame. Cross-frame store identity is still incomplete when the detector entirely misses an item; callers must not treat a prior transient index as a durable product identity |
+| Routed pack read/skip fell back to local macOS resolution | Those command branches have not adopted the inherited AUV context | The accidentally purchased pack was skipped through the generic typed screen-point operation. Routed pack operations remain a separate owner-approved slice |
+
+## Timing and reuse evidence
+
+On the local network, a warm 2560x1440 `display.capture` took approximately
+1.9-3.5 seconds. A CUDA `game state` observation took approximately 8.0-9.7
+seconds. After the latest settle/confirmation change, verified card commits
+typically took about 14-24 seconds. They still make several full observations,
+so inference and capture round trips dominate input delivery.
+
+The daemon kept one Linux driver session and reused its portal input and
+screencast sessions. The daemon also kept a Balatro Runner process alive. The
+Runner caches ONNX pipelines by model configuration; rebuilding the binary does
+not replace that live process, which the deployment probe made explicit. This
+reuse does not remove the current dominant costs:
+seven full-frame preprocessing/inference paths and repeated capture/observation
+round trips. Action orchestration now accepts the same `--cards-model` and
+`--device` policy as state observation, but it still creates several
+short-lived API clients inside one operation.
+
+## Candidate next slices
+
+These are not part of this probe and require owner approval:
+
+- Reuse one remote operation session across the observations made by a typed
+  action.
+- Add typed foreground/occlusion evidence before treating a partial display
+  capture as a complete game viewport.
+- Instrument paired-Device reconnect/backoff and recover stale transports
+  without restarting the local daemon.
+- Phase-gate typed hand inventory while preserving raw detector evidence and a
+  typed fallback reason.
+- Replace or retrain live-domain card identity recognition and measure per-card
+  rank/suit accuracy on real gameplay frames.
+- Give store products stable evidence-backed identity across detector misses;
+  frame-local vector indices are insufficient for read-then-buy workflows.
+- Route pack read/skip/choose through the inherited Device context.
+- Add an app-owned human table for `game state`.
+- Make Device-selection errors explain the local-inventory versus selected-
+  Device distinction.

--- a/docs/ai/references/apps/balatro/INDEX.md
+++ b/docs/ai/references/apps/balatro/INDEX.md
@@ -2,9 +2,15 @@
 
 Balatro consumption probe
 
-Count: **4**
+Count: **10**
 
+- [`2026-08-04-balatro-ground-truth-dataset-evidence.md`](2026-08-04-balatro-ground-truth-dataset-evidence.md)
+- [`2026-08-04-balatro-mod-dataset-api-research.md`](2026-08-04-balatro-mod-dataset-api-research.md)
+- [`2026-08-04-card-face-recognition-options-note.md`](2026-08-04-card-face-recognition-options-note.md)
+- [`2026-08-04-proj-airi-entities-dataset-structure-research.md`](2026-08-04-proj-airi-entities-dataset-structure-research.md)
 - [`2026-08-04-remote-linux-gameplay-evidence.md`](2026-08-04-remote-linux-gameplay-evidence.md)
+- [`2026-08-05-card-attribute-runner-integration.md`](2026-08-05-card-attribute-runner-integration.md)
+- [`2026-08-05-linux-live-gameplay-evidence.md`](2026-08-05-linux-live-gameplay-evidence.md)
 - [`2026-06-29-core-balatro-consumption-probe-design.md`](2026-06-29-core-balatro-consumption-probe-design.md)
 - [`2026-06-30-balatro-consumption-probe.md`](2026-06-30-balatro-consumption-probe.md)
 - [`2026-06-30-core-balatro-witness-lineage-closure-design.md`](2026-06-30-core-balatro-witness-lineage-closure-design.md)

--- a/supported/games/auv-game-balatro/Cargo.toml
+++ b/supported/games/auv-game-balatro/Cargo.toml
@@ -16,6 +16,7 @@ repository.workspace = true
 default = ["tracing"]
 tracing = ["dep:auv-tracing", "dep:futures-executor"]
 card-corner-onnx = ["dep:auv-inference-ort"]
+cuda = ["auv-inference-ultralytics/cuda"]
 
 [dependencies]
 auv = { path = "../../../crates/auv" }

--- a/supported/games/auv-game-balatro/README.md
+++ b/supported/games/auv-game-balatro/README.md
@@ -73,8 +73,70 @@ the matching `proj-airi/games-balatro-2024-entities-detection` and
 card-corner ONNX classifier resolves from
 `proj-airi/games-balatro-2024-card-corner-classifier` when the
 `card-corner-onnx` feature loads that classifier. Explicit `--entities-model`,
-`--entities-classes`, `--ui-model`, `--ui-classes`, and `--card-corner-model`
-arguments remain the highest-priority override.
+`--entities-classes`, `--cards-model`, `--card-identity-model`,
+`--card-enhancement-model`, `--card-edition-model`, `--card-seal-model`,
+`--ui-model`, `--ui-classes`, and `--card-corner-model` arguments remain the
+highest-priority override.
+
+Rank/suit, enhancement, edition, and seal detection default to the four
+published `proj-airi/games-balatro-2024-yolo-card-*-detection-mod-ground-truth`
+ONNX repositories. The models run on the full frame: identity keeps its trained
+960 input size, while the other three use 640. AUV associates their boxes with
+the hand detector's boxes by overlap. Rank/suit is returned in each hand slot's
+`reading`; enhancement, edition, and seal are returned in its `attributes`.
+All four raw detector outputs remain in `raw_entities` for inspection.
+
+Remote observation sends the full frame once through a batch RPC; the Runner
+runs its independent detectors concurrently against that shared frame. The
+Balatro Runner caches one ONNX session per complete detector configuration, so
+repeated observations reuse sessions while changes to model path, input size,
+thresholds, class names, or device produce a distinct session. Select the
+execution provider explicitly; CUDA is never assumed:
+
+```bash
+cargo build -p auv-game-balatro --features cuda \
+  --bin auv-game-balatro --bin auv-runner-balatro
+auv-game-balatro game state --device cuda:0 --json
+```
+
+A Runner built without the `cuda` feature rejects `--device cuda:N` instead of
+silently falling back to CPU.
+
+The host must also expose the CUDA 12 runtime libraries required by ONNX
+Runtime (`cudart`, `cublas`, `curand`, `cufft`, and cuDNN) in the Runner's
+dynamic-library search path. Verify the loaded Runner with `nvidia-smi` and
+`nvtop -s`; compiling the feature alone cannot make missing host libraries
+available.
+
+`--cards-model` is an opt-in hand detector, not a replacement for the global
+entities detector. AUV resolves the game viewport when Linux falls back to a
+full-display capture, crops the normalized hand band relative to that viewport,
+runs the specialized model there, maps its boxes back into source-frame
+coordinates, and uses those boxes as the hand-slot source. Global entities
+still supply jokers, consumables, store items, and phase evidence. The current
+prototype model is in the private
+`proj-airi/games-balatro-2024-yolo-card-detection-mod-ground-truth` repository
+pending a redistribution-rights review, so callers must provide a downloaded
+local ONNX path:
+
+```bash
+auv-game-balatro game state \
+  --image frame.png \
+  --cards-model model.onnx \
+  --json
+```
+
+Remote mutating operations accept the same hand-detector and inference-device
+policy. Pass them again on each operation so state resolution and the slot
+indices acted on come from the same detector configuration:
+
+```bash
+auv-game-balatro cards play \
+  --slots hand:0,hand:2 \
+  --cards-model model.onnx \
+  --device cuda:0 \
+  --verify
+```
 
 `cards read` can optionally use the local Balatro deck atlas as a visual
 template fallback for rank glyphs. AUV does not redistribute this game asset.

--- a/supported/games/auv-game-balatro/proto/auv/game/balatro/v1/object_detection.proto
+++ b/supported/games/auv-game-balatro/proto/auv/game/balatro/v1/object_detection.proto
@@ -13,6 +13,12 @@ service BalatroDetectionService {
     option (auv.api.annotations.v1.discoverable) = true;
     option (auv.api.annotations.v1.effect) = METHOD_EFFECT_READ_ONLY;
   }
+  // Sends one source frame once and runs independent cached detectors in
+  // parallel inside the Runner.
+  rpc DetectObjectsBatch(DetectObjectsBatchRequest) returns (DetectObjectsBatchResponse) {
+    option (auv.api.annotations.v1.discoverable) = true;
+    option (auv.api.annotations.v1.effect) = METHOD_EFFECT_READ_ONLY;
+  }
 }
 
 enum InferenceDeviceKind {
@@ -37,10 +43,11 @@ message InferenceDevice {
 message ObjectDetectorSpec {
   // Caller-defined diagnostic identity; it is part of the cache key.
   string detector_id = 1;
-  // Path on the Runner host.
-  // TODO(balatro-model-source): replace host paths with an authorized model
-  // source before registering this Runner against a different host.
-  string model_path = 2;
+  oneof source {
+    // Explicit path on the Runner host. A caller-local path is never implied.
+    string runner_path = 2;
+    HuggingFaceAsset hugging_face = 9;
+  }
   optional uint32 input_size = 3;
   optional float confidence_threshold = 4;
   optional float iou_threshold = 5;
@@ -48,6 +55,19 @@ message ObjectDetectorSpec {
   InferenceDevice device = 7;
   // Empty selects class labels embedded in the model.
   repeated string class_names = 8;
+}
+
+message HuggingFaceAsset {
+  enum RepositoryKind {
+    REPOSITORY_KIND_UNSPECIFIED = 0;
+    REPOSITORY_KIND_MODEL = 1;
+    REPOSITORY_KIND_DATASET = 2;
+  }
+
+  RepositoryKind repository_kind = 1;
+  string owner = 2;
+  string repository = 3;
+  string filename = 4;
 }
 
 message DetectObjectsRequest {
@@ -58,6 +78,20 @@ message DetectObjectsRequest {
 message DetectObjectsResponse {
   ImageSize image_size = 1;
   repeated Detection detections = 2;
+}
+
+message DetectObjectsBatchRequest {
+  repeated ObjectDetectorSpec detectors = 1;
+  auv.api.image.v1.RgbFrame frame = 2;
+}
+
+message DetectObjectsBatchResponse {
+  repeated DetectObjectsBatchResult results = 1;
+}
+
+message DetectObjectsBatchResult {
+  string detector_id = 1;
+  DetectObjectsResponse result = 2;
 }
 
 message ImageSize {

--- a/supported/games/auv-game-balatro/runner-provider.example.json
+++ b/supported/games/auv-game-balatro/runner-provider.example.json
@@ -1,0 +1,12 @@
+{
+  "runner_class": "auv.game.balatro",
+  "runtime": {
+    "type": "executable",
+    "config": {
+      "executable": "../../../target/debug/auv-runner-balatro",
+      "arguments": [],
+      "working_directory": "../../..",
+      "environment": {}
+    }
+  }
+}

--- a/supported/games/auv-game-balatro/src/blind_action.rs
+++ b/supported/games/auv-game-balatro/src/blind_action.rs
@@ -1,7 +1,7 @@
 use auv_driver::{InputActionResult, WindowPoint};
 use serde::{Deserialize, Serialize};
 
-use crate::model::{BalatroPhase, BalatroState, ButtonTarget, SlotId};
+use crate::model::{ActionPoint, BalatroPhase, BalatroState, ButtonTarget, SlotId};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BlindSelectRequest {
@@ -65,12 +65,17 @@ pub enum BlindSkipConfirmation {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct BlindSelectAttempt {
+  pub selected_button: ButtonTarget,
+  pub point: ActionPoint,
+  pub delivery: InputActionResult,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct BlindSelectResult {
   pub target: String,
   pub slot: SlotId,
-  pub selected_button: ButtonTarget,
-  pub window_point: WindowPoint,
-  pub delivery: InputActionResult,
+  pub attempts: Vec<BlindSelectAttempt>,
   pub confirmation: BlindSelectConfirmation,
 }
 
@@ -78,6 +83,8 @@ pub struct BlindSelectResult {
 pub struct BlindSkipResult {
   pub target: String,
   pub selected_button: ButtonTarget,
+  // TODO(balatro-remote-blind-skip): migrate this to ActionPoint when the
+  // owner-approved remote skip operation lands.
   pub window_point: WindowPoint,
   pub delivery: InputActionResult,
   pub confirmation: BlindSkipConfirmation,
@@ -88,15 +95,14 @@ pub struct BlindSkipResult {
 struct BlindSelectCompleted<'a> {
   target: &'a str,
   slot: SlotId,
-  selected_button: &'a ButtonTarget,
-  window_point: WindowPoint,
+  attempts: &'a [BlindSelectAttempt],
   confirmation: &'a BlindSelectConfirmation,
 }
 
 #[cfg(feature = "tracing")]
 impl auv_tracing::EventPayload for BlindSelectCompleted<'_> {
   const NAME: &'static str = "auv.balatro.blind_select.completed";
-  const VERSION: u32 = 1;
+  const VERSION: u32 = 3;
 }
 
 #[cfg(feature = "tracing")]
@@ -104,8 +110,7 @@ pub(crate) fn emit_blind_select_completed(result: &BlindSelectResult) {
   auv_tracing::emit_event!(BlindSelectCompleted {
     target: &result.target,
     slot: result.slot,
-    selected_button: &result.selected_button,
-    window_point: result.window_point,
+    attempts: &result.attempts,
     confirmation: &result.confirmation,
   });
 }

--- a/supported/games/auv-game-balatro/src/cards_action.rs
+++ b/supported/games/auv-game-balatro/src/cards_action.rs
@@ -1,10 +1,10 @@
-use auv_driver::{InputActionResult, WindowPoint};
+use auv_driver::InputActionResult;
 use serde::{Deserialize, Serialize};
 
 use crate::hand_selection::HandSelectionResult;
 #[cfg(feature = "tracing")]
 use crate::hand_selection::HandSelectionState;
-use crate::model::{BalatroPhase, BalatroState, ButtonTarget, SlotId};
+use crate::model::{ActionPoint, BalatroPhase, BalatroState, ButtonTarget, SlotId};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CardsSelectRequest {
@@ -50,9 +50,21 @@ pub enum CardCommitAction {
     selection: HandSelectionResult,
   },
   Submit {
-    button: ButtonTarget,
-    window_point: WindowPoint,
+    control: CardCommitControl,
+    point: ActionPoint,
     delivery: InputActionResult,
+  },
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+#[serde(tag = "source", rename_all = "snake_case")]
+pub enum CardCommitControl {
+  DetectedButton {
+    button: ButtonTarget,
+  },
+  PlayingHandLayout {
+    sort_rank: ButtonTarget,
+    sort_suits: ButtonTarget,
   },
 }
 
@@ -61,6 +73,9 @@ pub enum CardCommitAction {
 pub enum CardCommitChange {
   PhaseChanged,
   HandCountChanged,
+  RoundScoreChanged,
+  HandsLeftChanged,
+  DiscardsLeftChanged,
   HandFingerprintsChanged,
 }
 
@@ -90,6 +105,7 @@ impl CardCommitChanges {
 pub enum CardCommitConfirmationFailure {
   OriginNotPlaying,
   NoHandStateChange,
+  UnstableVisualChange,
   StateReadFailed { message: String },
 }
 
@@ -171,8 +187,8 @@ enum CardCommitActionFact<'a> {
     toggle_count: usize,
   },
   Submit {
-    button: &'a ButtonTarget,
-    window_point: WindowPoint,
+    control: &'a CardCommitControl,
+    point: &'a ActionPoint,
   },
 }
 
@@ -189,7 +205,7 @@ struct CardCommitCompleted<'a> {
 #[cfg(feature = "tracing")]
 impl auv_tracing::EventPayload for CardCommitCompleted<'_> {
   const NAME: &'static str = "auv.balatro.card_commit.completed";
-  const VERSION: u32 = 1;
+  const VERSION: u32 = 3;
 }
 
 #[cfg(feature = "tracing")]
@@ -203,14 +219,7 @@ pub(crate) fn emit_card_commit_completed(result: &CardCommitResult) {
         result: &selection.state,
         toggle_count: selection.toggles.len(),
       },
-      CardCommitAction::Submit {
-        button,
-        window_point,
-        ..
-      } => CardCommitActionFact::Submit {
-        button,
-        window_point: *window_point,
-      },
+      CardCommitAction::Submit { control, point, .. } => CardCommitActionFact::Submit { control, point },
     })
     .collect();
   auv_tracing::emit_event!(CardCommitCompleted {
@@ -246,7 +255,18 @@ pub(crate) fn evaluate_card_commit_confirmation(before: &BalatroState, after: Re
   if after.hand.len() != before.hand.len() {
     changes.push(CardCommitChange::HandCountChanged);
   }
-  if hand_fingerprints_changed(before, after) {
+  if observed_value_changed(&before.scores.round_score, &after.scores.round_score) {
+    changes.push(CardCommitChange::RoundScoreChanged);
+  }
+  if observed_value_changed(&before.rounds.hands_left, &after.rounds.hands_left) {
+    changes.push(CardCommitChange::HandsLeftChanged);
+  }
+  if observed_value_changed(&before.rounds.discards_left, &after.rounds.discards_left) {
+    changes.push(CardCommitChange::DiscardsLeftChanged);
+  }
+  let had_commit_control = before.buttons.iter().any(|button| matches!(button.id.as_str(), "button_play" | "button_discard"));
+  let commit_control_cleared = !after.buttons.iter().any(|button| matches!(button.id.as_str(), "button_play" | "button_discard"));
+  if hand_fingerprints_changed(before, after) && had_commit_control && commit_control_cleared {
     changes.push(CardCommitChange::HandFingerprintsChanged);
   }
   match CardCommitChanges::from_observed(changes) {
@@ -257,8 +277,160 @@ pub(crate) fn evaluate_card_commit_confirmation(before: &BalatroState, after: Re
   }
 }
 
+pub(crate) fn card_commit_confirmation_has_structural_change(confirmation: &CardCommitConfirmation) -> bool {
+  matches!(
+    confirmation,
+    CardCommitConfirmation::Applied { changes }
+      if changes.iter().any(|change| !matches!(change, CardCommitChange::HandFingerprintsChanged))
+  )
+}
+
+pub(crate) fn card_commit_confirmation_allows_resubmit(confirmation: &CardCommitConfirmation) -> bool {
+  matches!(
+    confirmation,
+    CardCommitConfirmation::NotConfirmed {
+      reason: CardCommitConfirmationFailure::NoHandStateChange,
+    }
+  )
+}
+
+fn observed_value_changed(before: &Option<String>, after: &Option<String>) -> bool {
+  matches!((before, after), (Some(before), Some(after)) if before != after)
+}
+
+pub(crate) fn reject_fingerprint_only_confirmation(confirmation: CardCommitConfirmation) -> CardCommitConfirmation {
+  if matches!(&confirmation, CardCommitConfirmation::Applied { .. }) && !card_commit_confirmation_has_structural_change(&confirmation) {
+    CardCommitConfirmation::NotConfirmed {
+      reason: CardCommitConfirmationFailure::UnstableVisualChange,
+    }
+  } else {
+    confirmation
+  }
+}
+
 fn hand_fingerprints_changed(before: &BalatroState, after: &BalatroState) -> bool {
   let before = before.hand.iter().filter_map(|card| card.cache.visual_fingerprint.as_deref()).collect::<Vec<_>>();
   let after = after.hand.iter().filter_map(|card| card.cache.visual_fingerprint.as_deref()).collect::<Vec<_>>();
   !before.is_empty() && !after.is_empty() && before != after
+}
+
+#[cfg(test)]
+mod tests {
+  use auv_inference_common::ImageSize;
+  use auv_task_object_detection::BoundingBox;
+
+  use super::*;
+  use crate::model::{BALATRO_STATE_SCHEMA_VERSION, CacheHint, CardSlot, FrameRef, ObjectZone, Reading, RoundState, ScoreState, StoreState};
+
+  #[test]
+  fn selection_only_fingerprint_change_does_not_confirm_submission() {
+    // ROOT CAUSE:
+    //
+    // If submission confirmation used the pre-selection frame as its baseline,
+    // raising a selected card changed its fingerprint and falsely proved Play.
+    //
+    // Before the fix, card_commit passed the pre-selection state here.
+    // The fix compares the after frame with the fully selected state.
+    let pre_selection = playing_state("lowered-card");
+    let selected = playing_state("raised-card");
+
+    assert_eq!(
+      evaluate_card_commit_confirmation(&pre_selection, Ok(&selected)),
+      CardCommitConfirmation::NotConfirmed {
+        reason: CardCommitConfirmationFailure::NoHandStateChange,
+      }
+    );
+    assert_eq!(
+      evaluate_card_commit_confirmation(&selected, Ok(&selected)),
+      CardCommitConfirmation::NotConfirmed {
+        reason: CardCommitConfirmationFailure::NoHandStateChange,
+      }
+    );
+  }
+
+  #[test]
+  fn fingerprint_only_confirmation_is_not_structural() {
+    // ROOT CAUSE:
+    //
+    // If one UI detection missed the still-active Play button, normal detector
+    // box jitter changed card fingerprints and falsely proved submission.
+    // Fingerprint-only evidence therefore needs repeated observation at the
+    // command layer; phase and hand-count changes remain immediately strong.
+    let fingerprint_only = CardCommitConfirmation::Applied {
+      changes: CardCommitChanges::from_observed(vec![CardCommitChange::HandFingerprintsChanged]).unwrap(),
+    };
+    let phase_change = CardCommitConfirmation::Applied {
+      changes: CardCommitChanges::from_observed(vec![CardCommitChange::PhaseChanged]).unwrap(),
+    };
+
+    assert!(!card_commit_confirmation_has_structural_change(&fingerprint_only));
+    assert!(!card_commit_confirmation_allows_resubmit(&fingerprint_only));
+    assert!(card_commit_confirmation_has_structural_change(&phase_change));
+    assert_eq!(
+      reject_fingerprint_only_confirmation(fingerprint_only),
+      CardCommitConfirmation::NotConfirmed {
+        reason: CardCommitConfirmationFailure::UnstableVisualChange,
+      }
+    );
+  }
+
+  #[test]
+  fn submission_is_retried_only_when_nothing_changed() {
+    // ROOT CAUSE:
+    //
+    // If the first post-click frame landed during Balatro's scoring animation,
+    // card fingerprints changed before score OCR became stable. Treating that
+    // partial evidence like no response clicked Play a second time.
+    //
+    // Before the fix, every non-structural confirmation allowed resubmission.
+    // The fix retries only when the observed frame contains no state change.
+    assert!(card_commit_confirmation_allows_resubmit(&CardCommitConfirmation::NotConfirmed {
+      reason: CardCommitConfirmationFailure::NoHandStateChange,
+    }));
+    assert!(!card_commit_confirmation_allows_resubmit(&CardCommitConfirmation::NotConfirmed {
+      reason: CardCommitConfirmationFailure::StateReadFailed {
+        message: "capture failed".to_string(),
+      },
+    }));
+  }
+
+  fn playing_state(fingerprint: &str) -> BalatroState {
+    BalatroState {
+      schema_version: BALATRO_STATE_SCHEMA_VERSION.to_string(),
+      frame: FrameRef {
+        source: "test://frame".to_string(),
+        image_size: ImageSize {
+          width: 100,
+          height: 100,
+        },
+      },
+      phase: BalatroPhase::Playing,
+      scores: ScoreState::default(),
+      rounds: RoundState::default(),
+      hand: vec![CardSlot {
+        slot: SlotId::new(ObjectZone::Hand, 0),
+        kind: "poker_card_front".to_string(),
+        bbox: BoundingBox {
+          x1: 10.0,
+          y1: 10.0,
+          x2: 30.0,
+          y2: 50.0,
+        },
+        confidence: 1.0,
+        reading: Reading::unread(),
+        attributes: Default::default(),
+        cache: CacheHint {
+          visual_fingerprint: Some(fingerprint.to_string()),
+          ..CacheHint::default()
+        },
+      }],
+      jokers: Vec::new(),
+      consumables: Vec::new(),
+      store: StoreState::default(),
+      buttons: Vec::new(),
+      diagnostics: Vec::new(),
+      raw_entities: Vec::new(),
+      raw_ui: Vec::new(),
+    }
+  }
 }

--- a/supported/games/auv-game-balatro/src/cash_out.rs
+++ b/supported/games/auv-game-balatro/src/cash_out.rs
@@ -1,7 +1,7 @@
-use auv_driver::{InputActionResult, WindowPoint};
+use auv_driver::InputActionResult;
 use serde::{Deserialize, Serialize};
 
-use crate::model::{BalatroPhase, BalatroState, ButtonTarget};
+use crate::model::{ActionPoint, BalatroPhase, BalatroState, ButtonTarget};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum CashOutConfirmationRequest {
@@ -49,11 +49,16 @@ pub enum CashOutConfirmation {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct CashOutAttempt {
+  pub selected_button: ButtonTarget,
+  pub point: ActionPoint,
+  pub delivery: InputActionResult,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct CashOutResult {
   pub target: String,
-  pub selected_button: ButtonTarget,
-  pub window_point: WindowPoint,
-  pub delivery: InputActionResult,
+  pub attempts: Vec<CashOutAttempt>,
   pub confirmation: CashOutConfirmation,
 }
 
@@ -61,23 +66,21 @@ pub struct CashOutResult {
 #[derive(Serialize)]
 struct CashOutCompleted<'a> {
   target: &'a str,
-  selected_button: &'a ButtonTarget,
-  window_point: WindowPoint,
+  attempts: &'a [CashOutAttempt],
   confirmation: &'a CashOutConfirmation,
 }
 
 #[cfg(feature = "tracing")]
 impl auv_tracing::EventPayload for CashOutCompleted<'_> {
   const NAME: &'static str = "auv.balatro.cash_out.completed";
-  const VERSION: u32 = 1;
+  const VERSION: u32 = 3;
 }
 
 #[cfg(feature = "tracing")]
 pub(crate) fn emit_cash_out_completed(result: &CashOutResult) {
   auv_tracing::emit_event!(CashOutCompleted {
     target: &result.target,
-    selected_button: &result.selected_button,
-    window_point: result.window_point,
+    attempts: &result.attempts,
     confirmation: &result.confirmation,
   });
 }

--- a/supported/games/auv-game-balatro/src/cli.rs
+++ b/supported/games/auv-game-balatro/src/cli.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command as ProcessCommand;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+use auv::AuvContext;
 use auv_driver::WindowInput as _;
 use auv_driver::capture::{Activation, Capture, CaptureOptions};
 use auv_driver::geometry::{Point, RatioRect, Rect, WindowPoint};
@@ -20,20 +21,23 @@ use sha2::{Digest, Sha256};
 use thiserror::Error;
 
 use crate::blind_action::{
-  BlindSelectConfirmation, BlindSelectConfirmationFailure, BlindSelectRequest, BlindSelectResult, BlindSkipConfirmation,
+  BlindSelectAttempt, BlindSelectConfirmation, BlindSelectConfirmationFailure, BlindSelectRequest, BlindSelectResult, BlindSkipConfirmation,
   BlindSkipConfirmationFailure, BlindSkipRequest, BlindSkipResult, emit_blind_select_completed, emit_blind_skip_completed,
   evaluate_blind_select_confirmation, evaluate_blind_skip_confirmation,
 };
 use crate::cards_action::{
-  CardCommitAction, CardCommitConfirmation, CardCommitKind, CardCommitRequest, CardCommitResult, CardCommitState, CardCommitStop,
-  CardsSelectRequest, CardsSelectResult, emit_card_commit_completed, emit_cards_select_completed, evaluate_card_commit_confirmation,
+  CardCommitAction, CardCommitConfirmation, CardCommitControl, CardCommitKind, CardCommitRequest, CardCommitResult, CardCommitState,
+  CardCommitStop, CardsSelectRequest, CardsSelectResult, card_commit_confirmation_allows_resubmit,
+  card_commit_confirmation_has_structural_change, emit_card_commit_completed, emit_cards_select_completed,
+  evaluate_card_commit_confirmation, reject_fingerprint_only_confirmation,
 };
 use crate::cards_clear::{
   CardSelectionToggle, CardsClearIncompleteReason, CardsClearOutcome, CardsClearRequest, CardsClearResult, classify_cards_clear_outcome,
   emit_cards_clear_completed,
 };
 use crate::cash_out::{
-  CashOutConfirmation, CashOutConfirmationRequest, CashOutRequest, CashOutResult, emit_cash_out_completed, evaluate_cash_out_confirmation,
+  CashOutAttempt, CashOutConfirmation, CashOutConfirmationRequest, CashOutRequest, CashOutResult, emit_cash_out_completed,
+  evaluate_cash_out_confirmation,
 };
 use crate::config::BalatroModelConfig;
 use crate::consumable_use::{
@@ -45,14 +49,17 @@ use crate::game_restart::{
   emit_game_restart_completed,
 };
 use crate::hand_selection::{HandSelectionResult, HandSelectionState, HandSelectionToggle, HandSelectionToggleKind};
-use crate::model::{BalatroPhase, BalatroState, ButtonTarget, CardSlot, ConsumableSlot, JokerSlot, ObjectZone, SlotId, StoreItem};
+use crate::model::{
+  ActionPoint, BalatroPhase, BalatroState, ButtonTarget, CardSlot, ConsumableSlot, JokerSlot, ObjectZone, Reading, ReadingStatus, SlotId,
+  StoreItem,
+};
 use crate::object_sell::{
   ObjectSellClick, ObjectSellConfirmation, ObjectSellIncompleteReason, ObjectSellOutcome, ObjectSellRequest, ObjectSellResult,
   SellableObject, emit_object_sell_completed, evaluate_object_sell_confirmation,
 };
 use crate::observation::{
-  ObservationError, apply_ui_numeric_reading, is_numeric_ui_label, is_score_ui_label, is_single_ui_digit_label, observe_image,
-  observe_live_via_api,
+  HoverReadRequest, ObservationError, apply_ui_numeric_reading, click_display_frame_point_via_api, hover_read_display_frame_points_via_api,
+  is_numeric_ui_label, is_score_ui_label, is_single_ui_digit_label, move_display_frame_point_via_api, observe_image, observe_live_via_api,
 };
 pub use crate::output::OutputMode;
 use crate::pack_choose::{
@@ -65,8 +72,8 @@ use crate::store_buy::{
   evaluate_store_buy_confirmation,
 };
 use crate::store_next_round::{
-  StoreNextRoundConfirmation, StoreNextRoundConfirmationRequest, StoreNextRoundRequest, StoreNextRoundResult, StoreNextRoundTarget,
-  emit_store_next_round_completed, evaluate_store_next_round_confirmation,
+  StoreNextRoundAttempt, StoreNextRoundConfirmation, StoreNextRoundConfirmationRequest, StoreNextRoundRequest, StoreNextRoundResult,
+  StoreNextRoundTarget, emit_store_next_round_completed, evaluate_store_next_round_confirmation,
 };
 
 const DECK_ATLAS_LOVE_PATH: &str = "resources/textures/2x/8BitDeck.png";
@@ -118,6 +125,8 @@ pub struct CliArgs {
 #[derive(Clone, Debug, Eq, PartialEq, Subcommand)]
 pub enum Command {
   Game(GameArgs),
+  /// Annotate one fixed frame and emit detection/click diagnostics.
+  Diagnostics(DiagnosticsArgs),
   Objective(ObjectiveArgs),
   Scores(ScoresArgs),
   Rounds(RoundsArgs),
@@ -128,6 +137,19 @@ pub enum Command {
   Pack(PackArgs),
   Blinds(BlindsArgs),
   Setup(SetupArgs),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Args)]
+pub struct DiagnosticsArgs {
+  #[command(flatten)]
+  pub observe: ObserveArgs,
+  /// Expected selected hand slots, for example `hand:0,hand:1`.
+  #[arg(long, value_name = "HAND_SLOTS")]
+  pub requested_slots: Option<String>,
+  #[arg(long, value_name = "PATH")]
+  pub annotated_out: PathBuf,
+  #[arg(long, value_name = "PATH")]
+  pub report_out: PathBuf,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Args)]
@@ -192,6 +214,21 @@ pub struct ObserveArgs {
   pub entities_model: Option<PathBuf>,
   #[arg(long, value_name = "PATH")]
   pub entities_classes: Option<PathBuf>,
+  /// Optional card-specialized detector applied only to the normalized hand region.
+  #[arg(long, value_name = "PATH")]
+  pub cards_model: Option<PathBuf>,
+  /// Full-frame rank/suit detector. Defaults to the published Mod ground-truth model.
+  #[arg(long, value_name = "PATH")]
+  pub card_identity_model: Option<PathBuf>,
+  /// Full-frame enhancement detector. Defaults to the published Mod ground-truth model.
+  #[arg(long, value_name = "PATH")]
+  pub card_enhancement_model: Option<PathBuf>,
+  /// Full-frame edition detector. Defaults to the published Mod ground-truth model.
+  #[arg(long, value_name = "PATH")]
+  pub card_edition_model: Option<PathBuf>,
+  /// Full-frame seal detector. Defaults to the published Mod ground-truth model.
+  #[arg(long, value_name = "PATH")]
+  pub card_seal_model: Option<PathBuf>,
   #[arg(long, value_name = "PATH")]
   pub ui_model: Option<PathBuf>,
   #[arg(long, value_name = "PATH")]
@@ -226,6 +263,12 @@ pub struct OperationControlArgs {
   pub timeout_ms: Option<u64>,
   #[arg(long, alias = "detailed")]
   pub details: bool,
+  /// Optional card-specialized detector used by every observation in this operation.
+  #[arg(long, value_name = "PATH")]
+  pub cards_model: Option<PathBuf>,
+  /// Inference device used by every observation in this operation.
+  #[arg(long, default_value = "cpu", value_parser = clap::value_parser!(InferenceDevice))]
+  pub device: InferenceDevice,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Args)]
@@ -426,11 +469,74 @@ fn open_macos_session() -> Result<auv_driver::LocalDriverSession, CliError> {
 }
 
 pub fn run_from_env() -> Result<(), CliError> {
-  run(CliArgs::parse())
+  let args = CliArgs::parse();
+  #[cfg(feature = "tracing")]
+  {
+    run_with_inherited_tracing(args)
+  }
+  #[cfg(not(feature = "tracing"))]
+  {
+    run(args)
+  }
+}
+
+#[cfg(feature = "tracing")]
+fn run_with_inherited_tracing(args: CliArgs) -> Result<(), CliError> {
+  use std::sync::Arc;
+
+  let Some(store_root) = std::env::var_os(auv_tracing::STORE_ROOT_ENV) else {
+    return run(args);
+  };
+  let context = AuvContext::from_env().map_err(|error| CliError::Message(format!("invalid inherited AUV context: {error}")))?;
+  let Some(control_run_id) = context.run_id.as_deref() else {
+    return run(args);
+  };
+  // TODO(resource-id-migration): Remove the legacy `run_` branch after old
+  // control-plane stores no longer expose prefixed UUID Run identities.
+  let run_uuid = uuid::Uuid::parse_str(control_run_id.strip_prefix("run_").unwrap_or(control_run_id))
+    .map_err(|error| CliError::Message(format!("inherited Run ID {control_run_id:?} is invalid for tracing: {error}")))?;
+  let run_id = run_uuid
+    .to_string()
+    .parse::<auv_tracing::RunId>()
+    .map_err(|error| CliError::Message(format!("inherited Run ID {control_run_id:?} is invalid for tracing: {error}")))?;
+  let store = Arc::new(
+    auv_tracing::FileTracingStore::open(PathBuf::from(store_root))
+      .map_err(|error| CliError::Message(format!("failed to open inherited tracing store: {error}")))?,
+  );
+  let dispatch = auv_tracing::configure()
+    .tracing_store(store)
+    .build()
+    .map_err(|error| CliError::Message(format!("failed to configure Balatro tracing: {error}")))?;
+  let result = auv_tracing::dispatcher::with_default(&dispatch, || {
+    let root = auv_tracing::Context::root(run_id);
+    root.in_scope(|| {
+      auv_tracing::emit_event!(BalatroFrontendLifecycle { frontend: "plugin" });
+      run(args)
+    })
+  });
+  let flush = futures_executor::block_on(dispatch.flush());
+  match (result, flush) {
+    (Ok(()), Ok(())) => Ok(()),
+    (Err(error), _) => Err(error),
+    (Ok(()), Err(error)) => Err(CliError::Message(format!("failed to flush Balatro tracing: {error}"))),
+  }
+}
+
+#[cfg(feature = "tracing")]
+#[derive(Serialize)]
+struct BalatroFrontendLifecycle {
+  frontend: &'static str,
+}
+
+#[cfg(feature = "tracing")]
+impl auv_tracing::EventPayload for BalatroFrontendLifecycle {
+  const NAME: &'static str = "auv.frontend.lifecycle";
+  const VERSION: u32 = 1;
 }
 
 pub fn run(args: CliArgs) -> Result<(), CliError> {
   match args.command {
+    Command::Diagnostics(args) => write_frame_diagnostics(args),
     Command::Game(GameArgs {
       command: GameCommand::State(args),
     }) => write_observed_state(&args),
@@ -467,7 +573,7 @@ pub fn run(args: CliArgs) -> Result<(), CliError> {
     }) => click_cards_commit(CardCommitKind::Discard, args),
     Command::Jokers(JokersArgs {
       command: JokersCommand::Ls(args),
-    }) => write_observed_state(&args),
+    }) => write_jokers(&args),
     Command::Jokers(JokersArgs {
       command: JokersCommand::Read(args),
     }) => write_object_read(&args, ObjectReadZone::Joker),
@@ -943,6 +1049,8 @@ struct CardReadValue {
   raw_text: Option<String>,
   normalized_text: Option<String>,
   rank: Option<String>,
+  rank_candidate: Option<String>,
+  rank_candidate_confidence: Option<f32>,
   suit: Option<String>,
   suit_symbol: Option<String>,
   short_code: Option<String>,
@@ -958,6 +1066,8 @@ impl CardReadValue {
       raw_text: None,
       normalized_text: None,
       rank: None,
+      rank_candidate: None,
+      rank_candidate_confidence: None,
       suit: None,
       suit_symbol: None,
       short_code: None,
@@ -977,6 +1087,9 @@ struct CardReadEvidence {
 
 fn write_observed_state(args: &ObserveArgs) -> Result<(), CliError> {
   let state = observe_from_args(args)?;
+  // TODO(balatro-state-human-output): the default renderer still prints Rust
+  // Debug output. Add an app-owned table only after its stable summary columns
+  // are owner-approved; see `2026-08-05-linux-live-gameplay-evidence.md`.
   write_output(args.output_mode(), &state)
 }
 
@@ -988,6 +1101,18 @@ fn write_scores(args: &ObserveArgs) -> Result<(), CliError> {
 fn write_rounds(args: &ObserveArgs) -> Result<(), CliError> {
   let state = observe_from_args(args)?;
   write_output(args.output_mode(), &state.rounds)
+}
+
+fn write_jokers(args: &ObserveArgs) -> Result<(), CliError> {
+  let mut state = observe_from_args(args)?;
+  if args.image.is_none() && std::env::var_os("AUV_CONTEXT").is_some() {
+    hover_read_jokers_via_api(&mut state)?;
+  } else {
+    // TODO(balatro-local-joker-auto-read): batch local hover OCR after the
+    // app-owned operation can retain one native session across list output;
+    // the current owner-approved slice is the routed Linux gameplay path.
+  }
+  write_output(args.output_mode(), &state.jokers)
 }
 
 fn write_card_read(args: &SlotObserveArgs) -> Result<(), CliError> {
@@ -1044,6 +1169,7 @@ fn write_pack_read(args: &ObserveArgs) -> Result<(), CliError> {
 
 #[cfg(target_os = "macos")]
 fn click_game_cash_out(args: OperationControlArgs) -> Result<(), CliError> {
+  let config = BalatroModelConfig::from_operation_args(&args);
   let details = args.details;
   let confirmation = if !args.verify || args.verify_mode == VerifyModeArg::ActivationOnly {
     CashOutConfirmationRequest::None
@@ -1052,17 +1178,42 @@ fn click_game_cash_out(args: OperationControlArgs) -> Result<(), CliError> {
   } else {
     CashOutConfirmationRequest::Weak
   };
-  let result = cash_out(CashOutRequest {
+  let request = CashOutRequest {
     target: args.target,
     confirmation,
     timeout_ms: args.timeout_ms.unwrap_or(1200),
-  })?;
+  };
+  let result = if std::env::var_os("AUV_CONTEXT").is_some() {
+    cash_out_via_api(request, config)?
+  } else {
+    cash_out(request)?
+  };
   write_cash_out_output(details, &result)
 }
 
 #[cfg(not(target_os = "macos"))]
-fn click_game_cash_out(_args: OperationControlArgs) -> Result<(), CliError> {
-  Err(CliError::Message("game cash-out live operation is only available on macOS".to_string()))
+fn click_game_cash_out(args: OperationControlArgs) -> Result<(), CliError> {
+  if std::env::var_os("AUV_CONTEXT").is_none() {
+    return Err(CliError::Message("game cash-out requires macOS locally or an inherited AUV device context".to_string()));
+  }
+  let config = BalatroModelConfig::from_operation_args(&args);
+  let confirmation = if !args.verify || args.verify_mode == VerifyModeArg::ActivationOnly {
+    CashOutConfirmationRequest::None
+  } else if args.verify_mode == VerifyModeArg::Targeted {
+    CashOutConfirmationRequest::Targeted
+  } else {
+    CashOutConfirmationRequest::Weak
+  };
+  let details = args.details;
+  let result = cash_out_via_api(
+    CashOutRequest {
+      target: args.target,
+      confirmation,
+      timeout_ms: args.timeout_ms.unwrap_or(1200),
+    },
+    config,
+  )?;
+  write_cash_out_output(details, &result)
 }
 
 #[cfg(target_os = "macos")]
@@ -1090,9 +1241,11 @@ pub fn cash_out(request: CashOutRequest) -> Result<CashOutResult, CliError> {
 
   let result = CashOutResult {
     target: request.target,
-    selected_button,
-    window_point: WindowPoint::new(point.x, point.y),
-    delivery,
+    attempts: vec![CashOutAttempt {
+      selected_button,
+      point: ActionPoint::window(window.reference.id.clone(), WindowPoint::new(point.x, point.y)),
+      delivery,
+    }],
     confirmation,
   };
   emit_cash_out_completed(&result);
@@ -1102,6 +1255,66 @@ pub fn cash_out(request: CashOutRequest) -> Result<CashOutResult, CliError> {
 #[cfg(not(target_os = "macos"))]
 pub fn cash_out(_request: CashOutRequest) -> Result<CashOutResult, CliError> {
   Err(CliError::Message("game cash-out live operation is only available on macOS".to_string()))
+}
+
+fn cash_out_via_api(request: CashOutRequest, config: BalatroModelConfig) -> Result<CashOutResult, CliError> {
+  let runtime = tokio::runtime::Builder::new_current_thread()
+    .enable_all()
+    .build()
+    .map_err(|error| CliError::Message(format!("failed to create daemon client runtime: {error}")))?;
+  let before = runtime.block_on(observe_live_via_api(&request.target, &config, None, true))?;
+  let mut current = before.clone();
+  let mut attempts = Vec::new();
+  let mut confirmation = CashOutConfirmation::NotRequested;
+  let attempt_limit = if request.confirmation == CashOutConfirmationRequest::None {
+    1
+  } else {
+    2
+  };
+  for attempt in 0..attempt_limit {
+    let selected_button = find_button(&current, "button_cash_out")?.clone();
+    let (screen_point, delivery) =
+      runtime.block_on(click_display_frame_point_via_api(&current.frame, bbox_center_point(selected_button.bbox)))?;
+    attempts.push(CashOutAttempt {
+      selected_button,
+      point: ActionPoint::screen(screen_point),
+      delivery,
+    });
+    if request.confirmation == CashOutConfirmationRequest::None {
+      break;
+    }
+    let settle_deadline = Instant::now() + Duration::from_millis((request.timeout_ms / attempt_limit as u64).max(350));
+    loop {
+      std::thread::sleep(Duration::from_millis(250));
+      match runtime.block_on(observe_live_via_api(&request.target, &config, None, true)) {
+        Ok(after) => {
+          confirmation = evaluate_cash_out_confirmation(request.confirmation, &before, Ok(&after));
+          current = after;
+          if matches!(confirmation, CashOutConfirmation::Confirmed { .. }) || Instant::now() >= settle_deadline {
+            break;
+          }
+        }
+        Err(error) => {
+          confirmation = evaluate_cash_out_confirmation(request.confirmation, &before, Err(error.to_string()));
+          break;
+        }
+      }
+    }
+    if matches!(confirmation, CashOutConfirmation::Confirmed { .. }) {
+      break;
+    }
+    if attempt + 1 < attempt_limit {
+      std::thread::sleep(Duration::from_millis(250));
+    }
+  }
+
+  let result = CashOutResult {
+    target: request.target,
+    attempts,
+    confirmation,
+  };
+  emit_cash_out_completed(&result);
+  Ok(result)
 }
 
 #[cfg(feature = "tracing")]
@@ -1116,30 +1329,35 @@ fn emit_input_delivery(_delivery: &auv_driver::InputActionResult) {}
 struct CashOutCliOutput<'a> {
   operation: &'static str,
   target: &'a str,
-  delivery: &'a auv_driver::InputActionResult,
   confirmation: &'a CashOutConfirmation,
-  #[serde(skip_serializing_if = "Option::is_none")]
-  selected_button: Option<&'a ButtonTarget>,
-  #[serde(skip_serializing_if = "Option::is_none")]
-  window_point: Option<WindowPoint>,
+  attempts: &'a [CashOutAttempt],
 }
 
-fn write_cash_out_output(details: bool, result: &CashOutResult) -> Result<(), CliError> {
+fn write_cash_out_output(_details: bool, result: &CashOutResult) -> Result<(), CliError> {
   write_output(
     OutputMode::Json,
     &CashOutCliOutput {
       operation: "game.cash_out",
       target: &result.target,
-      delivery: &result.delivery,
       confirmation: &result.confirmation,
-      selected_button: details.then_some(&result.selected_button),
-      window_point: details.then_some(result.window_point),
+      attempts: &result.attempts,
     },
   )
 }
 
 #[cfg(target_os = "macos")]
 fn click_game_restart(args: OperationControlArgs) -> Result<(), CliError> {
+  if std::env::var_os("AUV_CONTEXT").is_some() {
+    let config = BalatroModelConfig::from_operation_args(&args);
+    return write_game_restart_output(&game_restart_via_api(
+      GameRestartRequest {
+        target: args.target,
+        confirm_started: args.verify && args.verify_mode != VerifyModeArg::ActivationOnly,
+        timeout_ms: args.timeout_ms.unwrap_or(1800),
+      },
+      config,
+    )?);
+  }
   let result = game_restart(GameRestartRequest {
     target: args.target,
     confirm_started: args.verify && args.verify_mode != VerifyModeArg::ActivationOnly,
@@ -1244,8 +1462,19 @@ pub fn game_restart(request: GameRestartRequest) -> Result<GameRestartResult, Cl
 }
 
 #[cfg(not(target_os = "macos"))]
-fn click_game_restart(_args: OperationControlArgs) -> Result<(), CliError> {
-  Err(CliError::Message("game restart live operation is only available on macOS".to_string()))
+fn click_game_restart(args: OperationControlArgs) -> Result<(), CliError> {
+  if std::env::var_os("AUV_CONTEXT").is_some() {
+    let config = BalatroModelConfig::from_operation_args(&args);
+    return write_game_restart_output(&game_restart_via_api(
+      GameRestartRequest {
+        target: args.target,
+        confirm_started: args.verify && args.verify_mode != VerifyModeArg::ActivationOnly,
+        timeout_ms: args.timeout_ms.unwrap_or(1800),
+      },
+      config,
+    )?);
+  }
+  Err(CliError::Message("game restart live operation requires macOS locally or an inherited AUV device context".to_string()))
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -1264,10 +1493,127 @@ fn deliver_game_restart_click(
   let delivery = click_game_point(session, window, point)?;
   clicks.push(GameRestartClick {
     target,
-    window_point: WindowPoint::new(point.x, point.y),
+    point: ActionPoint::window(window.reference.id.clone(), WindowPoint::new(point.x, point.y)),
     delivery,
   });
   Ok(())
+}
+
+fn game_restart_via_api(request: GameRestartRequest, config: BalatroModelConfig) -> Result<GameRestartResult, CliError> {
+  let runtime = tokio::runtime::Builder::new_current_thread()
+    .enable_all()
+    .build()
+    .map_err(|error| CliError::Message(format!("failed to create daemon client runtime: {error}")))?;
+  let mut state = observe_restart_state_via_api(&runtime, &request.target, &config, RestartObservation::AnyControl)?;
+  let mut clicks = Vec::new();
+
+  for _ in 0..6 {
+    let Some(button) = restart_primary_button(&state.buttons).cloned() else {
+      state = observe_restart_state_via_api(&runtime, &request.target, &config, RestartObservation::AnyControl)?;
+      continue;
+    };
+    let opens_new_run_modal = button.id == "button_main_menu_play";
+    if button.id == "button_new_run_play" {
+      // TODO(balatro-new-run-tab-detector): replace this layout point after the
+      // New Run/Continue/Challenge tabs are represented in the UI dataset.
+      // Selecting New Run is required because Continue may hold a stale run.
+      let tab_point = Point::new(f64::from(state.frame.image_size.width) * 0.505, f64::from(state.frame.image_size.height) * 0.333);
+      let (screen_point, delivery) = runtime.block_on(click_display_frame_point_via_api(&state.frame, tab_point))?;
+      clicks.push(GameRestartClick {
+        target: GameRestartTarget::NewRunTabLayout,
+        point: ActionPoint::screen(screen_point),
+        delivery,
+      });
+      // The modal is translucent, so a fresh detector frame can momentarily
+      // prefer the occluded main-menu button. The modal geometry does not move
+      // when changing tabs; retain this frame's detector-backed Play target.
+      std::thread::sleep(Duration::from_millis(350));
+    }
+    let target = GameRestartTarget::DetectedButton {
+      button: button.clone(),
+    };
+    let point = bbox_center_point(button.bbox);
+    let (screen_point, delivery) = runtime.block_on(click_display_frame_point_via_api(&state.frame, point))?;
+    clicks.push(GameRestartClick {
+      target,
+      point: ActionPoint::screen(screen_point),
+      delivery,
+    });
+    std::thread::sleep(Duration::from_millis(900));
+    if opens_new_run_modal {
+      // TODO(balatro-new-run-modal-layout): replace both modal layout points
+      // after tab and Play recognition are reliable on translucent frames.
+      let tab_point = Point::new(f64::from(state.frame.image_size.width) * 0.505, f64::from(state.frame.image_size.height) * 0.333);
+      let (screen_point, delivery) = runtime.block_on(click_display_frame_point_via_api(&state.frame, tab_point))?;
+      clicks.push(GameRestartClick {
+        target: GameRestartTarget::NewRunTabLayout,
+        point: ActionPoint::screen(screen_point),
+        delivery,
+      });
+      std::thread::sleep(Duration::from_millis(350));
+      let play_point = Point::new(f64::from(state.frame.image_size.width) * 0.593, f64::from(state.frame.image_size.height) * 0.823);
+      let (screen_point, delivery) = runtime.block_on(click_display_frame_point_via_api(&state.frame, play_point))?;
+      clicks.push(GameRestartClick {
+        target: GameRestartTarget::NewRunPlayLayout,
+        point: ActionPoint::screen(screen_point),
+        delivery,
+      });
+      std::thread::sleep(Duration::from_millis(900));
+    }
+    let expected = if opens_new_run_modal {
+      RestartObservation::Started
+    } else {
+      RestartObservation::Started
+    };
+    state = observe_restart_state_via_api(&runtime, &request.target, &config, expected)?;
+    if matches!(state.phase, BalatroPhase::BlindSelect | BalatroPhase::Playing | BalatroPhase::Store) {
+      break;
+    }
+  }
+
+  let outcome = if request.confirm_started {
+    classify_game_restart_outcome(Ok(&state))
+  } else {
+    GameRestartOutcome::NotChecked
+  };
+  let result = GameRestartResult {
+    target: request.target,
+    clicks,
+    outcome,
+  };
+  emit_game_restart_completed(&result);
+  Ok(result)
+}
+
+#[derive(Clone, Copy)]
+enum RestartObservation {
+  AnyControl,
+  Started,
+}
+
+fn observe_restart_state_via_api(
+  runtime: &tokio::runtime::Runtime,
+  target: &str,
+  config: &BalatroModelConfig,
+  expected: RestartObservation,
+) -> Result<BalatroState, CliError> {
+  let mut last = None;
+  for attempt in 0..3 {
+    let state = runtime.block_on(observe_live_via_api(target, config, None, true))?;
+    let started = matches!(state.phase, BalatroPhase::BlindSelect | BalatroPhase::Playing | BalatroPhase::Store);
+    let matches_expected = match expected {
+      RestartObservation::AnyControl => restart_primary_button(&state.buttons).is_some() || started,
+      RestartObservation::Started => started,
+    };
+    if matches_expected {
+      return Ok(state);
+    }
+    last = Some(state);
+    if attempt < 2 {
+      std::thread::sleep(Duration::from_millis(250));
+    }
+  }
+  Ok(last.expect("bounded restart observation loop always records a state"))
 }
 
 #[derive(Debug, Serialize)]
@@ -1293,12 +1639,18 @@ fn write_game_restart_output(result: &GameRestartResult) -> Result<(), CliError>
 #[cfg(target_os = "macos")]
 fn click_store_buy(args: SlotOperationArgs) -> Result<(), CliError> {
   let slot_index = parse_store_slot_index(&args.slot)?;
-  let result = store_buy(StoreBuyRequest {
+  let config = BalatroModelConfig::from_operation_args(&args.control);
+  let request = StoreBuyRequest {
     target: args.control.target,
     slot: SlotId::new(ObjectZone::Store, slot_index),
     confirm_purchase: args.control.verify && args.control.verify_mode != VerifyModeArg::ActivationOnly,
     timeout_ms: args.control.timeout_ms.unwrap_or(1000),
-  })?;
+  };
+  let result = if std::env::var_os("AUV_CONTEXT").is_some() {
+    store_buy_via_api(request, config)?
+  } else {
+    store_buy(request)?
+  };
   write_store_buy_output(&result)
 }
 
@@ -1318,7 +1670,7 @@ pub fn store_buy(request: StoreBuyRequest) -> Result<StoreBuyResult, CliError> {
   let item = select_store_item(&before, request.slot.index)?.clone();
   let item_point = window_point_from_store_item(&before, &window, &item);
   let selection = StoreBuyClick {
-    window_point: WindowPoint::new(item_point.x, item_point.y),
+    point: ActionPoint::window(window.reference.id.clone(), WindowPoint::new(item_point.x, item_point.y)),
     delivery: click_game_point(&session, &window, item_point)?,
   };
 
@@ -1365,7 +1717,7 @@ pub fn store_buy(request: StoreBuyRequest) -> Result<StoreBuyResult, CliError> {
   };
   let confirm_point = window_point_from_button(&selected, &window, &confirmation_button);
   let submission = StoreBuyClick {
-    window_point: WindowPoint::new(confirm_point.x, confirm_point.y),
+    point: ActionPoint::window(window.reference.id.clone(), WindowPoint::new(confirm_point.x, confirm_point.y)),
     delivery: click_game_point(&session, &window, confirm_point)?,
   };
 
@@ -1399,13 +1751,113 @@ pub fn store_buy(request: StoreBuyRequest) -> Result<StoreBuyResult, CliError> {
 
 #[cfg(not(target_os = "macos"))]
 fn click_store_buy(args: SlotOperationArgs) -> Result<(), CliError> {
-  parse_store_slot_index(&args.slot)?;
-  Err(CliError::Message("store buy live operation is only available on macOS".to_string()))
+  if std::env::var_os("AUV_CONTEXT").is_none() {
+    return Err(CliError::Message("store buy requires macOS locally or an inherited AUV device context".to_string()));
+  }
+  let slot_index = parse_store_slot_index(&args.slot)?;
+  let config = BalatroModelConfig::from_operation_args(&args.control);
+  let result = store_buy_via_api(
+    StoreBuyRequest {
+      target: args.control.target,
+      slot: SlotId::new(ObjectZone::Store, slot_index),
+      confirm_purchase: args.control.verify && args.control.verify_mode != VerifyModeArg::ActivationOnly,
+      timeout_ms: args.control.timeout_ms.unwrap_or(1000),
+    },
+    config,
+  )?;
+  write_store_buy_output(&result)
 }
 
 #[cfg(not(target_os = "macos"))]
 pub fn store_buy(_request: StoreBuyRequest) -> Result<StoreBuyResult, CliError> {
   Err(CliError::Message("store buy live operation is only available on macOS".to_string()))
+}
+
+fn store_buy_via_api(request: StoreBuyRequest, config: BalatroModelConfig) -> Result<StoreBuyResult, CliError> {
+  if request.slot.zone != ObjectZone::Store {
+    return Err(CliError::Message(format!("store buy requires a store slot, got {}", request.slot)));
+  }
+  let runtime = tokio::runtime::Builder::new_current_thread()
+    .enable_all()
+    .build()
+    .map_err(|error| CliError::Message(format!("failed to create daemon client runtime: {error}")))?;
+  let probe = runtime.block_on(observe_live_via_api(&request.target, &config, None, true))?;
+  // A preceding read may leave a tooltip covering store detections. Move to a
+  // display corner outside the observed game viewport and obtain a fresh,
+  // stable frame before resolving the caller's slot index.
+  runtime.block_on(move_display_frame_point_via_api(&probe.frame, Point::new(1.0, 1.0)))?;
+  std::thread::sleep(Duration::from_millis(400));
+  let before = runtime.block_on(observe_live_via_api(&request.target, &config, None, true))?;
+  let item = select_store_item(&before, request.slot.index)?.clone();
+  let (screen_point, delivery) = runtime.block_on(click_display_frame_point_via_api(&before.frame, bbox_center_point(item.bbox)))?;
+  let selection = StoreBuyClick {
+    point: ActionPoint::screen(screen_point),
+    delivery,
+  };
+
+  std::thread::sleep(Duration::from_millis(500));
+  let selected = match runtime.block_on(observe_live_via_api(&request.target, &config, None, true)) {
+    Ok(selected) => selected,
+    Err(error) => {
+      let result = StoreBuyResult {
+        target: request.target,
+        slot: request.slot,
+        item,
+        outcome: StoreBuyOutcome::SelectionOnly {
+          selection,
+          reason: StoreBuyIncompleteReason::StateReadFailed {
+            message: error.to_string(),
+          },
+        },
+      };
+      emit_store_buy_completed(&result);
+      return Ok(result);
+    }
+  };
+  let confirmation_button = match select_store_buy_confirm_button(&selected) {
+    Ok(button) => button.clone(),
+    Err(_) => {
+      let result = StoreBuyResult {
+        target: request.target,
+        slot: request.slot,
+        item,
+        outcome: StoreBuyOutcome::SelectionOnly {
+          selection,
+          reason: StoreBuyIncompleteReason::PurchaseControlNotFound,
+        },
+      };
+      emit_store_buy_completed(&result);
+      return Ok(result);
+    }
+  };
+  let (screen_point, delivery) =
+    runtime.block_on(click_display_frame_point_via_api(&selected.frame, bbox_center_point(confirmation_button.bbox)))?;
+  let submission = StoreBuyClick {
+    point: ActionPoint::screen(screen_point),
+    delivery,
+  };
+  let confirmation = if request.confirm_purchase {
+    std::thread::sleep(Duration::from_millis(request.timeout_ms.max(500)));
+    evaluate_store_buy_confirmation(
+      &before,
+      runtime.block_on(observe_live_via_api(&request.target, &config, None, true)).as_ref().map_err(ToString::to_string),
+    )
+  } else {
+    StoreBuyConfirmation::NotRequested
+  };
+  let result = StoreBuyResult {
+    target: request.target,
+    slot: request.slot,
+    item,
+    outcome: StoreBuyOutcome::Submitted {
+      selection,
+      confirmation_button,
+      submission,
+      confirmation,
+    },
+  };
+  emit_store_buy_completed(&result);
+  Ok(result)
 }
 
 #[derive(Debug, Serialize)]
@@ -1463,6 +1915,223 @@ fn observe_from_args(args: &ObserveArgs) -> Result<BalatroState, CliError> {
   observe_live_target(&args.target, &config, args.no_cache)
 }
 
+#[derive(Clone, Debug, Serialize)]
+struct HandSlotDiagnostic {
+  slot: SlotId,
+  bbox: BoundingBox,
+  confidence: f32,
+  selected: bool,
+  requested: bool,
+  click_frame_point: Point,
+  click_inside_bbox: bool,
+  visual_fingerprint: Option<String>,
+  reading: Option<CardReadValue>,
+}
+
+#[derive(Debug, Serialize)]
+struct FrameDiagnosticReport<'a> {
+  schema_version: &'static str,
+  frame: &'a crate::model::FrameRef,
+  phase: BalatroPhase,
+  scores: &'a crate::model::ScoreState,
+  rounds: &'a crate::model::RoundState,
+  consumables: &'a [ConsumableSlot],
+  requested_slots: Vec<SlotId>,
+  selection_matches_request: Option<bool>,
+  hand: Vec<HandSlotDiagnostic>,
+  raw_entities: &'a [crate::model::ObjectEvidence],
+  raw_ui: &'a [crate::model::ObjectEvidence],
+  state_diagnostics: &'a [crate::model::BalatroDiagnostic],
+  warnings: Vec<String>,
+}
+
+fn write_frame_diagnostics(args: DiagnosticsArgs) -> Result<(), CliError> {
+  let image_path = args
+    .observe
+    .image
+    .as_deref()
+    .ok_or_else(|| CliError::Message("diagnostics requires --image PATH so the annotated output is reproducible".to_string()))?;
+  let state = observe_from_args(&args.observe)?;
+  let requested = args.requested_slots.as_deref().map(parse_hand_slot_indices).transpose()?.unwrap_or_default();
+  let interactions = hand_card_interactions(&state);
+  let mut read_indices = requested.clone();
+  read_indices.extend(interactions.iter().filter(|interaction| interaction.selected).map(|interaction| interaction.slot.index));
+  read_indices.sort_unstable();
+  read_indices.dedup();
+  if read_indices.is_empty() {
+    read_indices.extend(interactions.iter().map(|interaction| interaction.slot.index));
+  }
+  let reads = diagnostic_card_reads(image_path, &state, &read_indices)?;
+  let hand = interactions
+    .iter()
+    .map(|interaction| HandSlotDiagnostic {
+      slot: interaction.slot,
+      bbox: interaction.bbox,
+      confidence: interaction.confidence,
+      selected: interaction.selected,
+      requested: requested.contains(&interaction.slot.index),
+      click_frame_point: interaction.click_frame_point,
+      click_inside_bbox: point_inside_bbox(interaction.click_frame_point, interaction.bbox),
+      visual_fingerprint: interaction.visual_fingerprint.clone(),
+      reading: reads.iter().find(|read| read.slot == interaction.slot).map(|read| read.reading.clone()),
+    })
+    .collect::<Vec<_>>();
+  let selection_matches_request = (!requested.is_empty()).then(|| {
+    let mut selected = hand.iter().filter(|slot| slot.selected).map(|slot| slot.slot.index).collect::<Vec<_>>();
+    let mut requested = requested.clone();
+    selected.sort_unstable();
+    requested.sort_unstable();
+    selected == requested
+  });
+  let mut warnings = Vec::new();
+  if selection_matches_request == Some(false) {
+    warnings.push("observed raised-card selection does not match --requested-slots".to_string());
+  }
+  if hand.iter().any(|slot| !slot.click_inside_bbox) {
+    warnings.push("at least one computed hand click lies outside its detected bbox".to_string());
+  }
+  if hand.iter().any(|slot| slot.reading.as_ref().is_some_and(|reading| !reading.valid)) {
+    warnings.push("at least one requested or selected card could not be read as rank+suit".to_string());
+  }
+  let report = FrameDiagnosticReport {
+    schema_version: "auv.game.balatro.frame_diagnostic.v1",
+    frame: &state.frame,
+    phase: state.phase,
+    scores: &state.scores,
+    rounds: &state.rounds,
+    consumables: &state.consumables,
+    requested_slots: requested.into_iter().map(|index| SlotId::new(ObjectZone::Hand, index)).collect(),
+    selection_matches_request,
+    hand,
+    raw_entities: &state.raw_entities,
+    raw_ui: &state.raw_ui,
+    state_diagnostics: &state.diagnostics,
+    warnings,
+  };
+
+  let mut annotated = image::open(image_path)?.to_rgba8();
+  draw_frame_diagnostics(&mut annotated, &state, &report.hand);
+  ensure_parent_directory(&args.annotated_out)?;
+  annotated.save(&args.annotated_out)?;
+  ensure_parent_directory(&args.report_out)?;
+  fs::write(&args.report_out, serde_json::to_vec_pretty(&report)?)?;
+  println!(
+    "{}",
+    serde_json::to_string_pretty(&json!({
+      "annotated": args.annotated_out,
+      "report": args.report_out,
+      "phase": state.phase,
+      "selection_matches_request": report.selection_matches_request,
+      "warnings": report.warnings,
+    }))?
+  );
+  Ok(())
+}
+
+fn ensure_parent_directory(path: &Path) -> Result<(), CliError> {
+  if let Some(parent) = path.parent()
+    && !parent.as_os_str().is_empty()
+  {
+    fs::create_dir_all(parent)?;
+  }
+  Ok(())
+}
+
+fn point_inside_bbox(point: Point, bbox: BoundingBox) -> bool {
+  point.x >= f64::from(bbox.x1) && point.x <= f64::from(bbox.x2) && point.y >= f64::from(bbox.y1) && point.y <= f64::from(bbox.y2)
+}
+
+fn draw_frame_diagnostics(image: &mut RgbaImage, state: &BalatroState, hand: &[HandSlotDiagnostic]) {
+  for evidence in &state.raw_entities {
+    draw_bbox(image, evidence.detection.bbox, image::Rgba([40, 220, 90, 255]), 2);
+  }
+  for evidence in &state.raw_ui {
+    draw_bbox(image, evidence.detection.bbox, image::Rgba([40, 180, 255, 255]), 2);
+  }
+  for slot in hand {
+    let color = if slot.selected {
+      image::Rgba([255, 60, 210, 255])
+    } else {
+      image::Rgba([255, 210, 40, 255])
+    };
+    draw_bbox(image, slot.bbox, color, 4);
+    draw_cross(image, slot.click_frame_point, image::Rgba([255, 40, 40, 255]));
+  }
+}
+
+fn draw_bbox(image: &mut RgbaImage, bbox: BoundingBox, color: image::Rgba<u8>, thickness: u32) {
+  let max_x = image.width().saturating_sub(1);
+  let max_y = image.height().saturating_sub(1);
+  let x1 = bbox.x1.max(0.0).floor() as u32;
+  let y1 = bbox.y1.max(0.0).floor() as u32;
+  let x2 = bbox.x2.max(0.0).ceil() as u32;
+  let y2 = bbox.y2.max(0.0).ceil() as u32;
+  let (x1, x2) = (x1.min(max_x), x2.min(max_x));
+  let (y1, y2) = (y1.min(max_y), y2.min(max_y));
+  for offset in 0..thickness {
+    let left = x1.saturating_add(offset).min(x2);
+    let right = x2.saturating_sub(offset).max(x1);
+    let top = y1.saturating_add(offset).min(y2);
+    let bottom = y2.saturating_sub(offset).max(y1);
+    for x in left..=right {
+      image.put_pixel(x, top, color);
+      image.put_pixel(x, bottom, color);
+    }
+    for y in top..=bottom {
+      image.put_pixel(left, y, color);
+      image.put_pixel(right, y, color);
+    }
+  }
+}
+
+fn draw_cross(image: &mut RgbaImage, point: Point, color: image::Rgba<u8>) {
+  let x = point.x.round() as i64;
+  let y = point.y.round() as i64;
+  for delta in -9..=9 {
+    for (px, py) in [(x + delta, y), (x, y + delta)] {
+      if px >= 0 && py >= 0 && px < i64::from(image.width()) && py < i64::from(image.height()) {
+        image.put_pixel(px as u32, py as u32, color);
+      }
+    }
+  }
+}
+
+#[cfg(target_os = "macos")]
+fn diagnostic_card_reads(image: &Path, state: &BalatroState, indices: &[u32]) -> Result<Vec<CardReadResult>, CliError> {
+  let session = open_macos_session()?;
+  let capture = capture_from_image(image)?;
+  let templates = load_deck_rank_templates();
+  indices
+    .iter()
+    .map(|index| {
+      let card = select_hand_card(state, *index)?;
+      read_card_from_capture(&session, &capture, image, state, card, templates.as_deref())
+    })
+    .collect()
+}
+
+#[cfg(not(target_os = "macos"))]
+fn diagnostic_card_reads(image: &Path, state: &BalatroState, indices: &[u32]) -> Result<Vec<CardReadResult>, CliError> {
+  indices
+    .iter()
+    .map(|index| {
+      let card = select_hand_card(state, *index)?;
+      Ok(CardReadResult {
+        slot: card.slot,
+        bbox: card.bbox,
+        confidence: card.confidence,
+        reading: CardReadValue::unread(),
+        evidence: CardReadEvidence {
+          frame: image.display().to_string(),
+          ocr_region: ocr_region_for_card(state, card),
+          corner_crop: None,
+          source: "image_without_ocr_non_macos".to_string(),
+        },
+      })
+    })
+    .collect()
+}
+
 fn observe_image_with_ui_readings(image: &Path, config: &BalatroModelConfig, no_cache: bool) -> Result<BalatroState, CliError> {
   let mut state = observe_image(image, config, no_cache)?;
   enrich_ui_numeric_readings_from_image(&mut state, image);
@@ -1480,6 +2149,9 @@ fn read_cards_from_args(args: &SlotObserveArgs) -> Result<Vec<CardReadResult>, C
 
 #[cfg(target_os = "macos")]
 fn read_object_live(args: &SlotObserveArgs, zone: ObjectReadZone) -> Result<ObjectReadResult, CliError> {
+  if std::env::var_os("AUV_CONTEXT").is_some() {
+    return read_object_live_via_api(args, zone);
+  }
   let config = BalatroModelConfig::from_observe_args(&args.observe);
   let session = open_macos_session()?;
   let window = session.window().resolve(Window::main_visible().owned_by(App::name(args.observe.target.clone())))?;
@@ -1505,8 +2177,112 @@ fn read_object_live(args: &SlotObserveArgs, zone: ObjectReadZone) -> Result<Obje
 
 #[cfg(not(target_os = "macos"))]
 fn read_object_live(args: &SlotObserveArgs, zone: ObjectReadZone) -> Result<ObjectReadResult, CliError> {
+  read_object_live_via_api(args, zone)
+}
+
+fn read_object_live_via_api(args: &SlotObserveArgs, zone: ObjectReadZone) -> Result<ObjectReadResult, CliError> {
   let state = observe_from_args(&args.observe)?;
-  object_read_from_state(&state, &args.slot, zone)
+  let mut read = object_read_from_state(&state, &args.slot, zone)?;
+  let runtime = tokio::runtime::Builder::new_current_thread()
+    .enable_all()
+    .build()
+    .map_err(|error| CliError::Message(format!("failed to create daemon client runtime: {error}")))?;
+  let request = HoverReadRequest {
+    point: bbox_center_point(read.bbox),
+    region: object_hover_ocr_region(),
+    custom_words: object_ocr_words().into_iter().map(str::to_string).collect(),
+  };
+  match runtime.block_on(hover_read_display_frame_points_via_api(&state.frame, &[request])) {
+    Ok(mut observations) => {
+      let observation = observations.pop().expect("one hover request returns one observation");
+      apply_hover_read_observation(&mut read, observation.recognition, observation.frame_source);
+    }
+    Err(error) => {
+      read.evidence.source = "remote_hover_ocr_failed".to_string();
+      read.evidence.hover_error = Some(error.to_string());
+    }
+  }
+  Ok(read)
+}
+
+fn hover_read_jokers_via_api(state: &mut BalatroState) -> Result<(), CliError> {
+  let pending = state
+    .jokers
+    .iter()
+    .enumerate()
+    .filter(|(_, joker)| joker.cache.needs_reading || joker.reading.text.is_none())
+    .map(|(index, joker)| {
+      (
+        index,
+        HoverReadRequest {
+          point: bbox_center_point(joker.bbox),
+          region: object_hover_ocr_region(),
+          custom_words: object_ocr_words().into_iter().map(str::to_string).collect(),
+        },
+      )
+    })
+    .collect::<Vec<_>>();
+  if pending.is_empty() {
+    return Ok(());
+  }
+  let requests = pending.iter().map(|(_, request)| request.clone()).collect::<Vec<_>>();
+  let runtime = tokio::runtime::Builder::new_current_thread()
+    .enable_all()
+    .build()
+    .map_err(|error| CliError::Message(format!("failed to create daemon client runtime: {error}")))?;
+  let observations = runtime.block_on(hover_read_display_frame_points_via_api(&state.frame, &requests))?;
+  for ((index, _), observation) in pending.into_iter().zip(observations) {
+    if let Some((text, confidence)) = tooltip_recognition(&observation.recognition, state.jokers[index].bbox) {
+      let joker = &mut state.jokers[index];
+      joker.reading = Reading {
+        status: ReadingStatus::Read,
+        text: Some(text),
+        confidence,
+      };
+      joker.cache.needs_reading = false;
+      joker.cache.changed_since_last_read = false;
+    }
+  }
+  Ok(())
+}
+
+fn apply_hover_read_observation(read: &mut ObjectReadResult, recognition: auv_driver::TextRecognition, frame_source: String) {
+  if let Some((text, confidence)) = tooltip_recognition(&recognition, read.bbox) {
+    read.reading = ObjectReadValue {
+      status: "read",
+      raw_text: Some(text),
+      confidence,
+    };
+    read.evidence.hover_required = false;
+  }
+  read.evidence.source = "remote_hover_ocr".to_string();
+  read.evidence.hover_frame = Some(frame_source);
+  read.evidence.hover_ocr_region = Some(object_hover_ocr_region());
+}
+
+fn tooltip_recognition(recognition: &auv_driver::TextRecognition, bbox: BoundingBox) -> Option<(String, Option<f32>)> {
+  let width = f64::from((bbox.x2 - bbox.x1).max(1.0));
+  let height = f64::from((bbox.y2 - bbox.y1).max(1.0));
+  let x1 = f64::from(bbox.x1) - width * 1.8;
+  let y1 = f64::from(bbox.y1) - height * 0.7;
+  let x2 = f64::from(bbox.x2) + width * 1.8;
+  let y2 = f64::from(bbox.y2) + height * 0.7;
+  let regions = recognition
+    .regions
+    .iter()
+    .filter(|region| {
+      let bounds = region.bounds;
+      bounds.origin.x + bounds.size.width >= x1
+        && bounds.origin.x <= x2
+        && bounds.origin.y + bounds.size.height >= y1
+        && bounds.origin.y <= y2
+    })
+    .collect::<Vec<_>>();
+  let text = regions.iter().map(|region| region.text.trim()).filter(|text| !text.is_empty()).collect::<Vec<_>>().join("\n");
+  let text = non_empty_trimmed_text(&text).or_else(|| non_empty_trimmed_text(&recognition.text))?;
+  let confidences = regions.iter().filter_map(|region| region.confidence).collect::<Vec<_>>();
+  let confidence = (!confidences.is_empty()).then(|| confidences.iter().sum::<f32>() / confidences.len() as f32);
+  Some((text, confidence))
 }
 
 #[cfg(target_os = "macos")]
@@ -2071,6 +2847,7 @@ fn write_pack_choose_output(details: bool, result: &PackChooseResult) -> Result<
 
 #[cfg(target_os = "macos")]
 fn click_store_next_round(args: OperationControlArgs) -> Result<(), CliError> {
+  let config = BalatroModelConfig::from_operation_args(&args);
   let details = args.details;
   let confirmation = if !args.verify || args.verify_mode == VerifyModeArg::ActivationOnly {
     StoreNextRoundConfirmationRequest::None
@@ -2079,11 +2856,16 @@ fn click_store_next_round(args: OperationControlArgs) -> Result<(), CliError> {
   } else {
     StoreNextRoundConfirmationRequest::Weak
   };
-  let result = store_next_round(StoreNextRoundRequest {
+  let request = StoreNextRoundRequest {
     target: args.target,
     confirmation,
     timeout_ms: args.timeout_ms.unwrap_or(1200),
-  })?;
+  };
+  let result = if std::env::var_os("AUV_CONTEXT").is_some() {
+    store_next_round_via_api(request, config)?
+  } else {
+    store_next_round(request)?
+  };
   write_store_next_round_output(details, &result)
 }
 
@@ -2114,9 +2896,11 @@ pub fn store_next_round(request: StoreNextRoundRequest) -> Result<StoreNextRound
 
   let result = StoreNextRoundResult {
     target: request.target,
-    selected_target,
-    window_point: WindowPoint::new(point.x, point.y),
-    delivery,
+    attempts: vec![StoreNextRoundAttempt {
+      selected_target,
+      point: ActionPoint::window(window.reference.id.clone(), WindowPoint::new(point.x, point.y)),
+      delivery,
+    }],
     confirmation,
   };
   emit_store_next_round_completed(&result);
@@ -2124,8 +2908,28 @@ pub fn store_next_round(request: StoreNextRoundRequest) -> Result<StoreNextRound
 }
 
 #[cfg(not(target_os = "macos"))]
-fn click_store_next_round(_args: OperationControlArgs) -> Result<(), CliError> {
-  Err(CliError::Message("store next-round live operation is only available on macOS".to_string()))
+fn click_store_next_round(args: OperationControlArgs) -> Result<(), CliError> {
+  if std::env::var_os("AUV_CONTEXT").is_none() {
+    return Err(CliError::Message("store next-round requires macOS locally or an inherited AUV device context".to_string()));
+  }
+  let config = BalatroModelConfig::from_operation_args(&args);
+  let details = args.details;
+  let confirmation = if !args.verify || args.verify_mode == VerifyModeArg::ActivationOnly {
+    StoreNextRoundConfirmationRequest::None
+  } else if args.verify_mode == VerifyModeArg::Targeted {
+    StoreNextRoundConfirmationRequest::Targeted
+  } else {
+    StoreNextRoundConfirmationRequest::Weak
+  };
+  let result = store_next_round_via_api(
+    StoreNextRoundRequest {
+      target: args.target,
+      confirmation,
+      timeout_ms: args.timeout_ms.unwrap_or(1200),
+    },
+    config,
+  )?;
+  write_store_next_round_output(details, &result)
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -2133,28 +2937,80 @@ pub fn store_next_round(_request: StoreNextRoundRequest) -> Result<StoreNextRoun
   Err(CliError::Message("store next-round live operation is only available on macOS".to_string()))
 }
 
+fn store_next_round_via_api(request: StoreNextRoundRequest, config: BalatroModelConfig) -> Result<StoreNextRoundResult, CliError> {
+  let runtime = tokio::runtime::Builder::new_current_thread()
+    .enable_all()
+    .build()
+    .map_err(|error| CliError::Message(format!("failed to create daemon client runtime: {error}")))?;
+  let before = runtime.block_on(observe_live_via_api(&request.target, &config, None, true))?;
+  let mut current = before.clone();
+  let mut attempts = Vec::new();
+  let mut confirmation = StoreNextRoundConfirmation::NotRequested;
+  let attempt_limit = if request.confirmation == StoreNextRoundConfirmationRequest::None {
+    1
+  } else {
+    2
+  };
+  for attempt in 0..attempt_limit {
+    let selected_target = resolve_store_next_round_target(&current)?;
+    let (screen_point, delivery) = runtime.block_on(click_display_frame_point_via_api(&current.frame, selected_target.frame_point()))?;
+    attempts.push(StoreNextRoundAttempt {
+      selected_target,
+      point: ActionPoint::screen(screen_point),
+      delivery,
+    });
+    if request.confirmation == StoreNextRoundConfirmationRequest::None {
+      break;
+    }
+    let deadline = Instant::now() + Duration::from_millis((request.timeout_ms / attempt_limit as u64).max(350));
+    loop {
+      std::thread::sleep(Duration::from_millis(250));
+      match runtime.block_on(observe_live_via_api(&request.target, &config, None, true)) {
+        Ok(after) => {
+          confirmation = evaluate_store_next_round_confirmation(request.confirmation, &before, Ok(&after));
+          current = after;
+          if matches!(confirmation, StoreNextRoundConfirmation::Confirmed { .. }) || Instant::now() >= deadline {
+            break;
+          }
+        }
+        Err(error) => {
+          confirmation = evaluate_store_next_round_confirmation(request.confirmation, &before, Err(error.to_string()));
+          break;
+        }
+      }
+    }
+    if matches!(confirmation, StoreNextRoundConfirmation::Confirmed { .. }) {
+      break;
+    }
+    if attempt + 1 < attempt_limit {
+      std::thread::sleep(Duration::from_millis(250));
+    }
+  }
+  let result = StoreNextRoundResult {
+    target: request.target,
+    attempts,
+    confirmation,
+  };
+  emit_store_next_round_completed(&result);
+  Ok(result)
+}
+
 #[derive(Debug, Serialize)]
 struct StoreNextRoundCliOutput<'a> {
   operation: &'static str,
   target: &'a str,
-  delivery: &'a auv_driver::InputActionResult,
   confirmation: &'a StoreNextRoundConfirmation,
-  #[serde(skip_serializing_if = "Option::is_none")]
-  selected_target: Option<&'a StoreNextRoundTarget>,
-  #[serde(skip_serializing_if = "Option::is_none")]
-  window_point: Option<WindowPoint>,
+  attempts: &'a [StoreNextRoundAttempt],
 }
 
-fn write_store_next_round_output(details: bool, result: &StoreNextRoundResult) -> Result<(), CliError> {
+fn write_store_next_round_output(_details: bool, result: &StoreNextRoundResult) -> Result<(), CliError> {
   write_output(
     OutputMode::Json,
     &StoreNextRoundCliOutput {
       operation: "store.next_round",
       target: &result.target,
-      delivery: &result.delivery,
       confirmation: &result.confirmation,
-      selected_target: details.then_some(&result.selected_target),
-      window_point: details.then_some(result.window_point),
+      attempts: &result.attempts,
     },
   )
 }
@@ -2323,22 +3179,44 @@ fn write_cards_clear_output(result: &CardsClearResult) -> Result<(), CliError> {
 #[cfg(target_os = "macos")]
 fn click_cards_commit(kind: CardCommitKind, args: MultiSlotOperationArgs) -> Result<(), CliError> {
   let slot_indices = parse_hand_slot_indices(&args.slots)?;
+  let config = BalatroModelConfig::from_operation_args(&args.control);
   let request = CardCommitRequest {
     target: args.control.target,
     slots: slot_indices.into_iter().map(|index| SlotId::new(ObjectZone::Hand, index)).collect(),
     confirm_change: args.control.verify && args.control.verify_mode != VerifyModeArg::ActivationOnly,
     timeout_ms: args.control.timeout_ms.unwrap_or(1500),
   };
-  let result = match kind {
-    CardCommitKind::Play => cards_play(request),
-    CardCommitKind::Discard => cards_discard(request),
-  }?;
+  let result = if std::env::var_os("AUV_CONTEXT").is_some() {
+    card_commit_via_api(kind, request, config)?
+  } else {
+    match kind {
+      CardCommitKind::Play => cards_play(request),
+      CardCommitKind::Discard => cards_discard(request),
+    }?
+  };
   write_card_commit_output(&result)
 }
 
 #[cfg(not(target_os = "macos"))]
-fn click_cards_commit(_kind: CardCommitKind, _args: MultiSlotOperationArgs) -> Result<(), CliError> {
-  Err(CliError::Message("cards play/discard live operations are only available on macOS".to_string()))
+fn click_cards_commit(kind: CardCommitKind, args: MultiSlotOperationArgs) -> Result<(), CliError> {
+  if std::env::var_os("AUV_CONTEXT").is_none() {
+    return Err(CliError::Message(
+      "cards play/discard live operations require macOS locally or an inherited AUV device context".to_string(),
+    ));
+  }
+  let slot_indices = parse_hand_slot_indices(&args.slots)?;
+  let config = BalatroModelConfig::from_operation_args(&args.control);
+  let result = card_commit_via_api(
+    kind,
+    CardCommitRequest {
+      target: args.control.target,
+      slots: slot_indices.into_iter().map(|index| SlotId::new(ObjectZone::Hand, index)).collect(),
+      confirm_change: args.control.verify && args.control.verify_mode != VerifyModeArg::ActivationOnly,
+      timeout_ms: args.control.timeout_ms.unwrap_or(1500),
+    },
+    config,
+  )?;
+  write_card_commit_output(&result)
 }
 
 #[cfg(target_os = "macos")]
@@ -2393,8 +3271,8 @@ fn card_commit(kind: CardCommitKind, request: CardCommitRequest) -> Result<CardC
     unreachable!("a matched hand selection always retains its observed state");
   };
 
-  let button = match find_button(&selected, kind.button_id()) {
-    Ok(button) => button.clone(),
+  let (control, frame_point) = match resolve_card_commit_target(&selected, kind) {
+    Ok(target) => target,
     Err(error) => {
       let result = CardCommitResult {
         target: request.target,
@@ -2411,7 +3289,7 @@ fn card_commit(kind: CardCommitKind, request: CardCommitRequest) -> Result<CardC
       return Ok(result);
     }
   };
-  let point = window_point_from_button(&selected, &window, &button);
+  let point = window_point_from_frame_point(&selected, &window, frame_point);
   let delivery = match click_game_point(&session, &window, point) {
     Ok(delivery) => delivery,
     Err(error) => {
@@ -2431,8 +3309,8 @@ fn card_commit(kind: CardCommitKind, request: CardCommitRequest) -> Result<CardC
     }
   };
   actions.push(CardCommitAction::Submit {
-    button,
-    window_point: WindowPoint::new(point.x, point.y),
+    control,
+    point: ActionPoint::window(window.reference.id.clone(), WindowPoint::new(point.x, point.y)),
     delivery,
   });
 
@@ -2444,10 +3322,161 @@ fn card_commit(kind: CardCommitKind, request: CardCommitRequest) -> Result<CardC
       }
       Err(error) => Err(error.to_string()),
     };
-    evaluate_card_commit_confirmation(&before, after.as_ref().map_err(Clone::clone))
+    evaluate_card_commit_confirmation(&selected, after.as_ref().map_err(Clone::clone))
   } else {
     CardCommitConfirmation::NotRequested
   };
+  let result = CardCommitResult {
+    target: request.target,
+    kind,
+    requested_slots: request.slots,
+    actions,
+    state: CardCommitState::Submitted { confirmation },
+  };
+  emit_card_commit_completed(&result);
+  Ok(result)
+}
+
+fn card_commit_via_api(kind: CardCommitKind, request: CardCommitRequest, config: BalatroModelConfig) -> Result<CardCommitResult, CliError> {
+  validate_hand_slots(&request.slots, "card commit")?;
+  let runtime = tokio::runtime::Builder::new_current_thread()
+    .enable_all()
+    .build()
+    .map_err(|error| CliError::Message(format!("failed to create daemon client runtime: {error}")))?;
+  // TODO(balatro-remote-operation-session): observations still open several
+  // short-lived API clients. Reuse one operation session after that lifecycle
+  // contract is owner-approved; see
+  // `2026-08-05-linux-live-gameplay-evidence.md`.
+  let before = runtime.block_on(observe_live_via_api(&request.target, &config, None, true))?;
+  let requested = request.slots.iter().map(|slot| slot.index).collect::<Vec<_>>();
+  select_hand_cards(&before, &requested)?;
+  let mut current = before.clone();
+  let mut toggles = Vec::new();
+
+  for attempt in 1..=2 {
+    let clear = selected_slots_to_clear(&current, &requested);
+    let select = requested_slots_to_select(&current, &requested);
+    if clear.is_empty() && select.is_empty() {
+      break;
+    }
+    for (kind, indices) in [
+      (HandSelectionToggleKind::ClearUnexpected, clear),
+      (HandSelectionToggleKind::SelectRequested, select),
+    ] {
+      for index in indices {
+        let card = select_hand_card(&current, index)?;
+        let frame_point = hand_card_click_frame_point(&current, card);
+        let (screen_point, delivery) = runtime.block_on(click_display_frame_point_via_api(&current.frame, frame_point))?;
+        toggles.push(HandSelectionToggle {
+          kind,
+          attempt,
+          slot: SlotId::new(ObjectZone::Hand, index),
+          point: ActionPoint::screen(screen_point),
+          delivery,
+        });
+        std::thread::sleep(Duration::from_millis(220));
+      }
+    }
+    std::thread::sleep(Duration::from_millis(650));
+    current = runtime.block_on(observe_live_via_api(&request.target, &config, None, true))?;
+  }
+
+  let selected = selected_hand_slot_indices(&current, &hand_slot_indices(&current))
+    .into_iter()
+    .map(|index| SlotId::new(ObjectZone::Hand, index))
+    .collect::<Vec<_>>();
+  let matched = hand_selection_matches_requested(&current, &requested);
+  let selection = HandSelectionResult {
+    requested: request.slots.clone(),
+    toggles,
+    state: if matched {
+      HandSelectionState::Matched { selected }
+    } else {
+      HandSelectionState::NotMatched { selected }
+    },
+  };
+  let mut actions = vec![CardCommitAction::SelectHandTargets { selection }];
+  if !matched {
+    let result = CardCommitResult {
+      target: request.target,
+      kind,
+      requested_slots: request.slots,
+      actions,
+      state: CardCommitState::Stopped {
+        reason: CardCommitStop::HandTargetsNotReady,
+      },
+    };
+    emit_card_commit_completed(&result);
+    return Ok(result);
+  }
+
+  let selected_before_submit = current.clone();
+  let mut submit_state = current;
+  let mut confirmation = CardCommitConfirmation::NotRequested;
+  let submit_attempts = if request.confirm_change { 2 } else { 1 };
+  for attempt in 0..submit_attempts {
+    let (control, frame_point) = match resolve_card_commit_target(&submit_state, kind) {
+      Ok(target) => target,
+      Err(error) if attempt == 0 => {
+        let result = CardCommitResult {
+          target: request.target,
+          kind,
+          requested_slots: request.slots,
+          actions,
+          state: CardCommitState::Stopped {
+            reason: CardCommitStop::CommitControlNotFound {
+              message: error.to_string(),
+            },
+          },
+        };
+        emit_card_commit_completed(&result);
+        return Ok(result);
+      }
+      Err(_) => break,
+    };
+    let (screen_point, delivery) = runtime.block_on(click_display_frame_point_via_api(&submit_state.frame, frame_point))?;
+    actions.push(CardCommitAction::Submit {
+      control,
+      point: ActionPoint::screen(screen_point),
+      delivery,
+    });
+    if !request.confirm_change {
+      break;
+    }
+    let settle_deadline = Instant::now() + Duration::from_millis(request.timeout_ms.min(1200));
+    let mut observation_count = 0;
+    loop {
+      std::thread::sleep(Duration::from_millis(if observation_count == 0 { 750 } else { 500 }));
+      observation_count += 1;
+      match runtime.block_on(observe_live_via_api(&request.target, &config, None, true)) {
+        Ok(after) => {
+          confirmation = evaluate_card_commit_confirmation(&selected_before_submit, Ok(&after));
+          submit_state = after;
+          if card_commit_confirmation_has_structural_change(&confirmation) {
+            break;
+          }
+          // A changed hand with no stable score/round OCR is normally a frame
+          // captured during Balatro's scoring animation. Observe once more,
+          // but never turn that partial success evidence into a second click.
+          if observation_count >= 2 || (!matches!(confirmation, CardCommitConfirmation::Applied { .. }) && Instant::now() >= settle_deadline)
+          {
+            break;
+          }
+        }
+        Err(error) => {
+          confirmation = evaluate_card_commit_confirmation(&selected_before_submit, Err(error.to_string()));
+          break;
+        }
+      }
+    }
+    if card_commit_confirmation_has_structural_change(&confirmation) {
+      break;
+    }
+    if !card_commit_confirmation_allows_resubmit(&confirmation) {
+      break;
+    }
+  }
+  confirmation = reject_fingerprint_only_confirmation(confirmation);
   let result = CardCommitResult {
     target: request.target,
     kind,
@@ -2535,7 +3564,7 @@ fn click_hand_targets(
       kind: HandSelectionToggleKind::ClearUnexpected,
       attempt: 1,
       slot,
-      window_point: WindowPoint::new(point.x, point.y),
+      point: ActionPoint::window(window.reference.id.clone(), WindowPoint::new(point.x, point.y)),
       delivery,
     });
     std::thread::sleep(Duration::from_millis(160));
@@ -2566,7 +3595,7 @@ fn click_hand_targets(
         kind: HandSelectionToggleKind::SelectRequested,
         attempt,
         slot,
-        window_point: WindowPoint::new(point.x, point.y),
+        point: ActionPoint::window(window.reference.id.clone(), WindowPoint::new(point.x, point.y)),
         delivery,
       });
       std::thread::sleep(Duration::from_millis(180));
@@ -2649,18 +3678,38 @@ fn incomplete_hand_selection(
 #[cfg(target_os = "macos")]
 fn click_blind_select(args: SlotOperationArgs) -> Result<(), CliError> {
   let slot_index = parse_blind_slot_index(&args.slot)?;
-  let result = blind_select(BlindSelectRequest {
+  let config = BalatroModelConfig::from_operation_args(&args.control);
+  let request = BlindSelectRequest {
     target: args.control.target,
     slot: SlotId::new(ObjectZone::Blind, slot_index),
     confirm_started: args.control.verify && args.control.verify_mode != VerifyModeArg::ActivationOnly,
     timeout_ms: args.control.timeout_ms.unwrap_or(1200),
-  })?;
+  };
+  let result = if std::env::var_os("AUV_CONTEXT").is_some() {
+    blind_select_via_api(request, config)?
+  } else {
+    blind_select(request)?
+  };
   write_blind_select_output(&result)
 }
 
 #[cfg(not(target_os = "macos"))]
-fn click_blind_select(_args: SlotOperationArgs) -> Result<(), CliError> {
-  Err(CliError::Message("blinds select live operation is only available on macOS".to_string()))
+fn click_blind_select(args: SlotOperationArgs) -> Result<(), CliError> {
+  if std::env::var_os("AUV_CONTEXT").is_none() {
+    return Err(CliError::Message("blinds select live operation requires macOS locally or an inherited AUV device context".to_string()));
+  }
+  let slot_index = parse_blind_slot_index(&args.slot)?;
+  let config = BalatroModelConfig::from_operation_args(&args.control);
+  let result = blind_select_via_api(
+    BlindSelectRequest {
+      target: args.control.target,
+      slot: SlotId::new(ObjectZone::Blind, slot_index),
+      confirm_started: args.control.verify && args.control.verify_mode != VerifyModeArg::ActivationOnly,
+      timeout_ms: args.control.timeout_ms.unwrap_or(1200),
+    },
+    config,
+  )?;
+  write_blind_select_output(&result)
 }
 
 #[cfg(target_os = "macos")]
@@ -2717,9 +3766,64 @@ pub fn blind_select(request: BlindSelectRequest) -> Result<BlindSelectResult, Cl
   let result = BlindSelectResult {
     target: request.target,
     slot: request.slot,
-    selected_button,
-    window_point: WindowPoint::new(point.x, point.y),
-    delivery,
+    attempts: vec![BlindSelectAttempt {
+      selected_button,
+      point: ActionPoint::window(window.reference.id.clone(), WindowPoint::new(point.x, point.y)),
+      delivery,
+    }],
+    confirmation,
+  };
+  emit_blind_select_completed(&result);
+  Ok(result)
+}
+
+fn blind_select_via_api(request: BlindSelectRequest, config: BalatroModelConfig) -> Result<BlindSelectResult, CliError> {
+  if request.slot.zone != ObjectZone::Blind {
+    return Err(CliError::Message(format!("blind select requires a blind slot, got {}", request.slot)));
+  }
+  let runtime = tokio::runtime::Builder::new_current_thread()
+    .enable_all()
+    .build()
+    .map_err(|error| CliError::Message(format!("failed to create daemon client runtime: {error}")))?;
+  let before = runtime.block_on(observe_live_via_api(&request.target, &config, None, true))?;
+  let mut current = before.clone();
+  let mut attempts = Vec::new();
+  let mut confirmation = BlindSelectConfirmation::NotRequested;
+  let attempt_limit = if request.confirm_started { 2 } else { 1 };
+  for attempt in 0..attempt_limit {
+    let selected_button = select_button_for_slot(&current.buttons, "button_level_select", Some(request.slot.index))?.clone();
+    let frame_point = bbox_center_point(selected_button.bbox);
+    let (screen_point, delivery) = runtime.block_on(click_display_frame_point_via_api(&current.frame, frame_point))?;
+    attempts.push(BlindSelectAttempt {
+      selected_button,
+      point: ActionPoint::screen(screen_point),
+      delivery,
+    });
+    if !request.confirm_started {
+      break;
+    }
+    std::thread::sleep(Duration::from_millis(650));
+    match runtime.block_on(observe_live_via_api(&request.target, &config, None, true)) {
+      Ok(after) => {
+        confirmation = evaluate_blind_select_confirmation(&before, Ok(&after));
+        current = after;
+        if matches!(confirmation, BlindSelectConfirmation::Started { .. }) {
+          break;
+        }
+        if attempt + 1 < attempt_limit {
+          std::thread::sleep(Duration::from_millis(350));
+        }
+      }
+      Err(error) => {
+        confirmation = evaluate_blind_select_confirmation(&before, Err(error.to_string()));
+        break;
+      }
+    }
+  }
+  let result = BlindSelectResult {
+    target: request.target,
+    slot: request.slot,
+    attempts,
     confirmation,
   };
   emit_blind_select_completed(&result);
@@ -2783,10 +3887,8 @@ struct BlindSelectCliOutput<'a> {
   operation: &'static str,
   target: &'a str,
   slot: SlotId,
-  delivery: &'a auv_driver::InputActionResult,
   confirmation: &'a BlindSelectConfirmation,
-  selected_button: &'a ButtonTarget,
-  window_point: WindowPoint,
+  attempts: &'a [BlindSelectAttempt],
 }
 
 fn write_blind_select_output(result: &BlindSelectResult) -> Result<(), CliError> {
@@ -2796,10 +3898,8 @@ fn write_blind_select_output(result: &BlindSelectResult) -> Result<(), CliError>
       operation: "blinds.select",
       target: &result.target,
       slot: result.slot,
-      delivery: &result.delivery,
       confirmation: &result.confirmation,
-      selected_button: &result.selected_button,
-      window_point: result.window_point,
+      attempts: &result.attempts,
     },
   )
 }
@@ -3009,10 +4109,14 @@ fn read_card_from_capture(
   let mut source = "macos_vision_corner_ocr".to_string();
   let mut reading = parse_card_reading(&recognition.text, suit, None);
   if reading.rank.is_none()
-    && let Some((rank, confidence)) = infer_rank_from_deck_template(&corner_capture.image, rank_templates, suit)
+    && let Some((rank, confidence)) = best_rank_candidate_from_deck_template(&corner_capture.image, rank_templates, suit)
   {
-    apply_inferred_rank(&mut reading, rank, confidence);
-    source = format!("{source}+deck_template_rank");
+    reading.rank_candidate = Some(rank.clone());
+    reading.rank_candidate_confidence = Some(confidence);
+    // TODO(balatro-rank-template-calibration): Do not promote this candidate
+    // into verified card content until a committed fixed-frame corpus proves
+    // rank accuracy across scaled and perspective captures.
+    source = format!("{source}+deck_template_rank_candidate");
   }
   Ok(CardReadResult {
     slot: card.slot,
@@ -3217,6 +4321,63 @@ fn find_button<'a>(state: &'a BalatroState, id: &str) -> Result<&'a ButtonTarget
   select_button_for_slot(&state.buttons, id, None)
 }
 
+fn resolve_card_commit_target(state: &BalatroState, kind: CardCommitKind) -> Result<(CardCommitControl, Point), CliError> {
+  if let Ok(button) = find_button(state, kind.button_id()) {
+    let button = button.clone();
+    let point = bbox_center_point(button.bbox);
+    return Ok((CardCommitControl::DetectedButton { button }, point));
+  }
+
+  if state.phase != BalatroPhase::Playing || state.hand.is_empty() {
+    return Err(CliError::Message(format!("could not find {} without an observed playing hand", kind.button_id())));
+  }
+  let sort_rank = best_button(&state.buttons, "button_sort_hand_rank")
+    .ok_or_else(|| CliError::Message(format!("could not find {} or button_sort_hand_rank", kind.button_id())))?
+    .clone();
+  let sort_suits = best_button(&state.buttons, "button_sort_hand_suits")
+    .ok_or_else(|| CliError::Message(format!("could not find {} or button_sort_hand_suits", kind.button_id())))?
+    .clone();
+  let rank_center = bbox_center_point(sort_rank.bbox);
+  let suits_center = bbox_center_point(sort_suits.bbox);
+  let frame_width = f64::from(state.frame.image_size.width.max(1));
+  let frame_height = f64::from(state.frame.image_size.height.max(1));
+  if sort_rank.bbox.x1 >= sort_suits.bbox.x1
+    || (rank_center.y - suits_center.y).abs() > frame_height * 0.04
+    || rank_center.y < frame_height * 0.65
+  {
+    return Err(CliError::Message(format!(
+      "refusing {} layout fallback because Sort Hand controls are not a plausible lower-screen pair",
+      kind.button_id()
+    )));
+  }
+
+  let group_left = f64::from(sort_rank.bbox.x1);
+  let group_right = f64::from(sort_suits.bbox.x2);
+  let group_width = group_right - group_left;
+  if group_width <= frame_width * 0.03 || group_width >= frame_width * 0.20 {
+    return Err(CliError::Message(format!("refusing {} layout fallback because Sort Hand control width is implausible", kind.button_id())));
+  }
+  // NOTICE: Balatro places Play Hand and Discard immediately beside the
+  // two-button Sort Hand group. The 0.75 group-width offset is derived from a
+  // live 2560x1440 Linux capture (Sort Hand x=1112..1283, Play center x≈984,
+  // Discard center x≈1411). Keep the detected Sort Hand pair as the safety
+  // anchor; remove this fallback once the UI model reliably emits both active
+  // commit controls across live themes and scales.
+  let x = match kind {
+    CardCommitKind::Play => group_left - group_width * 0.75,
+    CardCommitKind::Discard => group_right + group_width * 0.75,
+  }
+  .clamp(0.0, frame_width - 1.0);
+  let y = ((rank_center.y + suits_center.y) / 2.0).clamp(0.0, frame_height - 1.0);
+  Ok((
+    CardCommitControl::PlayingHandLayout {
+      sort_rank,
+      sort_suits,
+    },
+    Point::new(x, y),
+  ))
+}
+
 fn select_store_buy_confirm_button(state: &BalatroState) -> Result<&ButtonTarget, CliError> {
   best_button(&state.buttons, "button_purchase")
     .or_else(|| best_button(&state.buttons, "button_use"))
@@ -3231,7 +4392,9 @@ fn best_button<'a>(buttons: &'a [ButtonTarget], id: &str) -> Option<&'a ButtonTa
 }
 
 fn restart_primary_button(buttons: &[ButtonTarget]) -> Option<&ButtonTarget> {
-  best_button(buttons, "button_new_run_play").or_else(|| best_button(buttons, "button_main_menu_play"))
+  best_button(buttons, "button_new_run")
+    .or_else(|| best_button(buttons, "button_new_run_play"))
+    .or_else(|| best_button(buttons, "button_main_menu_play"))
 }
 
 fn resolve_store_next_round_target(state: &BalatroState) -> Result<StoreNextRoundTarget, CliError> {
@@ -3440,7 +4603,7 @@ fn enrich_ui_numeric_readings_from_image(state: &mut BalatroState, image: &Path)
     .iter()
     .filter_map(|evidence| {
       let label = evidence.detection.label.as_str();
-      if state.phase != BalatroPhase::Playing && is_score_ui_label(label) {
+      if !matches!(state.phase, BalatroPhase::Playing | BalatroPhase::CashOut) && is_score_ui_label(label) {
         return None;
       }
       is_numeric_ui_label(label)
@@ -3528,19 +4691,22 @@ fn infer_ui_digit_text_from_image_with_foreground(image: &RgbaImage, foreground:
   let mut digits = String::new();
   for points in ui_digit_glyph_segments(image, foreground)? {
     let mask = normalized_ui_digit_mask_from_points(points)?;
-    if let Some(digit) = infer_ui_digit_from_mask(&mask) {
-      digits.push(char::from(b'0' + digit));
-    }
+    let digit = infer_ui_digit_from_mask(&mask)?;
+    digits.push(char::from(b'0' + digit));
   }
   (!digits.is_empty()).then_some(digits)
 }
 
 fn infer_ui_digit_from_mask(mask: &[bool; UI_DIGIT_MASK_CELLS]) -> Option<u8> {
-  UI_DIGIT_TEMPLATES
-    .iter()
-    .map(|template| (template.digit, ui_digit_mask_distance(&mask, template.rows)))
-    .min_by(|left, right| left.1.partial_cmp(&right.1).unwrap_or(std::cmp::Ordering::Equal))
-    .and_then(|(digit, distance)| (distance <= 0.32).then_some(digit))
+  let mut candidates =
+    UI_DIGIT_TEMPLATES.iter().map(|template| (template.digit, ui_digit_mask_distance(mask, template.rows))).collect::<Vec<_>>();
+  candidates.sort_by(|left, right| left.1.partial_cmp(&right.1).unwrap_or(std::cmp::Ordering::Equal));
+  let (digit, distance) = *candidates.first()?;
+  let runner_up = candidates.get(1).map(|candidate| candidate.1).unwrap_or(1.0);
+  // A wrong number is more harmful than an unread score. Require both an
+  // absolute template fit and separation from the next-best digit; live
+  // evidence showed Balatro's scaled `5` otherwise being reported as `3`.
+  (distance <= 0.32 && runner_up - distance >= 0.04).then_some(digit)
 }
 
 fn normalized_ui_digit_mask_from_points(foreground: Vec<(u32, u32)>) -> Option<[bool; UI_DIGIT_MASK_CELLS]> {
@@ -3701,7 +4867,7 @@ const UI_DIGIT_TEMPLATES: &[UiDigitTemplate] = &[
   UiDigitTemplate {
     digit: 5,
     rows: [
-      "#####", "#....", "#....", "#####", "....#", "....#", "#####",
+      "#####", "#####", "####.", "#####", "...##", "#####", "#####",
     ],
   },
   UiDigitTemplate {
@@ -3778,7 +4944,7 @@ fn hand_card_interactions(state: &BalatroState) -> Vec<HandCardInteraction> {
     .iter()
     .map(|card| HandCardInteraction {
       slot: card.slot,
-      bbox: card.bbox.clone(),
+      bbox: card.bbox,
       confidence: card.confidence,
       selected: hand_slot_is_selected(state, card.slot.index),
       click_frame_point: hand_card_click_frame_point(state, card),
@@ -3812,12 +4978,6 @@ fn requested_slots_to_select(state: &BalatroState, requested: &[u32]) -> Vec<u32
 }
 
 fn hand_slot_is_selected(state: &BalatroState, slot_index: u32) -> bool {
-  if best_button(&state.buttons, "button_play").is_none()
-    && best_button(&state.buttons, "button_discard").is_none()
-    && best_button(&state.buttons, "button_use").is_none()
-  {
-    return false;
-  }
   let Some(baseline_y) = hand_selection_baseline_y(state) else {
     return false;
   };
@@ -3828,7 +4988,7 @@ fn hand_slot_is_selected(state: &BalatroState, slot_index: u32) -> bool {
   // discard button is pressed. Use the current hand's lower row as the baseline
   // so stale selections from an earlier failed command are visible and can be
   // cleared before a new play/discard operation.
-  card.bbox.y1 <= baseline_y - 18.0
+  card.bbox.y1 <= baseline_y - 24.0
 }
 
 fn hand_selection_baseline_y(state: &BalatroState) -> Option<f32> {
@@ -4061,12 +5221,17 @@ fn card_corner_capture(capture: &Capture, state: &BalatroState, card: &CardSlot)
 #[cfg(target_os = "macos")]
 fn infer_suit_from_card_corner(capture: &Capture, state: &BalatroState, card: &CardSlot) -> Option<&'static str> {
   let (x, y, width, height) = card_corner_pixels(capture, state, card);
+  let suit_x_end = x + ((width as f32 * 0.58).ceil() as u32).max(1);
+  let suit_y_start = y + (height as f32 * 0.28).floor() as u32;
   let mut hearts = 0u32;
   let mut diamonds = 0u32;
   let mut clubs = 0u32;
   let mut spades = 0u32;
-  for py in y..(y + height) {
-    for px in x..(x + width) {
+  // The full corner of face cards includes colored portrait pixels. Restrict
+  // classification to the narrow glyph band directly below the rank so a
+  // queen's artwork cannot outvote its heart/diamond suit symbol.
+  for py in suit_y_start..(y + height) {
+    for px in x..suit_x_end {
       let [r, g, b, a] = capture.image.get_pixel(px, py).0;
       let r16 = i16::from(r);
       let g16 = i16::from(g);
@@ -4142,9 +5307,9 @@ fn load_deck_rank_templates() -> Option<Vec<RankTemplate>> {
       let x = rank_index as u32 * cell_w;
       let y = suit_index as u32 * cell_h;
       let width = (cell_w as f32 * 0.26).ceil() as u32;
-      let height = (cell_h as f32 * 0.35).ceil() as u32;
+      let height = (cell_h as f32 * 0.36).ceil() as u32;
       let crop = image::imageops::crop_imm(&atlas, x, y, width, height).to_image();
-      if let Some(mask) = normalized_foreground_mask(&crop) {
+      if let Some(mask) = top_glyph_mask(&crop) {
         templates.push(RankTemplate { rank, suit, mask });
       }
     }
@@ -4173,48 +5338,52 @@ fn load_deck_atlas_from_setup_cache(cache_dir: &Path) -> Option<RgbaImage> {
 }
 
 #[cfg(target_os = "macos")]
-fn infer_rank_from_deck_template(corner: &RgbaImage, templates: Option<&[RankTemplate]>, suit: Option<&str>) -> Option<(String, f32)> {
-  let width = (corner.width() as f32 * 0.45).ceil() as u32;
-  let height = (corner.height() as f32 * 0.56).ceil() as u32;
-  let observed_region = image::imageops::crop_imm(corner, 0, 0, width.max(1), height.max(1)).to_image();
-  let observed = normalized_observed_rank_mask(&observed_region)?;
+fn best_rank_candidate_from_deck_template(
+  corner: &RgbaImage,
+  templates: Option<&[RankTemplate]>,
+  suit: Option<&str>,
+) -> Option<(String, f32)> {
+  let x = (corner.width() as f32 * 0.12).floor() as u32;
+  let y = (corner.height() as f32 * 0.12).floor() as u32;
+  let width = (corner.width() as f32 * 0.48).ceil() as u32;
+  let height = (corner.height() as f32 * 0.50).ceil() as u32;
+  let observed_region =
+    image::imageops::crop_imm(corner, x, y, width.min(corner.width() - x).max(1), height.min(corner.height() - y).max(1)).to_image();
+  let observed = top_glyph_mask(&observed_region)?;
   templates?
     .iter()
     .filter(|template| suit.is_none_or(|suit| template.suit == suit))
     .map(|template| {
-      let distance = mask_distance(&observed, &template.mask);
-      (template.rank, 1.0 - distance)
+      let similarity = mask_similarity(&observed, &template.mask);
+      (template.rank, similarity)
     })
     .max_by(|left, right| left.1.partial_cmp(&right.1).unwrap_or(std::cmp::Ordering::Equal))
-    .and_then(|(rank, confidence)| (confidence >= 0.75).then(|| (rank.to_string(), confidence.clamp(0.0, 1.0))))
+    .map(|(rank, confidence)| (rank.to_string(), confidence.clamp(0.0, 1.0)))
 }
 
 #[cfg(target_os = "macos")]
-fn normalized_observed_rank_mask(image: &RgbaImage) -> Option<NormalizedMask> {
-  let mut min_x = image.width();
-  let mut min_y = image.height();
-  let mut max_x = 0;
-  let mut max_y = 0;
-  for y in 0..image.height() {
-    for x in 0..image.width() {
-      if is_card_glyph_pixel(image.get_pixel(x, y).0) {
-        min_x = min_x.min(x);
-        min_y = min_y.min(y);
-        max_x = max_x.max(x);
-        max_y = max_y.max(y);
+fn top_glyph_mask(image: &RgbaImage) -> Option<NormalizedMask> {
+  let active_rows = (0..image.height())
+    .map(|y| (0..image.width()).filter(|x| is_card_glyph_pixel(image.get_pixel(*x, y).0)).count() >= 2)
+    .collect::<Vec<_>>();
+  let start = active_rows.iter().position(|active| *active)? as u32;
+  let mut end = image.height();
+  let mut blank_run = 0u32;
+  for y in start..image.height() {
+    if active_rows[y as usize] {
+      blank_run = 0;
+    } else {
+      blank_run += 1;
+      if blank_run >= 3 {
+        end = y + 1 - blank_run;
+        break;
       }
     }
   }
-  if min_x > max_x || min_y > max_y {
+  if end <= start {
     return None;
   }
-
-  // The card-corner crop contains rank above suit. OCR benefits from seeing
-  // both, but template matching must isolate the rank glyph or a `9♥` can look
-  // closer to another rank plus suit blob than to the rank alone.
-  let bbox_h = max_y - min_y + 1;
-  let rank_h = ((bbox_h as f32 * 0.45).ceil() as u32).max(1);
-  let crop = image::imageops::crop_imm(image, min_x, min_y, max_x - min_x + 1, rank_h).to_image();
+  let crop = image::imageops::crop_imm(image, 0, start, image.width(), end - start).to_image();
   normalized_foreground_mask(&crop)
 }
 
@@ -4265,9 +5434,13 @@ fn is_card_glyph_pixel([r, g, b, a]: [u8; 4]) -> bool {
 }
 
 #[cfg(target_os = "macos")]
-fn mask_distance(left: &NormalizedMask, right: &NormalizedMask) -> f32 {
-  let different = left.pixels.iter().zip(&right.pixels).filter(|(left, right)| left != right).count();
-  different as f32 / left.pixels.len().max(1) as f32
+fn mask_similarity(left: &NormalizedMask, right: &NormalizedMask) -> f32 {
+  let intersection = left.pixels.iter().zip(&right.pixels).filter(|(left, right)| **left && **right).count();
+  let foreground = left.pixels.iter().filter(|pixel| **pixel).count() + right.pixels.iter().filter(|pixel| **pixel).count();
+  if foreground == 0 {
+    return 0.0;
+  }
+  2.0 * intersection as f32 / foreground as f32
 }
 
 fn parse_card_reading(raw_text: &str, suit: Option<&str>, confidence: Option<f32>) -> CardReadValue {
@@ -4293,31 +5466,14 @@ fn parse_card_reading(raw_text: &str, suit: Option<&str>, confidence: Option<f32
     raw_text: (!raw_text.trim().is_empty()).then(|| raw_text.to_string()),
     normalized_text: (!normalized.is_empty()).then_some(normalized),
     rank,
+    rank_candidate: None,
+    rank_candidate_confidence: None,
     suit,
     suit_symbol,
     short_code,
     confidence,
     valid,
   }
-}
-
-fn apply_inferred_rank(reading: &mut CardReadValue, rank: String, confidence: f32) {
-  reading.rank = Some(rank);
-  reading.confidence = Some(reading.confidence.unwrap_or(confidence).max(confidence));
-  reading.short_code = reading.rank.as_ref().zip(reading.suit.as_deref()).map(|(rank, suit)| {
-    format!(
-      "{rank}{}",
-      match suit {
-        "hearts" => "H",
-        "diamonds" => "D",
-        "clubs" => "C",
-        "spades" => "S",
-        _ => "?",
-      }
-    )
-  });
-  reading.valid = reading.rank.is_some() && reading.suit.is_some();
-  reading.status = if reading.valid { "read" } else { "partial" };
 }
 
 fn should_hover_reread_card(reading: &CardReadValue) -> bool {

--- a/supported/games/auv-game-balatro/src/cli_test.rs
+++ b/supported/games/auv-game-balatro/src/cli_test.rs
@@ -1,6 +1,204 @@
 use super::*;
 
 #[test]
+fn remote_hover_text_promotes_an_object_read_and_records_evidence() {
+  // ROOT CAUSE:
+  //
+  // If a Balatro command ran inside a routed non-macOS Device context,
+  // object reads stopped after detection and always returned `unread` because
+  // only the local macOS branch performed hover OCR.
+  //
+  // The fix promotes non-empty routed OCR text while preserving the hover
+  // frame and region that explain where the reading came from.
+  let mut read = ObjectReadResult {
+    slot: SlotId::new(ObjectZone::Joker, 0),
+    kind: "joker".to_string(),
+    bbox: BoundingBox {
+      x1: 10.0,
+      y1: 20.0,
+      x2: 30.0,
+      y2: 60.0,
+    },
+    confidence: 0.9,
+    reading: ObjectReadValue::unread(),
+    evidence: ObjectReadEvidence {
+      frame: "daemon://display/primary".to_string(),
+      source: "observation_without_hover_ocr".to_string(),
+      hover_required: true,
+      hover_frame: None,
+      hover_ocr_region: None,
+      hover_error: None,
+    },
+  };
+
+  apply_hover_read_observation(
+    &mut read,
+    auv_driver::TextRecognition {
+      text: "Telegram\nBlueprint\nCopies Joker to the right".to_string(),
+      regions: vec![
+        auv_driver::RecognizedText {
+          text: "Telegram".to_string(),
+          bounds: Rect::new(900.0, 900.0, 100.0, 20.0),
+          confidence: Some(0.99),
+        },
+        auv_driver::RecognizedText {
+          text: "Blueprint".to_string(),
+          bounds: Rect::new(15.0, 18.0, 80.0, 15.0),
+          confidence: Some(0.92),
+        },
+        auv_driver::RecognizedText {
+          text: "Copies Joker to the right".to_string(),
+          bounds: Rect::new(15.0, 36.0, 160.0, 15.0),
+          confidence: Some(0.88),
+        },
+      ],
+    },
+    "daemon://hover/0".to_string(),
+  );
+
+  assert_eq!(read.reading.status, "read");
+  assert_eq!(read.reading.raw_text.as_deref(), Some("Blueprint\nCopies Joker to the right"));
+  assert!(!read.evidence.hover_required);
+  assert_eq!(read.evidence.source, "remote_hover_ocr");
+  assert_eq!(read.evidence.hover_frame.as_deref(), Some("daemon://hover/0"));
+  assert_eq!(read.evidence.hover_ocr_region, Some(object_hover_ocr_region()));
+}
+
+#[test]
+fn card_commit_accepts_the_same_hand_detector_and_device_as_state_observation() {
+  // ROOT CAUSE:
+  //
+  // If a remote card action always constructed `BalatroModelConfig::default`,
+  // `game state --cards-model ... --device cuda:0` exposed eight slots while
+  // `cards play` silently switched back to the CPU entities detector and saw
+  // nine. The action must carry its observation policy explicitly.
+  let args = CliArgs::try_parse_from([
+    "auv-game-balatro",
+    "cards",
+    "play",
+    "--slots",
+    "hand:3,hand:4",
+    "--cards-model",
+    "/models/cards.onnx",
+    "--device",
+    "cuda:0",
+  ])
+  .expect("card action arguments");
+
+  let Command::Cards(CardsArgs {
+    command: CardsCommand::Play(args),
+  }) = args.command
+  else {
+    panic!("expected cards play command");
+  };
+  let config = BalatroModelConfig::from_operation_args(&args.control);
+  assert_eq!(config.cards_model, Some(crate::config::BalatroModelAsset::local("/models/cards.onnx")));
+  assert_eq!(config.device, InferenceDevice::Cuda(0));
+}
+
+#[test]
+fn raised_hand_card_is_selected_when_commit_buttons_are_missed() {
+  // ROOT CAUSE:
+  //
+  // If the UI detector missed Play Hand and Discard, selected-state inference
+  // returned false before inspecting card geometry. The remote action then
+  // clicked already-raised cards again instead of submitting the hand.
+  //
+  // The selected card remains 30 pixels above the lower-row baseline here;
+  // commit-button detection is intentionally absent.
+  let state = playing_hand_state(Vec::new(), vec![820.0, 850.0, 850.0]);
+
+  assert!(hand_slot_is_selected(&state, 0));
+  assert!(!hand_slot_is_selected(&state, 1));
+}
+
+#[test]
+fn shallow_detector_jitter_is_not_a_selected_card() {
+  // ROOT CAUSE:
+  //
+  // A 21-pixel detector shift on an unselected card crossed the old 18-pixel
+  // threshold. The command then treated a stale capture as selected and could
+  // report a no-op Play as successful.
+  let state = playing_hand_state(Vec::new(), vec![829.0, 850.0, 850.0]);
+
+  assert!(!hand_slot_is_selected(&state, 0));
+}
+
+#[test]
+fn card_commit_uses_sort_controls_as_playing_layout_evidence() {
+  // ROOT CAUSE:
+  //
+  // The live Linux UI model reliably detected both Sort Hand controls but
+  // omitted the active Play Hand and Discard controls. Requiring the latter
+  // left a correctly selected hand with no safe submission target.
+  let sort_rank = button("button_sort_hand_rank", 1112.0, 1175.0, 1193.0, 1238.0);
+  let sort_suits = button("button_sort_hand_suits", 1200.0, 1177.0, 1283.0, 1239.0);
+  let state = playing_hand_state(vec![sort_rank.clone(), sort_suits.clone()], vec![850.0; 8]);
+
+  let (control, point) = resolve_card_commit_target(&state, CardCommitKind::Play).expect("playing layout target");
+
+  assert_eq!(
+    control,
+    CardCommitControl::PlayingHandLayout {
+      sort_rank,
+      sort_suits,
+    }
+  );
+  assert!((point.x - 984.0).abs() < 3.0, "unexpected play x: {}", point.x);
+  assert!((point.y - 1207.5).abs() < 3.0, "unexpected play y: {}", point.y);
+}
+
+fn playing_hand_state(buttons: Vec<ButtonTarget>, y_positions: Vec<f32>) -> BalatroState {
+  BalatroState {
+    schema_version: crate::model::BALATRO_STATE_SCHEMA_VERSION.to_string(),
+    frame: crate::model::FrameRef {
+      source: "test://frame".to_string(),
+      image_size: auv_inference_common::ImageSize {
+        width: 2560,
+        height: 1440,
+      },
+    },
+    phase: BalatroPhase::Playing,
+    scores: Default::default(),
+    rounds: Default::default(),
+    hand: y_positions
+      .into_iter()
+      .enumerate()
+      .map(|(index, y1)| CardSlot {
+        slot: SlotId::new(ObjectZone::Hand, index as u32),
+        kind: "poker_card_front".to_string(),
+        bbox: BoundingBox {
+          x1: 650.0 + index as f32 * 125.0,
+          y1,
+          x2: 835.0 + index as f32 * 125.0,
+          y2: y1 + 240.0,
+        },
+        confidence: 0.95,
+        reading: crate::model::Reading::unread(),
+        attributes: Default::default(),
+        cache: Default::default(),
+      })
+      .collect(),
+    jokers: Vec::new(),
+    consumables: Vec::new(),
+    store: Default::default(),
+    buttons,
+    diagnostics: Vec::new(),
+    raw_entities: Vec::new(),
+    raw_ui: Vec::new(),
+  }
+}
+
+fn button(id: &str, x1: f32, y1: f32, x2: f32, y2: f32) -> ButtonTarget {
+  ButtonTarget {
+    id: id.to_string(),
+    label: id.trim_start_matches("button_").to_string(),
+    bbox: BoundingBox { x1, y1, x2, y2 },
+    confidence: 0.95,
+  }
+}
+
+#[test]
 fn ui_digit_reader_segments_multiple_glyphs() {
   let image = synthetic_ui_digit_image("300");
 
@@ -28,6 +226,32 @@ fn ui_digit_reader_matches_balatro_thick_one() {
   ]);
 
   assert_eq!(infer_ui_digit_from_mask(&mask), Some(1));
+}
+
+#[test]
+fn ui_digit_reader_keeps_scaled_five_distinct_from_three() {
+  // ROOT CAUSE:
+  //
+  // If nearest-neighbor scaling made the top, middle, and bottom strokes two
+  // sample rows thick, the thin five template was farther away than three.
+  // The template now represents the observed thick Balatro glyph.
+  let mask = mask_from_rows([
+    "#####", "#####", "####.", "#####", "...##", "#####", "#####",
+  ]);
+
+  assert_eq!(infer_ui_digit_from_mask(&mask), Some(5));
+}
+
+#[test]
+fn ambiguous_ui_digit_is_unread_instead_of_becoming_a_false_score() {
+  let three = mask_from_rows(UI_DIGIT_TEMPLATES.iter().find(|template| template.digit == 3).unwrap().rows);
+  let five = mask_from_rows(UI_DIGIT_TEMPLATES.iter().find(|template| template.digit == 5).unwrap().rows);
+  let mut ambiguous = three;
+  for index in (0..UI_DIGIT_MASK_CELLS).step_by(2) {
+    ambiguous[index] = five[index];
+  }
+
+  assert_eq!(infer_ui_digit_from_mask(&ambiguous), None);
 }
 
 #[test]

--- a/supported/games/auv-game-balatro/src/config.rs
+++ b/supported/games/auv-game-balatro/src/config.rs
@@ -10,6 +10,10 @@ const ENTITIES_DATASET_REPO: &str = "games-balatro-2024-entities-detection";
 const UI_MODEL_REPO: &str = "games-balatro-2024-yolo-ui-detection";
 const UI_DATASET_REPO: &str = "games-balatro-2024-ui-detection";
 const CARD_CORNER_MODEL_REPO: &str = "games-balatro-2024-card-corner-classifier";
+const CARD_IDENTITY_MODEL_REPO: &str = "games-balatro-2024-yolo-card-identity-detection-mod-ground-truth";
+const CARD_ENHANCEMENT_MODEL_REPO: &str = "games-balatro-2024-yolo-card-enhancement-detection-mod-ground-truth";
+const CARD_EDITION_MODEL_REPO: &str = "games-balatro-2024-yolo-card-edition-detection-mod-ground-truth";
+const CARD_SEAL_MODEL_REPO: &str = "games-balatro-2024-yolo-card-seal-detection-mod-ground-truth";
 const ONNX_MODEL_FILE: &str = "onnx/model.onnx";
 const CLASSES_FILE: &str = "data/train/yolo/classes.txt";
 
@@ -34,6 +38,11 @@ pub enum HuggingFaceRepoKind {
 pub struct BalatroModelConfig {
   pub entities_model: BalatroModelAsset,
   pub entities_classes: BalatroModelAsset,
+  pub cards_model: Option<BalatroModelAsset>,
+  pub card_identity_model: BalatroModelAsset,
+  pub card_enhancement_model: BalatroModelAsset,
+  pub card_edition_model: BalatroModelAsset,
+  pub card_seal_model: BalatroModelAsset,
   pub ui_model: BalatroModelAsset,
   pub ui_classes: BalatroModelAsset,
   pub card_corner_model: BalatroModelAsset,
@@ -44,6 +53,11 @@ pub struct BalatroModelConfig {
 pub struct ResolvedBalatroModelConfig {
   pub entities_model: PathBuf,
   pub entities_classes: PathBuf,
+  pub cards_model: Option<PathBuf>,
+  pub card_identity_model: PathBuf,
+  pub card_enhancement_model: PathBuf,
+  pub card_edition_model: PathBuf,
+  pub card_seal_model: PathBuf,
   pub ui_model: PathBuf,
   pub ui_classes: PathBuf,
   pub device: InferenceDevice,
@@ -70,10 +84,24 @@ impl BalatroModelConfig {
     Self {
       entities_model: args.entities_model.clone().map(BalatroModelAsset::Local).unwrap_or(defaults.entities_model),
       entities_classes: args.entities_classes.clone().map(BalatroModelAsset::Local).unwrap_or(defaults.entities_classes),
+      cards_model: args.cards_model.clone().map(BalatroModelAsset::Local).or(defaults.cards_model),
+      card_identity_model: args.card_identity_model.clone().map(BalatroModelAsset::Local).unwrap_or(defaults.card_identity_model),
+      card_enhancement_model: args.card_enhancement_model.clone().map(BalatroModelAsset::Local).unwrap_or(defaults.card_enhancement_model),
+      card_edition_model: args.card_edition_model.clone().map(BalatroModelAsset::Local).unwrap_or(defaults.card_edition_model),
+      card_seal_model: args.card_seal_model.clone().map(BalatroModelAsset::Local).unwrap_or(defaults.card_seal_model),
       ui_model: args.ui_model.clone().map(BalatroModelAsset::Local).unwrap_or(defaults.ui_model),
       ui_classes: args.ui_classes.clone().map(BalatroModelAsset::Local).unwrap_or(defaults.ui_classes),
       card_corner_model: args.card_corner_model.clone().map(BalatroModelAsset::Local).unwrap_or(defaults.card_corner_model),
       device: args.device.clone(),
+    }
+  }
+
+  pub fn from_operation_args(args: &crate::cli::OperationControlArgs) -> Self {
+    let defaults = Self::default();
+    Self {
+      cards_model: args.cards_model.clone().map(BalatroModelAsset::Local).or_else(|| defaults.cards_model.clone()),
+      device: args.device.clone(),
+      ..defaults
     }
   }
 
@@ -82,6 +110,11 @@ impl BalatroModelConfig {
     Ok(ResolvedBalatroModelConfig {
       entities_model: self.entities_model.resolve_with_client(&mut client)?,
       entities_classes: self.entities_classes.resolve_with_client(&mut client)?,
+      cards_model: self.cards_model.as_ref().map(|asset| asset.resolve_with_client(&mut client)).transpose()?,
+      card_identity_model: self.card_identity_model.resolve_with_client(&mut client)?,
+      card_enhancement_model: self.card_enhancement_model.resolve_with_client(&mut client)?,
+      card_edition_model: self.card_edition_model.resolve_with_client(&mut client)?,
+      card_seal_model: self.card_seal_model.resolve_with_client(&mut client)?,
       ui_model: self.ui_model.resolve_with_client(&mut client)?,
       ui_classes: self.ui_classes.resolve_with_client(&mut client)?,
       device: self.device.clone(),
@@ -150,6 +183,14 @@ impl Default for BalatroModelConfig {
     Self {
       entities_model: BalatroModelAsset::hugging_face_model(HF_OWNER, ENTITIES_MODEL_REPO, ONNX_MODEL_FILE),
       entities_classes: BalatroModelAsset::hugging_face_dataset(HF_OWNER, ENTITIES_DATASET_REPO, CLASSES_FILE),
+      // TODO(card-detector-publication): Keep the card-specialized model
+      // opt-in until its game-asset/derived-weight rights are reviewed and the
+      // private Hugging Face repository can become a usable default.
+      cards_model: None,
+      card_identity_model: BalatroModelAsset::hugging_face_model(HF_OWNER, CARD_IDENTITY_MODEL_REPO, ONNX_MODEL_FILE),
+      card_enhancement_model: BalatroModelAsset::hugging_face_model(HF_OWNER, CARD_ENHANCEMENT_MODEL_REPO, ONNX_MODEL_FILE),
+      card_edition_model: BalatroModelAsset::hugging_face_model(HF_OWNER, CARD_EDITION_MODEL_REPO, ONNX_MODEL_FILE),
+      card_seal_model: BalatroModelAsset::hugging_face_model(HF_OWNER, CARD_SEAL_MODEL_REPO, ONNX_MODEL_FILE),
       ui_model: BalatroModelAsset::hugging_face_model(HF_OWNER, UI_MODEL_REPO, ONNX_MODEL_FILE),
       ui_classes: BalatroModelAsset::hugging_face_dataset(HF_OWNER, UI_DATASET_REPO, CLASSES_FILE),
       card_corner_model: BalatroModelAsset::hugging_face_model(HF_OWNER, CARD_CORNER_MODEL_REPO, ONNX_MODEL_FILE),

--- a/supported/games/auv-game-balatro/src/detector.rs
+++ b/supported/games/auv-game-balatro/src/detector.rs
@@ -1,20 +1,52 @@
 use std::path::Path;
 
-use auv_inference_common::{InferenceResult, ModelId};
-use auv_task_object_detection::{DetectionOptions, DetectionResult, UltralyticsObjectDetector, UltralyticsObjectDetectorConfig};
+use auv_inference_common::{ImageFrame, ImageSize, InferenceResult, ModelId};
+use auv_task_object_detection::{Detection, DetectionOptions, DetectionResult, UltralyticsObjectDetector, UltralyticsObjectDetectorConfig};
+use image::RgbImage;
 
 use crate::config::{BalatroModelConfig, load_class_names};
 
 #[derive(Debug)]
 pub struct BalatroDetectors {
   entities: UltralyticsObjectDetector,
+  cards: Option<UltralyticsObjectDetector>,
+  card_identity: UltralyticsObjectDetector,
+  card_enhancement: UltralyticsObjectDetector,
+  card_edition: UltralyticsObjectDetector,
+  card_seal: UltralyticsObjectDetector,
   ui: UltralyticsObjectDetector,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct CardAttributeDetectionSets {
+  pub identity: Option<DetectionResult>,
+  pub enhancement: Option<DetectionResult>,
+  pub edition: Option<DetectionResult>,
+  pub seal: Option<DetectionResult>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct BalatroDetectionSets {
   pub entities: DetectionResult,
+  pub cards: Option<DetectionResult>,
+  pub card_attributes: CardAttributeDetectionSets,
   pub ui: DetectionResult,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct HandCrop {
+  pub x: u32,
+  pub y: u32,
+  pub width: u32,
+  pub height: u32,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct GameViewport {
+  x: u32,
+  y: u32,
+  width: u32,
+  height: u32,
 }
 
 impl BalatroDetectors {
@@ -30,6 +62,33 @@ impl BalatroDetectors {
       device: config.device.clone(),
       class_names_override: Some(load_class_names(&config.entities_classes)?),
     })?;
+    let cards = config
+      .cards_model
+      .map(|model_path| {
+        UltralyticsObjectDetector::load(UltralyticsObjectDetectorConfig {
+          model_id: ModelId("balatro-cards".to_owned()),
+          model_path,
+          input_size: Some(640),
+          options: balatro_detection_options(),
+          device: config.device.clone(),
+          class_names_override: Some(load_class_names(&config.entities_classes)?),
+        })
+      })
+      .transpose()?;
+    let load_attribute = |model_id: &str, model_path, input_size| {
+      UltralyticsObjectDetector::load(UltralyticsObjectDetectorConfig {
+        model_id: ModelId(model_id.to_owned()),
+        model_path,
+        input_size: Some(input_size),
+        options: balatro_detection_options(),
+        device: config.device.clone(),
+        class_names_override: None,
+      })
+    };
+    let card_identity = load_attribute("balatro-card-identity", config.card_identity_model, 960)?;
+    let card_enhancement = load_attribute("balatro-card-enhancement", config.card_enhancement_model, 640)?;
+    let card_edition = load_attribute("balatro-card-edition", config.card_edition_model, 640)?;
+    let card_seal = load_attribute("balatro-card-seal", config.card_seal_model, 640)?;
     let ui = UltralyticsObjectDetector::load(UltralyticsObjectDetectorConfig {
       model_id: ModelId("balatro-ui".to_owned()),
       model_path: config.ui_model,
@@ -39,15 +98,263 @@ impl BalatroDetectors {
       class_names_override: Some(load_class_names(&config.ui_classes)?),
     })?;
 
-    Ok(Self { entities, ui })
+    Ok(Self {
+      entities,
+      cards,
+      card_identity,
+      card_enhancement,
+      card_edition,
+      card_seal,
+      ui,
+    })
   }
 
   pub fn detect_path(&self, image: impl AsRef<Path>) -> InferenceResult<BalatroDetectionSets> {
     let image = image.as_ref();
     let entities = self.entities.detect_path(image)?;
+    let cards = self.cards.as_ref().map(|detector| detect_hand_cards(detector, &image::open(image)?.to_rgb8())).transpose()?;
+    let card_attributes = CardAttributeDetectionSets {
+      identity: Some(self.card_identity.detect_path(image)?),
+      enhancement: Some(self.card_enhancement.detect_path(image)?),
+      edition: Some(self.card_edition.detect_path(image)?),
+      seal: Some(self.card_seal.detect_path(image)?),
+    };
     let ui = self.ui.detect_path(image)?;
-    Ok(BalatroDetectionSets { entities, ui })
+    Ok(BalatroDetectionSets {
+      entities,
+      cards,
+      card_attributes,
+      ui,
+    })
   }
+}
+
+#[cfg(test)]
+fn hand_crop(image_size: ImageSize) -> HandCrop {
+  hand_crop_in_viewport(GameViewport {
+    x: 0,
+    y: 0,
+    width: image_size.width.max(1),
+    height: image_size.height.max(1),
+  })
+}
+
+fn hand_crop_in_viewport(viewport: GameViewport) -> HandCrop {
+  let width = viewport.width.max(1);
+  let height = viewport.height.max(1);
+  // NOTICE: These normalized bounds come from the 2043x1126 live Balatro
+  // layout used by the Mod corpus. They exclude the confirmed left score-panel
+  // and right deck-stack false positives while retaining highlighted hand
+  // cards. Replace them when observation owns a typed, dynamically resolved
+  // hand-region contract across UI scales.
+  let x = ((width as f32) * 0.265).floor() as u32;
+  let y = ((height as f32) * 0.52).floor() as u32;
+  let right = ((width as f32) * 0.815).floor() as u32;
+  let bottom = ((height as f32) * 0.84).floor() as u32;
+  HandCrop {
+    x: viewport.x + x,
+    y: viewport.y + y,
+    width: right.saturating_sub(x).max(1),
+    height: bottom.saturating_sub(y).max(1),
+  }
+}
+
+pub(crate) fn crop_hand_frame(image: &RgbImage) -> (HandCrop, ImageFrame) {
+  let crop = hand_crop_in_viewport(resolve_game_viewport(image));
+  let image = image::imageops::crop_imm(image, crop.x, crop.y, crop.width, crop.height).to_image();
+  (crop, ImageFrame::new(image))
+}
+
+fn resolve_game_viewport(image: &RgbImage) -> GameViewport {
+  let full = GameViewport {
+    x: 0,
+    y: 0,
+    width: image.width().max(1),
+    height: image.height().max(1),
+  };
+  if image.width() < 32 || image.height() < 32 {
+    return full;
+  }
+
+  // NOTICE: The Mod corpus viewport is 2043x1126. A small tolerance accepts
+  // ordinary capture rounding while distinguishing a 16:9 full-display
+  // fallback from the game client area.
+  let target_aspect = 2043.0 / 1126.0;
+  let full_aspect = image.width() as f32 / image.height() as f32;
+  if (full_aspect - target_aspect).abs() <= 0.015 {
+    return full;
+  }
+
+  if let Some(viewport) = resolve_floating_game_viewport(image, target_aspect) {
+    return viewport;
+  }
+
+  // Linux currently falls back to a primary-display capture when the window
+  // API is unavailable. In that observed layout the game viewport is clipped
+  // against the display's right and bottom edges. Scan possible top edges,
+  // derive the matching left edge from the corpus aspect ratio, then require
+  // both edges to survive grayscale thresholding. Requiring both long edges
+  // prevents a stronger internal score-panel divider from winning.
+  // TODO(balatro-floating-viewport): detect all four edges once Linux exposes
+  // movable-window fixtures; this slice fixes the reproduced right/bottom-
+  // clipped display fallback without claiming arbitrary desktop layouts.
+  let maximum_top = image.height() * 2 / 5;
+  let mut best = None;
+  for y in 2..=maximum_top {
+    let height = image.height() - y;
+    let width = ((height as f32) * target_aspect).round() as u32;
+    if width >= image.width() || width < image.width() * 3 / 5 {
+      continue;
+    }
+    let x = image.width() - width;
+    if x < 2 || x > image.width() * 2 / 5 {
+      continue;
+    }
+    let horizontal = horizontal_edge_evidence(image, x, y);
+    let vertical = vertical_edge_evidence(image, x, y);
+    let score = horizontal.min(vertical);
+    if best.is_none_or(|(_, best_score)| score > best_score) {
+      best = Some((
+        GameViewport {
+          x,
+          y,
+          width,
+          height,
+        },
+        score,
+      ));
+    }
+  }
+
+  best.filter(|(_, score)| *score >= 0.22).map(|(viewport, _)| viewport).unwrap_or(full)
+}
+
+fn resolve_floating_game_viewport(image: &RgbImage, target_aspect: f32) -> Option<GameViewport> {
+  let horizontal = strongest_edges((2..image.height().saturating_sub(2)).map(|y| (y, horizontal_edge_evidence(image, 0, y))), 24);
+  let vertical = strongest_edges((2..image.width().saturating_sub(2)).map(|x| (x, vertical_edge_evidence(image, x, 0))), 24);
+  let mut best = None;
+  for &(left, left_score) in &vertical {
+    for &(right, right_score) in &vertical {
+      if right <= left {
+        continue;
+      }
+      let width = right - left + 1;
+      if width < image.width() * 3 / 5 {
+        continue;
+      }
+      for &(top, top_score) in &horizontal {
+        for &(bottom, bottom_score) in &horizontal {
+          if bottom <= top {
+            continue;
+          }
+          let height = bottom - top + 1;
+          if height < image.height() * 3 / 5 {
+            continue;
+          }
+          let aspect_error = (width as f32 / height as f32 - target_aspect).abs();
+          if aspect_error > 0.05 {
+            continue;
+          }
+          let edge_score = left_score.min(right_score).min(top_score).min(bottom_score);
+          let score = edge_score - aspect_error * 2.0;
+          if best.is_none_or(|(_, best_score)| score > best_score) {
+            best = Some((
+              GameViewport {
+                x: left,
+                y: top,
+                width,
+                height,
+              },
+              score,
+            ));
+          }
+        }
+      }
+    }
+  }
+  best.filter(|(_, score)| *score >= 0.08).map(|(viewport, _)| viewport)
+}
+
+fn strongest_edges(edges: impl Iterator<Item = (u32, f32)>, limit: usize) -> Vec<(u32, f32)> {
+  let mut edges = edges.filter(|(_, score)| *score >= 0.08).collect::<Vec<_>>();
+  edges.sort_by(|left, right| right.1.total_cmp(&left.1));
+  let mut selected: Vec<(u32, f32)> = Vec::new();
+  for edge in edges {
+    if selected.iter().any(|(position, _)| position.abs_diff(edge.0) <= 3) {
+      continue;
+    }
+    selected.push(edge);
+    if selected.len() == limit {
+      break;
+    }
+  }
+  selected
+}
+
+fn horizontal_edge_evidence(image: &RgbImage, x: u32, y: u32) -> f32 {
+  edge_evidence((x..image.width()).step_by(4).map(|sample_x| {
+    let before = grayscale(image.get_pixel(sample_x, y - 2));
+    let after = grayscale(image.get_pixel(sample_x, (y + 2).min(image.height() - 1)));
+    before.abs_diff(after)
+  }))
+}
+
+fn vertical_edge_evidence(image: &RgbImage, x: u32, y: u32) -> f32 {
+  edge_evidence((y..image.height()).step_by(4).map(|sample_y| {
+    let before = grayscale(image.get_pixel(x - 2, sample_y));
+    let after = grayscale(image.get_pixel((x + 2).min(image.width() - 1), sample_y));
+    before.abs_diff(after)
+  }))
+}
+
+fn edge_evidence(samples: impl Iterator<Item = u8>) -> f32 {
+  let mut count = 0_u32;
+  let mut polarized = 0_u32;
+  let mut strength = 0_u32;
+  for contrast in samples {
+    count += 1;
+    polarized += u32::from(contrast >= 16);
+    strength += u32::from(contrast.min(64));
+  }
+  if count == 0 {
+    return 0.0;
+  }
+  let support = polarized as f32 / count as f32;
+  let normalized_strength = strength as f32 / (count * 64) as f32;
+  support * 0.7 + normalized_strength * 0.3
+}
+
+fn grayscale(pixel: &image::Rgb<u8>) -> u8 {
+  ((u16::from(pixel[0]) * 77 + u16::from(pixel[1]) * 150 + u16::from(pixel[2]) * 29) >> 8) as u8
+}
+
+pub(crate) fn remap_hand_detections(mut result: DetectionResult, crop: HandCrop, image_size: ImageSize) -> DetectionResult {
+  result
+    .detections
+    .retain(|detection| matches!(detection.label.as_str(), "poker_card_front" | "poker_card_back") && is_complete_hand_card(detection));
+  for detection in &mut result.detections {
+    detection.bbox.x1 += crop.x as f32;
+    detection.bbox.x2 += crop.x as f32;
+    detection.bbox.y1 += crop.y as f32;
+    detection.bbox.y2 += crop.y as f32;
+  }
+  result.image_size = image_size;
+  result
+}
+
+fn is_complete_hand_card(detection: &Detection) -> bool {
+  let width = detection.bbox.x2 - detection.bbox.x1;
+  let height = detection.bbox.y2 - detection.bbox.y1;
+  width.is_finite() && height.is_finite() && height > 0.0 && width / height >= 0.30
+}
+
+fn detect_hand_cards(detector: &UltralyticsObjectDetector, image: &RgbImage) -> InferenceResult<DetectionResult> {
+  let image_size = ImageSize {
+    width: image.width(),
+    height: image.height(),
+  };
+  let (crop, frame) = crop_hand_frame(image);
+  detector.detect_frame(&frame).map(|result| remap_hand_detections(result, crop, image_size))
 }
 
 fn balatro_detection_options() -> DetectionOptions {
@@ -55,5 +362,181 @@ fn balatro_detection_options() -> DetectionOptions {
     confidence_threshold: 0.25,
     iou_threshold: 0.45,
     max_detections: 300,
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use auv_task_object_detection::{BoundingBox, Detection};
+
+  use super::*;
+
+  #[test]
+  fn hand_crop_excludes_score_panel_and_deck_stack() {
+    let crop = hand_crop(ImageSize {
+      width: 2043,
+      height: 1126,
+    });
+
+    assert_eq!(
+      crop,
+      HandCrop {
+        x: 541,
+        y: 585,
+        width: 1124,
+        height: 360
+      }
+    );
+  }
+
+  #[test]
+  fn hand_crop_is_relative_to_an_offset_game_viewport() {
+    // ROOT CAUSE:
+    //
+    // If Linux window capture fell back to the full display, the normalized
+    // hand crop was applied to the desktop instead of the Balatro viewport.
+    // Before the fix, an offset viewport included the score panel and produced
+    // extra card slots. The fix resolves the viewport before deriving the hand.
+    let mut image = RgbImage::from_pixel(256, 144, image::Rgb([18, 18, 18]));
+    for y in 31..144 {
+      for x in 51..256 {
+        let shade = 86 + ((x + y) % 19) as u8;
+        image.put_pixel(x, y, image::Rgb([shade, shade, shade]));
+      }
+    }
+    // A stronger internal panel boundary must not replace the outer viewport.
+    for y in 31..144 {
+      image.put_pixel(61, y, image::Rgb([230, 230, 230]));
+    }
+
+    let (crop, _) = crop_hand_frame(&image);
+
+    assert_eq!(
+      crop,
+      HandCrop {
+        x: 105,
+        y: 89,
+        width: 113,
+        height: 36,
+      }
+    );
+  }
+
+  #[test]
+  fn hand_crop_is_relative_to_a_floating_game_viewport() {
+    // ROOT CAUSE:
+    //
+    // If the Linux window API was unavailable and Balatro did not touch the
+    // display's right/bottom edges, viewport detection assumed a clipped
+    // window and fell back to the whole display. The specialized hand crop
+    // then clipped the first card and included the deck stack as extra slots.
+    let mut image = RgbImage::from_pixel(256, 144, image::Rgb([18, 18, 18]));
+    for y in 15..127 {
+      for x in 7..211 {
+        let shade = 82 + ((x + y) % 23) as u8;
+        image.put_pixel(x, y, image::Rgb([shade, shade, shade]));
+      }
+    }
+    for x in 7..211 {
+      image.put_pixel(x, 15, image::Rgb([235, 235, 235]));
+      image.put_pixel(x, 126, image::Rgb([235, 235, 235]));
+    }
+    for y in 15..127 {
+      image.put_pixel(7, y, image::Rgb([235, 235, 235]));
+      image.put_pixel(210, y, image::Rgb([235, 235, 235]));
+      image.put_pixel(18, y, image::Rgb([245, 245, 245]));
+    }
+
+    let (crop, _) = crop_hand_frame(&image);
+
+    assert_eq!(
+      crop,
+      HandCrop {
+        x: 59,
+        y: 71,
+        width: 112,
+        height: 36,
+      }
+    );
+  }
+
+  #[test]
+  fn remap_hand_detections_restores_coordinates_and_filters_non_cards_and_clipped_edges() {
+    // ROOT CAUSE:
+    //
+    // If the hand crop included a sliver of the deck stack, the specialized
+    // model returned a very narrow poker_card_back and promoted it to a ninth
+    // hand slot.
+    //
+    // Before the fix, label filtering retained that unusable partial box. The
+    // fix requires enough card width to represent a complete clickable slot.
+    let result = DetectionResult {
+      image_size: ImageSize {
+        width: 1124,
+        height: 360,
+      },
+      detections: vec![
+        Detection {
+          class_id: 6,
+          label: "poker_card_front".to_string(),
+          confidence: 0.98,
+          bbox: BoundingBox {
+            x1: 10.0,
+            y1: 20.0,
+            x2: 110.0,
+            y2: 220.0,
+          },
+        },
+        Detection {
+          class_id: 2,
+          label: "joker_card".to_string(),
+          confidence: 0.51,
+          bbox: BoundingBox {
+            x1: 1.0,
+            y1: 2.0,
+            x2: 3.0,
+            y2: 4.0,
+          },
+        },
+        Detection {
+          class_id: 4,
+          label: "poker_card_back".to_string(),
+          confidence: 0.75,
+          bbox: BoundingBox {
+            x1: 1090.0,
+            y1: 170.0,
+            x2: 1118.0,
+            y2: 312.0,
+          },
+        },
+      ],
+    };
+    let image_size = ImageSize {
+      width: 2043,
+      height: 1126,
+    };
+
+    let remapped = remap_hand_detections(
+      result,
+      HandCrop {
+        x: 541,
+        y: 585,
+        width: 1124,
+        height: 360,
+      },
+      image_size,
+    );
+
+    assert_eq!(remapped.image_size, image_size);
+    assert_eq!(remapped.detections.len(), 1);
+    assert_eq!(
+      remapped.detections[0].bbox,
+      BoundingBox {
+        x1: 551.0,
+        y1: 605.0,
+        x2: 651.0,
+        y2: 805.0,
+      }
+    );
   }
 }

--- a/supported/games/auv-game-balatro/src/game_restart.rs
+++ b/supported/games/auv-game-balatro/src/game_restart.rs
@@ -1,7 +1,7 @@
-use auv_driver::{InputActionResult, WindowPoint};
+use auv_driver::InputActionResult;
 use serde::{Deserialize, Serialize};
 
-use crate::model::{BalatroPhase, BalatroState, ButtonTarget};
+use crate::model::{ActionPoint, BalatroPhase, BalatroState, ButtonTarget};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct GameRestartRequest {
@@ -14,6 +14,8 @@ pub struct GameRestartRequest {
 #[serde(rename_all = "snake_case")]
 pub enum GameRestartTarget {
   DetectedButton { button: ButtonTarget },
+  NewRunTabLayout,
+  NewRunPlayLayout,
   GameOverLayout,
   LocalizedTitleLayout,
 }
@@ -21,7 +23,7 @@ pub enum GameRestartTarget {
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct GameRestartClick {
   pub target: GameRestartTarget,
-  pub window_point: WindowPoint,
+  pub point: ActionPoint,
   pub delivery: InputActionResult,
 }
 
@@ -45,7 +47,7 @@ pub struct GameRestartResult {
 #[derive(Serialize)]
 struct GameRestartClickFact<'a> {
   target: &'a GameRestartTarget,
-  window_point: WindowPoint,
+  point: &'a ActionPoint,
 }
 
 #[cfg(feature = "tracing")]
@@ -59,7 +61,7 @@ struct GameRestartCompleted<'a> {
 #[cfg(feature = "tracing")]
 impl auv_tracing::EventPayload for GameRestartCompleted<'_> {
   const NAME: &'static str = "auv.balatro.game_restart.completed";
-  const VERSION: u32 = 1;
+  const VERSION: u32 = 2;
 }
 
 #[cfg(feature = "tracing")]
@@ -71,7 +73,7 @@ pub(crate) fn emit_game_restart_completed(result: &GameRestartResult) {
       .iter()
       .map(|click| GameRestartClickFact {
         target: &click.target,
-        window_point: click.window_point,
+        point: &click.point,
       })
       .collect(),
     outcome: &result.outcome,

--- a/supported/games/auv-game-balatro/src/hand_selection.rs
+++ b/supported/games/auv-game-balatro/src/hand_selection.rs
@@ -1,7 +1,7 @@
-use auv_driver::{InputActionResult, WindowPoint};
+use auv_driver::InputActionResult;
 use serde::Serialize;
 
-use crate::model::SlotId;
+use crate::model::{ActionPoint, SlotId};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -15,7 +15,7 @@ pub struct HandSelectionToggle {
   pub kind: HandSelectionToggleKind,
   pub attempt: u8,
   pub slot: SlotId,
-  pub window_point: WindowPoint,
+  pub point: ActionPoint,
   pub delivery: InputActionResult,
 }
 

--- a/supported/games/auv-game-balatro/src/lib.rs
+++ b/supported/games/auv-game-balatro/src/lib.rs
@@ -34,7 +34,7 @@ mod store_buy;
 mod store_next_round;
 
 pub use blind_action::{
-  BlindSelectConfirmation, BlindSelectConfirmationFailure, BlindSelectRequest, BlindSelectResult, BlindSkipConfirmation,
+  BlindSelectAttempt, BlindSelectConfirmation, BlindSelectConfirmationFailure, BlindSelectRequest, BlindSelectResult, BlindSkipConfirmation,
   BlindSkipConfirmationFailure, BlindSkipRequest, BlindSkipResult,
 };
 pub use cards_action::{
@@ -43,7 +43,8 @@ pub use cards_action::{
 };
 pub use cards_clear::{CardSelectionToggle, CardsClearIncompleteReason, CardsClearOutcome, CardsClearRequest, CardsClearResult};
 pub use cash_out::{
-  CashOutConfirmation, CashOutConfirmationBasis, CashOutConfirmationFailure, CashOutConfirmationRequest, CashOutRequest, CashOutResult,
+  CashOutAttempt, CashOutConfirmation, CashOutConfirmationBasis, CashOutConfirmationFailure, CashOutConfirmationRequest, CashOutRequest,
+  CashOutResult,
 };
 pub use cli::{
   CliArgs, Command, OutputMode, blind_select, blind_skip, cards_clear, cards_discard, cards_play, cards_select, cash_out, consumable_use,
@@ -57,8 +58,8 @@ pub use consumable_use::{
 pub use game_restart::{GameRestartClick, GameRestartOutcome, GameRestartRequest, GameRestartResult, GameRestartTarget};
 pub use hand_selection::{HandSelectionResult, HandSelectionState, HandSelectionToggle, HandSelectionToggleKind};
 pub use model::{
-  BalatroPhase, BalatroState, ButtonTarget, CardSlot, ConsumableSlot, JokerSlot, ObjectZone, RoundState, ScoreState, SlotId, StoreItem,
-  StoreState,
+  ActionPoint, BalatroPhase, BalatroState, ButtonTarget, CardSlot, ConsumableSlot, JokerSlot, ObjectZone, RoundState, ScoreState, SlotId,
+  StoreItem, StoreState,
 };
 pub use object_sell::{
   ObjectSellClick, ObjectSellConfirmation, ObjectSellConfirmationBasis, ObjectSellConfirmationFailure, ObjectSellIncompleteReason,
@@ -75,8 +76,8 @@ pub use store_buy::{
   StoreBuyRequest, StoreBuyResult,
 };
 pub use store_next_round::{
-  StoreNextRoundConfirmation, StoreNextRoundConfirmationFailure, StoreNextRoundConfirmationRequest, StoreNextRoundConfirmationStrength,
-  StoreNextRoundRequest, StoreNextRoundResult, StoreNextRoundTarget,
+  StoreNextRoundAttempt, StoreNextRoundConfirmation, StoreNextRoundConfirmationFailure, StoreNextRoundConfirmationRequest,
+  StoreNextRoundConfirmationStrength, StoreNextRoundRequest, StoreNextRoundResult, StoreNextRoundTarget,
 };
 
 pub use card_detection_eval_witness::{

--- a/supported/games/auv-game-balatro/src/model.rs
+++ b/supported/games/auv-game-balatro/src/model.rs
@@ -1,15 +1,39 @@
 use std::fmt;
 
+use auv_driver::{CoordinateSpace, Point, ScreenPoint, WindowPoint};
 use auv_inference_common::ImageSize;
 use auv_task_object_detection::{BoundingBox, Detection};
 use serde::{Deserialize, Serialize};
 
 pub const BALATRO_STATE_SCHEMA_VERSION: &str = "auv.game.balatro.state.v0";
 
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct ActionPoint {
+  pub coordinate_space: CoordinateSpace,
+  pub point: Point,
+}
+
+impl ActionPoint {
+  pub fn screen(point: ScreenPoint) -> Self {
+    Self {
+      coordinate_space: CoordinateSpace::Screen,
+      point: point.point(),
+    }
+  }
+
+  pub fn window(window_id: impl Into<String>, point: WindowPoint) -> Self {
+    Self {
+      coordinate_space: CoordinateSpace::Window(window_id.into()),
+      point: point.point(),
+    }
+  }
+}
+
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum BalatroPhase {
   Playing,
+  CashOut,
   Store,
   BlindSelect,
   GameOver,
@@ -103,6 +127,19 @@ impl Reading {
   }
 }
 
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct CardAttribute {
+  pub label: String,
+  pub confidence: f32,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+pub struct CardAttributes {
+  pub enhancement: Option<CardAttribute>,
+  pub edition: Option<CardAttribute>,
+  pub seal: Option<CardAttribute>,
+}
+
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct CacheHint {
   pub needs_reading: bool,
@@ -117,6 +154,8 @@ pub struct CardSlot {
   pub bbox: BoundingBox,
   pub confidence: f32,
   pub reading: Reading,
+  #[serde(default)]
+  pub attributes: CardAttributes,
   pub cache: CacheHint,
 }
 

--- a/supported/games/auv-game-balatro/src/observation.rs
+++ b/supported/games/auv-game-balatro/src/observation.rs
@@ -1,24 +1,26 @@
 use std::collections::HashMap;
 use std::path::Path;
 
+use auv_driver::{Capture, InputActionResult, Point, RatioRect, ScreenPoint, TextRecognition};
 use auv_inference_common::{ImageSize, InferenceError};
 use auv_task_object_detection::{BoundingBox, Detection, DetectionResult};
 use image::RgbImage;
 use thiserror::Error;
 
+use auv::client::runner::NormalizedRegion;
 use auv::client::{RunClient, RunOptions, RunnerOptions};
 use auv::{AuvContext, Client};
 use auv_api_client::ConnectEndpoint;
-use auv_api_proto::auv::api::{daemon::v1 as daemon_proto, driver::v1 as driver_proto, image::v1 as image_proto};
+use auv_api_proto::auv::api::image::v1 as image_proto;
 
 use crate::api::v1 as balatro_proto;
 use crate::cache::cache_hint_for_detection;
-use crate::config::BalatroModelConfig;
-use crate::detector::{BalatroDetectionSets, BalatroDetectors};
+use crate::config::{BalatroModelAsset, BalatroModelConfig, HuggingFaceRepoKind};
+use crate::detector::{BalatroDetectionSets, BalatroDetectors, CardAttributeDetectionSets, crop_hand_frame, remap_hand_detections};
 use crate::model::{
-  BALATRO_STATE_SCHEMA_VERSION, BalatroDiagnostic, BalatroPhase, BalatroState, ButtonTarget, CacheHint, CardSlot, ConsumableKind,
-  ConsumableSlot, FrameRef, JokerSlot, ObjectEvidence, ObjectZone, Reading, RoundState, ScoreState, SlotId, StoreItem, StoreItemKind,
-  StoreState,
+  BALATRO_STATE_SCHEMA_VERSION, BalatroDiagnostic, BalatroPhase, BalatroState, ButtonTarget, CacheHint, CardAttribute, CardAttributes,
+  CardSlot, ConsumableKind, ConsumableSlot, FrameRef, JokerSlot, ObjectEvidence, ObjectZone, Reading, ReadingStatus, RoundState, ScoreState,
+  SlotId, StoreItem, StoreItemKind, StoreState,
 };
 
 #[derive(Debug, Error)]
@@ -33,6 +35,21 @@ pub enum ObservationError {
   Api(String),
 }
 
+#[derive(Clone, Debug)]
+pub struct HoverReadRequest {
+  pub point: Point,
+  pub region: RatioRect,
+  pub custom_words: Vec<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct HoverReadObservation {
+  pub point: ScreenPoint,
+  pub delivery: InputActionResult,
+  pub recognition: TextRecognition,
+  pub frame_source: String,
+}
+
 /// Observes an image through an inference Runner attached to one AUV Run.
 pub async fn observe_image_via_api(
   image_path: impl AsRef<Path>,
@@ -41,7 +58,6 @@ pub async fn observe_image_via_api(
   no_cache: bool,
 ) -> Result<BalatroState, ObservationError> {
   let image_path = image_path.as_ref();
-  let resolved = config.resolve().map_err(|error| ObservationError::Api(error.to_string()))?;
   let image = image::open(image_path)?.to_rgb8();
   let image_size = ImageSize {
     width: image.width(),
@@ -52,15 +68,14 @@ pub async fn observe_image_via_api(
     height: image.height(),
     data: image.as_raw().clone(),
   };
-  let entities_classes = crate::config::load_class_names(&resolved.entities_classes)?;
-  let ui_classes = crate::config::load_class_names(&resolved.ui_classes)?;
+  let (entities_classes, ui_classes) = load_remote_class_names(config).await?;
   let auv = connect_auv(endpoint).await?;
   let run = auv.run(balatro_run_options()).await.map_err(api_error)?;
   let balatro = match run.runner(balatro_runner_options()).await {
     Ok(balatro) => balatro,
     Err(error) => return finish_run(run, Err(api_error(error))).await,
   };
-  let result = detect_via_api(&balatro, &resolved, entities_classes, ui_classes, frame)
+  let result = detect_via_api(&balatro, config, entities_classes, ui_classes, frame)
     .await
     .map(|detections| build_state_from_detections(image_path.display().to_string(), image_size, &image, detections, no_cache));
   finish_run(run, result).await
@@ -74,9 +89,7 @@ pub async fn observe_live_via_api(
   endpoint: Option<ConnectEndpoint>,
   no_cache: bool,
 ) -> Result<BalatroState, ObservationError> {
-  let resolved = config.resolve().map_err(|error| ObservationError::Api(error.to_string()))?;
-  let entities_classes = crate::config::load_class_names(&resolved.entities_classes)?;
-  let ui_classes = crate::config::load_class_names(&resolved.ui_classes)?;
+  let (entities_classes, ui_classes) = load_remote_class_names(config).await?;
   let auv = connect_auv(endpoint).await?;
   let run = auv.run(balatro_run_options()).await.map_err(api_error)?;
   let driver = match run.runner(driver_runner_options()).await {
@@ -89,15 +102,164 @@ pub async fn observe_live_via_api(
       return finish_run(run, Err(api_error(error))).await;
     }
   };
-  let result = observe_live_with_runners(&driver, &balatro, target, &resolved, entities_classes, ui_classes, no_cache).await;
+  let result = observe_live_with_runners(&driver, &balatro, target, config, entities_classes, ui_classes, no_cache).await;
   finish_run(run, result).await
+}
+
+/// Delivers a click for a point measured in an observed primary-display frame.
+///
+/// The returned point is in the Device screen's logical coordinate space; the
+/// caller retains the typed delivery result and verifies game state separately.
+pub async fn click_display_frame_point_via_api(
+  frame: &FrameRef,
+  point: Point,
+) -> Result<(ScreenPoint, InputActionResult), ObservationError> {
+  validate_primary_display_frame(frame, "remote screen click")?;
+
+  let auv = connect_auv(None).await?;
+  let run = auv.run(balatro_run_options()).await.map_err(api_error)?;
+  let result = async {
+    let driver = run.runner(driver_runner_options()).await.map_err(api_error)?;
+    let displays = driver.displays().list().await.map_err(api_error)?;
+    let display = displays
+      .displays
+      .iter()
+      .find(|display| display.is_primary)
+      .or_else(|| displays.displays.first())
+      .ok_or_else(|| ObservationError::Api("Driver Runner returned no displays".to_string()))?;
+    let screen_point = project_display_frame_point(frame, display.frame, point);
+    let response = driver.input().click_screen_point(screen_point.point(), auv_driver::Click::Single).await.map_err(api_error)?;
+    #[cfg(feature = "tracing")]
+    crate::run_read::emit_json_artifact(auv_driver::INPUT_ACTION_RESULT_PURPOSE, &response.action);
+    Ok((screen_point, response.action))
+  }
+  .await;
+  finish_run(run, result).await
+}
+
+/// Moves the pointer for a point measured in an observed display frame.
+pub async fn move_display_frame_point_via_api(frame: &FrameRef, point: Point) -> Result<(ScreenPoint, InputActionResult), ObservationError> {
+  validate_primary_display_frame(frame, "remote screen move")?;
+  let auv = connect_auv(None).await?;
+  let run = auv.run(balatro_run_options()).await.map_err(api_error)?;
+  let result = async {
+    let driver = run.runner(driver_runner_options()).await.map_err(api_error)?;
+    let displays = driver.displays().list().await.map_err(api_error)?;
+    let display = displays
+      .displays
+      .iter()
+      .find(|display| display.is_primary)
+      .or_else(|| displays.displays.first())
+      .ok_or_else(|| ObservationError::Api("Driver Runner returned no displays".to_string()))?;
+    let screen_point = project_display_frame_point(frame, display.frame, point);
+    let action = move_mouse_to(&driver, screen_point.point()).await?;
+    #[cfg(feature = "tracing")]
+    crate::run_read::emit_json_artifact(auv_driver::INPUT_ACTION_RESULT_PURPOSE, &action);
+    Ok((screen_point, action))
+  }
+  .await;
+  finish_run(run, result).await
+}
+
+/// Hovers observed display-frame points and OCRs the resulting tooltip frames.
+///
+/// One Driver Runner is retained for the entire batch so pointer delivery,
+/// capture, and OCR share the same routed session.
+pub async fn hover_read_display_frame_points_via_api(
+  frame: &FrameRef,
+  requests: &[HoverReadRequest],
+) -> Result<Vec<HoverReadObservation>, ObservationError> {
+  validate_primary_display_frame(frame, "remote hover read")?;
+  let auv = connect_auv(None).await?;
+  let run = auv.run(balatro_run_options()).await.map_err(api_error)?;
+  let result = async {
+    let driver = run.runner(driver_runner_options()).await.map_err(api_error)?;
+    let displays = driver.displays().list().await.map_err(api_error)?;
+    let display = displays
+      .displays
+      .iter()
+      .find(|display| display.is_primary)
+      .or_else(|| displays.displays.first())
+      .ok_or_else(|| ObservationError::Api("Driver Runner returned no displays".to_string()))?;
+    let mut observations = Vec::with_capacity(requests.len());
+    for (index, request) in requests.iter().enumerate() {
+      let screen_point = project_display_frame_point(frame, display.frame, request.point);
+      let moved = move_mouse_to(&driver, screen_point.point()).await?;
+      tokio::time::sleep(std::time::Duration::from_millis(450)).await;
+      let capture = driver.displays().capture(None).await.map_err(api_error)?.capture;
+      let recognition = driver
+        .recognize_text(
+          capture.clone(),
+          Some(NormalizedRegion {
+            x: request.region.x,
+            y: request.region.y,
+            width: request.region.width,
+            height: request.region.height,
+          }),
+          request.custom_words.clone(),
+          vec!["zh-Hans".to_string(), "en-US".to_string()],
+        )
+        .await
+        .map_err(api_error)?;
+      let frame_source = format!("daemon://display/primary?hover_read={index}");
+      #[cfg(feature = "tracing")]
+      {
+        crate::run_read::emit_json_artifact(auv_driver::INPUT_ACTION_RESULT_PURPOSE, &moved);
+        crate::run_read::emit_png_artifact("auv.balatro.object_hover.capture", &frame_source, &capture.image);
+      }
+      observations.push(HoverReadObservation {
+        point: screen_point,
+        delivery: moved,
+        recognition,
+        frame_source,
+      });
+    }
+    Ok(observations)
+  }
+  .await;
+  finish_run(run, result).await
+}
+
+async fn move_mouse_to(driver: &auv::client::runner::RunnerClient, point: Point) -> Result<InputActionResult, ObservationError> {
+  let mut stream = driver.input().move_mouse(auv_driver::MouseMotionPlan::direct(point)).await.map_err(api_error)?;
+  while let Some(event) = stream.next().await.map_err(api_error)? {
+    if let auv::client::runner::MouseMotionEvent::Completed { action, .. } = event {
+      return Ok(action);
+    }
+  }
+  Err(ObservationError::Api("MoveMouse ended without completion evidence".to_string()))
+}
+
+fn validate_primary_display_frame(frame: &FrameRef, operation: &str) -> Result<(), ObservationError> {
+  if !frame.source.starts_with("daemon://display/primary") {
+    // TODO(balatro-remote-window-projection): project resolved Window captures
+    // after a production Linux Window consumer exists; live Linux currently
+    // supplies the explicit primary-display fallback source.
+    return Err(ObservationError::Api(format!("{operation} requires a primary-display frame, received {:?}", frame.source)));
+  }
+  if frame.image_size.width == 0 || frame.image_size.height == 0 {
+    return Err(ObservationError::Api(format!("{operation} requires non-zero frame dimensions")));
+  }
+  Ok(())
+}
+
+fn project_display_frame_point(frame: &FrameRef, bounds: auv_driver::Rect, point: Point) -> ScreenPoint {
+  ScreenPoint::new(
+    bounds.origin.x + point.x / f64::from(frame.image_size.width) * bounds.size.width,
+    bounds.origin.y + point.y / f64::from(frame.image_size.height) * bounds.size.height,
+  )
 }
 
 async fn connect_auv(endpoint: Option<ConnectEndpoint>) -> Result<Client, ObservationError> {
   match std::env::var("AUV_CONTEXT") {
     Ok(_) => Client::from_context(AuvContext::from_env().map_err(api_error)?).await.map_err(api_error),
     Err(std::env::VarError::NotPresent) => match endpoint {
-      Some(endpoint) => auv_api_client::protocol::grpc::Client::connect(endpoint).await.map(Client::from_grpc).map_err(api_error),
+      Some(endpoint) => Client::from_context(AuvContext {
+        daemon_endpoint: Some(endpoint.to_string()),
+        ..AuvContext::default()
+      })
+      .await
+      .map_err(api_error),
       None => Client::from_env_or_local().await.map_err(api_error),
     },
     Err(error) => Err(api_error(error)),
@@ -113,23 +275,23 @@ fn balatro_run_options() -> RunOptions {
 
 fn driver_runner_options() -> RunnerOptions {
   RunnerOptions {
-    runner_class: "auv.core.local".to_string(),
+    runner_class: "auv.core.local".parse().expect("the local RunnerClass ID is valid"),
     ..RunnerOptions::default()
   }
 }
 
 fn balatro_runner_options() -> RunnerOptions {
   RunnerOptions {
-    runner_class: "auv.game.balatro".to_string(),
+    runner_class: "auv.game.balatro".parse().expect("the Balatro RunnerClass ID is valid"),
     ..RunnerOptions::default()
   }
 }
 
 async fn finish_run<T>(run: RunClient, result: Result<T, ObservationError>) -> Result<T, ObservationError> {
   let outcome = if result.is_ok() {
-    daemon_proto::RunOutcome::Succeeded
+    auv::runs::RunOutcome::Succeeded
   } else {
-    daemon_proto::RunOutcome::Failed
+    auv::runs::RunOutcome::Failed
   };
   merge_cleanup(result, run.finish_if_owned(outcome).await.map(|_| ()).map_err(api_error))
 }
@@ -147,102 +309,220 @@ fn api_error(error: impl std::fmt::Display) -> ObservationError {
   ObservationError::Api(error.to_string())
 }
 
-fn rgba_frame_to_rgb(frame: &image_proto::RgbaFrame) -> Result<image_proto::RgbFrame, ObservationError> {
-  let pixel_count = usize::try_from(frame.width)
-    .ok()
-    .and_then(|width| usize::try_from(frame.height).ok().and_then(|height| width.checked_mul(height)))
-    .ok_or_else(|| ObservationError::Api("CaptureWindow RGBA dimensions exceed addressable memory".to_string()))?;
-  let expected = pixel_count
-    .checked_mul(4)
-    .ok_or_else(|| ObservationError::Api("CaptureWindow RGBA byte length exceeds addressable memory".to_string()))?;
-  if frame.data.len() != expected {
-    return Err(ObservationError::Api(format!(
-      "CaptureWindow returned malformed RGBA frame: expected {expected} bytes, received {}",
-      frame.data.len()
-    )));
-  }
-  let mut data = Vec::with_capacity(pixel_count * 3);
-  for pixel in frame.data.chunks_exact(4) {
-    data.extend_from_slice(&pixel[..3]);
-  }
-  Ok(image_proto::RgbFrame {
-    width: frame.width,
-    height: frame.height,
-    data,
-  })
-}
-
 async fn detect_via_api(
   balatro: &auv::client::runner::RunnerClient,
-  resolved: &crate::config::ResolvedBalatroModelConfig,
+  config: &BalatroModelConfig,
   entities_classes: Vec<String>,
   ui_classes: Vec<String>,
   frame: image_proto::RgbFrame,
 ) -> Result<BalatroDetectionSets, ObservationError> {
-  let mut balatro =
-    balatro_proto::balatro_detection_service_client::BalatroDetectionServiceClient::new(balatro.transport().map_err(api_error)?);
-  let entities = balatro
-    .detect_objects(balatro_proto::DetectObjectsRequest {
-      detector: Some(detector_spec("balatro-entities", &resolved.entities_model, &resolved.device, entities_classes)?),
-      frame: Some(frame.clone()),
+  let balatro =
+    balatro_proto::balatro_detection_service_client::BalatroDetectionServiceClient::new(balatro.extension_transport().map_err(api_error)?)
+      .max_decoding_message_size(auv::client::runner::IMAGE_RPC_MESSAGE_SIZE_LIMIT)
+      .max_encoding_message_size(auv::client::runner::IMAGE_RPC_MESSAGE_SIZE_LIMIT);
+  let batch_detectors = vec![
+    detector_spec("balatro-entities", &config.entities_model, &config.device, 640, entities_classes.clone())?,
+    detector_spec("balatro-ui", &config.ui_model, &config.device, 640, ui_classes)?,
+    detector_spec("balatro-card-identity", &config.card_identity_model, &config.device, 960, Vec::new())?,
+    detector_spec("balatro-card-enhancement", &config.card_enhancement_model, &config.device, 640, Vec::new())?,
+    detector_spec("balatro-card-edition", &config.card_edition_model, &config.device, 640, Vec::new())?,
+    detector_spec("balatro-card-seal", &config.card_seal_model, &config.device, 640, Vec::new())?,
+  ];
+  let cards_request = if let Some(cards_model) = &config.cards_model {
+    let full_image_size = ImageSize {
+      width: frame.width,
+      height: frame.height,
+    };
+    let image = RgbImage::from_raw(frame.width, frame.height, frame.data.clone())
+      .ok_or_else(|| ObservationError::Api("card detector received an invalid RGB frame".to_string()))?;
+    let (crop, hand_frame) = crop_hand_frame(&image);
+    let hand_frame = image_proto::RgbFrame {
+      width: hand_frame.image.width(),
+      height: hand_frame.image.height(),
+      data: hand_frame.image.into_raw(),
+    };
+    Some((
+      balatro_proto::DetectObjectsRequest {
+        detector: Some(detector_spec("balatro-cards", cards_model, &config.device, 640, entities_classes)?),
+        frame: Some(hand_frame),
+      },
+      crop,
+      full_image_size,
+    ))
+  } else {
+    None
+  };
+
+  let detect = |mut client: balatro_proto::balatro_detection_service_client::BalatroDetectionServiceClient<_>, request| async move {
+    client.detect_objects(request).await.map(|response| response.into_inner()).map_err(api_error)
+  };
+  let cards = async {
+    let Some((request, crop, full_image_size)) = cards_request else {
+      return Ok(None);
+    };
+    let response = detect(balatro.clone(), request).await?;
+    Ok::<_, ObservationError>(Some(remap_hand_detections(detection_result_from_proto(response)?, crop, full_image_size)))
+  };
+  let batch = async {
+    let mut client = balatro.clone();
+    client
+      .detect_objects_batch(balatro_proto::DetectObjectsBatchRequest {
+        detectors: batch_detectors,
+        frame: Some(frame),
+      })
+      .await
+      .map(|response| response.into_inner())
+      .map_err(api_error)
+  };
+  let (batch, cards) = tokio::try_join!(batch, cards)?;
+  let mut batch = batch
+    .results
+    .into_iter()
+    .map(|entry| {
+      let result = entry.result.ok_or_else(|| ObservationError::Api(format!("batch result {} omitted result", entry.detector_id)))?;
+      Ok((entry.detector_id, result))
     })
-    .await
-    .map_err(api_error)?
-    .into_inner();
-  let ui = balatro
-    .detect_objects(balatro_proto::DetectObjectsRequest {
-      detector: Some(detector_spec("balatro-ui", &resolved.ui_model, &resolved.device, ui_classes)?),
-      frame: Some(frame),
-    })
-    .await
-    .map_err(api_error)?
-    .into_inner();
+    .collect::<Result<HashMap<_, _>, ObservationError>>()?;
   Ok(BalatroDetectionSets {
-    entities: detection_result_from_proto(entities)?,
-    ui: detection_result_from_proto(ui)?,
+    entities: detection_result_from_proto(take_batch_result(&mut batch, "balatro-entities")?)?,
+    cards,
+    card_attributes: CardAttributeDetectionSets {
+      identity: Some(detection_result_from_proto(take_batch_result(&mut batch, "balatro-card-identity")?)?),
+      enhancement: Some(detection_result_from_proto(take_batch_result(&mut batch, "balatro-card-enhancement")?)?),
+      edition: Some(detection_result_from_proto(take_batch_result(&mut batch, "balatro-card-edition")?)?),
+      seal: Some(detection_result_from_proto(take_batch_result(&mut batch, "balatro-card-seal")?)?),
+    },
+    ui: detection_result_from_proto(take_batch_result(&mut batch, "balatro-ui")?)?,
   })
+}
+
+fn take_batch_result(
+  results: &mut HashMap<String, balatro_proto::DetectObjectsResponse>,
+  detector_id: &str,
+) -> Result<balatro_proto::DetectObjectsResponse, ObservationError> {
+  results.remove(detector_id).ok_or_else(|| ObservationError::Api(format!("batch response omitted detector {detector_id}")))
 }
 
 async fn observe_live_with_runners(
   driver: &auv::client::runner::RunnerClient,
   balatro: &auv::client::runner::RunnerClient,
   target: &str,
-  resolved: &crate::config::ResolvedBalatroModelConfig,
+  config: &BalatroModelConfig,
   entities_classes: Vec<String>,
   ui_classes: Vec<String>,
   no_cache: bool,
 ) -> Result<BalatroState, ObservationError> {
+  // TODO(balatro-window-resolution-cache): cache a resolved Window only after
+  // Linux exposes a typed move/resize/close invalidation signal; stale window
+  // identity or geometry is worse than the current per-observation lookup.
   let window = driver
     .windows()
-    .resolve(driver_proto::WindowSelector {
-      application: Some(driver_proto::window_selector::Application::ApplicationName(target.to_string())),
-      window: Some(driver_proto::window_selector::Window::MainVisible(true)),
+    .resolve(auv_driver::WindowSelector {
+      app: Some(auv_driver::App::name(target)),
+      main_visible: true,
+      ..Default::default()
     })
-    .await
-    .map_err(api_error)?;
-  let captured = window.capture().await.map_err(api_error)?;
-  let capture = captured.capture.ok_or_else(|| ObservationError::Api("CaptureWindow response omitted capture".to_string()))?;
-  let rgba = capture.image.as_ref().ok_or_else(|| ObservationError::Api("CaptureWindow response omitted image".to_string()))?;
-  let frame = rgba_frame_to_rgb(rgba)?;
-  let image = RgbImage::from_raw(frame.width, frame.height, frame.data.clone())
-    .ok_or_else(|| ObservationError::Api("CaptureWindow returned malformed RGBA frame".to_string()))?;
+    .await;
+  let (source, captured) = match window {
+    Ok(window) => (format!("daemon://window/{}", window.reference().id), window.capture().await.map_err(api_error)?.capture),
+    Err(error) if matches!(error.client_kind(), Some(auv::error::ClientErrorKind::NotFound | auv::error::ClientErrorKind::Unsupported)) => {
+      ("daemon://display/primary?fallback=window_unavailable".to_string(), driver.displays().capture(None).await.map_err(api_error)?.capture)
+    }
+    Err(error) => return Err(api_error(error)),
+  };
+  let capture = captured;
+  #[cfg(feature = "tracing")]
+  crate::run_read::emit_png_artifact("auv.balatro.observation.capture", &source, &capture.image);
+  let image = image::DynamicImage::ImageRgba8(capture.image.clone()).to_rgb8();
+  let frame = image_proto::RgbFrame {
+    width: image.width(),
+    height: image.height(),
+    data: image.as_raw().clone(),
+  };
   let image_size = ImageSize {
     width: frame.width,
     height: frame.height,
   };
-  let recognition =
-    driver.recognize_text(capture.clone(), None, Vec::new(), vec!["zh-Hans".to_string(), "en-US".to_string()]).await.map_err(api_error)?;
-  let detections = detect_via_api(balatro, resolved, entities_classes, ui_classes, frame).await?;
-  let mut state =
-    build_state_from_detections(format!("daemon://window/{}", window.reference().window_id), image_size, &image, detections, no_cache);
+  let detections = detect_via_api(balatro, config, entities_classes, ui_classes, frame).await?;
+  let recognition = match ocr_capture_for_ui(&capture, &detections.ui) {
+    Some(ocr_capture) => {
+      driver.recognize_text(ocr_capture, None, Vec::new(), vec!["zh-Hans".to_string(), "en-US".to_string()]).await.map_err(api_error)?
+    }
+    None => Default::default(),
+  };
+  let mut state = build_state_from_detections(source, image_size, &image, detections, no_cache);
   enrich_ui_numeric_readings_from_recognition(&mut state, &capture, recognition);
+  #[cfg(feature = "tracing")]
+  crate::run_read::emit_json_artifact("auv.balatro.observation.state", &state);
   Ok(state)
+}
+
+fn ocr_region_for_ui(ui: &DetectionResult) -> Option<NormalizedRegion> {
+  if ui.image_size.width == 0 || ui.image_size.height == 0 {
+    return None;
+  }
+  let mut numeric = ui.detections.iter().filter(|detection| is_numeric_ui_label(&detection.label));
+  let first = numeric.next()?;
+  let (mut x1, mut y1, mut x2, mut y2) = (first.bbox.x1, first.bbox.y1, first.bbox.x2, first.bbox.y2);
+  for detection in numeric {
+    x1 = x1.min(detection.bbox.x1);
+    y1 = y1.min(detection.bbox.y1);
+    x2 = x2.max(detection.bbox.x2);
+    y2 = y2.max(detection.bbox.y2);
+  }
+
+  let image_width = f64::from(ui.image_size.width);
+  let image_height = f64::from(ui.image_size.height);
+  // NOTICE: One percent of the frame retains glyph strokes that touch a UI
+  // detector boundary without expanding OCR back into the full display.
+  let x1 = (f64::from(x1) / image_width - 0.01).clamp(0.0, 1.0);
+  let y1 = (f64::from(y1) / image_height - 0.01).clamp(0.0, 1.0);
+  let x2 = (f64::from(x2) / image_width + 0.01).clamp(0.0, 1.0);
+  let y2 = (f64::from(y2) / image_height + 0.01).clamp(0.0, 1.0);
+  (x2 > x1 && y2 > y1).then_some(NormalizedRegion {
+    x: x1,
+    y: y1,
+    width: x2 - x1,
+    height: y2 - y1,
+  })
+}
+
+fn ocr_capture_for_ui(capture: &Capture, ui: &DetectionResult) -> Option<Capture> {
+  let region = ocr_region_for_ui(ui)?;
+  let image_width = capture.image.width();
+  let image_height = capture.image.height();
+  if image_width == 0 || image_height == 0 {
+    return None;
+  }
+  let x = (region.x * f64::from(image_width)).round().clamp(0.0, f64::from(image_width)) as u32;
+  let y = (region.y * f64::from(image_height)).round().clamp(0.0, f64::from(image_height)) as u32;
+  let width = (region.width * f64::from(image_width)).round().clamp(0.0, f64::from(image_width - x)) as u32;
+  let height = (region.height * f64::from(image_height)).round().clamp(0.0, f64::from(image_height - y)) as u32;
+  if width == 0 || height == 0 {
+    return None;
+  }
+
+  let x_scale = capture.bounds.size.width / f64::from(image_width);
+  let y_scale = capture.bounds.size.height / f64::from(image_height);
+  Some(Capture {
+    image: image::imageops::crop_imm(&capture.image, x, y, width, height).to_image(),
+    bounds: auv_driver::Rect::new(
+      capture.bounds.origin.x + f64::from(x) * x_scale,
+      capture.bounds.origin.y + f64::from(y) * y_scale,
+      f64::from(width) * x_scale,
+      f64::from(height) * y_scale,
+    ),
+    scale_factor: capture.scale_factor,
+    backend: capture.backend.clone(),
+    fallback_reason: capture.fallback_reason.clone(),
+  })
 }
 
 fn detector_spec(
   detector_id: &str,
-  model_path: &Path,
+  model: &BalatroModelAsset,
   device: &auv_inference_ultralytics::InferenceDevice,
+  input_size: u32,
   class_names: Vec<String>,
 ) -> Result<balatro_proto::ObjectDetectorSpec, ObservationError> {
   let (kind, index) = match device {
@@ -261,11 +541,8 @@ fn detector_spec(
     .map_err(|_| ObservationError::Api("inference device index exceeds the protobuf uint32 range".to_string()))?;
   Ok(balatro_proto::ObjectDetectorSpec {
     detector_id: detector_id.to_string(),
-    model_path: model_path
-      .to_str()
-      .ok_or_else(|| ObservationError::Api(format!("model path is not valid UTF-8: {}", model_path.display())))?
-      .to_string(),
-    input_size: Some(640),
+    source: Some(model_source(model)?),
+    input_size: Some(input_size),
     confidence_threshold: Some(0.25),
     iou_threshold: Some(0.45),
     max_detections: Some(300),
@@ -275,6 +552,42 @@ fn detector_spec(
     }),
     class_names,
   })
+}
+
+fn model_source(model: &BalatroModelAsset) -> Result<balatro_proto::object_detector_spec::Source, ObservationError> {
+  Ok(match model {
+    BalatroModelAsset::Local(path) => balatro_proto::object_detector_spec::Source::RunnerPath(
+      path.to_str().ok_or_else(|| ObservationError::Api(format!("Runner model path is not valid UTF-8: {}", path.display())))?.to_string(),
+    ),
+    BalatroModelAsset::HuggingFace {
+      repo_kind,
+      owner,
+      repo,
+      filename,
+    } => balatro_proto::object_detector_spec::Source::HuggingFace(balatro_proto::HuggingFaceAsset {
+      repository_kind: match repo_kind {
+        HuggingFaceRepoKind::Model => balatro_proto::hugging_face_asset::RepositoryKind::Model as i32,
+        HuggingFaceRepoKind::Dataset => balatro_proto::hugging_face_asset::RepositoryKind::Dataset as i32,
+      },
+      owner: (*owner).to_string(),
+      repository: (*repo).to_string(),
+      filename: (*filename).to_string(),
+    }),
+  })
+}
+
+async fn load_remote_class_names(config: &BalatroModelConfig) -> Result<(Vec<String>, Vec<String>), ObservationError> {
+  let entities = config.entities_classes.clone();
+  let ui = config.ui_classes.clone();
+  tokio::task::spawn_blocking(move || {
+    let load = |asset: BalatroModelAsset| -> Result<Vec<String>, ObservationError> {
+      let path = asset.resolve_path().map_err(|error| ObservationError::Api(error.to_string()))?;
+      Ok(crate::config::load_class_names(&path)?)
+    };
+    Ok((load(entities)?, load(ui)?))
+  })
+  .await
+  .map_err(|error| ObservationError::Api(format!("class-asset task failed: {error}")))?
 }
 
 fn detection_result_from_proto(response: balatro_proto::DetectObjectsResponse) -> Result<DetectionResult, ObservationError> {
@@ -308,26 +621,21 @@ fn detection_result_from_proto(response: balatro_proto::DetectObjectsResponse) -
 
 fn enrich_ui_numeric_readings_from_recognition(
   state: &mut BalatroState,
-  capture: &driver_proto::CapturedFrame,
-  recognition: driver_proto::RecognizeTextResponse,
+  capture: &auv_driver::Capture,
+  recognition: auv_driver::TextRecognition,
 ) {
-  let Some(frame) = capture.image.as_ref() else {
-    return;
-  };
-  let Some(capture_bounds) = capture.bounds.as_ref() else {
-    return;
-  };
-  if capture_bounds.width <= 0.0 || capture_bounds.height <= 0.0 {
+  let capture_bounds = capture.bounds;
+  if capture_bounds.size.width <= 0.0 || capture_bounds.size.height <= 0.0 {
     return;
   }
-  let x_scale = f64::from(frame.width) / capture_bounds.width;
-  let y_scale = f64::from(frame.height) / capture_bounds.height;
+  let x_scale = f64::from(capture.image.width()) / capture_bounds.size.width;
+  let y_scale = f64::from(capture.image.height()) / capture_bounds.size.height;
   let readings = state
     .raw_ui
     .iter()
     .filter(|evidence| {
       is_numeric_ui_label(&evidence.detection.label)
-        && (state.phase == BalatroPhase::Playing || !is_score_ui_label(&evidence.detection.label))
+        && (matches!(state.phase, BalatroPhase::Playing | BalatroPhase::CashOut) || !is_score_ui_label(&evidence.detection.label))
     })
     .filter_map(|evidence| {
       let bbox = evidence.detection.bbox;
@@ -337,9 +645,9 @@ fn enrich_ui_numeric_readings_from_recognition(
         .regions
         .iter()
         .filter_map(|region| {
-          let bounds = region.bounds.as_ref()?;
-          let x = (bounds.x + bounds.width / 2.0 - capture_bounds.x) * x_scale;
-          let y = (bounds.y + bounds.height / 2.0 - capture_bounds.y) * y_scale;
+          let bounds = region.bounds;
+          let x = (bounds.origin.x + bounds.size.width / 2.0 - capture_bounds.origin.x) * x_scale;
+          let y = (bounds.origin.y + bounds.size.height / 2.0 - capture_bounds.origin.y) * y_scale;
           (x >= f64::from(bbox.x1) - pad_x
             && x <= f64::from(bbox.x2) + pad_x
             && y >= f64::from(bbox.y1) - pad_y
@@ -454,23 +762,53 @@ pub fn build_state_from_detections(
   detections: BalatroDetectionSets,
   no_cache: bool,
 ) -> BalatroState {
-  let raw_entities = evidence_from_result(&detections.entities, "balatro-entities");
+  let mut raw_entities = evidence_from_result(&detections.entities, "balatro-entities");
+  if let Some(cards) = &detections.cards {
+    raw_entities.extend(evidence_from_result(cards, "balatro-cards"));
+  }
+  if let Some(identity) = &detections.card_attributes.identity {
+    raw_entities.extend(evidence_from_result(identity, "balatro-card-identity"));
+  }
+  if let Some(enhancement) = &detections.card_attributes.enhancement {
+    raw_entities.extend(evidence_from_result(enhancement, "balatro-card-enhancement"));
+  }
+  if let Some(edition) = &detections.card_attributes.edition {
+    raw_entities.extend(evidence_from_result(edition, "balatro-card-edition"));
+  }
+  if let Some(seal) = &detections.card_attributes.seal {
+    raw_entities.extend(evidence_from_result(seal, "balatro-card-seal"));
+  }
   let raw_ui = evidence_from_result(&detections.ui, "balatro-ui");
   let mut entity_detections = detections.entities.detections;
+  let mut hand_detections = detections.cards.map(|cards| cards.detections);
+  let card_attributes = detections.card_attributes;
   let mut ui_detections = detections.ui.detections;
 
   entity_detections.sort_by(compare_left_to_right);
+  if let Some(cards) = &mut hand_detections {
+    cards.sort_by(compare_left_to_right);
+  }
   ui_detections.sort_by(compare_left_to_right);
 
   let hand = card_slots(
-    entity_detections.iter().filter(|detection| matches_label(detection, &["poker_card_front", "poker_card_back"])),
+    // TODO(card-detector-empty-result): A configured specialized detector is
+    // authoritative even when it returns no boxes; an entities fallback would
+    // silently restore the false positives this path removes. Add an explicit
+    // fallback reason only with an owner-approved observation contract.
+    hand_detections
+      .as_deref()
+      .unwrap_or(&entity_detections)
+      .iter()
+      .filter(|detection| matches_label(detection, &["poker_card_front", "poker_card_back"])),
     ObjectZone::Hand,
     image,
     no_cache,
+    &card_attributes,
   );
   let jokers = entity_detections
     .iter()
     .filter(|detection| detection.label == "joker_card")
+    .filter(|detection| is_owned_joker_candidate(detection, image.width(), image.height()))
     .enumerate()
     .map(|(index, detection)| JokerSlot {
       slot: SlotId::new(ObjectZone::Joker, index as u32),
@@ -483,6 +821,7 @@ pub fn build_state_from_detections(
   let consumables = entity_detections
     .iter()
     .filter_map(|detection| consumable_kind(&detection.label).map(|kind| (detection, kind)))
+    .filter(|(detection, _)| is_owned_consumable_candidate(detection, image.width(), image.height()))
     .enumerate()
     .map(|(index, (detection, kind))| ConsumableSlot {
       slot: SlotId::new(ObjectZone::Consumable, index as u32),
@@ -507,6 +846,11 @@ pub fn build_state_from_detections(
   let phase = infer_phase(&entity_detections, &ui_detections);
   let diagnostics = diagnostics_for_detections(&entity_detections, &ui_detections);
 
+  // TODO(balatro-phase-zones): hand detections are not phase-gated yet, so a
+  // menu or game-over frame can expose detector false positives as hand slots.
+  // Add the gate only after the state contract defines whether raw evidence or
+  // an explicit fallback reason remains visible outside `playing`; see
+  // `2026-08-05-linux-live-gameplay-evidence.md`.
   BalatroState {
     schema_version: BALATRO_STATE_SCHEMA_VERSION.to_owned(),
     frame: FrameRef {
@@ -525,6 +869,31 @@ pub fn build_state_from_detections(
     raw_entities,
     raw_ui,
   }
+}
+
+fn is_owned_joker_candidate(detection: &Detection, image_width: u32, image_height: u32) -> bool {
+  let width = image_width.max(1) as f32;
+  let height = image_height.max(1) as f32;
+  let center_x = center_x(detection) / width;
+  let center_y = (detection.bbox.y1 + detection.bbox.y2) / 2.0 / height;
+
+  // NOTICE: Owned jokers occupy the persistent upper inventory row. Store
+  // jokers use the same detector label, so zone promotion must remain
+  // geometry-gated until the detector exposes an explicit entity zone.
+  (0.20..=0.82).contains(&center_x) && center_y <= 0.34
+}
+
+fn is_owned_consumable_candidate(detection: &Detection, image_width: u32, image_height: u32) -> bool {
+  let width = image_width.max(1) as f32;
+  let height = image_height.max(1) as f32;
+  let center_x = center_x(detection) / width;
+  let center_y = (detection.bbox.y1 + detection.bbox.y2) / 2.0 / height;
+
+  // NOTICE: These normalized bounds come from the persistent top-right
+  // consumable row in live Balatro frames. They prevent store/pack cards and a
+  // confirmed right deck-stack false positive from becoming owned inventory.
+  // Replace them when the detector exposes an explicit entity-zone contract.
+  (0.50..=0.90).contains(&center_x) && center_y <= 0.34
 }
 
 fn diagnostics_for_detections(entities: &[Detection], ui: &[Detection]) -> Vec<BalatroDiagnostic> {
@@ -549,18 +918,99 @@ fn evidence_from_result(result: &DetectionResult, model: &str) -> Vec<ObjectEvid
     .collect()
 }
 
-fn card_slots<'a>(detections: impl Iterator<Item = &'a Detection>, zone: ObjectZone, image: &RgbImage, no_cache: bool) -> Vec<CardSlot> {
+fn card_slots<'a>(
+  detections: impl Iterator<Item = &'a Detection>,
+  zone: ObjectZone,
+  image: &RgbImage,
+  no_cache: bool,
+  attributes: &CardAttributeDetectionSets,
+) -> Vec<CardSlot> {
+  let detections = detections.collect::<Vec<_>>();
+  let identities =
+    match_card_attributes(&detections, attributes.identity.as_ref().map(|result| result.detections.as_slice()).unwrap_or_default());
+  let enhancements =
+    match_card_attributes(&detections, attributes.enhancement.as_ref().map(|result| result.detections.as_slice()).unwrap_or_default());
+  let editions =
+    match_card_attributes(&detections, attributes.edition.as_ref().map(|result| result.detections.as_slice()).unwrap_or_default());
+  let seals = match_card_attributes(&detections, attributes.seal.as_ref().map(|result| result.detections.as_slice()).unwrap_or_default());
   detections
+    .into_iter()
     .enumerate()
-    .map(|(index, detection)| CardSlot {
-      slot: SlotId::new(zone, index as u32),
-      kind: detection.label.clone(),
-      bbox: detection.bbox,
-      confidence: detection.confidence,
-      reading: Reading::unread(),
-      cache: cache_hint_for_detection(detection, image, no_cache),
+    .map(|(index, detection)| {
+      let identity = identities[index];
+      let reading = match identity {
+        Some(identity) if !matches!(identity.label.as_str(), "card_back" | "rank_suit_unreadable") => Reading {
+          status: ReadingStatus::Read,
+          text: Some(identity.label.clone()),
+          confidence: Some(identity.confidence),
+        },
+        _ => Reading::unread(),
+      };
+      let kind = match identity.map(|identity| identity.label.as_str()) {
+        Some("card_back") => "poker_card_back".to_string(),
+        Some("rank_suit_unreadable") | Some(_) => "poker_card_front".to_string(),
+        None => detection.label.clone(),
+      };
+      CardSlot {
+        slot: SlotId::new(zone, index as u32),
+        kind,
+        bbox: detection.bbox,
+        confidence: detection.confidence,
+        reading,
+        attributes: CardAttributes {
+          enhancement: card_attribute(enhancements[index]),
+          edition: card_attribute(editions[index]),
+          seal: card_attribute(seals[index]),
+        },
+        cache: cache_hint_for_detection(detection, image, no_cache),
+      }
     })
     .collect()
+}
+
+fn card_attribute(attribute: Option<&Detection>) -> Option<CardAttribute> {
+  attribute.map(|attribute| CardAttribute {
+    label: attribute.label.clone(),
+    confidence: attribute.confidence,
+  })
+}
+
+fn match_card_attributes<'a>(cards: &[&Detection], attributes: &'a [Detection]) -> Vec<Option<&'a Detection>> {
+  let mut candidates = cards
+    .iter()
+    .enumerate()
+    .flat_map(|(card_index, card)| {
+      attributes.iter().enumerate().filter_map(move |(attribute_index, attribute)| {
+        let overlap = bbox_iou(card.bbox, attribute.bbox);
+        (overlap >= 0.2).then_some((card_index, attribute_index, overlap))
+      })
+    })
+    .collect::<Vec<_>>();
+  candidates.sort_by(|left, right| right.2.partial_cmp(&left.2).unwrap_or(std::cmp::Ordering::Equal));
+
+  let mut matches = vec![None; cards.len()];
+  let mut used_attributes = vec![false; attributes.len()];
+  for (card_index, attribute_index, _) in candidates {
+    if matches[card_index].is_none() && !used_attributes[attribute_index] {
+      matches[card_index] = Some(&attributes[attribute_index]);
+      used_attributes[attribute_index] = true;
+    }
+  }
+  matches
+}
+
+fn bbox_iou(left: BoundingBox, right: BoundingBox) -> f32 {
+  let intersection_width = (left.x2.min(right.x2) - left.x1.max(right.x1)).max(0.0);
+  let intersection_height = (left.y2.min(right.y2) - left.y1.max(right.y1)).max(0.0);
+  let intersection = intersection_width * intersection_height;
+  let left_area = left.width().max(0.0) * left.height().max(0.0);
+  let right_area = right.width().max(0.0) * right.height().max(0.0);
+  let union = left_area + right_area - intersection;
+  if union <= 0.0 {
+    0.0
+  } else {
+    intersection / union
+  }
 }
 
 fn store_state(entities: &[Detection], ui: &[Detection], image: &RgbImage, no_cache: bool) -> StoreState {
@@ -584,10 +1034,24 @@ fn store_state(entities: &[Detection], ui: &[Detection], image: &RgbImage, no_ca
 }
 
 fn store_items_for_store_context(entities: &[Detection], image: &RgbImage, no_cache: bool) -> Vec<StoreItem> {
-  let mut items = entities
+  let candidates = entities
     .iter()
     .filter_map(|detection| store_item_kind(&detection.label).map(|kind| (detection, kind)))
     .filter(|(detection, kind)| is_store_item_candidate(detection, kind, image.width(), image.height()))
+    .collect::<Vec<_>>();
+  let mut distinct = Vec::<(&Detection, StoreItemKind)>::new();
+  for (detection, kind) in candidates {
+    if let Some(index) = distinct.iter().position(|(existing, _)| bbox_iou(existing.bbox, detection.bbox) >= 0.75) {
+      if detection.confidence > distinct[index].0.confidence {
+        distinct[index] = (detection, kind);
+      }
+    } else {
+      distinct.push((detection, kind));
+    }
+  }
+  distinct.sort_by(|(left, _), (right, _)| compare_left_to_right(left, right));
+  let mut items = distinct
+    .into_iter()
     .enumerate()
     .map(|(index, (detection, kind))| StoreItem {
       slot: SlotId::new(ObjectZone::Store, index as u32),
@@ -625,6 +1089,8 @@ fn is_store_item_candidate(detection: &Detection, kind: &StoreItemKind, image_wi
 fn infer_phase(entities: &[Detection], ui: &[Detection]) -> BalatroPhase {
   if ui.iter().any(is_store_control) {
     BalatroPhase::Store
+  } else if ui.iter().any(|detection| detection.label == "button_cash_out") {
+    BalatroPhase::CashOut
   } else if ui.iter().any(|detection| matches_label(detection, &["button_play", "button_discard"]))
     || (entities.iter().any(is_hand_card) && ui.iter().any(is_hand_sort_control))
   {

--- a/supported/games/auv-game-balatro/src/observation_test.rs
+++ b/supported/games/auv-game-balatro/src/observation_test.rs
@@ -1,13 +1,15 @@
-use auv_api_proto::auv::api::{driver::v1 as driver_proto, image::v1 as image_proto};
+use auv_driver::{Capture, RecognizedText, Rect, TextRecognition};
 use auv_inference_common::ImageSize;
 use auv_task_object_detection::{BoundingBox, Detection, DetectionResult};
-use image::{Rgb, RgbImage};
+use image::{Rgb, RgbImage, RgbaImage};
 
 use crate::cache::cache_hint_for_detection;
+use crate::model::{BalatroPhase, StoreItemKind};
 
 use super::{
-  BalatroDetectionSets, balatro_runner_options, build_state_from_detections, driver_runner_options,
-  enrich_ui_numeric_readings_from_recognition, rgba_frame_to_rgb,
+  BalatroDetectionSets, CardAttributeDetectionSets, balatro_runner_options, build_state_from_detections, detector_spec,
+  driver_runner_options, enrich_ui_numeric_readings_from_recognition, load_remote_class_names, ocr_capture_for_ui,
+  store_items_for_store_context,
 };
 
 #[test]
@@ -15,23 +17,32 @@ fn observation_routes_distinct_driver_and_balatro_runner_classes() {
   let driver = driver_runner_options();
   let balatro = balatro_runner_options();
 
-  assert_eq!(driver.runner_class, "auv.core.local");
-  assert_eq!(balatro.runner_class, "auv.game.balatro");
+  assert_eq!(driver.runner_class.as_str(), "auv.core.local");
+  assert_eq!(balatro.runner_class.as_str(), "auv.game.balatro");
 }
 
-#[test]
-fn rgba_capture_is_converted_to_packed_rgb_for_inference() {
-  let frame = image_proto::RgbaFrame {
-    width: 2,
-    height: 1,
-    data: vec![1, 2, 3, 4, 5, 6, 7, 8],
+#[tokio::test]
+async fn class_assets_load_outside_the_async_runtime_thread() {
+  // ROOT CAUSE:
+  //
+  // If a remote observation resolved synchronous Hugging Face assets directly
+  // inside Tokio, hf-hub tried to start a nested runtime and panicked. Asset
+  // resolution must stay on the blocking pool while gRPC remains async.
+  let directory = tempfile::tempdir().expect("class fixture directory");
+  let entities = directory.path().join("entities.txt");
+  let ui = directory.path().join("ui.txt");
+  std::fs::write(&entities, "card\njoker\n").expect("write entity classes");
+  std::fs::write(&ui, "button_play\n").expect("write UI classes");
+  let config = crate::config::BalatroModelConfig {
+    entities_classes: crate::config::BalatroModelAsset::local(entities),
+    ui_classes: crate::config::BalatroModelAsset::local(ui),
+    ..Default::default()
   };
 
-  let rgb = rgba_frame_to_rgb(&frame).expect("valid RGBA frame");
+  let (entities, ui) = load_remote_class_names(&config).await.expect("load class assets");
 
-  assert_eq!(rgb.width, 2);
-  assert_eq!(rgb.height, 1);
-  assert_eq!(rgb.data, vec![1, 2, 3, 5, 6, 7]);
+  assert_eq!(entities, ["card", "joker"]);
+  assert_eq!(ui, ["button_play"]);
 }
 
 #[test]
@@ -53,6 +64,266 @@ fn cache_hint_handles_partially_out_of_bounds_bbox() {
 
   assert!(hint.needs_reading);
   assert!(hint.visual_fingerprint.is_some());
+}
+
+#[test]
+fn specialized_card_detections_replace_noisy_entity_cards_for_the_hand() {
+  let image_size = ImageSize {
+    width: 1000,
+    height: 600,
+  };
+  let card = |x1: f32, confidence: f32| Detection {
+    class_id: 6,
+    label: "poker_card_front".to_string(),
+    confidence,
+    bbox: BoundingBox {
+      x1,
+      y1: 300.0,
+      x2: x1 + 80.0,
+      y2: 520.0,
+    },
+  };
+  let state = build_state_from_detections(
+    "fixture.png",
+    image_size,
+    &RgbImage::new(image_size.width, image_size.height),
+    BalatroDetectionSets {
+      entities: DetectionResult {
+        image_size,
+        detections: vec![card(20.0, 0.55), card(400.0, 0.91), card(800.0, 0.60)],
+      },
+      cards: Some(DetectionResult {
+        image_size,
+        detections: vec![card(410.0, 0.99)],
+      }),
+      card_attributes: CardAttributeDetectionSets {
+        identity: Some(DetectionResult {
+          image_size,
+          detections: vec![Detection {
+            class_id: 51,
+            label: "S_A".to_string(),
+            confidence: 0.98,
+            bbox: card(412.0, 0.98).bbox,
+          }],
+        }),
+        enhancement: Some(DetectionResult {
+          image_size,
+          detections: vec![Detection {
+            class_id: 2,
+            label: "steel".to_string(),
+            confidence: 0.97,
+            bbox: card(412.0, 0.97).bbox,
+          }],
+        }),
+        edition: Some(DetectionResult {
+          image_size,
+          detections: vec![Detection {
+            class_id: 1,
+            label: "foil".to_string(),
+            confidence: 0.96,
+            bbox: card(412.0, 0.96).bbox,
+          }],
+        }),
+        seal: Some(DetectionResult {
+          image_size,
+          detections: vec![Detection {
+            class_id: 3,
+            label: "red".to_string(),
+            confidence: 0.95,
+            bbox: card(412.0, 0.95).bbox,
+          }],
+        }),
+      },
+      ui: DetectionResult {
+        image_size,
+        detections: Vec::new(),
+      },
+    },
+    true,
+  );
+
+  assert_eq!(state.hand.len(), 1);
+  assert_eq!(state.hand[0].bbox.x1, 410.0);
+  assert_eq!(state.hand[0].reading.text.as_deref(), Some("S_A"));
+  assert_eq!(state.hand[0].attributes.enhancement.as_ref().map(|attribute| attribute.label.as_str()), Some("steel"));
+  assert_eq!(state.hand[0].attributes.edition.as_ref().map(|attribute| attribute.label.as_str()), Some("foil"));
+  assert_eq!(state.hand[0].attributes.seal.as_ref().map(|attribute| attribute.label.as_str()), Some("red"));
+  assert!(state.raw_entities.iter().any(|evidence| evidence.model == "balatro-cards"));
+  assert!(state.raw_entities.iter().any(|evidence| evidence.model == "balatro-card-identity"));
+}
+
+#[test]
+fn detector_spec_preserves_model_input_size_and_cuda_index() {
+  let spec = detector_spec(
+    "balatro-card-identity",
+    &crate::config::BalatroModelAsset::local("identity.onnx"),
+    &auv_inference_ultralytics::InferenceDevice::Cuda(2),
+    960,
+    Vec::new(),
+  )
+  .expect("valid detector spec");
+
+  assert_eq!(spec.input_size, Some(960));
+  let device = spec.device.expect("device");
+  assert_eq!(device.kind, crate::api::v1::InferenceDeviceKind::Cuda as i32);
+  assert_eq!(device.index, Some(2));
+}
+
+#[test]
+fn one_identity_detection_cannot_read_multiple_overlapping_hand_slots() {
+  // ROOT CAUSE:
+  //
+  // If fanned hand boxes overlap, independently selecting each slot's best IoU
+  // reused one identity detection for adjacent cards. Attribute association is
+  // a one-to-one assignment even when a single box clears multiple thresholds.
+  let image_size = ImageSize {
+    width: 500,
+    height: 300,
+  };
+  let card = |x1: f32| Detection {
+    class_id: 6,
+    label: "poker_card_front".to_string(),
+    confidence: 0.9,
+    bbox: BoundingBox {
+      x1,
+      y1: 100.0,
+      x2: x1 + 120.0,
+      y2: 260.0,
+    },
+  };
+  let state = build_state_from_detections(
+    "fixture://overlapping-hand",
+    image_size,
+    &RgbImage::new(image_size.width, image_size.height),
+    BalatroDetectionSets {
+      entities: DetectionResult {
+        image_size,
+        detections: Vec::new(),
+      },
+      cards: Some(DetectionResult {
+        image_size,
+        detections: vec![card(100.0), card(150.0)],
+      }),
+      card_attributes: CardAttributeDetectionSets {
+        identity: Some(DetectionResult {
+          image_size,
+          detections: vec![Detection {
+            class_id: 0,
+            label: "H_A".to_string(),
+            confidence: 0.99,
+            bbox: card(125.0).bbox,
+          }],
+        }),
+        ..Default::default()
+      },
+      ui: DetectionResult {
+        image_size,
+        detections: Vec::new(),
+      },
+    },
+    true,
+  );
+
+  assert_eq!(state.hand.iter().filter(|card| card.reading.text.as_deref() == Some("H_A")).count(), 1);
+}
+
+#[test]
+fn ocr_capture_is_limited_to_detected_numeric_ui_and_preserves_screen_projection() {
+  // ROOT CAUSE:
+  //
+  // If live observation sent the entire display back to Linux Tesseract, OCR
+  // dominated latency even though Balatro numeric readings occupy a small UI
+  // region. The fix derives one padded OCR crop from numeric UI detections and
+  // ignores unrelated controls.
+  let image_size = ImageSize {
+    width: 1000,
+    height: 600,
+  };
+  let detection = |label: &str, bbox: BoundingBox| Detection {
+    class_id: 0,
+    label: label.to_string(),
+    confidence: 0.9,
+    bbox,
+  };
+  let ui = DetectionResult {
+    image_size,
+    detections: vec![
+      detection(
+        "ui_score_chips",
+        BoundingBox {
+          x1: 100.0,
+          y1: 120.0,
+          x2: 200.0,
+          y2: 180.0,
+        },
+      ),
+      detection(
+        "ui_data_cash",
+        BoundingBox {
+          x1: 300.0,
+          y1: 400.0,
+          x2: 450.0,
+          y2: 500.0,
+        },
+      ),
+      detection(
+        "button_play",
+        BoundingBox {
+          x1: 0.0,
+          y1: 0.0,
+          x2: 1000.0,
+          y2: 600.0,
+        },
+      ),
+    ],
+  };
+
+  let capture = Capture {
+    image: RgbaImage::new(1000, 600),
+    bounds: Rect::new(10.0, 20.0, 500.0, 300.0),
+    scale_factor: 2.0,
+    backend: "fixture".to_string(),
+    fallback_reason: None,
+  };
+
+  let crop = ocr_capture_for_ui(&capture, &ui).expect("numeric UI should produce an OCR capture");
+
+  assert_eq!(crop.image.dimensions(), (370, 392));
+  assert_eq!(crop.bounds, Rect::new(55.0, 77.0, 185.0, 196.0));
+  assert_eq!(crop.scale_factor, 2.0);
+  assert_eq!(crop.backend, "fixture");
+}
+
+#[test]
+fn ocr_capture_is_absent_without_numeric_ui() {
+  let image_size = ImageSize {
+    width: 1000,
+    height: 600,
+  };
+  let ui = DetectionResult {
+    image_size,
+    detections: vec![Detection {
+      class_id: 0,
+      label: "button_play".to_string(),
+      confidence: 0.9,
+      bbox: BoundingBox {
+        x1: 100.0,
+        y1: 100.0,
+        x2: 200.0,
+        y2: 200.0,
+      },
+    }],
+  };
+
+  let capture = Capture {
+    image: RgbaImage::new(1000, 600),
+    bounds: Rect::new(0.0, 0.0, 1000.0, 600.0),
+    scale_factor: 1.0,
+    backend: "fixture".to_string(),
+    fallback_reason: None,
+  };
+
+  assert_eq!(ocr_capture_for_ui(&capture, &ui), None);
 }
 
 #[test]
@@ -98,36 +369,24 @@ fn driver_runner_ocr_logical_bounds_enrich_pixel_space_numeric_detection() {
         image_size,
         detections: Vec::new(),
       },
+      cards: None,
+      card_attributes: Default::default(),
       ui,
     },
     true,
   );
-  let capture = driver_proto::CapturedFrame {
-    image: Some(image_proto::RgbaFrame {
-      width: 200,
-      height: 100,
-      data: vec![0; 200 * 100 * 4],
-    }),
-    bounds: Some(driver_proto::ScreenRect {
-      x: 10.0,
-      y: 20.0,
-      width: 20.0,
-      height: 10.0,
-    }),
+  let capture = Capture {
+    image: RgbaImage::new(200, 100),
+    bounds: Rect::new(10.0, 20.0, 20.0, 10.0),
     scale_factor: 10.0,
     backend: "fixture".to_string(),
     fallback_reason: None,
   };
-  let recognition = driver_proto::RecognizeTextResponse {
+  let recognition = TextRecognition {
     text: "$1,234".to_string(),
-    regions: vec![driver_proto::RecognizedText {
+    regions: vec![RecognizedText {
       text: "$1,234".to_string(),
-      bounds: Some(driver_proto::ScreenRect {
-        x: 20.0,
-        y: 23.0,
-        width: 2.0,
-        height: 1.0,
-      }),
+      bounds: Rect::new(20.0, 23.0, 2.0, 1.0),
       confidence: Some(0.99),
     }],
   };
@@ -135,4 +394,222 @@ fn driver_runner_ocr_logical_bounds_enrich_pixel_space_numeric_detection() {
   enrich_ui_numeric_readings_from_recognition(&mut state, &capture, recognition);
 
   assert_eq!(state.scores.chips.as_deref(), Some("$1234"));
+}
+
+#[test]
+fn cash_out_control_classifies_the_payout_phase() {
+  let image_size = ImageSize {
+    width: 2560,
+    height: 1440,
+  };
+  let image = RgbImage::new(image_size.width, image_size.height);
+  let state = build_state_from_detections(
+    "fixture://cash-out",
+    image_size,
+    &image,
+    BalatroDetectionSets {
+      entities: DetectionResult {
+        image_size,
+        detections: Vec::new(),
+      },
+      cards: None,
+      card_attributes: Default::default(),
+      ui: DetectionResult {
+        image_size,
+        detections: vec![Detection {
+          class_id: 2,
+          label: "button_cash_out".to_string(),
+          confidence: 0.96,
+          bbox: BoundingBox {
+            x1: 1044.0,
+            y1: 588.0,
+            x2: 1670.0,
+            y2: 695.0,
+          },
+        }],
+      },
+    },
+    true,
+  );
+
+  assert_eq!(state.phase, BalatroPhase::CashOut);
+}
+
+#[test]
+fn deck_stack_detection_is_not_promoted_to_an_owned_consumable() {
+  // ROOT CAUSE:
+  //
+  // If the entity model mislabeled the right-side deck stack as a tarot card,
+  // every tarot-shaped detection was promoted into the owned consumable row.
+  // The fix keeps promotion inside the top owned-consumable layout band.
+  let image_size = ImageSize {
+    width: 2560,
+    height: 1440,
+  };
+  let image = RgbImage::new(image_size.width, image_size.height);
+  let state = build_state_from_detections(
+    "fixture://playing-with-deck-stack-false-positive",
+    image_size,
+    &image,
+    BalatroDetectionSets {
+      entities: DetectionResult {
+        image_size,
+        detections: vec![Detection {
+          class_id: 7,
+          label: "tarot_card".to_string(),
+          confidence: 0.36,
+          bbox: BoundingBox {
+            x1: 2260.0,
+            y1: 610.0,
+            x2: 2490.0,
+            y2: 1040.0,
+          },
+        }],
+      },
+      cards: None,
+      card_attributes: Default::default(),
+      ui: DetectionResult {
+        image_size,
+        detections: vec![Detection {
+          class_id: 1,
+          label: "button_play".to_string(),
+          confidence: 0.95,
+          bbox: BoundingBox {
+            x1: 780.0,
+            y1: 1120.0,
+            x2: 1040.0,
+            y2: 1230.0,
+          },
+        }],
+      },
+    },
+    true,
+  );
+
+  assert!(state.consumables.is_empty());
+  assert_eq!(state.raw_entities[0].detection.label, "tarot_card");
+}
+
+#[test]
+fn top_row_consumable_is_promoted_to_owned_inventory() {
+  let image_size = ImageSize {
+    width: 2560,
+    height: 1440,
+  };
+  let image = RgbImage::new(image_size.width, image_size.height);
+  let state = build_state_from_detections(
+    "fixture://owned-consumable",
+    image_size,
+    &image,
+    BalatroDetectionSets {
+      entities: DetectionResult {
+        image_size,
+        detections: vec![Detection {
+          class_id: 7,
+          label: "tarot_card".to_string(),
+          confidence: 0.91,
+          bbox: BoundingBox {
+            x1: 1700.0,
+            y1: 90.0,
+            x2: 1880.0,
+            y2: 390.0,
+          },
+        }],
+      },
+      cards: None,
+      card_attributes: Default::default(),
+      ui: DetectionResult {
+        image_size,
+        detections: Vec::new(),
+      },
+    },
+    true,
+  );
+
+  assert_eq!(state.consumables.len(), 1);
+}
+
+#[test]
+fn store_joker_is_not_promoted_to_owned_inventory() {
+  // ROOT CAUSE:
+  //
+  // Store and owned jokers share the `joker_card` detector label. Without a
+  // zone gate, a shop product appeared in both `store.items` and `jokers`, so
+  // `jokers ls` auto-read inventory that the player did not own.
+  let image_size = ImageSize {
+    width: 2560,
+    height: 1440,
+  };
+  let image = RgbImage::new(image_size.width, image_size.height);
+  let state = build_state_from_detections(
+    "fixture://store-joker",
+    image_size,
+    &image,
+    BalatroDetectionSets {
+      entities: DetectionResult {
+        image_size,
+        detections: vec![Detection {
+          class_id: 1,
+          label: "joker_card".to_string(),
+          confidence: 0.93,
+          bbox: BoundingBox {
+            x1: 1420.0,
+            y1: 575.0,
+            x2: 1590.0,
+            y2: 825.0,
+          },
+        }],
+      },
+      cards: None,
+      card_attributes: Default::default(),
+      ui: DetectionResult {
+        image_size,
+        detections: vec![Detection {
+          class_id: 2,
+          label: "button_store_reroll".to_string(),
+          confidence: 0.95,
+          bbox: BoundingBox {
+            x1: 1000.0,
+            y1: 1000.0,
+            x2: 1200.0,
+            y2: 1100.0,
+          },
+        }],
+      },
+    },
+    true,
+  );
+
+  assert!(state.jokers.is_empty());
+  assert_eq!(state.store.items.len(), 2, "one detector item plus the voucher fallback");
+}
+
+#[test]
+fn overlapping_store_class_predictions_share_one_slot() {
+  let image = RgbImage::new(2560, 1440);
+  let bbox = BoundingBox {
+    x1: 1420.0,
+    y1: 575.0,
+    x2: 1590.0,
+    y2: 825.0,
+  };
+  let entities = vec![
+    Detection {
+      class_id: 1,
+      label: "joker_card".to_string(),
+      confidence: 0.89,
+      bbox,
+    },
+    Detection {
+      class_id: 2,
+      label: "tarot_card".to_string(),
+      confidence: 0.91,
+      bbox,
+    },
+  ];
+
+  let items = store_items_for_store_context(&entities, &image, true);
+
+  assert_eq!(items.len(), 2, "one detector item plus the voucher fallback");
+  assert_eq!(items[0].kind, StoreItemKind::Tarot);
 }

--- a/supported/games/auv-game-balatro/src/run_read.rs
+++ b/supported/games/auv-game-balatro/src/run_read.rs
@@ -1,6 +1,9 @@
 //! Balatro tracing artifact producers.
 
-use auv_tracing::{ArtifactMetadata, ArtifactPurpose, Attributes, ByteLength, Context, EventPayload, JsonArtifactError, StoreError};
+use auv_tracing::{
+  ArtifactMetadata, ArtifactPurpose, AttributeValue, Attributes, ByteLength, Context, EmitBytesOptions, EventPayload, JsonArtifactError,
+  StoreError,
+};
 use serde::Serialize;
 
 pub const BALATRO_STRUCTURED_ARTIFACT_JSON_BYTE_LIMIT: u64 = 4 * 1024 * 1024;
@@ -38,6 +41,37 @@ pub(crate) fn emit_json_artifact<T: Serialize>(purpose: &'static str, value: &T)
     return;
   }
   match prepare_json_emission(purpose, value) {
+    Ok(emission) => drop(emission),
+    Err(error) => context.in_scope(|| {
+      auv_tracing::emit_event!(BalatroArtifactPreparationFailed {
+        purpose,
+        error: error.to_string(),
+      });
+    }),
+  }
+}
+
+pub(crate) fn emit_png_artifact(purpose: &'static str, source: &str, image: &image::RgbaImage) {
+  let context = Context::current();
+  if !context.can_publish_artifacts() {
+    return;
+  }
+  let mut encoded = std::io::Cursor::new(Vec::new());
+  if let Err(error) = image::DynamicImage::ImageRgba8(image.clone()).write_to(&mut encoded, image::ImageFormat::Png) {
+    context.in_scope(|| {
+      auv_tracing::emit_event!(BalatroArtifactPreparationFailed {
+        purpose,
+        error: error.to_string(),
+      });
+    });
+    return;
+  }
+  let options = EmitBytesOptions::new()
+    .with_purpose(purpose)
+    .with_content_type("image/png")
+    .with_file_extension("png")
+    .with_attributes(Attributes::from_iter([("source", AttributeValue::string(source))]));
+  match auv_tracing::emit_bytes_artifact(options, encoded.into_inner()) {
     Ok(emission) => drop(emission),
     Err(error) => context.in_scope(|| {
       auv_tracing::emit_event!(BalatroArtifactPreparationFailed {
@@ -89,3 +123,28 @@ fn prepare_json_emission<T: Serialize>(
 
 // TODO(auv-inspector): typed Balatro artifact readers remain deferred until an
 // owner-approved inspector contract defines discovery and validation inputs.
+
+#[cfg(test)]
+mod tests {
+  use std::sync::Arc;
+
+  use auv_tracing::{Context, MemoryTracingStore, RunId, TraceRecord, configure, dispatcher};
+
+  use super::emit_png_artifact;
+
+  #[test]
+  fn observed_frame_png_is_visible_in_the_run_store() {
+    futures_executor::block_on(async {
+      let store = Arc::new(MemoryTracingStore::new());
+      let dispatch = configure().tracing_store(store.clone()).build().expect("memory tracing dispatch");
+      let context = dispatcher::with_default(&dispatch, || Context::root(RunId::new()));
+
+      context.in_scope(|| emit_png_artifact("auv.balatro.observation.capture", "fixture://before", &image::RgbaImage::new(2, 2)));
+      dispatch.flush().await.expect("flush tracing");
+
+      assert!(store.records().iter().any(|record| {
+        matches!(record, TraceRecord::Artifact { metadata, .. } if metadata.purpose().as_str() == "auv.balatro.observation.capture")
+      }));
+    });
+  }
+}

--- a/supported/games/auv-game-balatro/src/runner.rs
+++ b/supported/games/auv-game-balatro/src/runner.rs
@@ -9,6 +9,7 @@ use auv_api_proto::auv::api::image::v1 as image_proto;
 use auv_inference_common::{ImageFrame, ModelId};
 use auv_inference_ultralytics::InferenceDevice;
 use auv_task_object_detection::{DetectionOptions, UltralyticsObjectDetector, UltralyticsObjectDetectorConfig};
+use hf_hub::HFClientSync;
 use tonic::{Request, Response, Status};
 
 use crate::api::v1 as proto;
@@ -29,6 +30,19 @@ impl BalatroDetectionService for Service {
     tokio::task::spawn_blocking(move || detect_objects(&detectors, detector, frame))
       .await
       .map_err(|error| Status::internal(format!("object-detection task failed: {error}")))?
+      .map(Response::new)
+  }
+
+  async fn detect_objects_batch(
+    &self,
+    request: Request<proto::DetectObjectsBatchRequest>,
+  ) -> Result<Response<proto::DetectObjectsBatchResponse>, Status> {
+    let request = request.into_inner();
+    let frame = request.frame.ok_or_else(|| Status::invalid_argument("frame is required"))?;
+    let detectors = Arc::clone(&self.detectors);
+    tokio::task::spawn_blocking(move || detect_objects_batch(&detectors, request.detectors, frame))
+      .await
+      .map_err(|error| Status::internal(format!("object-detection batch task failed: {error}")))?
       .map(Response::new)
   }
 }
@@ -101,7 +115,7 @@ impl DetectorKey {
     if spec.detector_id.trim().is_empty() {
       return Err(Status::invalid_argument("detector.detector_id must not be empty"));
     }
-    let model_path = PathBuf::from(spec.model_path);
+    let model_path = resolve_model_source(spec.source)?;
     let defaults = DetectionOptions::default();
     let max_detections = usize::try_from(spec.max_detections.unwrap_or(defaults.max_detections as u32))
       .map_err(|_| Status::invalid_argument("detector.max_detections is too large"))?;
@@ -123,6 +137,34 @@ impl DetectorKey {
       device: DeviceKey::from_proto(spec.device)?,
       class_names: spec.class_names,
     })
+  }
+}
+
+fn resolve_model_source(source: Option<proto::object_detector_spec::Source>) -> Result<PathBuf, Status> {
+  match source.ok_or_else(|| Status::invalid_argument("detector.source is required"))? {
+    proto::object_detector_spec::Source::RunnerPath(path) if !path.trim().is_empty() => Ok(PathBuf::from(path)),
+    proto::object_detector_spec::Source::RunnerPath(_) => Err(Status::invalid_argument("detector.runner_path must not be empty")),
+    proto::object_detector_spec::Source::HuggingFace(asset) => {
+      if asset.owner.trim().is_empty() || asset.repository.trim().is_empty() || asset.filename.trim().is_empty() {
+        return Err(Status::invalid_argument("detector.hugging_face owner, repository, and filename are required"));
+      }
+      let kind = proto::hugging_face_asset::RepositoryKind::try_from(asset.repository_kind)
+        .map_err(|_| Status::invalid_argument("detector.hugging_face.repository_kind is unknown"))?;
+      let client =
+        HFClientSync::new().map_err(|error| Status::failed_precondition(format!("failed to initialize Hugging Face client: {error}")))?;
+      match kind {
+        proto::hugging_face_asset::RepositoryKind::Model => {
+          client.model(asset.owner, asset.repository).download_file().filename(asset.filename).send()
+        }
+        proto::hugging_face_asset::RepositoryKind::Dataset => {
+          client.dataset(asset.owner, asset.repository).download_file().filename(asset.filename).send()
+        }
+        proto::hugging_face_asset::RepositoryKind::Unspecified => {
+          return Err(Status::invalid_argument("detector.hugging_face.repository_kind is required"));
+        }
+      }
+      .map_err(|error| Status::failed_precondition(format!("failed to resolve Runner model asset: {error}")))
+    }
   }
 }
 
@@ -169,6 +211,41 @@ fn detect_objects(
   detector: proto::ObjectDetectorSpec,
   frame: image_proto::RgbFrame,
 ) -> Result<proto::DetectObjectsResponse, Status> {
+  let frame = image_frame_from_proto(frame)?;
+  detect_frame(detectors, detector, &frame)
+}
+
+fn detect_objects_batch(
+  detectors: &LazyResourceCache<DetectorKey, UltralyticsObjectDetector>,
+  specs: Vec<proto::ObjectDetectorSpec>,
+  frame: image_proto::RgbFrame,
+) -> Result<proto::DetectObjectsBatchResponse, Status> {
+  if specs.is_empty() {
+    return Err(Status::invalid_argument("detectors must not be empty"));
+  }
+  let frame = image_frame_from_proto(frame)?;
+  let results = std::thread::scope(|scope| {
+    let frame = &frame;
+    specs
+      .into_iter()
+      .map(|spec| {
+        let detector_id = spec.detector_id.clone();
+        scope.spawn(move || {
+          detect_frame(detectors, spec, frame).map(|result| proto::DetectObjectsBatchResult {
+            detector_id,
+            result: Some(result),
+          })
+        })
+      })
+      .collect::<Vec<_>>()
+      .into_iter()
+      .map(|thread| thread.join().map_err(|_| Status::internal("object detector thread panicked"))?)
+      .collect::<Result<Vec<_>, Status>>()
+  })?;
+  Ok(proto::DetectObjectsBatchResponse { results })
+}
+
+fn image_frame_from_proto(frame: image_proto::RgbFrame) -> Result<ImageFrame, Status> {
   let expected_len = usize::try_from(frame.width)
     .ok()
     .and_then(|width| usize::try_from(frame.height).ok().and_then(|height| width.checked_mul(height)))
@@ -184,12 +261,31 @@ fn detect_objects(
   }
   let image = image::RgbImage::from_raw(frame.width, frame.height, frame.data)
     .ok_or_else(|| Status::invalid_argument("frame.data is not a valid tightly packed RGB8 image"))?;
+  Ok(ImageFrame::new(image))
+}
+
+fn detect_frame(
+  detectors: &LazyResourceCache<DetectorKey, UltralyticsObjectDetector>,
+  detector: proto::ObjectDetectorSpec,
+  frame: &ImageFrame,
+) -> Result<proto::DetectObjectsResponse, Status> {
   let key = DetectorKey::from_proto(detector)?;
   let detector = detectors
     .get_or_try_init(key.clone(), |key| {
       let device = match key.device {
         DeviceKey::Cpu => InferenceDevice::Cpu,
-        DeviceKey::Cuda(index) => InferenceDevice::Cuda(index),
+        DeviceKey::Cuda(index) => {
+          #[cfg(feature = "cuda")]
+          {
+            InferenceDevice::Cuda(index)
+          }
+          #[cfg(not(feature = "cuda"))]
+          {
+            return Err(Arc::<str>::from(format!(
+              "CUDA device {index} was requested, but the Balatro Runner was built without its `cuda` feature"
+            )));
+          }
+        }
         DeviceKey::CoreMl => InferenceDevice::CoreMl,
         DeviceKey::DirectMl(index) => InferenceDevice::DirectMl(index),
         DeviceKey::OpenVino => InferenceDevice::OpenVino,
@@ -212,8 +308,7 @@ fn detect_objects(
       .map_err(|error| Arc::<str>::from(error.to_string()))
     })
     .map_err(|error| Status::failed_precondition(format!("failed to load detector {}: {error}", key.detector_id)))?;
-  let result =
-    detector.detect_frame(&ImageFrame::new(image)).map_err(|error| Status::internal(format!("object detection failed: {error}")))?;
+  let result = detector.detect_frame(frame).map_err(|error| Status::internal(format!("object detection failed: {error}")))?;
   Ok(proto::DetectObjectsResponse {
     image_size: Some(proto::ImageSize {
       width: result.image_size.width,

--- a/supported/games/auv-game-balatro/src/runner_test.rs
+++ b/supported/games/auv-game-balatro/src/runner_test.rs
@@ -1,4 +1,6 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::mpsc;
+use std::time::Duration;
 
 use super::*;
 
@@ -8,7 +10,7 @@ fn rejects_malformed_rgb_frame_before_model_loading() {
     &LazyResourceCache::default(),
     proto::ObjectDetectorSpec {
       detector_id: "test".to_string(),
-      model_path: "/missing/model.onnx".to_string(),
+      source: Some(proto::object_detector_spec::Source::RunnerPath("/missing/model.onnx".to_string())),
       ..Default::default()
     },
     image_proto::RgbFrame {
@@ -23,6 +25,23 @@ fn rejects_malformed_rgb_frame_before_model_loading() {
 }
 
 #[test]
+fn rejects_empty_detector_batch_before_frame_decoding() {
+  let error = detect_objects_batch(
+    &LazyResourceCache::default(),
+    Vec::new(),
+    image_proto::RgbFrame {
+      width: 0,
+      height: 0,
+      data: Vec::new(),
+    },
+  )
+  .expect_err("empty detector batch");
+
+  assert_eq!(error.code(), tonic::Code::InvalidArgument);
+  assert!(error.message().contains("detectors must not be empty"));
+}
+
+#[test]
 fn lazy_resource_cache_initializes_once_per_key() {
   let cache = LazyResourceCache::<String, usize>::default();
   let loads = AtomicUsize::new(0);
@@ -30,4 +49,41 @@ fn lazy_resource_cache_initializes_once_per_key() {
   let second = cache.get_or_try_init("detector".to_string(), |_| Ok(loads.fetch_add(1, Ordering::SeqCst))).expect("cached load");
   assert!(Arc::ptr_eq(&first, &second));
   assert_eq!(loads.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn lazy_resource_cache_loads_distinct_models_concurrently() {
+  // ROOT CAUSE:
+  //
+  // If model construction held the cache map lock, the four independent card
+  // attribute sessions would load serially before inference could overlap.
+  // The cache must hold that lock only while resolving each per-key OnceLock.
+  let cache = Arc::new(LazyResourceCache::<String, usize>::default());
+  let (entered_tx, entered_rx) = mpsc::channel();
+  let (release_tx, release_rx) = mpsc::channel();
+  let release_rx = Arc::new(Mutex::new(release_rx));
+  let mut threads = Vec::new();
+  for key in ["identity", "edition"] {
+    let cache = Arc::clone(&cache);
+    let entered_tx = entered_tx.clone();
+    let release_rx = Arc::clone(&release_rx);
+    threads.push(std::thread::spawn(move || {
+      cache
+        .get_or_try_init(key.to_string(), |_| {
+          entered_tx.send(key).expect("announce model load");
+          release_rx.lock().expect("release receiver mutex").recv().expect("release model load");
+          Ok(1)
+        })
+        .expect("model load")
+    }));
+  }
+
+  let first = entered_rx.recv_timeout(Duration::from_secs(1)).expect("first model entered loader");
+  let second = entered_rx.recv_timeout(Duration::from_secs(1)).expect("second model entered loader without waiting for first");
+  assert_ne!(first, second);
+  release_tx.send(()).expect("release first model");
+  release_tx.send(()).expect("release second model");
+  for thread in threads {
+    thread.join().expect("loader thread");
+  }
 }

--- a/supported/games/auv-game-balatro/src/store_buy.rs
+++ b/supported/games/auv-game-balatro/src/store_buy.rs
@@ -1,7 +1,7 @@
-use auv_driver::{InputActionResult, WindowPoint};
+use auv_driver::InputActionResult;
 use serde::{Deserialize, Serialize};
 
-use crate::model::{BalatroState, ButtonTarget, SlotId, StoreItem};
+use crate::model::{ActionPoint, BalatroState, ButtonTarget, SlotId, StoreItem};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct StoreBuyRequest {
@@ -13,7 +13,7 @@ pub struct StoreBuyRequest {
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct StoreBuyClick {
-  pub window_point: WindowPoint,
+  pub point: ActionPoint,
   pub delivery: InputActionResult,
 }
 
@@ -75,13 +75,13 @@ pub struct StoreBuyResult {
 #[serde(rename_all = "snake_case")]
 enum StoreBuyOutcomeFact<'a> {
   SelectionOnly {
-    selection_window_point: WindowPoint,
+    selection_point: &'a ActionPoint,
     reason: &'a StoreBuyIncompleteReason,
   },
   Submitted {
-    selection_window_point: WindowPoint,
+    selection_point: &'a ActionPoint,
     confirmation_button: &'a ButtonTarget,
-    submission_window_point: WindowPoint,
+    submission_point: &'a ActionPoint,
     confirmation: &'a StoreBuyConfirmation,
   },
 }
@@ -105,7 +105,7 @@ impl auv_tracing::EventPayload for StoreBuyCompleted<'_> {
 pub(crate) fn emit_store_buy_completed(result: &StoreBuyResult) {
   let outcome = match &result.outcome {
     StoreBuyOutcome::SelectionOnly { selection, reason } => StoreBuyOutcomeFact::SelectionOnly {
-      selection_window_point: selection.window_point,
+      selection_point: &selection.point,
       reason,
     },
     StoreBuyOutcome::Submitted {
@@ -114,9 +114,9 @@ pub(crate) fn emit_store_buy_completed(result: &StoreBuyResult) {
       submission,
       confirmation,
     } => StoreBuyOutcomeFact::Submitted {
-      selection_window_point: selection.window_point,
+      selection_point: &selection.point,
       confirmation_button,
-      submission_window_point: submission.window_point,
+      submission_point: &submission.point,
       confirmation,
     },
   };

--- a/supported/games/auv-game-balatro/src/store_next_round.rs
+++ b/supported/games/auv-game-balatro/src/store_next_round.rs
@@ -1,8 +1,8 @@
+use auv_driver::InputActionResult;
 use auv_driver::geometry::Point;
-use auv_driver::{InputActionResult, WindowPoint};
 use serde::{Deserialize, Serialize};
 
-use crate::model::{BalatroPhase, BalatroState, ButtonTarget};
+use crate::model::{ActionPoint, BalatroPhase, BalatroState, ButtonTarget};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum StoreNextRoundConfirmationRequest {
@@ -70,11 +70,16 @@ pub enum StoreNextRoundConfirmation {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct StoreNextRoundAttempt {
+  pub selected_target: StoreNextRoundTarget,
+  pub point: ActionPoint,
+  pub delivery: InputActionResult,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct StoreNextRoundResult {
   pub target: String,
-  pub selected_target: StoreNextRoundTarget,
-  pub window_point: WindowPoint,
-  pub delivery: InputActionResult,
+  pub attempts: Vec<StoreNextRoundAttempt>,
   pub confirmation: StoreNextRoundConfirmation,
 }
 
@@ -82,23 +87,21 @@ pub struct StoreNextRoundResult {
 #[derive(Serialize)]
 struct StoreNextRoundCompleted<'a> {
   target: &'a str,
-  selected_target: &'a StoreNextRoundTarget,
-  window_point: WindowPoint,
+  attempts: &'a [StoreNextRoundAttempt],
   confirmation: &'a StoreNextRoundConfirmation,
 }
 
 #[cfg(feature = "tracing")]
 impl auv_tracing::EventPayload for StoreNextRoundCompleted<'_> {
   const NAME: &'static str = "auv.balatro.store_next_round.completed";
-  const VERSION: u32 = 1;
+  const VERSION: u32 = 3;
 }
 
 #[cfg(feature = "tracing")]
 pub(crate) fn emit_store_next_round_completed(result: &StoreNextRoundResult) {
   auv_tracing::emit_event!(StoreNextRoundCompleted {
     target: &result.target,
-    selected_target: &result.selected_target,
-    window_point: result.window_point,
+    attempts: &result.attempts,
     confirmation: &result.confirmation,
   });
 }

--- a/supported/games/auv-game-balatro/tests/custom_runner_e2e.rs
+++ b/supported/games/auv-game-balatro/tests/custom_runner_e2e.rs
@@ -2,19 +2,20 @@
 
 use auv_api_proto::auv::api::daemon::v1 as daemon_proto;
 use auv_api_proto::auv::api::image::v1 as image_proto;
-use auv_api_server::runner_provider::{ExecutableRunnerRuntime, RunnerProviderConfig, RunnerRuntime};
-use auv_api_server::server::{ListenEndpoint, Server, ServerConfig};
+use auv_daemon::runner_provider::{ExecutableRunnerRuntime, RunnerProviderConfig, RunnerRuntime};
+use auv_daemon::{Config, ListenEndpoint, Server};
 
 #[tokio::test]
 async fn daemon_routes_the_app_owned_balatro_runner() {
   let directory = tempfile::tempdir().expect("create isolated daemon state");
   let socket = directory.path().join("auv.sock");
-  let bound = Server::bind(ServerConfig {
+  let bound = Server::bind(Config {
     pairing_store: None,
-    listen: ListenEndpoint::Unix {
+    listeners: vec![ListenEndpoint::Unix {
       path: socket.clone(),
-    },
-    additional_listeners: Vec::new(),
+    }],
+    discovery_file: None,
+    publish_discovery: false,
     store_root: directory.path().join("store"),
     runner_providers: vec![RunnerProviderConfig {
       runner_class: "auv.game.balatro".to_string(),
@@ -59,7 +60,7 @@ async fn daemon_routes_the_app_owned_balatro_runner() {
     .detect_objects(auv_game_balatro::api::v1::DetectObjectsRequest {
       detector: Some(auv_game_balatro::api::v1::ObjectDetectorSpec {
         detector_id: "test".to_string(),
-        model_path: "/missing/model.onnx".to_string(),
+        source: Some(auv_game_balatro::api::v1::object_detector_spec::Source::RunnerPath("/missing/model.onnx".to_string())),
         ..Default::default()
       }),
       frame: Some(image_proto::RgbFrame {


### PR DESCRIPTION
## Summary

- load and reuse the Balatro card detector and rank, suit, enhancement, edition, and seal ONNX sessions
- run independent attribute models concurrently on detected card crops
- resolve the game viewport before assigning hand slots
- expose typed card readings and attributes through the Balatro state command
- add runner configuration, fixtures, tests, and dataset/training evidence

## Why

The existing detector could locate cards but could not reliably report their identity or special attributes. Full-screen offsets also caused false hand slots when the game viewport did not fill the display.

## Impact

Balatro observations now include card identity and independent enhancement, edition, and seal predictions while preserving raw detections and confidence values.

## Dependency

Stacked on #159, which provides the typed runner and input contracts used by this change.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo check --workspace`
- recorded Linux live-game observations and model evaluation evidence included in the PR