### PR TITLE
fix(auv-driver-macos): preserve permission probe failures

### DIFF
--- a/crates/auv-cli/src/commands/doctor.rs
+++ b/crates/auv-cli/src/commands/doctor.rs
@@ -19,6 +19,7 @@ struct PermissionCheckReport {
   accessibility: &'static str,
   screen_recording_preflight: &'static str,
   screen_capture_kit: &'static str,
+  screen_capture_kit_error: Option<String>,
   all_ok: bool,
   warnings: Vec<String>,
   recommendation: String,
@@ -42,6 +43,12 @@ fn collect_permission_check() -> Result<PermissionCheckReport, String> {
   if native.screen_recording == "missing" && native.screen_capture_kit == "granted" {
     warnings.push("CGPreflightScreenCaptureAccess reports missing, but the ScreenCaptureKit probe works; this can happen when the launch host owns TCC attribution.".to_string());
   }
+  if matches!(native.screen_capture_kit, "timed_out" | "failed") {
+    warnings.push(
+      "The ScreenCaptureKit probe did not establish a permission result; the current Screen Recording grant may be unchanged.".to_string(),
+    );
+  }
+  let recommendation = recommendation(native.accessibility, native.screen_capture_kit);
   Ok(PermissionCheckReport {
     platform: "macos",
     process_id: std::process::id(),
@@ -49,9 +56,10 @@ fn collect_permission_check() -> Result<PermissionCheckReport, String> {
     accessibility: native.accessibility,
     screen_recording_preflight: native.screen_recording,
     screen_capture_kit: native.screen_capture_kit,
+    screen_capture_kit_error: native.screen_capture_kit_error,
     all_ok,
     warnings,
-    recommendation: recommendation(native.accessibility, native.screen_capture_kit),
+    recommendation,
   })
 }
 
@@ -68,6 +76,12 @@ fn recommendation(accessibility: &str, screen_capture_kit: &str) -> String {
     }
     ("missing", _) => "Grant Accessibility to the terminal or app that launches auv, then rerun this check.".to_string(),
     (_, "missing") => "Grant Screen Recording to the terminal or app that launches auv, then rerun this check.".to_string(),
+    (_, "timed_out") => {
+      "Retry the ScreenCaptureKit probe; a timeout does not establish that Screen Recording permission is missing.".to_string()
+    }
+    (_, "failed") => {
+      "Review the ScreenCaptureKit probe detail and retry; a probe failure does not establish that permission is missing.".to_string()
+    }
     _ => "Review the permission statuses above before running desktop automation.".to_string(),
   }
 }
