### PR TITLE
fix(auv-driver-linux): reuse Wayland capture streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,8 +629,10 @@ dependencies = [
 name = "auv-driver-linux"
 version = "0.0.1"
 dependencies = [
+ "async-io",
  "auv-driver-common",
  "fs2",
+ "futures-lite",
  "image",
  "leptess",
  "pipewire",

--- a/crates/auv-driver-linux/Cargo.toml
+++ b/crates/auv-driver-linux/Cargo.toml
@@ -23,7 +23,9 @@ image.workspace = true
 serde.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
+async-io = "2"
 fs2.workspace = true
+futures-lite = "2"
 leptess.workspace = true
 pipewire = "0.8"
 wayland-client = "0.31"

--- a/crates/auv-driver-linux/src/capture.rs
+++ b/crates/auv-driver-linux/src/capture.rs
@@ -14,7 +14,7 @@ use auv_driver_common::geometry::Rect;
 
 #[cfg(target_os = "linux")]
 use crate::driver::LinuxDriverSessionState;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", test))]
 use crate::error::backend;
 #[cfg(any(target_os = "linux", test))]
 use crate::error::invalid_input;
@@ -60,10 +60,10 @@ pub fn capture_display(state: &Arc<Mutex<LinuxDriverSessionState>>, selector: Op
       Ok(DisplayCapture { display, capture })
     }
     Err(error) => {
-      let captured = match target.as_ref() {
-        Some(target) => capture_area(target.display.frame, target.display.frame)?,
-        None => capture_full()?,
-      };
+      let captured = capture_fallback(PORTAL_SCREENCAST_BACKEND, &error, || match target.as_ref() {
+        Some(target) => capture_area(target.display.frame, target.display.frame),
+        None => capture_full(),
+      })?;
       capture_display_from_captured(target, with_primary_capture_failure(captured, PORTAL_SCREENCAST_BACKEND, &error.to_string()))
     }
   }
@@ -101,7 +101,11 @@ pub fn capture_region(state: &Arc<Mutex<LinuxDriverSessionState>>, selector: Opt
       backend: format!("{PORTAL_SCREENCAST_BACKEND}.crop"),
       fallback_reason: Some("region pixels were cropped from PipeWire screencast using Wayland xdg-output logical bounds".to_string()),
     },
-    Err(error) => with_primary_capture_failure(capture_area(region, target.display.frame)?, PORTAL_SCREENCAST_BACKEND, &error.to_string()),
+    Err(error) => with_primary_capture_failure(
+      capture_fallback(PORTAL_SCREENCAST_BACKEND, &error, || capture_area(region, target.display.frame))?,
+      PORTAL_SCREENCAST_BACKEND,
+      &error.to_string(),
+    ),
   };
   let scale_factor = capture_scale_factor(&captured.image, region, target.display.scale_factor);
   let capture = Capture {
@@ -132,11 +136,26 @@ struct CapturedImage {
   fallback_reason: Option<String>,
 }
 
+#[cfg(any(target_os = "linux", test))]
+fn capture_fallback<T>(
+  primary_backend: &str,
+  primary_error: &auv_driver_common::error::DriverError,
+  fallback: impl FnOnce() -> DriverResult<T>,
+) -> DriverResult<T> {
+  fallback()
+    .map_err(|fallback_error| backend(format!("{primary_backend} failed: {primary_error}; fallback capture also failed: {fallback_error}")))
+}
+
 #[cfg(target_os = "linux")]
 fn capture_monitor_frame_for_session(
   state: &Arc<Mutex<LinuxDriverSessionState>>,
   target_bounds: Option<Rect>,
 ) -> DriverResult<ScreenCastFrame> {
+  // TODO(linux-capture-session-lock): the outer session mutex remains held
+  // during the bounded frame wait because ScreenCastSession is currently
+  // stored directly in this shared state. Move capture ownership behind its
+  // own synchronization only when a concurrent driver-session slice defines
+  // how capture, input, and session invalidation coordinate.
   let mut state = state.lock().expect("linux driver session state poisoned");
   if state.screencast_session.is_none() {
     let restore_tokens = state.restore_tokens.clone();

--- a/crates/auv-driver-linux/src/capture/display.rs
+++ b/crates/auv-driver-linux/src/capture/display.rs
@@ -33,6 +33,9 @@ pub struct DisplayTarget {
 
 #[cfg(target_os = "linux")]
 pub fn list_targets() -> DriverResult<Vec<DisplayTarget>> {
+  // TODO(wayland-output-cache): output metadata still performs compositor
+  // roundtrips per call. Cache it only with an owner-approved hotplug and
+  // invalidation contract so stale geometry cannot corrupt window crops.
   wayland_display_targets()
 }
 

--- a/crates/auv-driver-linux/src/capture_test.rs
+++ b/crates/auv-driver-linux/src/capture_test.rs
@@ -19,3 +19,13 @@ fn portal_crop_maps_logical_bounds_to_screenshot_pixels() {
   assert_eq!(cropped.height(), 10);
   assert_eq!(*cropped.get_pixel(0, 0), image::Rgba([1, 2, 3, 4]));
 }
+
+#[test]
+fn fallback_failure_preserves_the_primary_capture_error() {
+  let primary = backend("screencast timed out");
+
+  let error = capture_fallback::<()>("portal.screencast", &primary, || Err(backend("screenshot returned no URI")))
+    .expect_err("both capture paths fail");
+
+  assert_eq!(error.to_string(), "portal.screencast failed: screencast timed out; fallback capture also failed: screenshot returned no URI");
+}

--- a/crates/auv-driver-linux/src/native/portal/clipboard.rs
+++ b/crates/auv-driver-linux/src/native/portal/clipboard.rs
@@ -134,9 +134,7 @@ fn start_remote_desktop(connection: &Connection, session_handle: &OwnedObjectPat
   let proxy = portal_proxy(connection, REMOTE_DESKTOP_INTERFACE)?;
   let mut options = HashMap::new();
   options.insert("handle_token", Value::from(handle_token.as_str()));
-  proxy
-    .call_method("Start", &(session_handle, "", options))
-    .map_err(|error| backend(format!("failed to start remote desktop portal session: {error}")))?;
+  super::request::call_method(&proxy, REMOTE_DESKTOP_INTERFACE, "Start", &(session_handle, "", options))?;
   super::request::wait_response(&mut responses, REMOTE_DESKTOP_INTERFACE, "Start")
 }
 

--- a/crates/auv-driver-linux/src/native/portal/input.rs
+++ b/crates/auv-driver-linux/src/native/portal/input.rs
@@ -302,9 +302,7 @@ fn start_remote_desktop(connection: &Connection, session_handle: &OwnedObjectPat
   let proxy = portal_proxy(connection, REMOTE_DESKTOP_INTERFACE)?;
   let mut options = HashMap::new();
   options.insert("handle_token", Value::from(handle_token.as_str()));
-  proxy
-    .call_method("Start", &(session_handle, "", options))
-    .map_err(|error| backend(format!("failed to start remote desktop portal session: {error}")))?;
+  super::request::call_method(&proxy, REMOTE_DESKTOP_INTERFACE, "Start", &(session_handle, "", options))?;
   super::request::wait_response(&mut responses, REMOTE_DESKTOP_INTERFACE, "Start")
 }
 

--- a/crates/auv-driver-linux/src/native/portal/request.rs
+++ b/crates/auv-driver-linux/src/native/portal/request.rs
@@ -1,14 +1,19 @@
 use std::collections::HashMap;
+use std::time::Duration;
 
 use auv_driver_common::error::DriverResult;
+use futures_lite::{StreamExt, future};
+use serde::Serialize;
 use zbus::blocking::{Connection, Proxy};
 use zbus::message::Message;
-use zbus::zvariant::{OwnedObjectPath, OwnedValue, Value};
+use zbus::proxy::SignalStream;
+use zbus::zvariant::{DynamicType, OwnedObjectPath, OwnedValue, Value};
 
 use crate::error::backend;
 
 pub(super) const PORTAL_DESTINATION: &str = "org.freedesktop.portal.Desktop";
 pub(super) const PORTAL_PATH: &str = "/org/freedesktop/portal/desktop";
+const PORTAL_RESPONSE_TIMEOUT: Duration = Duration::from_secs(10);
 
 pub(super) fn session_connection() -> DriverResult<Connection> {
   Connection::session().map_err(|error| backend(format!("failed to connect to session bus: {error}")))
@@ -20,9 +25,29 @@ pub(super) fn portal_proxy<'a>(connection: &'a Connection, interface: &'static s
 }
 
 pub(super) fn interface_version(connection: &Connection, interface: &'static str) -> DriverResult<u32> {
-  portal_proxy(connection, interface)?
-    .get_property("version")
-    .map_err(|error| backend(format!("failed to read {interface}.version: {error}")))
+  let proxy = portal_proxy(connection, interface)?;
+  future::block_on(future::race(
+    async { proxy.inner().get_property("version").await.map_err(|error| backend(format!("failed to read {interface}.version: {error}"))) },
+    async {
+      async_io::Timer::after(PORTAL_RESPONSE_TIMEOUT).await;
+      Err(backend(format!("timed out after {}s reading {interface}.version", PORTAL_RESPONSE_TIMEOUT.as_secs())))
+    },
+  ))
+}
+
+pub(super) fn call_method<B>(proxy: &Proxy<'_>, interface: &'static str, method: &'static str, body: &B) -> DriverResult<Message>
+where
+  B: Serialize + DynamicType,
+{
+  future::block_on(future::race(
+    async {
+      proxy.inner().call_method(method, body).await.map_err(|error| backend(format!("failed to call {interface}.{method}: {error}")))
+    },
+    async {
+      async_io::Timer::after(PORTAL_RESPONSE_TIMEOUT).await;
+      Err(backend(format!("timed out after {}s calling {interface}.{method}", PORTAL_RESPONSE_TIMEOUT.as_secs())))
+    },
+  ))
 }
 
 pub(super) fn restore_token(results: &HashMap<String, OwnedValue>, interface: &'static str) -> DriverResult<Option<String>> {
@@ -46,7 +71,7 @@ pub(super) fn call_request(
   let proxy = portal_proxy(connection, interface)?;
   let mut options = options;
   options.insert("handle_token", Value::from(handle_token.as_str()));
-  proxy.call_method(method, &(options)).map_err(|error| backend(format!("failed to call {interface}.{method}: {error}")))?;
+  call_method(&proxy, interface, method, &(options))?;
   wait_response(&mut responses, interface, method)
 }
 
@@ -63,7 +88,7 @@ pub(super) fn session_request(
   let proxy = portal_proxy(connection, interface)?;
   let mut options = options;
   options.insert("handle_token", Value::from(handle_token.as_str()));
-  proxy.call_method(method, &(session_handle, options)).map_err(|error| backend(format!("failed to call {interface}.{method}: {error}")))?;
+  call_method(&proxy, interface, method, &(session_handle, options))?;
   wait_response(&mut responses, interface, method)
 }
 
@@ -76,19 +101,20 @@ pub(super) fn create_session(connection: &Connection, interface: &'static str) -
   let mut options = HashMap::new();
   options.insert("session_handle_token", Value::from(session_handle_token.as_str()));
   let results = call_request(connection, interface, "CreateSession", options)?;
-  if let Some(value) = results.get("session_handle") {
-    if let Ok(handle) = <&str>::try_from(value) {
-      return OwnedObjectPath::try_from(handle.to_string())
-        .map_err(|error| backend(format!("portal returned invalid session handle: {error}")));
-    }
+  if let Some(value) = results.get("session_handle")
+    && let Ok(handle) = <&str>::try_from(value)
+  {
+    return OwnedObjectPath::try_from(handle.to_string())
+      .map_err(|error| backend(format!("portal returned invalid session handle: {error}")));
   }
   expected_session_path(connection, &session_handle_token)
 }
 
 pub(super) fn close_session(connection: &Connection, session_handle: &OwnedObjectPath) -> DriverResult<()> {
-  let session = Proxy::new(connection, PORTAL_DESTINATION, session_handle.clone(), "org.freedesktop.portal.Session")
+  const SESSION_INTERFACE: &str = "org.freedesktop.portal.Session";
+  let session = Proxy::new(connection, PORTAL_DESTINATION, session_handle.clone(), SESSION_INTERFACE)
     .map_err(|error| backend(format!("failed to create portal session proxy: {error}")))?;
-  session.call_method("Close", &()).map_err(|error| backend(format!("failed to close portal session: {error}")))?;
+  call_method(&session, SESSION_INTERFACE, "Close", &())?;
   Ok(())
 }
 
@@ -100,20 +126,38 @@ pub(super) fn portal_token(prefix: &str) -> String {
   )
 }
 
-pub(super) fn response_signal<'a>(
-  request: &'a Proxy<'_>,
-  interface: &'static str,
-  method: &'static str,
-) -> DriverResult<impl Iterator<Item = Message> + 'a> {
-  request.receive_signal("Response").map_err(|error| backend(format!("failed to subscribe to {interface}.{method} response: {error}")))
+pub(super) fn response_signal<'a>(request: &'a Proxy<'_>, interface: &'static str, method: &'static str) -> DriverResult<SignalStream<'a>> {
+  future::block_on(future::race(
+    async {
+      request
+        .inner()
+        .receive_signal("Response")
+        .await
+        .map_err(|error| backend(format!("failed to subscribe to {interface}.{method} response: {error}")))
+    },
+    async {
+      async_io::Timer::after(PORTAL_RESPONSE_TIMEOUT).await;
+      Err(backend(format!("timed out after {}s subscribing to {interface}.{method} portal response", PORTAL_RESPONSE_TIMEOUT.as_secs())))
+    },
+  ))
 }
 
 pub(super) fn wait_response(
-  responses: &mut impl Iterator<Item = Message>,
+  responses: &mut SignalStream<'_>,
   interface: &'static str,
   method: &'static str,
 ) -> DriverResult<HashMap<String, OwnedValue>> {
-  let response = responses.next().ok_or_else(|| backend(format!("{interface}.{method} did not return a response")))?;
+  let response: Message = future::block_on(future::race(
+    async { responses.next().await.ok_or_else(|| backend(format!("{interface}.{method} did not return a response"))) },
+    async {
+      async_io::Timer::after(PORTAL_RESPONSE_TIMEOUT).await;
+      // TODO(portal-request-cancellation): do not synchronously call
+      // Request.Close here because a stalled portal can also stall that method
+      // reply. Add no-reply cancellation only when the D-Bus lifecycle owner
+      // can guarantee cleanup without weakening this deadline.
+      Err(backend(format!("timed out after {}s waiting for {interface}.{method} portal response", PORTAL_RESPONSE_TIMEOUT.as_secs())))
+    },
+  ))?;
   let (code, results): (u32, HashMap<String, OwnedValue>) =
     response.body().deserialize().map_err(|error| backend(format!("failed to decode {interface}.{method} response: {error}")))?;
   if code == 0 {

--- a/crates/auv-driver-linux/src/native/portal/screencast.rs
+++ b/crates/auv-driver-linux/src/native/portal/screencast.rs
@@ -1,7 +1,10 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::fmt;
 use std::os::fd::OwnedFd as StdOwnedFd;
 use std::rc::Rc;
+use std::sync::{Arc, mpsc};
+use std::thread;
 use std::time::{Duration, Instant};
 
 use auv_driver_common::error::DriverResult;
@@ -27,6 +30,7 @@ const CURSOR_HIDDEN: u32 = 1;
 const PERSIST_UNTIL_REVOKED: u32 = 2;
 const PERSISTENCE_INTERFACE_VERSION: u32 = 4;
 const PIPEWIRE_FRAME_TIMEOUT: Duration = Duration::from_secs(5);
+const PIPEWIRE_REFRESH_WAIT: Duration = Duration::from_millis(100);
 
 #[derive(Debug)]
 pub struct ScreenCastFrame {
@@ -139,6 +143,7 @@ pub struct ScreenCastSession {
   connection: Connection,
   session_handle: OwnedObjectPath,
   streams: Vec<ScreenCastStream>,
+  receivers: FrameReceiverPool,
 }
 
 impl ScreenCastSession {
@@ -150,14 +155,17 @@ impl ScreenCastSession {
 
   pub fn capture_monitor_frame(&mut self, target_bounds: Option<Rect>) -> DriverResult<ScreenCastFrame> {
     let stream = select_stream(&self.streams, target_bounds)?.clone();
-    let fd = open_pipewire_remote(&self.connection, &self.session_handle)?;
-    let image = read_pipewire_frame(fd.into(), stream.id)?;
+    let image = self.receivers.capture(stream.id, || {
+      let fd = open_pipewire_remote(&self.connection, &self.session_handle)?;
+      Ok(Box::new(PipeWireFrameReceiver::open(fd.into(), stream.id)?))
+    })?;
     Ok(ScreenCastFrame { stream, image })
   }
 }
 
 impl Drop for ScreenCastSession {
   fn drop(&mut self) {
+    self.receivers.clear();
     let _ = close_session(&self.connection, &self.session_handle);
   }
 }
@@ -200,6 +208,7 @@ fn start_session(
     connection,
     session_handle,
     streams,
+    receivers: FrameReceiverPool::default(),
   })
 }
 
@@ -210,21 +219,18 @@ fn start_screencast(connection: &Connection, session_handle: &OwnedObjectPath) -
   let proxy = portal_proxy(connection, SCREENCAST_INTERFACE)?;
   let mut options = HashMap::new();
   options.insert("handle_token", Value::from(handle_token.as_str()));
-  proxy
-    .call_method("Start", &(session_handle, "", options))
-    .map_err(|error| backend(format!("failed to start screencast portal session: {error}")))?;
+  super::request::call_method(&proxy, SCREENCAST_INTERFACE, "Start", &(session_handle, "", options))?;
   wait_response(&mut responses, SCREENCAST_INTERFACE, "Start")
 }
 
 fn open_pipewire_remote(connection: &Connection, session_handle: &OwnedObjectPath) -> DriverResult<ZbusOwnedFd> {
   let proxy = portal_proxy(connection, SCREENCAST_INTERFACE)?;
   let options: HashMap<&str, Value<'_>> = HashMap::new();
-  proxy
-    .call("OpenPipeWireRemote", &(session_handle, options))
-    .map_err(|error| backend(format!("failed to open portal PipeWire remote: {error}")))
+  let response = super::request::call_method(&proxy, SCREENCAST_INTERFACE, "OpenPipeWireRemote", &(session_handle, options))?;
+  response.body().deserialize().map_err(|error| backend(format!("failed to decode portal PipeWire remote: {error}")))
 }
 
-fn select_stream<'a>(streams: &'a [ScreenCastStream], target_bounds: Option<Rect>) -> DriverResult<&'a ScreenCastStream> {
+fn select_stream(streams: &[ScreenCastStream], target_bounds: Option<Rect>) -> DriverResult<&ScreenCastStream> {
   if let Some(target_bounds) = target_bounds {
     return streams
       .iter()
@@ -243,18 +249,161 @@ fn rect_contains_rect(container: Rect, candidate: Rect) -> bool {
 
 struct PipeWireCaptureState {
   format: spa::param::video::VideoInfoRaw,
-  result: Rc<RefCell<Option<DriverResult<image::RgbaImage>>>>,
+  latest: Rc<RefCell<Option<Arc<image::RgbaImage>>>>,
+  pending: Rc<RefCell<Option<PendingFrameRequest>>>,
+  terminal_error: Rc<RefCell<Option<String>>>,
 }
 
-fn read_pipewire_frame(fd: StdOwnedFd, node_id: u32) -> DriverResult<image::RgbaImage> {
-  pw::init();
+type WorkerFrameResult = Result<Arc<image::RgbaImage>, String>;
+
+struct PendingFrameRequest {
+  sender: mpsc::SyncSender<WorkerFrameResult>,
+  stale_after: Option<Instant>,
+}
+
+fn take_stale_frame_response(
+  pending: &RefCell<Option<PendingFrameRequest>>,
+  latest: &RefCell<Option<Arc<image::RgbaImage>>>,
+  now: Instant,
+) -> Option<(mpsc::SyncSender<WorkerFrameResult>, Arc<image::RgbaImage>)> {
+  let is_stale = pending.borrow().as_ref().and_then(|request| request.stale_after).is_some_and(|deadline| now >= deadline);
+  if !is_stale {
+    return None;
+  }
+  let sender = pending.borrow_mut().take()?.sender;
+  let image = latest.borrow().clone()?;
+  Some((sender, image))
+}
+
+trait FrameReceiver: Send {
+  fn capture_frame(&mut self) -> DriverResult<image::RgbaImage>;
+}
+
+#[derive(Default)]
+struct FrameReceiverPool {
+  receivers: HashMap<u32, Box<dyn FrameReceiver>>,
+}
+
+impl fmt::Debug for FrameReceiverPool {
+  fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    formatter.debug_struct("FrameReceiverPool").field("stream_ids", &self.receivers.keys()).finish()
+  }
+}
+
+impl FrameReceiverPool {
+  fn capture(&mut self, stream_id: u32, create: impl FnOnce() -> DriverResult<Box<dyn FrameReceiver>>) -> DriverResult<image::RgbaImage> {
+    if let std::collections::hash_map::Entry::Vacant(entry) = self.receivers.entry(stream_id) {
+      entry.insert(create()?);
+    }
+    let result = self.receivers.get_mut(&stream_id).expect("receiver was inserted above").capture_frame();
+    if result.is_err() {
+      self.receivers.remove(&stream_id);
+    }
+    result
+  }
+
+  fn clear(&mut self) {
+    self.receivers.clear();
+  }
+}
+
+enum PipeWireWorkerCommand {
+  Capture(mpsc::SyncSender<WorkerFrameResult>),
+  Stop,
+}
+
+struct PipeWireFrameReceiver {
+  commands: mpsc::Sender<PipeWireWorkerCommand>,
+  worker: Option<thread::JoinHandle<()>>,
+}
+
+impl fmt::Debug for PipeWireFrameReceiver {
+  fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    formatter.debug_struct("PipeWireFrameReceiver").finish_non_exhaustive()
+  }
+}
+
+impl PipeWireFrameReceiver {
+  fn open(fd: StdOwnedFd, node_id: u32) -> DriverResult<Self> {
+    let (commands, command_receiver) = mpsc::channel();
+    let (ready_sender, ready_receiver) = mpsc::sync_channel(1);
+    let worker = thread::Builder::new()
+      .name(format!("auv-pipewire-{node_id}"))
+      .spawn(move || {
+        if let Err(error) = run_pipewire_receiver(fd, node_id, command_receiver, &ready_sender) {
+          let _ = ready_sender.try_send(Err(error.to_string()));
+        }
+      })
+      .map_err(|error| backend(format!("failed to start PipeWire capture worker: {error}")))?;
+    let mut receiver = Self {
+      commands,
+      worker: Some(worker),
+    };
+    match ready_receiver.recv_timeout(PIPEWIRE_FRAME_TIMEOUT) {
+      Ok(Ok(())) => Ok(receiver),
+      Ok(Err(error)) => {
+        receiver.stop();
+        Err(backend(error))
+      }
+      Err(mpsc::RecvTimeoutError::Timeout) => {
+        receiver.stop();
+        Err(backend("timed out initializing PipeWire screencast receiver"))
+      }
+      Err(mpsc::RecvTimeoutError::Disconnected) => {
+        receiver.stop();
+        Err(backend("PipeWire screencast receiver stopped during initialization"))
+      }
+    }
+  }
+
+  fn stop(&mut self) {
+    let _ = self.commands.send(PipeWireWorkerCommand::Stop);
+    if let Some(worker) = self.worker.take() {
+      let _ = worker.join();
+    }
+  }
+}
+
+impl FrameReceiver for PipeWireFrameReceiver {
+  fn capture_frame(&mut self) -> DriverResult<image::RgbaImage> {
+    let (frame_sender, frame_receiver) = mpsc::sync_channel(1);
+    self.commands.send(PipeWireWorkerCommand::Capture(frame_sender)).map_err(|_| backend("PipeWire screencast receiver stopped"))?;
+    match frame_receiver.recv_timeout(PIPEWIRE_FRAME_TIMEOUT) {
+      Ok(Ok(image)) => Ok((*image).clone()),
+      Ok(Err(error)) => Err(backend(error)),
+      Err(mpsc::RecvTimeoutError::Timeout) => Err(backend("timed out waiting for PipeWire screencast frame")),
+      Err(mpsc::RecvTimeoutError::Disconnected) => Err(backend("PipeWire screencast receiver stopped while waiting for a frame")),
+    }
+  }
+}
+
+impl Drop for PipeWireFrameReceiver {
+  fn drop(&mut self) {
+    self.stop();
+  }
+}
+
+fn run_pipewire_receiver(
+  fd: StdOwnedFd,
+  node_id: u32,
+  commands: mpsc::Receiver<PipeWireWorkerCommand>,
+  ready: &mpsc::SyncSender<Result<(), String>>,
+) -> DriverResult<()> {
+  // TODO(pipewire-serial-target): ScreenCast v6 deprecates reusable numeric
+  // node IDs in favor of `pipewire-serial` plus PW_KEY_TARGET_OBJECT. Keep the
+  // current node ID until the minimum portal/PipeWire compatibility boundary
+  // is explicitly raised and tested.
   let mainloop = pw::main_loop::MainLoop::new(None).map_err(|error| backend(format!("failed to create PipeWire mainloop: {error}")))?;
   let context = pw::context::Context::new(&mainloop).map_err(|error| backend(format!("failed to create PipeWire context: {error}")))?;
   let core = context.connect_fd(fd, None).map_err(|error| backend(format!("failed to connect to portal PipeWire remote: {error}")))?;
-  let result = Rc::new(RefCell::new(None));
+  let latest = Rc::new(RefCell::new(None));
+  let pending = Rc::new(RefCell::new(None));
+  let terminal_error = Rc::new(RefCell::new(None));
   let state = PipeWireCaptureState {
     format: Default::default(),
-    result: Rc::clone(&result),
+    latest: Rc::clone(&latest),
+    pending: Rc::clone(&pending),
+    terminal_error: Rc::clone(&terminal_error),
   };
   let stream = pw::stream::Stream::new(
     &core,
@@ -270,7 +419,11 @@ fn read_pipewire_frame(fd: StdOwnedFd, node_id: u32) -> DriverResult<image::Rgba
     .add_local_listener_with_user_data(state)
     .state_changed(|_, state, _, new| {
       if let pw::stream::StreamState::Error(error) = new {
-        *state.result.borrow_mut() = Some(Err(backend(format!("PipeWire stream error: {error}"))));
+        let error = format!("PipeWire stream error: {error}");
+        *state.terminal_error.borrow_mut() = Some(error.clone());
+        if let Some(pending) = state.pending.borrow_mut().take() {
+          let _ = pending.sender.send(Err(error));
+        }
       }
     })
     .param_changed(|_, state, id, param| {
@@ -281,30 +434,52 @@ fn read_pipewire_frame(fd: StdOwnedFd, node_id: u32) -> DriverResult<image::Rgba
         return;
       }
       let Ok((media_type, media_subtype)) = spa::param::format_utils::parse_format(param) else {
-        *state.result.borrow_mut() = Some(Err(backend("failed to parse PipeWire stream format")));
+        *state.terminal_error.borrow_mut() = Some("failed to parse PipeWire stream format".to_string());
         return;
       };
       if media_type != spa::param::format::MediaType::Video || media_subtype != spa::param::format::MediaSubtype::Raw {
-        *state.result.borrow_mut() = Some(Err(backend(format!("unsupported PipeWire stream media type {media_type:?}/{media_subtype:?}"))));
+        *state.terminal_error.borrow_mut() = Some(format!("unsupported PipeWire stream media type {media_type:?}/{media_subtype:?}"));
         return;
       }
       if let Err(error) = state.format.parse(param) {
-        *state.result.borrow_mut() = Some(Err(backend(format!("failed to parse PipeWire raw video format: {error}"))));
+        *state.terminal_error.borrow_mut() = Some(format!("failed to parse PipeWire raw video format: {error}"));
       }
     })
     .process(|stream, state| {
-      if state.result.borrow().is_some() {
+      let pending = state.pending.borrow_mut().take();
+      let Some(mut buffer) = stream.dequeue_buffer() else {
+        if let Some(pending) = pending {
+          *state.pending.borrow_mut() = Some(pending);
+        }
+        return;
+      };
+      if pending.is_none() && state.latest.borrow().is_some() {
+        // Dequeue and immediately release frames when nobody is waiting. This
+        // keeps the persistent stream live without continuously converting a
+        // full RGBA display while AUV is idle.
         return;
       }
-      let Some(mut buffer) = stream.dequeue_buffer() else {
-        return;
-      };
       let datas = buffer.datas_mut();
       let Some(data) = datas.first_mut() else {
+        if let Some(pending) = pending {
+          let _ = pending.sender.send(Err("PipeWire frame contained no data planes".to_string()));
+        }
         return;
       };
-      let frame = decode_pipewire_frame(data, state.format);
-      *state.result.borrow_mut() = Some(frame);
+      match decode_pipewire_frame(data, state.format) {
+        Ok(image) => {
+          let image = Arc::new(image);
+          *state.latest.borrow_mut() = Some(Arc::clone(&image));
+          if let Some(pending) = pending {
+            let _ = pending.sender.send(Ok(image));
+          }
+        }
+        Err(error) => {
+          if let Some(pending) = pending {
+            let _ = pending.sender.send(Err(error.to_string()));
+          }
+        }
+      }
     })
     .register()
     .map_err(|error| backend(format!("failed to register PipeWire stream listener: {error}")))?;
@@ -320,11 +495,30 @@ fn read_pipewire_frame(fd: StdOwnedFd, node_id: u32) -> DriverResult<image::Rgba
     )
     .map_err(|error| backend(format!("failed to connect PipeWire stream {node_id}: {error}")))?;
 
-  let deadline = Instant::now() + PIPEWIRE_FRAME_TIMEOUT;
-  while result.borrow().is_none() && Instant::now() < deadline {
-    mainloop.loop_().iterate(Duration::from_millis(100));
+  ready.send(Ok(())).map_err(|_| backend("PipeWire receiver initializer stopped waiting"))?;
+  loop {
+    match commands.try_recv() {
+      Ok(PipeWireWorkerCommand::Capture(sender)) => {
+        if let Some(error) = terminal_error.borrow().clone() {
+          let _ = sender.send(Err(error));
+        } else if pending.borrow().is_some() {
+          let _ = sender.send(Err("PipeWire receiver already has a pending frame request".to_string()));
+        } else {
+          *pending.borrow_mut() = Some(PendingFrameRequest {
+            sender,
+            stale_after: latest.borrow().as_ref().map(|_| Instant::now() + PIPEWIRE_REFRESH_WAIT),
+          });
+        }
+      }
+      Ok(PipeWireWorkerCommand::Stop) | Err(mpsc::TryRecvError::Disconnected) => break,
+      Err(mpsc::TryRecvError::Empty) => {}
+    }
+    mainloop.loop_().iterate(Duration::from_millis(20));
+    if let Some((sender, latest)) = take_stale_frame_response(&pending, &latest, Instant::now()) {
+      let _ = sender.send(Ok(latest));
+    }
   }
-  result.borrow_mut().take().unwrap_or_else(|| Err(backend("timed out waiting for PipeWire screencast frame")))
+  Ok(())
 }
 
 fn pipewire_raw_video_format_param() -> Vec<u8> {

--- a/crates/auv-driver-linux/src/native/portal/screencast_test.rs
+++ b/crates/auv-driver-linux/src/native/portal/screencast_test.rs
@@ -47,3 +47,88 @@ fn xrgb_pixel_converts_to_rgba() {
 
   assert_eq!(dest, [1, 2, 3, 255]);
 }
+
+#[test]
+fn frame_receiver_pool_reuses_a_connected_receiver_for_repeated_captures() {
+  use std::sync::atomic::{AtomicUsize, Ordering};
+
+  struct FakeReceiver;
+
+  impl FrameReceiver for FakeReceiver {
+    fn capture_frame(&mut self) -> DriverResult<image::RgbaImage> {
+      Ok(image::RgbaImage::new(1, 1))
+    }
+  }
+
+  // ROOT CAUSE:
+  //
+  // If callers requested consecutive frames from one portal stream, AUV
+  // rebuilt the PipeWire remote, main loop, core, and stream for every frame
+  // because no receiver lived beyond `read_pipewire_frame`.
+  //
+  // Before the fix, two captures implied two complete PipeWire negotiations.
+  // The fix keeps one connected receiver per stream until it fails.
+  let creations = AtomicUsize::new(0);
+  let mut pool = FrameReceiverPool::default();
+  for _ in 0..2 {
+    pool
+      .capture(7, || {
+        creations.fetch_add(1, Ordering::Relaxed);
+        Ok(Box::new(FakeReceiver))
+      })
+      .expect("frame capture succeeds");
+  }
+
+  assert_eq!(creations.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+fn frame_receiver_pool_recreates_a_receiver_after_capture_failure() {
+  struct FailingReceiver;
+
+  impl FrameReceiver for FailingReceiver {
+    fn capture_frame(&mut self) -> DriverResult<image::RgbaImage> {
+      Err(backend("stream stopped"))
+    }
+  }
+
+  struct WorkingReceiver;
+
+  impl FrameReceiver for WorkingReceiver {
+    fn capture_frame(&mut self) -> DriverResult<image::RgbaImage> {
+      Ok(image::RgbaImage::new(1, 1))
+    }
+  }
+
+  let mut pool = FrameReceiverPool::default();
+  assert!(pool.capture(7, || Ok(Box::new(FailingReceiver))).is_err());
+  pool.capture(7, || Ok(Box::new(WorkingReceiver))).expect("failed receiver was invalidated");
+}
+
+#[test]
+fn static_stream_returns_the_latest_frame_after_the_refresh_wait() {
+  // ROOT CAUSE:
+  //
+  // If a Wayland surface had no new damage, PipeWire could legitimately stop
+  // delivering buffers. AUV treated the absence of a newer buffer as capture
+  // failure even though the connected stream's latest frame was still valid.
+  //
+  // Before the fix, the second capture waited five seconds and entered the
+  // interactive Screenshot fallback. The fix returns the cached frame after a
+  // short refresh opportunity.
+  let now = Instant::now();
+  let (sender, receiver) = mpsc::sync_channel(1);
+  let pending = RefCell::new(Some(PendingFrameRequest {
+    sender,
+    stale_after: Some(now - Duration::from_millis(1)),
+  }));
+  let expected = Arc::new(image::RgbaImage::new(2, 3));
+  let latest = RefCell::new(Some(Arc::clone(&expected)));
+
+  let (sender, image) = take_stale_frame_response(&pending, &latest, now).expect("cached frame is ready");
+  sender.send(Ok(image)).expect("request is still receiving");
+
+  let actual = receiver.recv().expect("response arrives").expect("frame succeeds");
+  assert_eq!(actual.dimensions(), expected.dimensions());
+  assert!(pending.borrow().is_none());
+}

--- a/docs/ai/references/driver/2026-08-07-wayland-capture-obs-sunshine-evidence.md
+++ b/docs/ai/references/driver/2026-08-07-wayland-capture-obs-sunshine-evidence.md
@@ -255,3 +255,28 @@ Live probing on `neko-gpu-1` separated the phases:
 The accuracy samples from that final timing run are not model-quality
 evidence: Steam was in front of Balatro in the captured desktop. They confirm
 the capture and inference execution paths only.
+
+A corrected foreground probe activated the existing Proton/XWayland Balatro
+window and verified the result with a fresh Wayland PipeWire screenshot before
+measurement. The frame contained eight visible hand cards. Twenty consecutive
+CUDA observations returned the same eight readings (`S_K`, `C_Q`, `S_T`,
+`S_8`, `D_8`, `S_7`, `H_4`, `D_2`) with no missing slots; the first observation
+reported identity confidences from 0.973 to 0.999. This is single-frame
+repeatability evidence, not a dataset-level accuracy rate.
+
+The Cargo feature graph confirmed that `auv-game-balatro --features cuda`
+enabled CUDA in `auv-inference-ultralytics`, `ultralytics-inference`, `ort`, and
+`ort-sys`. The initial CPU fallback happened because the daemon-launched Runner
+could not resolve the CUDA 12 runtime libraries required by ONNX Runtime;
+`nvidia-smi` alone provides a working driver, not those user-space libraries.
+After the Balatro Runner provider supplied the installed CUDA 12 library paths,
+`nvidia-smi` reported `auv-runner-balatro` using 1416 MiB of GPU memory.
+
+On that foreground frame, CUDA cold start took 2.68 seconds. Twenty warm live
+observations averaged 1.413 seconds (1.260--1.567 seconds), versus 1.556 seconds
+for six warm CPU observations. Fixed-image inference averaged 1.340 seconds on
+CUDA and 1.453 seconds on CPU; ten complete display captures averaged 111 ms.
+CUDA was therefore active but improved this seven-small-model pipeline by only
+about nine percent. The remaining cost is inside inference and its CPU
+pre/post-processing, image copies, and multi-session scheduling rather than
+window lookup or OCR.

--- a/docs/ai/references/driver/2026-08-07-wayland-capture-obs-sunshine-evidence.md
+++ b/docs/ai/references/driver/2026-08-07-wayland-capture-obs-sunshine-evidence.md
@@ -236,6 +236,22 @@ Live probing on `neko-gpu-1` separated the phases:
 - After the GNOME portal session was restarted, the stored restore token no
   longer completed unattended `Start`. Stage probes measured CreateSession and
   SelectSources method/response pairs below 2 ms each, followed by the full
-  ten-second wait for `ScreenCast.Start` response. The final repeated-frame
-  throughput therefore still requires one interactive source authorization;
-  it was not inferred from the unit tests.
+  ten-second wait for `ScreenCast.Start` response. One interactive source
+  authorization produced a replacement restore token; the next daemon restart
+  then restored capture without another prompt.
+- After authorization, ten complete remote `display.capture` CLI invocations
+  measured 336 ms for the first sample and 86--132 ms for the next nine
+  samples. The hot mean was 112 ms. These measurements include daemon routing,
+  gRPC image transfer, 2560x1440 PNG encoding, run recording, and artifact
+  persistence, not only the PipeWire snapshot.
+- A separate Balatro probe showed that an unsuccessful AT-SPI window lookup
+  still cost 2.44 seconds per observation on this GNOME Wayland/Wine desktop.
+  Fixed-image inference through the persistent seven-model Runner averaged
+  1.37 seconds, while the live path averaged 3.81 seconds. Linux Balatro now
+  skips the unavailable accessibility-window lookup and uses the persistent
+  display stream directly; eight live samples then averaged 1.40 seconds
+  (1.12--1.52 seconds).
+
+The accuracy samples from that final timing run are not model-quality
+evidence: Steam was in front of Balatro in the captured desktop. They confirm
+the capture and inference execution paths only.

--- a/docs/ai/references/driver/2026-08-07-wayland-capture-obs-sunshine-evidence.md
+++ b/docs/ai/references/driver/2026-08-07-wayland-capture-obs-sunshine-evidence.md
@@ -1,0 +1,241 @@
+# Wayland capture lifecycle evidence from OBS and Sunshine
+
+Date: 2026-08-07
+
+This note compares AUV's current xdg-desktop-portal/PipeWire capture path with
+OBS Studio commit
+[`88de106c`](https://github.com/obsproject/obs-studio/tree/88de106cff4bcdf2a511e2e3801ffa3de729f6bd)
+and Sunshine commit
+[`0784774`](https://github.com/LizardByte/Sunshine/tree/0784774fecb4ffcd7ff1bf1c26bba84af516590e).
+Only upstream specifications and first-party source repositories are used.
+
+## Finding
+
+The live-capture stall is not explained by window/output resolution alone.
+AUV does reuse the portal `ScreenCast` session, but it recreates the entire
+PipeWire data plane for every requested frame. OBS and Sunshine open the
+PipeWire remote once, keep a PipeWire core, stream, and event loop alive, and
+consume frames from that long-lived stream.
+
+The immediate AUV fix should therefore make the PipeWire receiver a durable
+part of `ScreenCastSession`, with a bounded wait for a recent frame. It should
+also bound and cancel portal requests. Caching only Wayland output geometry
+would remove two compositor roundtrips, but would not fix repeated PipeWire
+negotiation or an unbounded Screenshot fallback.
+
+## Portal contract
+
+The `ScreenCast` lifecycle is `CreateSession -> SelectSources -> Start ->
+OpenPipeWireRemote`. `Start` returns one or more PipeWire streams, and
+`OpenPipeWireRemote` returns an fd that is used to create a `pw_core` with
+`pw_context_connect_fd`. The specification does not require clients to reopen
+that remote for each frame. A session remains open until the client closes it
+or the portal emits `Session.Closed`.
+([ScreenCast specification](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.ScreenCast.html))
+
+Restore tokens persist permission/source selection, not an active PipeWire
+connection. They are single-use: after a token is consumed, the client must
+store the replacement returned by the next successful `Start`. If restoration
+is impossible, the token is ignored and normal user selection may be shown.
+([`SelectSources` restore-token contract](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.ScreenCast.html#org.freedesktop.portal.ScreenCast.SelectSources))
+
+Since ScreenCast version 6, the tuple's numeric PipeWire node ID is deprecated
+for targeting because it can be reused after node destruction. A client should
+prefer the returned `pipewire-serial` and set `PW_KEY_TARGET_OBJECT` when that
+property is available.
+([`Start` stream contract](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.ScreenCast.html#org.freedesktop.portal.ScreenCast.Start))
+
+The portal supports monitor, window, and virtual-monitor source categories,
+but `SelectSources` does not let a client identify an arbitrary application
+window by title or PID. In practice the user selects the window, or a later
+session restores the portal's opaque selection. The absence of a programmatic
+name/process selector is tracked by the portal project as a proposed new API,
+not as existing behavior.
+([available source types](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.ScreenCast.html#org.freedesktop.portal.ScreenCast.AvailableSourceTypes),
+[`xdg-desktop-portal` issue #1064](https://github.com/flatpak/xdg-desktop-portal/issues/1064))
+
+Consequently, AUV cannot portably ask the portal for “the Balatro window” by
+its AT-SPI/Wayland title. It can either:
+
+- keep one user-approved monitor stream and crop it using separately observed
+  window geometry; or
+- ask the user to select a window once and restore that opaque portal choice
+  later, without claiming that the token is a stable title/PID selector.
+
+## OBS Studio
+
+OBS creates a portal capture object that owns the session handle, restore
+token, PipeWire connection, and PipeWire stream. After `Start`, it invokes
+`OpenPipeWireRemote` once, connects the returned fd to PipeWire, and stores the
+resulting `obs_pw` and `obs_pw_stream` in that capture object.
+([portal capture fields and one-time open](https://github.com/obsproject/obs-studio/blob/88de106cff4bcdf2a511e2e3801ffa3de729f6bd/plugins/linux-pipewire/screencast-portal.c#L44-L60),
+[`OpenPipeWireRemote` callback](https://github.com/obsproject/obs-studio/blob/88de106cff4bcdf2a511e2e3801ffa3de729f6bd/plugins/linux-pipewire/screencast-portal.c#L154-L210),
+[`Start` response](https://github.com/obsproject/obs-studio/blob/88de106cff4bcdf2a511e2e3801ffa3de729f6bd/plugins/linux-pipewire/screencast-portal.c#L214-L270))
+
+The PipeWire connection owns a `pw_thread_loop`, context, core, and registered
+stream. The stream remains connected while the OBS source exists; show/hide
+only activates or deactivates it. OBS destroys the stream, PipeWire connection,
+and portal session when the source is destroyed or the user explicitly reloads
+the selection.
+([PipeWire connection lifetime](https://github.com/obsproject/obs-studio/blob/88de106cff4bcdf2a511e2e3801ffa3de729f6bd/plugins/linux-pipewire/pipewire.c#L1116-L1160),
+[`pw_stream` connection](https://github.com/obsproject/obs-studio/blob/88de106cff4bcdf2a511e2e3801ffa3de729f6bd/plugins/linux-pipewire/pipewire.c#L1192-L1254),
+[source destruction](https://github.com/obsproject/obs-studio/blob/88de106cff4bcdf2a511e2e3801ffa3de729f6bd/plugins/linux-pipewire/screencast-portal.c#L556-L578))
+
+Frame processing drains queued buffers to the newest one rather than rebuilding
+the stream for a snapshot. This is the useful architectural precedent for an
+AUV latest-frame cache.
+([OBS PipeWire frame processing](https://github.com/obsproject/obs-studio/blob/88de106cff4bcdf2a511e2e3801ffa3de729f6bd/plugins/linux-pipewire/pipewire.c#L661-L709))
+
+OBS requests persistence when ScreenCast version 4 is available, supplies the
+previous token, and saves the replacement from `Start` into source settings.
+([selection persistence](https://github.com/obsproject/obs-studio/blob/88de106cff4bcdf2a511e2e3801ffa3de729f6bd/plugins/linux-pipewire/screencast-portal.c#L345-L382),
+[replacement-token handling](https://github.com/obsproject/obs-studio/blob/88de106cff4bcdf2a511e2e3801ffa3de729f6bd/plugins/linux-pipewire/screencast-portal.c#L253-L265),
+[settings persistence](https://github.com/obsproject/obs-studio/blob/88de106cff4bcdf2a511e2e3801ffa3de729f6bd/plugins/linux-pipewire/screencast-portal.c#L580-L590))
+
+OBS's portal method calls use GLib's default/infinite timeout, so OBS is not a
+good timeout value to copy. It does, however, attach a `GCancellable` to the
+asynchronous calls. Cancelling also closes the portal `Request` object and
+unsubscribes the pending response handler.
+([cancellable portal request handling](https://github.com/obsproject/obs-studio/blob/88de106cff4bcdf2a511e2e3801ffa3de729f6bd/plugins/linux-pipewire/portal.c#L129-L189),
+[asynchronous call sites](https://github.com/obsproject/obs-studio/blob/88de106cff4bcdf2a511e2e3801ffa3de729f6bd/plugins/linux-pipewire/screencast-portal.c#L287-L304))
+
+## Sunshine
+
+Sunshine likewise runs portal setup once during display initialization:
+`connect_to_portal` creates/starts the session and calls
+`OpenPipeWireRemote`; `configure_stream` returns that fd and the chosen stream
+identity to the owning `pipewire_display_t`.
+([portal setup](https://github.com/LizardByte/Sunshine/blob/0784774fecb4ffcd7ff1bf1c26bba84af516590e/src/platform/linux/portalgrab.cpp#L228-L256),
+[`OpenPipeWireRemote`](https://github.com/LizardByte/Sunshine/blob/0784774fecb4ffcd7ff1bf1c26bba84af516590e/src/platform/linux/portalgrab.cpp#L633-L648),
+[display stream configuration](https://github.com/LizardByte/Sunshine/blob/0784774fecb4ffcd7ff1bf1c26bba84af516590e/src/platform/linux/portalgrab.cpp#L708-L758))
+
+Its `pipewire_t` owns a threaded loop, context, core, stream, buffer state,
+mutex, and condition variable for the lifetime of the display capture object.
+The process callback retains the newest DMA-BUF or swaps a double-buffered CPU
+copy, then wakes consumers. `snapshot` waits for a frame on that already-active
+stream; the continuous capture loop gives each snapshot a 1000 ms deadline.
+([persistent PipeWire owner](https://github.com/LizardByte/Sunshine/blob/0784774fecb4ffcd7ff1bf1c26bba84af516590e/src/platform/linux/pipewire.cpp#L77-L114),
+[thread-loop lifetime](https://github.com/LizardByte/Sunshine/blob/0784774fecb4ffcd7ff1bf1c26bba84af516590e/src/platform/linux/pipewire.cpp#L138-L192),
+[frame handoff](https://github.com/LizardByte/Sunshine/blob/0784774fecb4ffcd7ff1bf1c26bba84af516590e/src/platform/linux/pipewire.cpp#L570-L620),
+[bounded snapshot and capture loop](https://github.com/LizardByte/Sunshine/blob/0784774fecb4ffcd7ff1bf1c26bba84af516590e/src/platform/linux/pipewire.cpp#L893-L921))
+
+Sunshine also bounds initial format negotiation to 1500 ms and returns a typed
+timeout/reinitialize/error outcome when frames stop or the stream dies.
+([negotiation deadline](https://github.com/LizardByte/Sunshine/blob/0784774fecb4ffcd7ff1bf1c26bba84af516590e/src/platform/linux/pipewire.cpp#L846-L881),
+[capture outcomes](https://github.com/LizardByte/Sunshine/blob/0784774fecb4ffcd7ff1bf1c26bba84af516590e/src/platform/linux/pipewire.cpp#L955-L1019),
+[closed-session handling](https://github.com/LizardByte/Sunshine/blob/0784774fecb4ffcd7ff1bf1c26bba84af516590e/src/platform/linux/portalgrab.cpp#L760-L782))
+
+Sunshine persists the restore token on disk, passes it to a persistent
+ScreenCast-only selection, and replaces it with the next token returned by
+`Start`.
+([token store](https://github.com/LizardByte/Sunshine/blob/0784774fecb4ffcd7ff1bf1c26bba84af516590e/src/platform/linux/portalgrab.cpp#L38-L105),
+[selection](https://github.com/LizardByte/Sunshine/blob/0784774fecb4ffcd7ff1bf1c26bba84af516590e/src/platform/linux/portalgrab.cpp#L469-L490),
+[rotation after `Start`](https://github.com/LizardByte/Sunshine/blob/0784774fecb4ffcd7ff1bf1c26bba84af516590e/src/platform/linux/portalgrab.cpp#L522-L579))
+
+Sunshine currently requests monitor sources only and matches returned portal
+streams to Wayland monitor geometry/name. It does not demonstrate
+programmatic portal window selection.
+([monitor-only `SelectSources`](https://github.com/LizardByte/Sunshine/blob/0784774fecb4ffcd7ff1bf1c26bba84af516590e/src/platform/linux/portalgrab.cpp#L469-L489),
+[stream-to-monitor matching](https://github.com/LizardByte/Sunshine/blob/0784774fecb4ffcd7ff1bf1c26bba84af516590e/src/platform/linux/portalgrab.cpp#L581-L628))
+
+One Sunshine behavior should not be copied: its portal setup uses synchronous
+D-Bus calls with an infinite timeout and waits in `g_main_loop_run` without an
+explicit deadline or cancellable. Its bounded waits begin only after PipeWire
+stream setup.
+([unbounded response wait](https://github.com/LizardByte/Sunshine/blob/0784774fecb4ffcd7ff1bf1c26bba84af516590e/src/platform/linux/portalgrab.cpp#L694-L702),
+[synchronous `Start`](https://github.com/LizardByte/Sunshine/blob/0784774fecb4ffcd7ff1bf1c26bba84af516590e/src/platform/linux/portalgrab.cpp#L522-L555))
+
+## Current AUV delta
+
+Current AUV behavior is split across
+[`native/portal/screencast.rs`](../../../../crates/auv-driver-linux/src/native/portal/screencast.rs),
+[`native/portal/request.rs`](../../../../crates/auv-driver-linux/src/native/portal/request.rs),
+[`capture.rs`](../../../../crates/auv-driver-linux/src/capture.rs), and
+[`capture/display.rs`](../../../../crates/auv-driver-linux/src/capture/display.rs).
+
+| Concern | AUV now | OBS/Sunshine evidence | Required correction |
+| --- | --- | --- | --- |
+| Portal session | Cached in `LinuxDriverSessionState` | Long-lived | Keep this behavior |
+| Restore token | Atomically rotates a single-use token | Both replace the consumed token | Keep this behavior |
+| PipeWire remote | Reopened in every `capture_monitor_frame` | Opened once during source/display initialization | Store one remote/core per active session |
+| PipeWire loop and stream | Created inside `read_pipewire_frame`, destroyed after first frame | Persistent threaded loop and stream | Move ownership into `ScreenCastSession` or a dedicated deep receiver module |
+| Frame delivery | Waits for the first frame after each new negotiation | Callback maintains newest frame/buffer | Maintain latest frame plus sequence/freshness and wait only when no acceptable frame exists |
+| PipeWire timeout | Five seconds per newly-created stream | Sunshine uses bounded negotiation and per-frame waits | Preserve a bounded wait, but apply it to an existing receiver and return a typed timeout/stall reason |
+| Portal request timeout | `responses.next()` can block indefinitely | OBS is cancellable; Sunshine is also unbounded here | Add deadline/cancellation and call `Request.Close` on timeout |
+| Screenshot fallback | Interactive fallback also waits indefinitely | Neither project uses a one-shot interactive screenshot as the normal frame path | Do not enter an unbounded fallback after a bounded stream failure |
+| Stream targeting | Parses `pipewire-serial` but connects by numeric node ID | Portal v6 and Sunshine prefer object serial | Use `PW_KEY_TARGET_OBJECT` when available; retain node ID only as versioned compatibility |
+| Output discovery | Opens a Wayland connection and performs two roundtrips for every display/region capture | Sunshine correlates monitor metadata during stream setup | Cache output metadata with an explicit invalidation/re-enumeration trigger |
+| Window selection | Always requests monitor streams and crops | Portal cannot select by title/PID; OBS window source is user-selected/restored | Keep monitor crop as the automatic path; expose portal-window selection only with its consent/opaque-token boundary |
+
+The observed long wall time can therefore be a composition of:
+
+1. fresh Wayland output enumeration (two roundtrips);
+2. a portal session start on the first call;
+3. `OpenPipeWireRemote`, core/stream creation, and format negotiation on every
+   call;
+4. up to five seconds waiting for the first frame;
+5. an unbounded interactive Screenshot request after the ScreenCast path
+   fails.
+
+The last two stages explain why a caller can exceed the PipeWire five-second
+deadline. A trace that reports only the enclosing `window.capture` operation
+cannot attribute that delay to “window resolution” safely.
+
+## Recommended narrow fix
+
+1. Make a started `ScreenCastSession` own the opened PipeWire fd/core, one
+   connected receiver per selected stream, and the event-loop thread.
+2. Have the receiver publish the latest decoded frame with a monotonically
+   increasing sequence and arrival time. `capture_monitor_frame` selects the
+   receiver and returns its latest acceptable frame, with a bounded wait only
+   when necessary.
+3. Observe PipeWire stream errors and portal `Session.Closed`; invalidate the
+   cached session and allow one explicit reinitialization on the next capture.
+4. Add deadlines to all portal response waits. On timeout, close the portal
+   `Request`; do not immediately enter another unbounded interactive portal
+   operation.
+5. Do not hold the outer `LinuxDriverSessionState` mutex while waiting for a
+   frame. The durable receiver should own its internal synchronization.
+6. Cache Wayland output metadata separately. Treat hotplug/output change as an
+   invalidation trigger rather than paying two roundtrips on every frame.
+
+This slice should remain a CPU-frame correctness and lifecycle fix. DMA-BUF
+zero-copy and direct GPU inference are valuable follow-ups, but neither is
+required to remove the current setup and blocking costs.
+
+## Implemented slice and live evidence
+
+The 2026-08-07 fix makes `ScreenCastSession` own a receiver pool keyed by
+portal stream ID. Each receiver owns a dedicated PipeWire worker thread and
+keeps its main loop, context, core, listener, and stream connected. A failed
+receiver is removed so the next capture can initialize it again.
+
+The worker drains buffers while idle without converting the full display. On
+capture it waits up to 100 ms for a newer buffer; if a static Wayland surface
+produces no damage, it returns the latest decoded frame instead of waiting five
+seconds and entering the Screenshot fallback. Focused regression tests cover
+receiver reuse, invalidation after failure, and static-stream latest-frame
+delivery.
+
+Portal method calls and `Request.Response` waits now each have a ten-second
+deadline. The Screenshot fallback remains available, but if it also fails the
+returned error preserves both the primary ScreenCast failure and fallback
+failure. No-reply `Request.Close`, output hotplug caching, moving frame waits
+outside the outer driver mutex, and serial-based PipeWire targeting remain
+explicitly deferred at their call sites.
+
+Live probing on `neko-gpu-1` separated the phases:
+
+- A successful authorized first `display.capture` completed in 2.65 seconds,
+  including CLI/run recording, PNG encoding, and artifact persistence.
+- An intermediate persistent-stream build reproduced the static-frame bug:
+  capture 1 completed in 2.65 seconds, while capture 2 reached the caller's
+  20-second timeout after the five-second fresh-frame wait entered the
+  interactive Screenshot fallback. This motivated the latest-frame policy and
+  its regression test.
+- After the GNOME portal session was restarted, the stored restore token no
+  longer completed unattended `Start`. Stage probes measured CreateSession and
+  SelectSources method/response pairs below 2 ms each, followed by the full
+  ten-second wait for `ScreenCast.Start` response. The final repeated-frame
+  throughput therefore still requires one interactive source authorization;
+  it was not inferred from the unit tests.

--- a/docs/ai/references/driver/INDEX.md
+++ b/docs/ai/references/driver/INDEX.md
@@ -2,7 +2,7 @@
 
 Platform drivers, input, window, capture, permissions
 
-Count: **27**
+Count: **28**
 
 - [`2026-05-20-macos-driver-namespace-after-window-screen-design.md`](2026-05-20-macos-driver-namespace-after-window-screen-design.md)
 - [`2026-05-20-macos-osascript-backend-design.md`](2026-05-20-macos-osascript-backend-design.md)
@@ -33,6 +33,7 @@ Count: **27**
 - [`2026-08-05-mouse-motion-streaming-design.md`](2026-08-05-mouse-motion-streaming-design.md)
 - [`2026-08-06-open-source-mouse-motion-implementation-research.md`](2026-08-06-open-source-mouse-motion-implementation-research.md)
 - [`2026-08-06-input-performance-evidence.md`](2026-08-06-input-performance-evidence.md)
+- [`2026-08-07-wayland-capture-obs-sunshine-evidence.md`](2026-08-07-wayland-capture-obs-sunshine-evidence.md)
 
 ## Related
 

--- a/supported/games/auv-game-balatro/src/observation.rs
+++ b/supported/games/auv-game-balatro/src/observation.rs
@@ -421,23 +421,44 @@ async fn observe_live_with_runners(
   ui_classes: Vec<String>,
   no_cache: bool,
 ) -> Result<BalatroState, ObservationError> {
-  // TODO(balatro-window-resolution-cache): cache a resolved Window only after
-  // Linux exposes a typed move/resize/close invalidation signal; stale window
-  // identity or geometry is worse than the current per-observation lookup.
-  let window = driver
-    .windows()
-    .resolve(auv_driver::WindowSelector {
-      app: Some(auv_driver::App::name(target)),
-      main_visible: true,
-      ..Default::default()
-    })
-    .await;
-  let (source, captured) = match window {
-    Ok(window) => (format!("daemon://window/{}", window.reference().id), window.capture().await.map_err(api_error)?.capture),
-    Err(error) if matches!(error.client_kind(), Some(auv::error::ClientErrorKind::NotFound | auv::error::ClientErrorKind::Unsupported)) => {
-      ("daemon://display/primary?fallback=window_unavailable".to_string(), driver.displays().capture(None).await.map_err(api_error)?.capture)
+  #[cfg(target_os = "linux")]
+  let (source, captured) = {
+    let _ = target;
+    // NOTICE(balatro-linux-display-capture): Wine/Proton Balatro windows are
+    // not exposed through AT-SPI on GNOME Wayland. Resolving one therefore
+    // performs a full accessibility-tree scan before every frame and always
+    // falls back to the display. The image pipeline already resolves the game
+    // viewport from the captured frame, so use the persistent display stream
+    // directly on Linux.
+    // TODO(balatro-linux-window-capture): reconsider window capture only when
+    // a compositor-native window identity and invalidation contract exists.
+    ("daemon://display/primary?window_resolution=unavailable".to_string(), driver.displays().capture(None).await.map_err(api_error)?.capture)
+  };
+  #[cfg(not(target_os = "linux"))]
+  let (source, captured) = {
+    // TODO(balatro-window-resolution-cache): cache a resolved Window only after
+    // the platform exposes a typed move/resize/close invalidation signal; stale
+    // window identity or geometry is worse than the current per-observation lookup.
+    let window = driver
+      .windows()
+      .resolve(auv_driver::WindowSelector {
+        app: Some(auv_driver::App::name(target)),
+        main_visible: true,
+        ..Default::default()
+      })
+      .await;
+    match window {
+      Ok(window) => (format!("daemon://window/{}", window.reference().id), window.capture().await.map_err(api_error)?.capture),
+      Err(error)
+        if matches!(error.client_kind(), Some(auv::error::ClientErrorKind::NotFound | auv::error::ClientErrorKind::Unsupported)) =>
+      {
+        (
+          "daemon://display/primary?fallback=window_unavailable".to_string(),
+          driver.displays().capture(None).await.map_err(api_error)?.capture,
+        )
+      }
+      Err(error) => return Err(api_error(error)),
     }
-    Err(error) => return Err(api_error(error)),
   };
   let capture = captured;
   #[cfg(feature = "tracing")]


### PR DESCRIPTION
## Summary

- keep the portal PipeWire receiver and latest frame alive across capture RPCs
- bound portal requests and preserve primary/fallback capture failures
- skip the unavailable AT-SPI Balatro window lookup on Linux and use the persistent display stream directly
- document OBS/Sunshine lifecycle evidence and foreground CUDA benchmarks

## Evidence

- repeated remote `display.capture`: 112 ms hot mean at 2560x1440, including gRPC, PNG artifact persistence, and run recording
- foreground Balatro live state: 3.81 s -> 1.40 s after removing the unsuccessful 2.44 s window lookup
- foreground CUDA: 20/20 observations returned the same 8/8 hand readings; runner held 1416 MiB GPU memory
- CUDA live mean 1.413 s versus CPU live mean 1.556 s

## Verification

- `cargo fmt --check`
- `git diff --check`
- Linux `auv-driver-linux` tests: 62 passed
- Linux Balatro observation tests: 15 passed
- release builds of `auv`, `auv-game-balatro`, and CUDA-enabled `auv-runner-balatro` on `neko-gpu-1`

## Validation boundary

The 20/20 card result is repeatability evidence for one foreground frame, not a dataset-level accuracy claim. Full macOS workspace validation remains blocked by the uninitialized `auv-media-macos/vendor/mediaremote-adapter` submodule in this worktree.