### PR TITLE
fix(auv-game-balatro): crop card attribute inference to hand

### DIFF
--- a/supported/games/auv-game-balatro/src/cli.rs
+++ b/supported/games/auv-game-balatro/src/cli.rs
@@ -217,16 +217,16 @@ pub struct ObserveArgs {
   /// Optional card-specialized detector applied only to the normalized hand region.
   #[arg(long, value_name = "PATH")]
   pub cards_model: Option<PathBuf>,
-  /// Full-frame rank/suit detector. Defaults to the published Mod ground-truth model.
+  /// Hand-region rank/suit detector. Defaults to the published Mod ground-truth model.
   #[arg(long, value_name = "PATH")]
   pub card_identity_model: Option<PathBuf>,
-  /// Full-frame enhancement detector. Defaults to the published Mod ground-truth model.
+  /// Hand-region enhancement detector. Defaults to the published Mod ground-truth model.
   #[arg(long, value_name = "PATH")]
   pub card_enhancement_model: Option<PathBuf>,
-  /// Full-frame edition detector. Defaults to the published Mod ground-truth model.
+  /// Hand-region edition detector. Defaults to the published Mod ground-truth model.
   #[arg(long, value_name = "PATH")]
   pub card_edition_model: Option<PathBuf>,
-  /// Full-frame seal detector. Defaults to the published Mod ground-truth model.
+  /// Hand-region seal detector. Defaults to the published Mod ground-truth model.
   #[arg(long, value_name = "PATH")]
   pub card_seal_model: Option<PathBuf>,
   #[arg(long, value_name = "PATH")]

--- a/supported/games/auv-game-balatro/src/detector.rs
+++ b/supported/games/auv-game-balatro/src/detector.rs
@@ -110,16 +110,26 @@ impl BalatroDetectors {
   }
 
   pub fn detect_path(&self, image: impl AsRef<Path>) -> InferenceResult<BalatroDetectionSets> {
-    let image = image.as_ref();
-    let entities = self.entities.detect_path(image)?;
-    let cards = self.cards.as_ref().map(|detector| detect_hand_cards(detector, &image::open(image)?.to_rgb8())).transpose()?;
-    let card_attributes = CardAttributeDetectionSets {
-      identity: Some(self.card_identity.detect_path(image)?),
-      enhancement: Some(self.card_enhancement.detect_path(image)?),
-      edition: Some(self.card_edition.detect_path(image)?),
-      seal: Some(self.card_seal.detect_path(image)?),
+    let image_path = image.as_ref();
+    let image = image::open(image_path)?.to_rgb8();
+    let image_size = ImageSize {
+      width: image.width(),
+      height: image.height(),
     };
-    let ui = self.ui.detect_path(image)?;
+    let (hand_crop, hand_frame) = crop_hand_frame(&image);
+    let entities = self.entities.detect_path(image_path)?;
+    let cards = self
+      .cards
+      .as_ref()
+      .map(|detector| detector.detect_frame(&hand_frame).map(|result| remap_hand_detections(result, hand_crop, image_size)))
+      .transpose()?;
+    let card_attributes = CardAttributeDetectionSets {
+      identity: Some(remap_card_attribute_detections(self.card_identity.detect_frame(&hand_frame)?, hand_crop, image_size)),
+      enhancement: Some(remap_card_attribute_detections(self.card_enhancement.detect_frame(&hand_frame)?, hand_crop, image_size)),
+      edition: Some(remap_card_attribute_detections(self.card_edition.detect_frame(&hand_frame)?, hand_crop, image_size)),
+      seal: Some(remap_card_attribute_detections(self.card_seal.detect_frame(&hand_frame)?, hand_crop, image_size)),
+    };
+    let ui = self.ui.detect_path(image_path)?;
     Ok(BalatroDetectionSets {
       entities,
       cards,
@@ -332,6 +342,10 @@ pub(crate) fn remap_hand_detections(mut result: DetectionResult, crop: HandCrop,
   result
     .detections
     .retain(|detection| matches!(detection.label.as_str(), "poker_card_front" | "poker_card_back") && is_complete_hand_card(detection));
+  remap_card_attribute_detections(result, crop, image_size)
+}
+
+pub(crate) fn remap_card_attribute_detections(mut result: DetectionResult, crop: HandCrop, image_size: ImageSize) -> DetectionResult {
   for detection in &mut result.detections {
     detection.bbox.x1 += crop.x as f32;
     detection.bbox.x2 += crop.x as f32;
@@ -346,15 +360,6 @@ fn is_complete_hand_card(detection: &Detection) -> bool {
   let width = detection.bbox.x2 - detection.bbox.x1;
   let height = detection.bbox.y2 - detection.bbox.y1;
   width.is_finite() && height.is_finite() && height > 0.0 && width / height >= 0.30
-}
-
-fn detect_hand_cards(detector: &UltralyticsObjectDetector, image: &RgbImage) -> InferenceResult<DetectionResult> {
-  let image_size = ImageSize {
-    width: image.width(),
-    height: image.height(),
-  };
-  let (crop, frame) = crop_hand_frame(image);
-  detector.detect_frame(&frame).map(|result| remap_hand_detections(result, crop, image_size))
 }
 
 fn balatro_detection_options() -> DetectionOptions {
@@ -529,6 +534,59 @@ mod tests {
 
     assert_eq!(remapped.image_size, image_size);
     assert_eq!(remapped.detections.len(), 1);
+    assert_eq!(
+      remapped.detections[0].bbox,
+      BoundingBox {
+        x1: 551.0,
+        y1: 605.0,
+        x2: 651.0,
+        y2: 805.0,
+      }
+    );
+  }
+
+  #[test]
+  fn remap_card_attribute_detections_restores_full_frame_coordinates_without_filtering_labels() {
+    // ROOT CAUSE:
+    //
+    // If card-attribute models received the full game frame, unrelated UI
+    // regions produced high-confidence identities while the hand became too
+    // small to read. Attribute inference must use the normalized hand crop,
+    // then restore every attribute label to full-frame coordinates before
+    // slot association.
+    let crop = HandCrop {
+      x: 541,
+      y: 585,
+      width: 1124,
+      height: 360,
+    };
+    let image_size = ImageSize {
+      width: 2043,
+      height: 1126,
+    };
+    let result = DetectionResult {
+      image_size: ImageSize {
+        width: crop.width,
+        height: crop.height,
+      },
+      detections: vec![Detection {
+        class_id: 51,
+        label: "S_A".to_string(),
+        confidence: 0.99,
+        bbox: BoundingBox {
+          x1: 10.0,
+          y1: 20.0,
+          x2: 110.0,
+          y2: 220.0,
+        },
+      }],
+    };
+
+    let remapped = remap_card_attribute_detections(result, crop, image_size);
+
+    assert_eq!(remapped.image_size, image_size);
+    assert_eq!(remapped.detections.len(), 1);
+    assert_eq!(remapped.detections[0].label, "S_A");
     assert_eq!(
       remapped.detections[0].bbox,
       BoundingBox {

--- a/supported/games/auv-game-balatro/src/observation.rs
+++ b/supported/games/auv-game-balatro/src/observation.rs
@@ -16,7 +16,10 @@ use auv_api_proto::auv::api::image::v1 as image_proto;
 use crate::api::v1 as balatro_proto;
 use crate::cache::cache_hint_for_detection;
 use crate::config::{BalatroModelAsset, BalatroModelConfig, HuggingFaceRepoKind};
-use crate::detector::{BalatroDetectionSets, BalatroDetectors, CardAttributeDetectionSets, crop_hand_frame, remap_hand_detections};
+use crate::detector::{
+  BalatroDetectionSets, BalatroDetectors, CardAttributeDetectionSets, crop_hand_frame, remap_card_attribute_detections,
+  remap_hand_detections,
+};
 use crate::model::{
   BALATRO_STATE_SCHEMA_VERSION, BalatroDiagnostic, BalatroPhase, BalatroState, ButtonTarget, CacheHint, CardAttribute, CardAttributes,
   CardSlot, ConsumableKind, ConsumableSlot, FrameRef, JokerSlot, ObjectEvidence, ObjectZone, Reading, ReadingStatus, RoundState, ScoreState,
@@ -320,80 +323,86 @@ async fn detect_via_api(
     balatro_proto::balatro_detection_service_client::BalatroDetectionServiceClient::new(balatro.extension_transport().map_err(api_error)?)
       .max_decoding_message_size(auv::client::runner::IMAGE_RPC_MESSAGE_SIZE_LIMIT)
       .max_encoding_message_size(auv::client::runner::IMAGE_RPC_MESSAGE_SIZE_LIMIT);
-  let batch_detectors = vec![
+  let full_image_size = ImageSize {
+    width: frame.width,
+    height: frame.height,
+  };
+  let image = RgbImage::from_raw(frame.width, frame.height, frame.data.clone())
+    .ok_or_else(|| ObservationError::Api("card attribute detectors received an invalid RGB frame".to_string()))?;
+  let (hand_crop, hand_frame) = crop_hand_frame(&image);
+  let hand_frame = image_proto::RgbFrame {
+    width: hand_frame.image.width(),
+    height: hand_frame.image.height(),
+    data: hand_frame.image.into_raw(),
+  };
+  let full_frame_detectors = vec![
     detector_spec("balatro-entities", &config.entities_model, &config.device, 640, entities_classes.clone())?,
     detector_spec("balatro-ui", &config.ui_model, &config.device, 640, ui_classes)?,
+  ];
+  let mut hand_frame_detectors = vec![
     detector_spec("balatro-card-identity", &config.card_identity_model, &config.device, 960, Vec::new())?,
     detector_spec("balatro-card-enhancement", &config.card_enhancement_model, &config.device, 640, Vec::new())?,
     detector_spec("balatro-card-edition", &config.card_edition_model, &config.device, 640, Vec::new())?,
     detector_spec("balatro-card-seal", &config.card_seal_model, &config.device, 640, Vec::new())?,
   ];
-  let cards_request = if let Some(cards_model) = &config.cards_model {
-    let full_image_size = ImageSize {
-      width: frame.width,
-      height: frame.height,
-    };
-    let image = RgbImage::from_raw(frame.width, frame.height, frame.data.clone())
-      .ok_or_else(|| ObservationError::Api("card detector received an invalid RGB frame".to_string()))?;
-    let (crop, hand_frame) = crop_hand_frame(&image);
-    let hand_frame = image_proto::RgbFrame {
-      width: hand_frame.image.width(),
-      height: hand_frame.image.height(),
-      data: hand_frame.image.into_raw(),
-    };
-    Some((
-      balatro_proto::DetectObjectsRequest {
-        detector: Some(detector_spec("balatro-cards", cards_model, &config.device, 640, entities_classes)?),
-        frame: Some(hand_frame),
-      },
-      crop,
-      full_image_size,
-    ))
-  } else {
-    None
-  };
+  if let Some(cards_model) = &config.cards_model {
+    hand_frame_detectors.push(detector_spec("balatro-cards", cards_model, &config.device, 640, entities_classes)?);
+  }
 
-  let detect = |mut client: balatro_proto::balatro_detection_service_client::BalatroDetectionServiceClient<_>, request| async move {
-    client.detect_objects(request).await.map(|response| response.into_inner()).map_err(api_error)
-  };
-  let cards = async {
-    let Some((request, crop, full_image_size)) = cards_request else {
-      return Ok(None);
-    };
-    let response = detect(balatro.clone(), request).await?;
-    Ok::<_, ObservationError>(Some(remap_hand_detections(detection_result_from_proto(response)?, crop, full_image_size)))
-  };
-  let batch = async {
-    let mut client = balatro.clone();
+  let detect_batch = |mut client: balatro_proto::balatro_detection_service_client::BalatroDetectionServiceClient<_>, detectors, frame| async move {
     client
       .detect_objects_batch(balatro_proto::DetectObjectsBatchRequest {
-        detectors: batch_detectors,
+        detectors,
         frame: Some(frame),
       })
       .await
       .map(|response| response.into_inner())
       .map_err(api_error)
   };
-  let (batch, cards) = tokio::try_join!(batch, cards)?;
-  let mut batch = batch
+  let (full_frame_batch, hand_frame_batch) = tokio::try_join!(
+    detect_batch(balatro.clone(), full_frame_detectors, frame),
+    detect_batch(balatro.clone(), hand_frame_detectors, hand_frame),
+  )?;
+  let mut full_frame_batch = batch_results(full_frame_batch)?;
+  let mut hand_frame_batch = batch_results(hand_frame_batch)?;
+  let cards = config
+    .cards_model
+    .as_ref()
+    .map(|_| {
+      take_batch_result(&mut hand_frame_batch, "balatro-cards")
+        .and_then(detection_result_from_proto)
+        .map(|result| remap_hand_detections(result, hand_crop, full_image_size))
+    })
+    .transpose()?;
+  let mut card_attribute = |detector_id| {
+    take_batch_result(&mut hand_frame_batch, detector_id)
+      .and_then(detection_result_from_proto)
+      .map(|result| remap_card_attribute_detections(result, hand_crop, full_image_size))
+  };
+  Ok(BalatroDetectionSets {
+    entities: detection_result_from_proto(take_batch_result(&mut full_frame_batch, "balatro-entities")?)?,
+    cards,
+    card_attributes: CardAttributeDetectionSets {
+      identity: Some(card_attribute("balatro-card-identity")?),
+      enhancement: Some(card_attribute("balatro-card-enhancement")?),
+      edition: Some(card_attribute("balatro-card-edition")?),
+      seal: Some(card_attribute("balatro-card-seal")?),
+    },
+    ui: detection_result_from_proto(take_batch_result(&mut full_frame_batch, "balatro-ui")?)?,
+  })
+}
+
+fn batch_results(
+  batch: balatro_proto::DetectObjectsBatchResponse,
+) -> Result<HashMap<String, balatro_proto::DetectObjectsResponse>, ObservationError> {
+  batch
     .results
     .into_iter()
     .map(|entry| {
       let result = entry.result.ok_or_else(|| ObservationError::Api(format!("batch result {} omitted result", entry.detector_id)))?;
       Ok((entry.detector_id, result))
     })
-    .collect::<Result<HashMap<_, _>, ObservationError>>()?;
-  Ok(BalatroDetectionSets {
-    entities: detection_result_from_proto(take_batch_result(&mut batch, "balatro-entities")?)?,
-    cards,
-    card_attributes: CardAttributeDetectionSets {
-      identity: Some(detection_result_from_proto(take_batch_result(&mut batch, "balatro-card-identity")?)?),
-      enhancement: Some(detection_result_from_proto(take_batch_result(&mut batch, "balatro-card-enhancement")?)?),
-      edition: Some(detection_result_from_proto(take_batch_result(&mut batch, "balatro-card-edition")?)?),
-      seal: Some(detection_result_from_proto(take_batch_result(&mut batch, "balatro-card-seal")?)?),
-    },
-    ui: detection_result_from_proto(take_batch_result(&mut batch, "balatro-ui")?)?,
-  })
+    .collect()
 }
 
 fn take_batch_result(


### PR DESCRIPTION
## What changed

- run rank/suit, enhancement, edition, seal, and optional card detection against one shared normalized hand crop
- remap all hand-region detections back into full-frame coordinates before slot association
- keep full-frame entity and UI detection separate while issuing both runner batches concurrently
- document the corrected CLI model scope and add a coordinate-remapping regression test

## Root cause

The card-attribute models received the full 2560×1440 game frame. The hand occupied too little of that input, while unrelated UI regions could produce high-confidence false identities. The specialized models were trained for card-focused imagery and correctly identify the cards when given the existing normalized hand crop.

## Impact

On the captured live Balatro frame, four consecutive observations recognized all eight visible cards as `K♠ Q♣ 10♠ 8♠ 8♦ 7♠ 4♥ 2♦`, with identity confidence around 0.983–0.999. Card detections retain full-frame coordinates for downstream slot association.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo check -p auv-game-balatro --lib`
- `cargo test -p auv-game-balatro`
- live Linux/CUDA observation against the captured Balatro frame, repeated four times