@@ -82,6 +96,9 @@ fn print_report(report: &PermissionCheckReport) {
   println!("accessibility: {}", status_line(report.accessibility));
   println!("screen recording preflight: {}", status_line(report.screen_recording_preflight));
   println!("screen capture kit probe: {}", status_line(report.screen_capture_kit));
+  if let Some(error) = &report.screen_capture_kit_error {
+    println!("screen capture kit detail: {error}");
+  }
   for warning in &report.warnings {
     println!("warning: {warning}");
   }
@@ -94,5 +111,22 @@ fn status_line(status: &str) -> String {
     "granted" => "[ok] granted".to_string(),
     "missing" => "[missing] missing".to_string(),
     other => format!("[unknown] {other}"),
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn timed_out_probe_does_not_recommend_granting_permission() {
+    assert_eq!(status_line("timed_out"), "[unknown] timed_out");
+    assert!(recommendation("granted", "timed_out").contains("does not establish"));
+  }
+
+  #[test]
+  fn failed_probe_does_not_recommend_granting_permission() {
+    assert_eq!(status_line("failed"), "[unknown] failed");
+    assert!(recommendation("granted", "failed").contains("does not establish"));
   }
 }

--- a/crates/auv-driver-macos/native/swift/Sources/AuvMacosNative/Permission.swift
+++ b/crates/auv-driver-macos/native/swift/Sources/AuvMacosNative/Permission.swift
@@ -4,34 +4,51 @@ import Foundation
 import ScreenCaptureKit
 
 func probe_permissions() -> NativePermissionProbeResponse {
-  NativePermissionProbeResponse(
+  let screenCaptureKit = probeScreenCaptureKitAccess()
+  return NativePermissionProbeResponse(
     screen_recording: CGPreflightScreenCaptureAccess()
       ? NativePermissionStatus.Granted
       : NativePermissionStatus.Missing,
-    screen_capture_kit: probeScreenCaptureKitAccess()
-      ? NativePermissionStatus.Granted
-      : NativePermissionStatus.Missing,
+    screen_capture_kit: screenCaptureKit.status,
+    screen_capture_kit_error: screenCaptureKit.errorMessage?.intoRustString(),
     accessibility: AXIsProcessTrusted()
       ? NativePermissionStatus.Granted
       : NativePermissionStatus.Missing
   )
 }
 
-private func probeScreenCaptureKitAccess() -> Bool {
+private struct ScreenCaptureKitProbe {
+  let status: NativePermissionStatus
+  let errorMessage: String?
+}
+
+private func probeScreenCaptureKitAccess() -> ScreenCaptureKitProbe {
   guard #available(macOS 12.3, *) else {
-    return false
+    return ScreenCaptureKitProbe(
+      status: .Failed,
+      errorMessage: "ScreenCaptureKit permission probing requires macOS 12.3 or newer"
+    )
   }
 
   let semaphore = DispatchSemaphore(value: 0)
-  var granted = false
+  var result = ScreenCaptureKitProbe(status: .Failed, errorMessage: "ScreenCaptureKit returned no result")
 
   SCShareableContent.getWithCompletionHandler { content, error in
-    granted = error == nil && content != nil
+    if let error {
+      result = ScreenCaptureKitProbe(status: .Failed, errorMessage: error.localizedDescription)
+    } else if content != nil {
+      result = ScreenCaptureKitProbe(status: .Granted, errorMessage: nil)
+    } else {
+      result = ScreenCaptureKitProbe(status: .Failed, errorMessage: "ScreenCaptureKit returned no shareable content")
+    }
     semaphore.signal()
   }
 
   if semaphore.wait(timeout: .now() + .seconds(3)) == .timedOut {
-    return false
+    return ScreenCaptureKitProbe(
+      status: .TimedOut,
+      errorMessage: "ScreenCaptureKit permission probe timed out after 3 seconds"
+    )
   }
-  return granted
+  return result
 }

--- a/crates/auv-driver-macos/src/native/binding.rs
+++ b/crates/auv-driver-macos/src/native/binding.rs
@@ -8,6 +8,8 @@ pub(crate) mod ffi {
   enum NativePermissionStatus {
     Granted,
     Missing,
+    TimedOut,
+    Failed,
   }
 
   enum NativeHumanApprovalStatus {
@@ -21,6 +23,7 @@ pub(crate) mod ffi {
   struct NativePermissionProbeResponse {
     screen_recording: NativePermissionStatus,
     screen_capture_kit: NativePermissionStatus,
+    screen_capture_kit_error: Option<String>,
     accessibility: NativePermissionStatus,
   }
 

--- a/crates/auv-driver-macos/src/native/permission.rs
+++ b/crates/auv-driver-macos/src/native/permission.rs
@@ -17,6 +17,7 @@ pub fn probe_native_permissions() -> AuvResult<NativePermissionProbe> {
 pub struct NativePermissionProbe {
   pub screen_recording: &'static str,
   pub screen_capture_kit: &'static str,
+  pub screen_capture_kit_error: Option<String>,
   pub accessibility: &'static str,
 }
 
@@ -26,6 +27,7 @@ impl From<NativePermissionProbeResponse> for NativePermissionProbe {
     Self {
       screen_recording: permission_status_label(value.screen_recording),
       screen_capture_kit: permission_status_label(value.screen_capture_kit),
+      screen_capture_kit_error: value.screen_capture_kit_error,
       accessibility: permission_status_label(value.accessibility),
     }
   }
@@ -36,6 +38,8 @@ fn permission_status_label(status: NativePermissionStatus) -> &'static str {
   match status {
     NativePermissionStatus::Granted => "granted",
     NativePermissionStatus::Missing => "missing",
+    NativePermissionStatus::TimedOut => "timed_out",
+    NativePermissionStatus::Failed => "failed",
   }
 }
 

--- a/crates/auv-driver-macos/src/native/permission_test.rs
+++ b/crates/auv-driver-macos/src/native/permission_test.rs
@@ -9,3 +9,17 @@ fn permission_status_label_maps_granted() {
 fn permission_status_label_maps_missing() {
   assert_eq!(permission_status_label(NativePermissionStatus::Missing), "missing");
 }
+
+// ROOT CAUSE:
+//
+// If the ScreenCaptureKit callback missed the probe deadline, `auv doctor`
+// reported a missing permission because the native probe collapsed timeout
+// and permission denial into the same boolean result.
+//
+// Before the fix, only granted and missing crossed the native boundary.
+// The fix keeps operational probe failures distinct from permission state.
+#[test]
+fn permission_status_label_preserves_probe_failures() {
+  assert_eq!(permission_status_label(NativePermissionStatus::TimedOut), "timed_out");
+  assert_eq!(permission_status_label(NativePermissionStatus::Failed), "failed");
+}

--- a/crates/auv-driver-macos/src/session_test.rs
+++ b/crates/auv-driver-macos/src/session_test.rs
@@ -282,6 +282,8 @@ mod no_steal_tests {
   fn permission_status_from_label_handles_native_labels() {
     assert_eq!(permission_status_from_label("granted"), PermissionStatus::Granted);
     assert_eq!(permission_status_from_label("missing"), PermissionStatus::Missing);
+    assert_eq!(permission_status_from_label("timed_out"), PermissionStatus::Unknown);
+    assert_eq!(permission_status_from_label("failed"), PermissionStatus::Unknown);
     assert_eq!(permission_status_from_label("new-native-status"), PermissionStatus::Unknown);
   }
 


### PR DESCRIPTION
## Summary

- preserve ScreenCaptureKit probe timeouts and operational failures across the Swift/Rust boundary
- report probe details through `auv doctor` without treating inconclusive results as missing permission
- map native operational failures to the shared `PermissionStatus::Unknown` contract
- add regression coverage for native status labels, driver mapping, and doctor recommendations

## Root cause

The native ScreenCaptureKit probe returned a Boolean and converted its three-second semaphore timeout into `false`. The Rust bridge then labeled every `false` result as `missing`, so concurrent `auv doctor` processes reported lost Screen Recording permission when some `SCShareableContent` callbacks merely missed the local deadline.

## Impact

Concurrent doctor runs now distinguish `timed_out` and `failed` from an actual missing permission. Human-readable and JSON reports retain the probe detail, and remediation no longer tells users to grant Screen Recording when the probe was inconclusive.

A five-process concurrent reproduction changed from false `[missing]` results to:

- 0 `missing`
- 4 `timed_out`
- 1 `granted`

## Validation

- `scripts/generate-swift-bridge`
- `cd crates/auv-driver-macos/native/swift && swift build`
- `cargo fmt --check`
- `cargo check`
- `cargo test`
- `git diff --check`
- `cargo run --quiet -- invoke --help`
- five-process concurrent `target/debug/auv doctor` reproduction
