### PR TITLE
feat(auv-cli-invoke): unify targeted point clicks

### DIFF
--- a/crates/auv-cli-invoke/src/command.rs
+++ b/crates/auv-cli-invoke/src/command.rs
@@ -18,7 +18,7 @@ type InvokeCommandParser = fn(&'static str, &'static str, &[String]) -> Result<I
 pub enum InvokeCommandCliParse {
   Help,
   Invoke {
-    target_application_id: Option<String>,
+    target: Option<crate::ExecutionTarget>,
     inputs: BTreeMap<String, String>,
     typed_args: TypedInvokeArgs,
     store_root: Option<PathBuf>,
@@ -112,7 +112,7 @@ pub struct InvokeCancelled;
 #[derive(Clone, Debug)]
 pub struct InvokeCommandInput {
   pub command_id: String,
-  pub target_application_id: Option<String>,
+  pub target: Option<crate::ExecutionTarget>,
   pub inputs: BTreeMap<String, String>,
   pub typed_args: Option<TypedInvokeArgs>,
   pub dry_run: bool,
@@ -129,8 +129,13 @@ impl InvokeCommandInput {
       .ok_or_else(|| format!("{} requires --{name}", self.command_id))
   }
 
-  pub fn target_or_input_target(&self) -> Option<&str> {
-    self.target_application_id.as_deref().or_else(|| self.inputs.get("target").map(String::as_str)).filter(|value| !value.trim().is_empty())
+  pub fn application_target(&self) -> Result<Option<&str>, String> {
+    match self.target.as_ref() {
+      Some(crate::ExecutionTarget::Application { id }) => Ok(Some(id)),
+      Some(crate::ExecutionTarget::Window { .. }) => Err(format!("{} requires an app: target, not window:", self.command_id)),
+      Some(crate::ExecutionTarget::Display { .. }) => Err(format!("{} requires an app: target, not display:", self.command_id)),
+      None => Ok(self.inputs.get("target").map(String::as_str).filter(|value| !value.trim().is_empty())),
+    }
   }
 
   /// Resolves the shared invoke presentation policy. Overlay presentation is
@@ -449,7 +454,7 @@ where
   let args = T::from_arg_matches(&matches).map_err(|error| error.to_string())?;
   let inputs = encode_args(&args).map_err(|error| format!("failed to encode parsed {id} arguments: {error}"))?;
   Ok(InvokeCommandCliParse::Invoke {
-    target_application_id: matches.get_one::<String>("auv_target").cloned(),
+    target: matches.get_one::<String>("auv_target").map(|value| crate::ExecutionTarget::parse(value)).transpose()?,
     inputs,
     typed_args: TypedInvokeArgs::new(args),
     store_root: matches.get_one::<PathBuf>("auv_store_root").cloned(),
@@ -463,7 +468,12 @@ where
 
 pub(crate) fn with_invoke_context(command: Command) -> Command {
   command
-    .arg(Arg::new("auv_target").long("target").value_name("APP").help("Application used to select the operation target."))
+    .arg(
+      Arg::new("auv_target")
+        .long("target")
+        .value_name("TARGET")
+        .help("Typed target: app:<bundle-id>, window:<window-id>, or display:<display-id>. Bare values select an application."),
+    )
     .arg(Arg::new("auv_dry_run").long("dry-run").action(ArgAction::SetTrue).help("Validate the operation without performing it."))
     .arg(Arg::new("auv_no_overlay").long("no-overlay").action(ArgAction::SetTrue).help("Disable live visual overlay presentation."))
     .arg(

--- a/crates/auv-cli-invoke/src/commands/app.rs
+++ b/crates/auv-cli-invoke/src/commands/app.rs
@@ -17,7 +17,7 @@ pub fn group() -> CommandGroup {
   input = ProbePermissionsArgs,
 )]
 async fn probe_permissions(input: InvokeCommandInput, _args: ProbePermissionsArgs) -> InvokeCommandResult {
-  if input.target_application_id.is_some() {
+  if input.target.is_some() {
     return Err("app.probePermissions cannot use --target".to_string());
   }
   if input.dry_run {
@@ -54,7 +54,7 @@ struct ActivateAppArgs {}
   input = ActivateAppArgs,
 )]
 async fn activate_app(input: InvokeCommandInput, _args: ActivateAppArgs) -> InvokeCommandResult {
-  let result = activate_application(input.target_application_id).await?;
+  let result = activate_application(input.application_target()?.map(str::to_string)).await?;
   activation_output(&result)
 }
 

--- a/crates/auv-cli-invoke/src/commands/app_test.rs
+++ b/crates/auv-cli-invoke/src/commands/app_test.rs
@@ -36,7 +36,9 @@ fn field_value<'a>(section: &'a InvokeReportSection, label: &str) -> &'a str {
 fn permission_probe_rejects_target_before_platform_access() {
   let input = crate::InvokeCommandInput {
     command_id: "app.probePermissions".to_string(),
-    target_application_id: Some("com.example.App".to_string()),
+    target: Some(crate::ExecutionTarget::Application {
+      id: "com.example.App".to_string(),
+    }),
     inputs: Default::default(),
     typed_args: None,
     dry_run: false,

--- a/crates/auv-cli-invoke/src/commands/input.rs
+++ b/crates/auv-cli-invoke/src/commands/input.rs
@@ -4,7 +4,6 @@ use auv_tracing::{Attributes, ByteLength, NewArtifact};
 use clap::{Args, ValueEnum};
 use futures_util::io::Cursor as AsyncCursor;
 
-use auv_driver::overlay::{Overlay, components::ClickTarget};
 use auv_driver::{INPUT_ACTION_RESULT_PURPOSE, ScreenPoint, WindowInput as _};
 const ROOT_STRUCTURED_ARTIFACT_JSON_BYTE_LIMIT: u64 = 4 * 1024 * 1024;
 
@@ -18,8 +17,7 @@ pub fn group() -> CommandGroup {
     .command(paste_text_preserve_clipboard_invoke_command())
     .command(press_key_invoke_command())
     .command(move_mouse_invoke_command())
-    .command(click_screen_point_invoke_command())
-    .command(click_window_point_invoke_command())
+    .command(click_point_invoke_command())
 }
 
 #[derive(Clone, Debug, Args, serde::Serialize, serde::Deserialize)]
@@ -101,7 +99,7 @@ async fn focus_text_input(input: InvokeCommandInput, _args: FocusTextArgs) -> In
   if input.dry_run {
     return Ok(InvokeCommandOutput::completed());
   }
-  let app = input.target_or_input_target().ok_or_else(|| "input.focusText requires --target".to_string())?.to_string();
+  let app = input.application_target()?.ok_or_else(|| "input.focusText requires --target app:".to_string())?.to_string();
   let query = input.inputs.get("query").cloned().unwrap_or_default();
   let candidate = input.inputs.get("candidate").cloned().unwrap_or_default();
   let result = focus_text(app, query, candidate.clone()).await?;
@@ -155,7 +153,7 @@ async fn ax_focus_text_input(input: InvokeCommandInput, _args: AxFocusTextArgs) 
   if input.dry_run {
     return Ok(InvokeCommandOutput::completed());
   }
-  let app = input.target_or_input_target().ok_or_else(|| "input.axFocusText requires --target".to_string())?.to_string();
+  let app = input.application_target()?.ok_or_else(|| "input.axFocusText requires --target app:".to_string())?.to_string();
   let query = input.inputs.get("query").cloned().unwrap_or_default();
   let candidate = input.inputs.get("candidate").cloned().unwrap_or_default();
   let result = focus_text(app, query, candidate.clone()).await?;
@@ -319,98 +317,26 @@ pub async fn press_key_in_active_app(key: String) -> Result<auv_driver::InputAct
 }
 
 #[derive(Clone, Debug, Args, serde::Serialize, serde::Deserialize)]
-#[command(after_long_help = "Examples:\n  auv invoke input.clickScreenPoint 1032.5 1212")]
-struct ClickScreenPointArgs {
-  /// Logical screen X coordinate.
-  x: f64,
-  /// Logical screen Y coordinate.
-  y: f64,
-  /// Number of consecutive clicks.
-  #[arg(long, value_parser = clap::value_parser!(u8).range(1..))]
-  #[serde(rename = "click-count", default)]
-  click_count: Option<u8>,
-  /// Delay between clicks in milliseconds.
-  #[arg(long)]
-  #[serde(rename = "click-interval-ms", default)]
-  click_interval_ms: Option<u64>,
-}
-
-#[invoke_command(
-  id = "input.clickScreenPoint",
-  group = "input",
-  description = "Click a logical screen coordinate through the platform input driver.",
-  input = ClickScreenPointArgs,
+#[command(
+  after_long_help = "Examples:\n  auv invoke input.clickPoint 1032.5 1212\n  auv invoke input.clickPoint 0.5 0.5 --target app:com.apple.TextEdit --relative-to window --normalized\n  auv invoke input.clickPoint 100 80 --target display:1 --relative-to display"
 )]
-async fn click_screen_point(input: InvokeCommandInput, args: ClickScreenPointArgs) -> InvokeCommandResult {
-  if !args.x.is_finite() || !args.y.is_finite() {
-    return Err("input.clickScreenPoint requires finite coordinates".to_string());
-  }
-  let point = ScreenPoint::new(args.x, args.y);
-  let click = click_options(None, args.click_count, args.click_interval_ms).click;
-  if input.dry_run {
-    return screen_point_click_output(ScreenPointClickResult {
-      point,
-      action: None,
-    });
-  }
-  #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-  {
-    let session = auv_driver::open_local().map_err(|error| error.to_string())?;
-    let action = session.input().click_at(point.point(), click).map_err(|error| error.to_string())?;
-    emit_input_action_result(&action);
-    screen_point_click_output(ScreenPointClickResult {
-      point,
-      action: Some(action),
-    })
-  }
-  #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
-  {
-    let _ = (input, click);
-    Err("input.clickScreenPoint is unavailable on this platform".to_string())
-  }
-}
-
-#[derive(Clone, Debug, serde::Serialize)]
-pub struct ScreenPointClickResult {
-  pub point: ScreenPoint,
-  pub action: Option<auv_driver::InputActionResult>,
-}
-
-pub fn screen_point_click_output(result: ScreenPointClickResult) -> InvokeCommandResult {
-  let mut fields = match result.action.as_ref() {
-    Some(action) => input_action_report_fields(action),
-    None => vec![
-      InvokeReportField::new("Delivery", "not_performed"),
-      InvokeReportField::new("Verification", "validation_only"),
-    ],
-  };
-  fields.push(InvokeReportField::new("Screen point", format!("{:.1},{:.1}", result.point.point().x, result.point.point().y)));
-  Ok(InvokeCommandOutput::from_result(&result)?.with_report(InvokeReport::new(fields, Vec::new())))
-}
-
-#[derive(Clone, Debug, Args, serde::Serialize, serde::Deserialize)]
-#[command(after_long_help = "Examples:\n  auv invoke input.clickWindowPoint --target com.apple.TextEdit --relative-x 0.5 --relative-y 0.5")]
-struct ClickWindowPointArgs {
-  /// Window title text used to select the target.
+struct ClickPointArgs {
+  /// X coordinate in the selected coordinate basis.
+  x: f64,
+  /// Y coordinate in the selected coordinate basis.
+  y: f64,
+  /// Coordinate basis. Defaults from --target: screen, window, or display.
+  #[arg(long, value_enum)]
+  #[serde(rename = "relative-to", default)]
+  relative_to: Option<RelativeToArg>,
+  /// Interpret X and Y as normalized values in 0..=1.
+  #[arg(long)]
+  #[serde(default)]
+  normalized: bool,
+  /// Window title text used with an app target.
   #[arg(long, value_name = "TEXT")]
   title: Option<String>,
-  /// Absolute window-pixel X coordinate.
-  #[arg(long, requires = "offset_y", conflicts_with = "relative_x")]
-  #[serde(rename = "offset-x", default)]
-  offset_x: Option<f64>,
-  /// Absolute window-pixel Y coordinate.
-  #[arg(long, requires = "offset_x", conflicts_with = "relative_y")]
-  #[serde(rename = "offset-y", default)]
-  offset_y: Option<f64>,
-  /// Relative window X coordinate in 0..1.
-  #[arg(long, requires = "relative_y")]
-  #[serde(rename = "relative-x", default)]
-  relative_x: Option<f64>,
-  /// Relative window Y coordinate in 0..1.
-  #[arg(long, requires = "relative_x")]
-  #[serde(rename = "relative-y", default)]
-  relative_y: Option<f64>,
-  /// Window input delivery policy.
+  /// Window input delivery policy. Valid only with --relative-to window.
   #[arg(long, value_enum)]
   #[serde(rename = "input-policy")]
   input_policy: Option<InputPolicyArg>,
@@ -424,8 +350,255 @@ struct ClickWindowPointArgs {
   click_count: Option<u8>,
   /// Delay between clicks in milliseconds.
   #[arg(long)]
-  #[serde(rename = "click-interval-ms")]
+  #[serde(rename = "click-interval-ms", default)]
   click_interval_ms: Option<u64>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum RelativeToArg {
+  Screen,
+  Window,
+  Display,
+}
+
+impl RelativeToArg {
+  pub(crate) fn as_str(self) -> &'static str {
+    match self {
+      Self::Screen => "screen",
+      Self::Window => "window",
+      Self::Display => "display",
+    }
+  }
+}
+
+impl ClickPointArgs {
+  fn basis(&self, target: Option<&crate::ExecutionTarget>) -> Result<RelativeToArg, String> {
+    let basis = click_point_basis(
+      target,
+      self.relative_to.map(RelativeToArg::as_str),
+      self.normalized,
+      self.input_policy.is_some(),
+      self.title.is_some(),
+    )?;
+    if !self.x.is_finite() || !self.y.is_finite() {
+      return Err("input.clickPoint requires finite coordinates".to_string());
+    }
+    if self.normalized && (!(0.0..=1.0).contains(&self.x) || !(0.0..=1.0).contains(&self.y)) {
+      return Err("input.clickPoint --normalized coordinates must be within 0..=1".to_string());
+    }
+    if self.click_count.unwrap_or(1) > 1 && self.click_interval_ms == Some(0) {
+      return Err("input.clickPoint requires a positive --click-interval-ms for repeated clicks".to_string());
+    }
+    Ok(basis)
+  }
+
+  fn click_options(&self) -> auv_driver::ClickOptions {
+    click_options(self.input_policy.map(InputPolicyArg::driver_policy), self.click_count, self.click_interval_ms)
+  }
+}
+
+pub(crate) fn click_point_basis(
+  target: Option<&crate::ExecutionTarget>,
+  relative_to: Option<&str>,
+  normalized: bool,
+  has_input_policy: bool,
+  has_title: bool,
+) -> Result<RelativeToArg, String> {
+  let basis = match relative_to {
+    Some("screen") => RelativeToArg::Screen,
+    Some("window") => RelativeToArg::Window,
+    Some("display") => RelativeToArg::Display,
+    Some(value) => return Err(format!("input.clickPoint has unknown --relative-to {value:?}")),
+    None => match target {
+      None => RelativeToArg::Screen,
+      Some(crate::ExecutionTarget::Application { .. } | crate::ExecutionTarget::Window { .. }) => RelativeToArg::Window,
+      Some(crate::ExecutionTarget::Display { .. }) => RelativeToArg::Display,
+    },
+  };
+  match (target, basis) {
+    (None, RelativeToArg::Screen)
+    | (Some(crate::ExecutionTarget::Application { .. } | crate::ExecutionTarget::Window { .. }), RelativeToArg::Window)
+    | (Some(crate::ExecutionTarget::Display { .. }), RelativeToArg::Display) => {}
+    (None, RelativeToArg::Window) => return Err("input.clickPoint --relative-to window requires --target app: or window:".to_string()),
+    (None, RelativeToArg::Display) => return Err("input.clickPoint --relative-to display requires --target display:".to_string()),
+    (Some(_), _) => return Err(format!("input.clickPoint --target kind is incompatible with --relative-to {}", basis.as_str())),
+  }
+  if normalized && basis == RelativeToArg::Screen {
+    return Err("input.clickPoint --normalized is valid only relative to a window or display".to_string());
+  }
+  if has_input_policy && basis != RelativeToArg::Window {
+    return Err("input.clickPoint --input-policy is valid only with --relative-to window".to_string());
+  }
+  if has_title && !matches!(target, Some(crate::ExecutionTarget::Application { .. })) {
+    return Err("input.clickPoint --title requires --target app:".to_string());
+  }
+  Ok(basis)
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ClickPointResult {
+  pub relative_to: String,
+  pub requested_point: auv_driver::Point,
+  pub normalized: bool,
+  pub screen_point: ScreenPoint,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub window: Option<auv_driver::Window>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub display: Option<auv_driver::Display>,
+  pub action: Option<auv_driver::InputActionResult>,
+}
+
+#[invoke_command(
+  id = "input.clickPoint",
+  group = "input",
+  description = "Click a point relative to the screen, a target window, or a target display.",
+  input = ClickPointArgs,
+)]
+async fn click_point(input: InvokeCommandInput, args: ClickPointArgs) -> InvokeCommandResult {
+  let basis = args.basis(input.target.as_ref())?;
+  let click = args.click_options();
+  #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+  {
+    match basis {
+      RelativeToArg::Screen => {
+        let screen_point = ScreenPoint::new(args.x, args.y);
+        let action = if input.dry_run {
+          None
+        } else {
+          input.cancellation.check().map_err(|error| error.to_string())?;
+          let session = auv_driver::open_local().map_err(|error| error.to_string())?;
+          let action = session.input().click_at(screen_point.point(), click.click).map_err(|error| error.to_string())?;
+          emit_input_action_result(&action);
+          Some(action)
+        };
+        click_point_output(ClickPointResult {
+          relative_to: basis.as_str().to_string(),
+          requested_point: auv_driver::Point::new(args.x, args.y),
+          normalized: args.normalized,
+          screen_point,
+          window: None,
+          display: None,
+          action,
+        })
+      }
+      RelativeToArg::Window => {
+        let session = auv_driver::open_local().map_err(|error| error.to_string())?;
+        let target = input.target.as_ref().expect("window-relative target validated");
+        let window = match target {
+          crate::ExecutionTarget::Application { id } => {
+            session.window().resolve(click_window_selector(id, args.title.as_deref())).map_err(|error| error.to_string())?
+          }
+          crate::ExecutionTarget::Window { id } => session
+            .window()
+            .list()
+            .map_err(|error| error.to_string())?
+            .into_iter()
+            .find(|window| window.reference.id == *id)
+            .ok_or_else(|| format!("input.clickPoint could not find window target {id:?}"))?,
+          crate::ExecutionTarget::Display { .. } => unreachable!("target/basis validated"),
+        };
+        let point = resolve_local_point(args.x, args.y, args.normalized, window.frame.size, "window")?;
+        let window_point = auv_driver::WindowPoint::new(point.x, point.y);
+        let screen_point = ScreenPoint::new(window.frame.origin.x + point.x, window.frame.origin.y + point.y);
+        let action = if input.dry_run {
+          None
+        } else {
+          input.cancellation.check().map_err(|error| error.to_string())?;
+          let action = session.window().click(&window, window_point, click).map_err(|error| error.to_string())?;
+          emit_input_action_result(&action);
+          Some(action)
+        };
+        click_point_output(ClickPointResult {
+          relative_to: basis.as_str().to_string(),
+          requested_point: auv_driver::Point::new(args.x, args.y),
+          normalized: args.normalized,
+          screen_point,
+          window: Some(window),
+          display: None,
+          action,
+        })
+      }
+      RelativeToArg::Display => {
+        let session = auv_driver::open_local().map_err(|error| error.to_string())?;
+        let crate::ExecutionTarget::Display { id } = input.target.as_ref().expect("display-relative target validated") else {
+          unreachable!("target/basis validated")
+        };
+        let display = session
+          .display()
+          .list()
+          .map_err(|error| error.to_string())?
+          .displays
+          .into_iter()
+          .find(|display| display.id == *id)
+          .ok_or_else(|| format!("input.clickPoint could not find display target {id:?}"))?;
+        let point = resolve_local_point(args.x, args.y, args.normalized, display.frame.size, "display")?;
+        let screen_point = ScreenPoint::new(display.frame.origin.x + point.x, display.frame.origin.y + point.y);
+        let action = if input.dry_run {
+          None
+        } else {
+          input.cancellation.check().map_err(|error| error.to_string())?;
+          let action = session.input().click_at(screen_point.point(), click.click).map_err(|error| error.to_string())?;
+          emit_input_action_result(&action);
+          Some(action)
+        };
+        click_point_output(ClickPointResult {
+          relative_to: basis.as_str().to_string(),
+          requested_point: auv_driver::Point::new(args.x, args.y),
+          normalized: args.normalized,
+          screen_point,
+          window: None,
+          display: Some(display),
+          action,
+        })
+      }
+    }
+  }
+  #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+  {
+    let _ = (input, args, basis, click);
+    Err("input.clickPoint is unavailable on this platform".to_string())
+  }
+}
+
+pub(crate) fn resolve_local_point(
+  x: f64,
+  y: f64,
+  normalized: bool,
+  size: auv_driver::Size,
+  basis: &str,
+) -> Result<auv_driver::Point, String> {
+  let point = if normalized {
+    auv_driver::Point::new(size.width * x, size.height * y)
+  } else {
+    auv_driver::Point::new(x, y)
+  };
+  if !(0.0..=size.width).contains(&point.x) || !(0.0..=size.height).contains(&point.y) {
+    return Err(format!(
+      "input.clickPoint point {},{} is outside target {basis} bounds 0..={},0..={}",
+      point.x, point.y, size.width, size.height
+    ));
+  }
+  Ok(point)
+}
+
+pub fn click_point_output(result: ClickPointResult) -> InvokeCommandResult {
+  let mut fields = match result.action.as_ref() {
+    Some(action) => input_action_report_fields(action),
+    None => vec![
+      InvokeReportField::new("Delivery", "not_performed"),
+      InvokeReportField::new("Verification", "validation_only"),
+    ],
+  };
+  fields.push(InvokeReportField::new("Relative to", result.relative_to.clone()));
+  fields.push(InvokeReportField::new("Screen point", format!("{:.1},{:.1}", result.screen_point.point().x, result.screen_point.point().y)));
+  if let Some(window) = &result.window {
+    fields.push(InvokeReportField::new("Window ID", window.reference.id.clone()));
+  }
+  if let Some(display) = &result.display {
+    fields.push(InvokeReportField::new("Display ID", display.id.clone()));
+  }
+  Ok(InvokeCommandOutput::from_result(&result)?.with_report(InvokeReport::new(fields, Vec::new())))
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum, serde::Serialize, serde::Deserialize)]
@@ -436,26 +609,6 @@ enum InputPolicyArg {
   ForegroundPreferred,
 }
 
-impl ClickWindowPointArgs {
-  fn point(&self, command_id: &str) -> Result<WindowPointInput, String> {
-    match (self.offset_x, self.offset_y, self.relative_x, self.relative_y) {
-      (Some(x), Some(y), None, None) if x.is_finite() && y.is_finite() && x >= 0.0 && y >= 0.0 => {
-        Ok(WindowPointInput(WindowPointKind::Offset(auv_driver::geometry::WindowPoint::new(x, y))))
-      }
-      (None, None, Some(x), Some(y)) if x.is_finite() && y.is_finite() && (0.0..=1.0).contains(&x) && (0.0..=1.0).contains(&y) => {
-        Ok(WindowPointInput(WindowPointKind::Relative(RelativeWindowPoint { x, y })))
-      }
-      (Some(_), Some(_), None, None) => Err(format!("{command_id} requires finite non-negative window offsets")),
-      (None, None, Some(_), Some(_)) => Err(format!("{command_id} requires relative coordinates within 0..=1")),
-      _ => Err(format!("{command_id} requires --offset-x/--offset-y or --relative-x/--relative-y")),
-    }
-  }
-
-  fn click_options(&self) -> auv_driver::ClickOptions {
-    click_options(self.input_policy.map(InputPolicyArg::driver_policy), self.click_count, self.click_interval_ms)
-  }
-}
-
 impl InputPolicyArg {
   fn driver_policy(self) -> auv_driver::InputPolicy {
     match self {
@@ -464,240 +617,6 @@ impl InputPolicyArg {
       Self::ForegroundPreferred => auv_driver::InputPolicy::ForegroundPreferred,
     }
   }
-}
-
-#[invoke_command(
-  id = "input.clickWindowPoint",
-  group = "input",
-  description = "Click a point relative to a target macOS window using either --offset-x/--offset-y or --relative-x/--relative-y coordinates.",
-  input = ClickWindowPointArgs,
-)]
-async fn click_window_point(input: InvokeCommandInput, args: ClickWindowPointArgs) -> InvokeCommandResult {
-  let point = args.point(&input.command_id)?;
-  let options = args.click_options();
-  #[cfg(target_os = "macos")]
-  {
-    let presentation_input = input.clone();
-    let capability = LocalWindowPointCapability::open()?;
-    let outcome = click_resolved_point_with_capability(input, args.title.as_deref(), point, options, &capability).await?;
-    let result = outcome.into_result();
-    let point = result.point.point();
-    let screen_point = ScreenPoint::new(result.window.frame.origin.x + point.x, result.window.frame.origin.y + point.y);
-    let click_overlay =
-      Overlay::new().with_layer(ClickTarget::new(screen_point).with_cursor_label("auv · click").with_status("click delivered"));
-    let overlay = super::overlay::show_overlay(
-      &presentation_input,
-      &capability.session,
-      click_overlay,
-      auv_driver::overlay::ShowOptions::new()
-        .with_motion_ease(std::time::Duration::from_millis(420), auv_driver::overlay::Easing::EaseInOutExpo)
-        .with_auto_removal_after(std::time::Duration::from_millis(140)),
-    )?;
-    window_point_click_output(result, overlay)
-  }
-  #[cfg(not(target_os = "macos"))]
-  {
-    let _ = (input, point, options);
-    Err("input.clickWindowPoint is only available on macOS".to_string())
-  }
-}
-
-// Resolves target-window geometry and optionally delivers its validated click.
-trait WindowPointCapability {
-  fn resolve(&self, selector: auv_driver::WindowSelector) -> auv_driver::DriverResult<auv_driver::Window>;
-
-  fn click(
-    &self,
-    window: &auv_driver::Window,
-    point: auv_driver::geometry::WindowPoint,
-    options: auv_driver::ClickOptions,
-  ) -> auv_driver::DriverResult<auv_driver::InputActionResult>;
-}
-
-#[cfg(target_os = "macos")]
-struct LocalWindowPointCapability {
-  session: auv_driver::LocalDriverSession,
-}
-
-#[cfg(target_os = "macos")]
-impl LocalWindowPointCapability {
-  fn open() -> Result<Self, String> {
-    auv_driver::open_local().map(|session| Self { session }).map_err(|error| error.to_string())
-  }
-}
-
-#[cfg(target_os = "macos")]
-impl WindowPointCapability for LocalWindowPointCapability {
-  fn resolve(&self, selector: auv_driver::WindowSelector) -> auv_driver::DriverResult<auv_driver::Window> {
-    self.session.window().resolve(selector)
-  }
-
-  fn click(
-    &self,
-    window: &auv_driver::Window,
-    point: auv_driver::geometry::WindowPoint,
-    options: auv_driver::ClickOptions,
-  ) -> auv_driver::DriverResult<auv_driver::InputActionResult> {
-    self.session.window().click(window, point, options)
-  }
-}
-
-async fn click_resolved_point_with_capability<C>(
-  input: InvokeCommandInput,
-  title: Option<&str>,
-  point: WindowPointInput,
-  options: auv_driver::ClickOptions,
-  capability: &C,
-) -> Result<WindowPointClickOutcome, String>
-where
-  C: WindowPointCapability + Sync + ?Sized,
-{
-  // TODO(invoke-input-click-window-point-candidate): candidate promotion is
-  // intentionally deferred until an owner-approved typed candidate input exists.
-  let window = capability.resolve(click_window_selector(&input, title)).map_err(|error| error.to_string())?;
-  let point = point.resolve(&window, &input.command_id)?;
-  input.cancellation.check().map_err(|error| error.to_string())?;
-  if input.dry_run {
-    return Ok(WindowPointClickOutcome::Validated { window, point });
-  }
-
-  let click = click_resolved_window_point(capability, window, point, options).await?;
-  Ok(WindowPointClickOutcome::Delivered { click })
-}
-
-#[derive(Clone, Debug)]
-struct WindowPointInput(WindowPointKind);
-
-#[derive(Clone, Debug)]
-enum WindowPointKind {
-  Offset(auv_driver::geometry::WindowPoint),
-  Relative(RelativeWindowPoint),
-}
-
-#[derive(Clone, Copy, Debug)]
-struct RelativeWindowPoint {
-  x: f64,
-  y: f64,
-}
-
-impl WindowPointInput {
-  fn resolve(&self, window: &auv_driver::Window, command_id: &str) -> Result<auv_driver::geometry::WindowPoint, String> {
-    let point = match self.0 {
-      WindowPointKind::Offset(point) => point,
-      WindowPointKind::Relative(relative) => {
-        auv_driver::geometry::WindowPoint::new(window.frame.size.width * relative.x, window.frame.size.height * relative.y)
-      }
-    };
-    let coordinates = point.point();
-    if !(0.0..=window.frame.size.width).contains(&coordinates.x) || !(0.0..=window.frame.size.height).contains(&coordinates.y) {
-      return Err(format!(
-        "{command_id} point {},{} is outside target window bounds 0..={},0..={}",
-        coordinates.x, coordinates.y, window.frame.size.width, window.frame.size.height
-      ));
-    }
-    Ok(point)
-  }
-}
-
-#[derive(Clone, Debug)]
-pub struct WindowPointClick {
-  pub window: auv_driver::Window,
-  pub point: auv_driver::geometry::WindowPoint,
-  pub action: auv_driver::InputActionResult,
-}
-
-#[derive(Clone, Debug)]
-pub enum WindowPointClickOutcome {
-  Validated {
-    window: auv_driver::Window,
-    point: auv_driver::geometry::WindowPoint,
-  },
-  Delivered {
-    click: WindowPointClick,
-  },
-}
-
-#[derive(Clone, Debug, serde::Serialize)]
-pub struct WindowPointClickResult {
-  pub window: auv_driver::Window,
-  pub point: auv_driver::geometry::WindowPoint,
-  pub action: Option<auv_driver::InputActionResult>,
-}
-
-impl WindowPointClickOutcome {
-  pub fn into_result(self) -> WindowPointClickResult {
-    match self {
-      Self::Validated { window, point } => WindowPointClickResult {
-        window,
-        point,
-        action: None,
-      },
-      Self::Delivered { click } => WindowPointClickResult {
-        window: click.window,
-        point: click.point,
-        action: Some(click.action),
-      },
-    }
-  }
-}
-
-fn window_point_click_output(result: WindowPointClickResult, overlay: super::overlay::OverlayStatus) -> InvokeCommandResult {
-  let mut output = window_point_click_output_without_overlay(result)?;
-  output.report.as_mut().expect("window point output always has a report").fields.push(overlay.report_field());
-  Ok(output)
-}
-
-/// Builds the transport-independent `input.clickWindowPoint` result. Visual
-/// overlay presentation remains a local frontend concern.
-pub fn window_point_click_output_without_overlay(result: WindowPointClickResult) -> InvokeCommandResult {
-  match &result.action {
-    None => {
-      let mut output = InvokeCommandOutput::from_result(&result)?;
-      output.report = Some(InvokeReport::new(
-        vec![
-          InvokeReportField::new("Delivery", "not_performed"),
-          InvokeReportField::new("Verification", "validation_only"),
-          InvokeReportField::new("Window ID", result.window.reference.id.clone()),
-          InvokeReportField::new("Window point", format!("{:.0},{:.0}", result.point.point().x, result.point.point().y)),
-        ],
-        Vec::new(),
-      ));
-      Ok(output)
-    }
-    Some(action) => {
-      let mut fields = input_action_report_fields(action);
-      fields.push(InvokeReportField::new("Window ID", result.window.reference.id.clone()));
-      if let Some(title) = &result.window.title {
-        fields.push(InvokeReportField::new("Window title", title.clone()));
-      }
-      if let Some(app_name) = &result.window.app_name {
-        fields.push(InvokeReportField::new("Application", app_name.clone()));
-      }
-      if let Some(bundle_id) = &result.window.app_bundle_id {
-        fields.push(InvokeReportField::new("Bundle ID", bundle_id.clone()));
-      }
-      fields.push(InvokeReportField::new("Window point", format!("{:.0},{:.0}", result.point.point().x, result.point.point().y)));
-      Ok(InvokeCommandOutput::from_result(&result)?.with_report(InvokeReport::new(fields, Vec::new())))
-    }
-  }
-}
-
-async fn click_resolved_window_point<C>(
-  capability: &C,
-  window: auv_driver::Window,
-  point: auv_driver::geometry::WindowPoint,
-  options: auv_driver::ClickOptions,
-) -> Result<WindowPointClick, String>
-where
-  C: WindowPointCapability + Sync + ?Sized,
-{
-  let action = capability.click(&window, point, options).map_err(|error| error.to_string())?;
-  emit_input_action_result(&action);
-  Ok(WindowPointClick {
-    window,
-    point,
-    action,
-  })
 }
 
 pub(crate) fn click_options(
@@ -723,24 +642,19 @@ pub(crate) fn click_options(
   }
 }
 
-fn click_window_selector(input: &InvokeCommandInput, title: Option<&str>) -> auv_driver::WindowSelector {
+fn click_window_selector(application_id: &str, title: Option<&str>) -> auv_driver::WindowSelector {
   use auv_driver::{App, TextMatcher, WindowSelector};
 
-  let mut selector = WindowSelector {
-    main_visible: true,
-    ..WindowSelector::default()
-  };
-  if let Some(target) = input.target_or_input_target() {
-    selector.app = Some(App::bundle_id(target));
+  let title = title.filter(|value| !value.trim().is_empty()).map(|title| TextMatcher::Contains(title.to_string()));
+  WindowSelector {
+    app: Some(App::bundle_id(application_id)),
+    main_visible: title.is_none(),
+    title,
   }
-  if let Some(title) = title.filter(|value| !value.trim().is_empty()) {
-    selector.title = Some(TextMatcher::Contains(title.to_string()));
-  }
-  selector
 }
 
 fn reject_target_activation(input: &InvokeCommandInput, command_id: &str) -> Result<(), String> {
-  if input.target_application_id.is_some() {
+  if input.target.is_some() {
     // TODO(invoke-input-target-activation): foreground input APIs currently
     // act on the active control; add a typed app/window input lease before
     // honoring --target here.

--- a/crates/auv-cli-invoke/src/commands/input_test.rs
+++ b/crates/auv-cli-invoke/src/commands/input_test.rs
@@ -2,9 +2,7 @@ use super::*;
 use crate::{InvokeOutputOptions, InvokeResult};
 use auv_driver::{InputActionResult, InputDeliveryPath};
 use auv_tracing::{Context, MemoryTracingStore, RunId, TraceRecord, configure, dispatcher};
-use std::collections::BTreeMap;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
 
 #[test]
 fn window_click_options_parse_policy_and_repeated_clicks() {
@@ -19,184 +17,17 @@ fn window_click_options_parse_policy_and_repeated_clicks() {
   );
 }
 
-#[derive(Clone)]
-struct ControlledWindowCapability {
-  window: auv_driver::Window,
-  action: InputActionResult,
-  resolve_calls: Arc<AtomicUsize>,
-  click_calls: Arc<AtomicUsize>,
-}
-
-impl ControlledWindowCapability {
-  fn new() -> Self {
-    Self {
-      window: test_window(),
-      action: InputActionResult::single_success(InputDeliveryPath::WindowTargetedMouse),
-      resolve_calls: Arc::new(AtomicUsize::new(0)),
-      click_calls: Arc::new(AtomicUsize::new(0)),
-    }
-  }
-
-  fn resolve_count(&self) -> usize {
-    self.resolve_calls.load(Ordering::SeqCst)
-  }
-
-  fn click_count(&self) -> usize {
-    self.click_calls.load(Ordering::SeqCst)
-  }
-
-  fn with_action(mut self, action: InputActionResult) -> Self {
-    self.action = action;
-    self
-  }
-}
-
-impl WindowPointCapability for ControlledWindowCapability {
-  fn resolve(&self, _selector: auv_driver::WindowSelector) -> auv_driver::DriverResult<auv_driver::Window> {
-    self.resolve_calls.fetch_add(1, Ordering::SeqCst);
-    Ok(self.window.clone())
-  }
-
-  fn click(
-    &self,
-    _window: &auv_driver::Window,
-    _point: auv_driver::geometry::WindowPoint,
-    _options: auv_driver::ClickOptions,
-  ) -> auv_driver::DriverResult<auv_driver::InputActionResult> {
-    self.click_calls.fetch_add(1, Ordering::SeqCst);
-    Ok(self.action.clone())
-  }
-}
-
-#[test]
-fn click_window_point_missing_point_args_returns_error() {
-  let inputs = BTreeMap::new();
-  let input = InvokeCommandInput {
-    command_id: "input.clickWindowPoint".to_string(),
-    target_application_id: Some("com.example.App".to_string()),
-    inputs,
-    typed_args: None,
-    dry_run: false,
-    cancellation: crate::InvokeCancellation::new(),
-  };
-  let error = futures_executor::block_on(click_window_point_invoke_command().invoke(input)).expect_err("missing point args should fail");
-  assert!(error.contains("requires --offset-x/--offset-y or --relative-x/--relative-y"));
-}
-
-#[test]
-fn click_window_point_valid_dry_run_resolves_window_without_clicking() {
-  let capability = ControlledWindowCapability::new();
-  let mut inputs = BTreeMap::new();
-  inputs.insert("offset-x".to_string(), "640".to_string());
-  inputs.insert("offset-y".to_string(), "360".to_string());
-  let input = InvokeCommandInput {
-    command_id: "input.clickWindowPoint".to_string(),
-    target_application_id: Some("com.example.App".to_string()),
-    inputs,
-    typed_args: None,
-    dry_run: true,
-    cancellation: crate::InvokeCancellation::new(),
-  };
-  let outcome = futures_executor::block_on(click_resolved_point_with_capability(
-    input,
-    None,
-    offset_point(640.0, 360.0),
-    auv_driver::ClickOptions::default(),
-    &capability,
-  ))
-  .expect("dry run should succeed");
-
-  assert!(matches!(outcome, WindowPointClickOutcome::Validated { .. }));
-  assert_eq!(capability.resolve_count(), 1);
-  assert_eq!(capability.click_count(), 0);
-}
-
-#[test]
-fn click_window_point_out_of_bounds_dry_run_fails_without_clicking() {
-  let capability = ControlledWindowCapability::new();
-  let input = InvokeCommandInput {
-    command_id: "input.clickWindowPoint".to_string(),
-    target_application_id: Some("com.example.App".to_string()),
-    inputs: BTreeMap::from([
-      ("offset-x".to_string(), "1280.01".to_string()),
-      ("offset-y".to_string(), "360".to_string()),
-    ]),
-    typed_args: None,
-    dry_run: true,
-    cancellation: crate::InvokeCancellation::new(),
-  };
-
-  // ROOT CAUSE:
-  //
-  // If a syntactically valid positive offset exceeded the resolved window,
-  // dry-run completed because the handler returned before window resolution.
-  //
-  // Before the fix, this input completed without consulting window geometry.
-  // The fix resolves containment before dry-run returns and never clicks.
-  let error = futures_executor::block_on(click_resolved_point_with_capability(
-    input,
-    None,
-    offset_point(1280.01, 360.0),
-    auv_driver::ClickOptions::default(),
-    &capability,
-  ))
-  .expect_err("out-of-bounds dry-run offset must fail");
-
-  assert!(error.contains("outside target window bounds"), "{error}");
-  assert_eq!(capability.resolve_count(), 1);
-  assert_eq!(capability.click_count(), 0);
-}
-
-#[test]
-fn click_window_point_live_resolves_once_before_clicking() {
-  let capability = ControlledWindowCapability::new();
-  let input = InvokeCommandInput {
-    command_id: "input.clickWindowPoint".to_string(),
-    target_application_id: Some("com.example.App".to_string()),
-    inputs: BTreeMap::from([
-      ("offset-x".to_string(), "640".to_string()),
-      ("offset-y".to_string(), "360".to_string()),
-    ]),
-    typed_args: None,
-    dry_run: false,
-    cancellation: crate::InvokeCancellation::new(),
-  };
-
-  let outcome = futures_executor::block_on(click_resolved_point_with_capability(
-    input,
-    None,
-    offset_point(640.0, 360.0),
-    auv_driver::ClickOptions::default(),
-    &capability,
-  ))
-  .expect("valid live point");
-
-  assert!(matches!(outcome, WindowPointClickOutcome::Delivered { .. }));
-  assert_eq!(capability.resolve_count(), 1);
-  assert_eq!(capability.click_count(), 1);
-}
-
 #[tokio::test]
-async fn resolved_window_click_returns_direct_action_and_publishes_through_typed_driver_contract() {
-  let capability = ControlledWindowCapability::new();
+async fn input_action_publishes_through_typed_driver_contract() {
   let store = Arc::new(MemoryTracingStore::new());
   let dispatch = configure().tracing_store(store.clone()).build().expect("memory dispatch");
   let root = dispatcher::with_default(&dispatch, || Context::root(RunId::new()));
   let expected = InputActionResult::single_success(InputDeliveryPath::WindowTargetedMouse);
-  let future = root.in_scope(|| {
-    click_resolved_window_point(
-      &capability,
-      test_window(),
-      auv_driver::geometry::WindowPoint::new(640.0, 360.0),
-      auv_driver::ClickOptions::default(),
-    )
-  });
-
-  let delivered = root.instrument(future).await.expect("direct window click result");
+  let future = root.in_scope(|| async { emit_input_action_result(&expected) });
+  root.instrument(future).await;
   dispatch.flush().await.expect("flush input action telemetry");
   let records = store.records();
 
-  assert_eq!(delivered.action, expected);
   let metadata = records
     .iter()
     .find_map(|record| match record {
@@ -224,24 +55,13 @@ async fn invalid_input_artifact_does_not_change_the_typed_call_or_reexecute_driv
     focus_disturbance: auv_driver::DisturbanceLevel::None,
     clipboard_disturbance: auv_driver::DisturbanceLevel::None,
   };
-  let capability = ControlledWindowCapability::new().with_action(invalid.clone());
   let store = Arc::new(MemoryTracingStore::new());
   let dispatch = configure().tracing_store(store.clone()).build().expect("memory dispatch");
   let root = dispatcher::with_default(&dispatch, || Context::root(RunId::new()));
-  let future = root.in_scope(|| {
-    click_resolved_window_point(
-      &capability,
-      test_window(),
-      auv_driver::geometry::WindowPoint::new(640.0, 360.0),
-      auv_driver::ClickOptions::default(),
-    )
-  });
-
-  let delivered = root.instrument(future).await.expect("artifact preparation must not replace the direct input result");
+  let future = root.in_scope(|| async { emit_input_action_result(&invalid) });
+  root.instrument(future).await;
   dispatch.flush().await.expect("typed preparation diagnostic should flush");
 
-  assert_eq!(delivered.action, invalid);
-  assert_eq!(capability.click_count(), 1, "artifact preparation must not reexecute direct input");
   assert!(
     store.records().iter().all(|record| !matches!(record, TraceRecord::Artifact { .. })),
     "invalid evidence must not commit an artifact"
@@ -295,68 +115,25 @@ fn input_action_artifact_enforces_domain_and_four_mibibyte_bounds() {
 }
 
 #[test]
-fn click_window_point_negative_offset_dry_run_fails_without_driver() {
-  let input = InvokeCommandInput {
-    command_id: "input.clickWindowPoint".to_string(),
-    target_application_id: Some("com.example.App".to_string()),
-    inputs: BTreeMap::from([
-      ("offset-x".to_string(), "-0.01".to_string()),
-      ("offset-y".to_string(), "20".to_string()),
-    ]),
-    typed_args: None,
-    dry_run: true,
-    cancellation: crate::InvokeCancellation::new(),
+fn click_point_projects_normalized_local_coordinates() {
+  let point = resolve_local_point(0.5, 0.5, true, auv_driver::Size::new(1280.0, 720.0), "window").expect("normalized point");
+  assert_eq!(point, auv_driver::Point::new(640.0, 360.0));
+}
+
+#[test]
+fn click_point_rejects_local_coordinates_outside_target_bounds() {
+  let error =
+    resolve_local_point(1280.01, 20.0, false, auv_driver::Size::new(1280.0, 720.0), "window").expect_err("out-of-window point must fail");
+  assert!(error.contains("outside target window bounds"), "{error}");
+}
+
+#[test]
+fn click_point_rejects_incompatible_target_and_coordinate_basis() {
+  let target = crate::ExecutionTarget::Display {
+    id: "primary".to_string(),
   };
-
-  let error = futures_executor::block_on(click_window_point_invoke_command().invoke(input))
-    .expect_err("negative dry-run offset must fail before driver work");
-
-  assert!(error.contains("non-negative"), "{error}");
-}
-
-#[test]
-fn resolve_click_window_point_accepts_inclusive_offset_boundaries() {
-  let window = test_window();
-  for (x, y) in [(0.0, 0.0), (1280.0, 720.0)] {
-    let point = offset_point(x, y).resolve(&window, "input.clickWindowPoint").expect("inclusive window boundary");
-    assert_eq!(point, auv_driver::geometry::WindowPoint::new(x, y));
-  }
-}
-
-#[test]
-fn resolve_click_window_point_rejects_offsets_outside_window_bounds() {
-  let window = test_window();
-  for (name, x, y) in [
-    ("oversized x", 1280.01, 20.0),
-    ("oversized y", 10.0, 720.01),
-  ] {
-    let error = offset_point(x, y).resolve(&window, "input.clickWindowPoint").expect_err("out-of-window offset must fail");
-    assert!(error.contains("outside target window"), "{name}: {error}");
-  }
-}
-
-#[test]
-fn resolve_click_window_point_converts_relative_pair() {
-  let window = test_window();
-  let point = relative_point(0.5, 0.5).resolve(&window, "input.clickWindowPoint").expect("relative pair");
-  assert_eq!(point, auv_driver::geometry::WindowPoint::new(640.0, 360.0));
-}
-
-#[test]
-fn resolve_click_window_point_accepts_inclusive_relative_boundaries() {
-  let window = test_window();
-  for (relative_x, relative_y, expected_x, expected_y) in [(0.0, 0.0, 0.0, 0.0), (1.0, 1.0, 1280.0, 720.0)] {
-    let point = relative_point(relative_x, relative_y).resolve(&window, "input.clickWindowPoint").expect("inclusive relative boundary");
-    assert_eq!(point, auv_driver::geometry::WindowPoint::new(expected_x, expected_y));
-  }
-}
-
-fn offset_point(x: f64, y: f64) -> WindowPointInput {
-  WindowPointInput(WindowPointKind::Offset(auv_driver::geometry::WindowPoint::new(x, y)))
-}
-
-fn relative_point(x: f64, y: f64) -> WindowPointInput {
-  WindowPointInput(WindowPointKind::Relative(RelativeWindowPoint { x, y }))
+  let error = click_point_basis(Some(&target), Some("window"), false, false, false).expect_err("display target cannot use window basis");
+  assert!(error.contains("incompatible"), "{error}");
 }
 
 fn test_window() -> auv_driver::Window {
@@ -446,21 +223,22 @@ fn focus_text_human_output_exposes_target_selection_delivery_and_verification_bo
 }
 
 #[test]
-fn window_point_click_result_keeps_resolved_target_and_delivery_together() {
-  let click = WindowPointClick {
-    window: test_window(),
-    point: auv_driver::geometry::WindowPoint::new(640.0, 360.0),
-    action: InputActionResult::single_success(InputDeliveryPath::WindowTargetedMouse),
-  };
-
-  let output =
-    window_point_click_output(WindowPointClickOutcome::Delivered { click }.into_result(), crate::commands::overlay::OverlayStatus::Disabled)
-      .expect("click result should serialize");
+fn click_point_result_keeps_resolved_target_and_delivery_together() {
+  let output = click_point_output(ClickPointResult {
+    relative_to: "window".to_string(),
+    requested_point: auv_driver::Point::new(640.0, 360.0),
+    normalized: false,
+    screen_point: auv_driver::ScreenPoint::new(640.0, 360.0),
+    window: Some(test_window()),
+    display: None,
+    action: Some(InputActionResult::single_success(InputDeliveryPath::WindowTargetedMouse)),
+  })
+  .expect("click result should serialize");
   let result = output.result().expect("click should have a result");
 
   assert_eq!(result["window"]["reference"]["id"], "window-1");
-  assert_eq!(result["point"]["x"], 640.0);
-  assert_eq!(result["point"]["y"], 360.0);
+  assert_eq!(result["screen_point"]["x"], 640.0);
+  assert_eq!(result["screen_point"]["y"], 360.0);
   assert_eq!(result["action"]["selected_path"], "window_targeted_mouse");
   let report = output.report.as_ref().expect("window point click report");
   assert_eq!(field_value(report, "Delivery"), "delivered");
@@ -468,15 +246,16 @@ fn window_point_click_result_keeps_resolved_target_and_delivery_together() {
 }
 
 #[test]
-fn window_point_dry_run_reports_validation_without_delivery() {
-  let output = window_point_click_output(
-    WindowPointClickOutcome::Validated {
-      window: test_window(),
-      point: auv_driver::geometry::WindowPoint::new(640.0, 360.0),
-    }
-    .into_result(),
-    crate::commands::overlay::OverlayStatus::Disabled,
-  )
+fn click_point_dry_run_reports_validation_without_delivery() {
+  let output = click_point_output(ClickPointResult {
+    relative_to: "window".to_string(),
+    requested_point: auv_driver::Point::new(640.0, 360.0),
+    normalized: false,
+    screen_point: auv_driver::ScreenPoint::new(640.0, 360.0),
+    window: Some(test_window()),
+    display: None,
+    action: None,
+  })
   .expect("validated point should serialize");
 
   let report = output.report.as_ref().expect("window point validation report");

--- a/crates/auv-cli-invoke/src/commands/media_control.rs
+++ b/crates/auv-cli-invoke/src/commands/media_control.rs
@@ -24,7 +24,7 @@ pub fn group() -> CommandGroup {
   input = NowPlayingArgs,
 )]
 async fn media_control_now_playing(input: InvokeCommandInput, _args: NowPlayingArgs) -> InvokeCommandResult {
-  if input.target_application_id.is_some() {
+  if input.target.is_some() {
     return Err("mediaControl.nowPlaying cannot use --target; the macOS now-playing state is system-wide".to_string());
   }
   let result = read_now_playing().await?;
@@ -133,7 +133,7 @@ pub fn media_control_output(result: &MediaControlOutcome) -> InvokeCommandResult
 }
 
 fn reject_media_target(input: &InvokeCommandInput, command_id: &str) -> Result<(), String> {
-  if input.target_application_id.is_some() {
+  if input.target.is_some() {
     return Err(format!("{command_id} cannot use --target; macOS media controls are system-wide"));
   }
   Ok(())

--- a/crates/auv-cli-invoke/src/commands/media_control_test.rs
+++ b/crates/auv-cli-invoke/src/commands/media_control_test.rs
@@ -45,7 +45,9 @@ fn now_playing_human_output_exposes_the_current_media_state() {
 fn now_playing_rejects_target_before_platform_access() {
   let input = crate::InvokeCommandInput {
     command_id: "mediaControl.nowPlaying".to_string(),
-    target_application_id: Some("com.example.Player".to_string()),
+    target: Some(crate::ExecutionTarget::Application {
+      id: "com.example.Player".to_string(),
+    }),
     inputs: Default::default(),
     typed_args: None,
     dry_run: false,
@@ -67,7 +69,9 @@ fn media_commands_reject_target_before_platform_access() {
   ] {
     let input = crate::InvokeCommandInput {
       command_id: command_id.to_string(),
-      target_application_id: Some("com.example.Player".to_string()),
+      target: Some(crate::ExecutionTarget::Application {
+        id: "com.example.Player".to_string(),
+      }),
       inputs: Default::default(),
       typed_args: None,
       dry_run: false,

--- a/crates/auv-cli-invoke/src/commands/overlay.rs
+++ b/crates/auv-cli-invoke/src/commands/overlay.rs
@@ -462,7 +462,7 @@ fn plan_click_target(command_id: &str, args: ClickTargetArgs) -> Result<OverlayP
 }
 
 fn debug_output(input: &InvokeCommandInput, component: &str, overlay: Overlay, options: ShowOptions) -> InvokeCommandResult {
-  if input.target_application_id.is_some() {
+  if input.target.is_some() {
     return Err(format!("{} cannot use --target; overlays use global screen coordinates", input.command_id));
   }
   let layers = overlay.layers().len();

--- a/crates/auv-cli-invoke/src/commands/overlay_test.rs
+++ b/crates/auv-cli-invoke/src/commands/overlay_test.rs
@@ -17,7 +17,7 @@ fn every_overlay_primitive_and_component_is_registered_and_dry_run_visualizable(
     let command = registry.resolve(command_id).unwrap_or_else(|| panic!("{command_id} should be registered"));
     let output = futures_executor::block_on(command.invoke(InvokeCommandInput {
       command_id: command_id.to_string(),
-      target_application_id: None,
+      target: None,
       inputs,
       typed_args: None,
       dry_run: true,
@@ -54,7 +54,9 @@ fn overlay_commands_reject_target_before_native_rendering() {
     let command = registry.resolve(command_id).expect("registered overlay command");
     let error = futures_executor::block_on(command.invoke(InvokeCommandInput {
       command_id: command_id.to_string(),
-      target_application_id: Some("com.example.App".to_string()),
+      target: Some(crate::ExecutionTarget::Application {
+        id: "com.example.App".to_string(),
+      }),
       inputs,
       typed_args: None,
       dry_run: false,

--- a/crates/auv-cli-invoke/src/commands/scan_test.rs
+++ b/crates/auv-cli-invoke/src/commands/scan_test.rs
@@ -25,7 +25,7 @@ fn scan_coverage_artifact_enforces_four_mibibyte_bound() {
 fn scan_frame_requires_fixture_dir() {
   let err = futures_executor::block_on(frame_invoke_command().invoke(crate::InvokeCommandInput {
     command_id: "scan.frame".to_string(),
-    target_application_id: None,
+    target: None,
     inputs: BTreeMap::new(),
     typed_args: None,
     dry_run: false,
@@ -40,7 +40,7 @@ fn scan_frame_requires_fixture_dir() {
 fn scan_coverage_requires_fixture_dir() {
   let err = futures_executor::block_on(coverage_invoke_command().invoke(crate::InvokeCommandInput {
     command_id: "scan.coverage".to_string(),
-    target_application_id: None,
+    target: None,
     inputs: BTreeMap::new(),
     typed_args: None,
     dry_run: false,
@@ -55,7 +55,7 @@ fn scan_coverage_requires_fixture_dir() {
 fn scan_frame_dry_run_produces_no_artifacts() {
   let output = futures_executor::block_on(frame_invoke_command().invoke(crate::InvokeCommandInput {
     command_id: "scan.frame".to_string(),
-    target_application_id: None,
+    target: None,
     inputs: BTreeMap::from([("fixture-dir".to_string(), "unused".to_string())]),
     typed_args: None,
     dry_run: true,
@@ -70,7 +70,7 @@ fn scan_frame_dry_run_produces_no_artifacts() {
 fn scan_coverage_dry_run_produces_no_artifacts() {
   let output = futures_executor::block_on(coverage_invoke_command().invoke(crate::InvokeCommandInput {
     command_id: "scan.coverage".to_string(),
-    target_application_id: None,
+    target: None,
     inputs: BTreeMap::from([("fixture-dir".to_string(), "unused".to_string())]),
     typed_args: None,
     dry_run: true,
@@ -88,7 +88,7 @@ async fn scan_frame_returns_both_primary_artifact_receipts() {
   let root = dispatcher::with_default(&dispatch, || Context::root(RunId::new()));
   let input = crate::InvokeCommandInput {
     command_id: "scan.frame".to_string(),
-    target_application_id: None,
+    target: None,
     inputs: BTreeMap::from([("fixture-dir".to_string(), scan_fixture("temporal/single_frame_v0").display().to_string())]),
     typed_args: None,
     dry_run: false,
@@ -109,7 +109,7 @@ async fn scan_coverage_returns_its_primary_artifact_receipt() {
   let root = dispatcher::with_default(&dispatch, || Context::root(RunId::new()));
   let input = crate::InvokeCommandInput {
     command_id: "scan.coverage".to_string(),
-    target_application_id: None,
+    target: None,
     inputs: BTreeMap::from([("fixture-dir".to_string(), scan_fixture("coverage/coverage_stable_v0").display().to_string())]),
     typed_args: None,
     dry_run: false,

--- a/crates/auv-cli-invoke/src/commands/screen.rs
+++ b/crates/auv-cli-invoke/src/commands/screen.rs
@@ -307,7 +307,7 @@ pub async fn click_recognized_screen_text(query: String) -> Result<ScreenTextCli
 }
 
 fn reject_target_activation(input: &InvokeCommandInput, command_id: &str) -> Result<(), String> {
-  if input.target_application_id.is_some() {
+  if input.target.is_some() {
     // TODO(invoke-screen-activation): target activation for screen capture/OCR
     // needs a typed app activation lease before these handlers can honor
     // --target without returning to the root driver adapter.

--- a/crates/auv-cli-invoke/src/commands/screen_test.rs
+++ b/crates/auv-cli-invoke/src/commands/screen_test.rs
@@ -13,7 +13,7 @@ fn inputs(values: [(&str, &str); 4]) -> BTreeMap<String, String> {
 fn capture_region_validates_the_same_region_before_dry_and_live_branches() {
   let valid_dry_run = InvokeCommandInput {
     command_id: "screen.captureRegion".to_string(),
-    target_application_id: None,
+    target: None,
     inputs: inputs([("x", "1"), ("y", "2"), ("width", "3"), ("height", "4")]),
     typed_args: None,
     dry_run: true,
@@ -23,7 +23,7 @@ fn capture_region_validates_the_same_region_before_dry_and_live_branches() {
 
   let invalid_live = InvokeCommandInput {
     command_id: "screen.captureRegion".to_string(),
-    target_application_id: None,
+    target: None,
     inputs: inputs([("x", "1"), ("y", "2"), ("width", "0"), ("height", "4")]),
     typed_args: None,
     dry_run: false,

--- a/crates/auv-cli-invoke/src/commands/window.rs
+++ b/crates/auv-cli-invoke/src/commands/window.rs
@@ -96,7 +96,8 @@ async fn capture_window(input: InvokeCommandInput, args: CaptureWindowArgs) -> I
     }
 
     let session = auv_driver::open_local().map_err(|error| error.to_string())?;
-    let (result, artifact) = capture_selected_window_recorded_with_session(&session, window_selector(&input, args.title.as_deref())).await?;
+    let (result, artifact) =
+      capture_selected_window_recorded_with_session(&session, window_selector(&input, args.title.as_deref())?).await?;
     let capture_overlay = Overlay::new().with_layer(
       CaptureFrame::new(result.window.frame).with_label(result.window.title.clone().unwrap_or_else(|| "selected window".to_string())),
     );
@@ -205,7 +206,7 @@ async fn find_window_text(input: InvokeCommandInput, args: FindWindowTextArgs) -
 
     let query = args.query;
     let session = auv_driver::open_local().map_err(|error| error.to_string())?;
-    let result = recognize_window_text_with_session(&session, window_selector(&input, args.title.as_deref()), query, false).await?;
+    let result = recognize_window_text_with_session(&session, window_selector(&input, args.title.as_deref())?, query, false).await?;
     let overlay = super::overlay::show_overlay(&input, &session, window_text_overlay(&result.matches, None), show_options(120, 420))?;
     window_text_matches_output(&input.command_id, &result, overlay)
   }
@@ -242,7 +243,7 @@ async fn wait_for_window_text(input: InvokeCommandInput, args: WaitForWindowText
 
     let query = args.query;
     let session = auv_driver::open_local().map_err(|error| error.to_string())?;
-    let result = recognize_window_text_with_session(&session, window_selector(&input, args.title.as_deref()), query, true).await?;
+    let result = recognize_window_text_with_session(&session, window_selector(&input, args.title.as_deref())?, query, true).await?;
     let overlay = super::overlay::show_overlay(&input, &session, window_text_overlay(&result.matches, None), show_options(120, 420))?;
     window_text_matches_output(&input.command_id, &result, overlay)
   }
@@ -321,7 +322,7 @@ async fn click_window_text(input: InvokeCommandInput, args: ClickWindowTextArgs)
 
     let session = auv_driver::open_local().map_err(|error| error.to_string())?;
     let result =
-      click_recognized_window_text_with_session(&session, window_selector(&input, args.title.as_deref()), args.query, args.index, options)
+      click_recognized_window_text_with_session(&session, window_selector(&input, args.title.as_deref())?, args.query, args.index, options)
         .await?;
     let overlay = super::overlay::show_overlay(
       &input,
@@ -554,20 +555,20 @@ fn show_options(motion_ms: u64, auto_removal_ms: u64) -> auv_driver::overlay::Sh
 }
 
 #[cfg(target_os = "macos")]
-fn window_selector(input: &InvokeCommandInput, title: Option<&str>) -> auv_driver::WindowSelector {
+fn window_selector(input: &InvokeCommandInput, title: Option<&str>) -> Result<auv_driver::WindowSelector, String> {
   use auv_driver::{App, TextMatcher, WindowSelector};
 
   let mut selector = WindowSelector {
     main_visible: true,
     ..WindowSelector::default()
   };
-  if let Some(target) = input.target_or_input_target() {
+  if let Some(target) = input.application_target()? {
     selector.app = Some(App::bundle_id(target));
   }
   if let Some(title) = title.filter(|value| !value.trim().is_empty()) {
     selector.title = Some(TextMatcher::Contains(title.to_string()));
   }
-  selector
+  Ok(selector)
 }
 
 fn window_report_fields(window: &auv_driver::Window) -> Vec<InvokeReportField> {

--- a/crates/auv-cli-invoke/src/help.rs
+++ b/crates/auv-cli-invoke/src/help.rs
@@ -16,7 +16,7 @@ pub fn render_help_index(registry: &InvokeRegistry) -> String {
   }
   help.push_str(&format!("  {:<command_width$}Print help for invoke or one command\n", "help"));
   help.push_str(
-    "\nOptions:\n  --target <APP>       Select the operation target application\n  --dry-run            Validate without performing the operation\n  --store-root <PATH>  Persist the recorded run under this directory\n  --no-overlay         Disable live visual overlay presentation\n  --json               Render machine-readable JSON output\n  --detail             Include diagnostic detail in human output\n  --wide               Include extra columns in human table output\n\nUse \"auv invoke <COMMAND> --help\" for command-specific options.\n",
+    "\nOptions:\n  --target <TARGET>    Select app:<bundle-id>, window:<window-id>, or display:<display-id>\n  --dry-run            Validate without performing the operation\n  --store-root <PATH>  Persist the recorded run under this directory\n  --no-overlay         Disable live visual overlay presentation\n  --json               Render machine-readable JSON output\n  --detail             Include diagnostic detail in human output\n  --wide               Include extra columns in human table output\n\nUse \"auv invoke <COMMAND> --help\" for command-specific options.\n",
   );
 
   help

--- a/crates/auv-cli-invoke/src/lib.rs
+++ b/crates/auv-cli-invoke/src/lib.rs
@@ -39,7 +39,7 @@ pub enum InvokeCliParse {
   },
   Invoke {
     command_id: String,
-    target_application_id: Option<String>,
+    target: Option<ExecutionTarget>,
     inputs: BTreeMap<String, String>,
     typed_args: TypedInvokeArgs,
     store_root: Option<PathBuf>,
@@ -65,7 +65,7 @@ pub fn parse_invoke_args(arguments: &[String]) -> Result<InvokeCliParse, String>
       command_id: Some(command.id.to_string()),
     }),
     InvokeCommandCliParse::Invoke {
-      target_application_id,
+      target,
       mut inputs,
       typed_args,
       store_root,
@@ -80,7 +80,7 @@ pub fn parse_invoke_args(arguments: &[String]) -> Result<InvokeCliParse, String>
       }
       Ok(InvokeCliParse::Invoke {
         command_id: command.id.to_string(),
-        target_application_id,
+        target,
         inputs,
         typed_args,
         store_root,

--- a/crates/auv-cli-invoke/src/lib_test.rs
+++ b/crates/auv-cli-invoke/src/lib_test.rs
@@ -9,3 +9,67 @@ fn no_overlay_is_a_global_flag_without_a_value() {
 
   assert_eq!(inputs.get("overlay").map(String::as_str), Some("false"));
 }
+
+#[test]
+fn click_point_parses_screen_relative_coordinates() {
+  let parsed = parse_invoke_args(&[
+    "input.clickPoint".to_string(),
+    "120".to_string(),
+    "80".to_string(),
+    "--relative-to".to_string(),
+    "screen".to_string(),
+  ])
+  .expect("screen-relative click point should parse");
+  let InvokeCliParse::Invoke { inputs, .. } = parsed else {
+    panic!("expected invoke request");
+  };
+
+  assert_eq!(inputs.get("x").map(String::as_str), Some("120.0"));
+  assert_eq!(inputs.get("y").map(String::as_str), Some("80.0"));
+  assert_eq!(inputs.get("relative-to").map(String::as_str), Some("screen"));
+}
+
+#[test]
+fn click_point_parses_typed_resource_targets() {
+  for (value, expected) in [
+    (
+      "app:com.example.Player",
+      ExecutionTarget::Application {
+        id: "com.example.Player".to_string(),
+      },
+    ),
+    (
+      "window:5063",
+      ExecutionTarget::Window {
+        id: "5063".to_string(),
+      },
+    ),
+    (
+      "display:primary",
+      ExecutionTarget::Display {
+        id: "primary".to_string(),
+      },
+    ),
+  ] {
+    let parsed = parse_invoke_args(&[
+      "input.clickPoint".to_string(),
+      "10".to_string(),
+      "20".to_string(),
+      "--target".to_string(),
+      value.to_string(),
+    ])
+    .expect("typed target should parse");
+    let InvokeCliParse::Invoke { target, .. } = parsed else {
+      panic!("expected invoke request");
+    };
+    assert_eq!(target, Some(expected));
+  }
+}
+
+#[test]
+fn retired_point_command_ids_are_not_registered() {
+  for command_id in ["input.clickScreenPoint", "input.clickWindowPoint"] {
+    let error = parse_invoke_args(&[command_id.to_string()]).expect_err("retired command id must not resolve");
+    assert!(error.contains("unknown invoke command"), "{error}");
+  }
+}

--- a/crates/auv-cli-invoke/src/models/mod.rs
+++ b/crates/auv-cli-invoke/src/models/mod.rs
@@ -7,15 +7,53 @@ pub use invoke_report::{InvokeReport, InvokeReportField, InvokeReportSection, In
 pub(crate) use invoke_report::{InvokeReportValue, OptionalReportText};
 pub use invoke_result::{InvokeResult, InvokeStatus};
 
-#[derive(Clone, Debug, Default)]
-pub struct ExecutionTarget {
-  pub application_id: Option<String>,
+/// Explicit resource selected by the shared invoke frontend.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ExecutionTarget {
+  Application { id: String },
+  Window { id: String },
+  Display { id: String },
+}
+
+impl ExecutionTarget {
+  pub fn parse(value: &str) -> Result<Self, String> {
+    let value = value.trim();
+    if value.is_empty() {
+      return Err("--target cannot be empty".to_string());
+    }
+    if let Some((kind, id)) = value.split_once(':') {
+      let id = id.trim();
+      if id.is_empty() {
+        return Err(format!("--target {kind}: requires a non-empty id"));
+      }
+      return match kind {
+        "app" => Ok(Self::Application { id: id.to_string() }),
+        "window" => Ok(Self::Window { id: id.to_string() }),
+        "display" => Ok(Self::Display { id: id.to_string() }),
+        _ => Err(format!("--target has unknown kind {kind:?}; expected app:, window:, or display:")),
+      };
+    }
+
+    // NOTICE(invoke-target-bare-app): Bare targets remain application ids so
+    // existing invoke calls keep their meaning. Remove this form only through
+    // an owner-approved CLI compatibility boundary.
+    Ok(Self::Application {
+      id: value.to_string(),
+    })
+  }
+
+  pub fn application_id(&self) -> Option<&str> {
+    match self {
+      Self::Application { id } => Some(id),
+      Self::Window { .. } | Self::Display { .. } => None,
+    }
+  }
 }
 
 #[derive(Clone, Debug, Default)]
 pub struct InvokeRequest {
   pub command_id: String,
-  pub target: ExecutionTarget,
+  pub target: Option<ExecutionTarget>,
   pub inputs: BTreeMap<String, String>,
   pub dry_run: bool,
 }

--- a/crates/auv-cli-invoke/src/runner.rs
+++ b/crates/auv-cli-invoke/src/runner.rs
@@ -32,25 +32,25 @@ where
 
 pub async fn invoke(input: crate::InvokeCommandInput, context: auv::AuvContext) -> crate::InvokeCommandResult {
   let command_id = input.command_id.as_str();
-  if command_id == "app.probePermissions" && input.target_application_id.is_some() {
+  if command_id == "app.probePermissions" && input.target.is_some() {
     return Err("app.probePermissions cannot use --target".to_string());
   }
-  if command_id == "app.activate" && input.target_application_id.as_ref().is_none_or(|target| target.trim().is_empty()) {
-    return Err("app.activate requires --target".to_string());
+  if command_id == "app.activate" && input.application_target()?.is_none_or(|target| target.trim().is_empty()) {
+    return Err("app.activate requires --target app:".to_string());
   }
   if matches!(command_id, "input.focusText" | "input.axFocusText")
-    && input.target_application_id.as_ref().is_none_or(|target| target.trim().is_empty())
+    && input.application_target()?.is_none_or(|target| target.trim().is_empty())
   {
     return Err(format!("{command_id} requires --target"));
   }
-  if command_id.starts_with("mediaControl.") && input.target_application_id.is_some() {
+  if command_id.starts_with("mediaControl.") && input.target.is_some() {
     return Err(if command_id == "mediaControl.nowPlaying" {
       "mediaControl.nowPlaying cannot use --target; the macOS now-playing state is system-wide".to_string()
     } else {
       format!("{command_id} cannot use --target; macOS media controls are system-wide")
     });
   }
-  if command_id.starts_with("overlay.") && input.target_application_id.is_some() {
+  if command_id.starts_with("overlay.") && input.target.is_some() {
     return Err(format!("{command_id} cannot use --target; overlays use global screen coordinates"));
   }
   if command_id.starts_with("overlay.") {
@@ -59,12 +59,10 @@ pub async fn invoke(input: crate::InvokeCommandInput, context: auv::AuvContext) 
       return crate::commands::overlay::selected_overlay_output(&plan, false);
     }
   }
-  if matches!(command_id, "input.typeText" | "input.pasteText" | "input.key") && input.target_application_id.is_some() {
+  if matches!(command_id, "input.typeText" | "input.pasteText" | "input.key") && input.target.is_some() {
     return Err(format!("{command_id} cannot use --target until typed input target activation is available"));
   }
-  if matches!(command_id, "screen.findText" | "screen.waitForText" | "screen.clickText" | "screen.captureRegion")
-    && input.target_application_id.is_some()
-  {
+  if matches!(command_id, "screen.findText" | "screen.waitForText" | "screen.clickText" | "screen.captureRegion") && input.target.is_some() {
     return Err(format!("{command_id} cannot use --target until typed target activation is available"));
   }
   let auv = auv::Client::from_context(context).await.map_err(|error| error.to_string())?;
@@ -74,9 +72,9 @@ pub async fn invoke(input: crate::InvokeCommandInput, context: auv::AuvContext) 
     .await
     .map_err(|error| format!("route core Runner for {command_id} failed: {error}"))?;
 
-  let invoked = match command_id {
+  match command_id {
     "app.activate" => {
-      let target = input.target_application_id.as_deref().expect("validated target").trim();
+      let target = input.application_target()?.expect("validated target").trim();
       runner
         .macos()
         .applications()
@@ -108,7 +106,7 @@ pub async fn invoke(input: crate::InvokeCommandInput, context: auv::AuvContext) 
         .macos()
         .accessibility()
         .focus_text(auv_driver::FocusTextOptions {
-          app: input.target_application_id.clone().expect("validated target"),
+          app: input.application_target()?.expect("validated target").to_string(),
           selector,
           expected_role: None,
         })
@@ -421,46 +419,121 @@ pub async fn invoke(input: crate::InvokeCommandInput, context: auv::AuvContext) 
       }
       .await
     }
-    "input.clickScreenPoint" => {
-      async {
-        let point = selected_screen_point(&input, "input.clickScreenPoint")?;
-        let click = selected_click_options(&input)?.click;
-        let response = runner
-          .input()
-          .click_screen_point(point.point(), click)
-          .await
-          .map_err(|status| format!("InputService/ClickScreenPoint failed: {status}"))?;
-        crate::emit_input_action_result(&response.action);
-        crate::commands::input::screen_point_click_output(crate::commands::input::ScreenPointClickResult {
-          point: auv_driver::ScreenPoint::new(response.point.x, response.point.y),
-          action: Some(response.action),
-        })
-      }
-      .await
-    }
-    "input.clickWindowPoint" => match runner.windows().resolve(selected_window_selector(&input)).await {
-      Err(status) => Err(format!("WindowService/ResolveWindow failed: {status}")),
-      Ok(resolved) => {
-        let window = resolved.resource().clone();
-        match (selected_window_point(&input, &window), selected_click_options(&input)) {
-          (Err(error), _) | (_, Err(error)) => Err(error),
-          (Ok(point), Ok(options)) => match resolved.click(point, options).await {
-            Err(status) => Err(format!("InputService/ClickWindowPoint failed: {status}")),
-            Ok(response) => {
-              crate::emit_input_action_result(&response.action);
-              crate::commands::input::window_point_click_output_without_overlay(crate::commands::input::WindowPointClickResult {
-                window: response.window,
-                point: response.point,
-                action: Some(response.action),
-              })
-            }
-          },
-        }
-      }
-    },
+    "input.clickPoint" => selected_click_point(&input, &runner).await,
     _ => unreachable!("typed Runner adapter was selected above"),
-  };
-  invoked
+  }
+}
+
+async fn selected_click_point(input: &crate::InvokeCommandInput, runner: &auv::client::runner::RunnerClient) -> crate::InvokeCommandResult {
+  let requested = selected_screen_point(input, "input.clickPoint")?;
+  let normalized = input
+    .inputs
+    .get("normalized")
+    .map(|value| value.parse::<bool>().map_err(|error| format!("input.clickPoint has invalid --normalized value: {error}")))
+    .transpose()?
+    .unwrap_or(false);
+  if normalized && (!(0.0..=1.0).contains(&requested.point().x) || !(0.0..=1.0).contains(&requested.point().y)) {
+    return Err("input.clickPoint --normalized coordinates must be within 0..=1".to_string());
+  }
+  let basis = crate::commands::input::click_point_basis(
+    input.target.as_ref(),
+    input.inputs.get("relative-to").map(String::as_str),
+    normalized,
+    input.inputs.contains_key("input-policy"),
+    input.inputs.contains_key("title"),
+  )?;
+  let requested_point = requested.point();
+  match basis {
+    crate::commands::input::RelativeToArg::Screen => {
+      let response = runner
+        .input()
+        .click_screen_point(requested_point, selected_click_options(input)?.click)
+        .await
+        .map_err(|status| format!("InputService/ClickScreenPoint failed: {status}"))?;
+      crate::emit_input_action_result(&response.action);
+      crate::commands::input::click_point_output(crate::commands::input::ClickPointResult {
+        relative_to: basis.as_str().to_string(),
+        requested_point,
+        normalized,
+        screen_point: auv_driver::ScreenPoint::new(response.point.x, response.point.y),
+        window: None,
+        display: None,
+        action: Some(response.action),
+      })
+    }
+    crate::commands::input::RelativeToArg::Window => {
+      let windows = runner.windows();
+      let resolved = match input.target.as_ref().expect("window-relative target validated") {
+        crate::ExecutionTarget::Application { .. } => {
+          windows.resolve(selected_window_selector(input)).await.map_err(|status| format!("WindowService/ResolveWindow failed: {status}"))?
+        }
+        crate::ExecutionTarget::Window { id } => {
+          let window = windows
+            .list()
+            .await
+            .map_err(|status| format!("WindowService/ListWindows failed: {status}"))?
+            .into_iter()
+            .find(|window| window.reference.id == *id)
+            .ok_or_else(|| format!("input.clickPoint could not find window target {id:?}"))?;
+          windows.bind(window).map_err(|error| format!("WindowService/BindWindow failed: {error}"))?
+        }
+        crate::ExecutionTarget::Display { .. } => unreachable!("target/basis validated"),
+      };
+      let window = resolved.resource();
+      let point =
+        crate::commands::input::resolve_local_point(requested_point.x, requested_point.y, normalized, window.frame.size, "window")?;
+      let response = resolved
+        .click(auv_driver::WindowPoint::new(point.x, point.y), selected_click_options(input)?)
+        .await
+        .map_err(|status| format!("InputService/ClickWindowPoint failed: {status}"))?;
+      crate::emit_input_action_result(&response.action);
+      let screen_point = auv_driver::ScreenPoint::new(
+        response.window.frame.origin.x + response.point.point().x,
+        response.window.frame.origin.y + response.point.point().y,
+      );
+      crate::commands::input::click_point_output(crate::commands::input::ClickPointResult {
+        relative_to: basis.as_str().to_string(),
+        requested_point,
+        normalized,
+        screen_point,
+        window: Some(response.window),
+        display: None,
+        action: Some(response.action),
+      })
+    }
+    crate::commands::input::RelativeToArg::Display => {
+      let crate::ExecutionTarget::Display { id } = input.target.as_ref().expect("display-relative target validated") else {
+        unreachable!("target/basis validated")
+      };
+      let display = runner
+        .displays()
+        .list()
+        .await
+        .map_err(|status| format!("DisplayService/ListDisplays failed: {status}"))?
+        .displays
+        .into_iter()
+        .find(|display| display.id == *id)
+        .ok_or_else(|| format!("input.clickPoint could not find display target {id:?}"))?;
+      let point =
+        crate::commands::input::resolve_local_point(requested_point.x, requested_point.y, normalized, display.frame.size, "display")?;
+      let screen_point = auv_driver::ScreenPoint::new(display.frame.origin.x + point.x, display.frame.origin.y + point.y);
+      let response = runner
+        .input()
+        .click_screen_point(screen_point.point(), selected_click_options(input)?.click)
+        .await
+        .map_err(|status| format!("InputService/ClickScreenPoint failed: {status}"))?;
+      crate::emit_input_action_result(&response.action);
+      crate::commands::input::click_point_output(crate::commands::input::ClickPointResult {
+        relative_to: basis.as_str().to_string(),
+        requested_point,
+        normalized,
+        screen_point: auv_driver::ScreenPoint::new(response.point.x, response.point.y),
+        window: None,
+        display: Some(display),
+        action: Some(response.action),
+      })
+    }
+  }
 }
 
 fn selected_screen_point(input: &crate::InvokeCommandInput, command_id: &str) -> Result<auv_driver::ScreenPoint, String> {
@@ -500,37 +573,6 @@ fn selected_screen_region(input: &crate::InvokeCommandInput) -> Result<auv_drive
     return Err("screen.captureRegion requires --width and --height greater than zero".to_string());
   }
   Ok(auv_driver::Rect::new(x, y, width, height))
-}
-
-fn selected_window_point(input: &crate::InvokeCommandInput, window: &auv_driver::Window) -> Result<auv_driver::WindowPoint, String> {
-  let number = |name: &str| {
-    input
-      .inputs
-      .get(name)
-      .map(|value| value.parse::<f64>().map_err(|error| format!("input.clickWindowPoint has invalid --{name}: {error}")))
-      .transpose()
-  };
-  let offset_x = number("offset-x")?;
-  let offset_y = number("offset-y")?;
-  let relative_x = number("relative-x")?;
-  let relative_y = number("relative-y")?;
-  let point = match (offset_x, offset_y, relative_x, relative_y) {
-    (Some(x), Some(y), None, None) if x.is_finite() && y.is_finite() && x >= 0.0 && y >= 0.0 => auv_driver::WindowPoint::new(x, y),
-    (None, None, Some(x), Some(y)) if x.is_finite() && y.is_finite() && (0.0..=1.0).contains(&x) && (0.0..=1.0).contains(&y) => {
-      auv_driver::WindowPoint::new(window.frame.size.width * x, window.frame.size.height * y)
-    }
-    (Some(_), Some(_), None, None) => return Err("input.clickWindowPoint requires finite non-negative window offsets".to_string()),
-    (None, None, Some(_), Some(_)) => return Err("input.clickWindowPoint requires relative coordinates within 0..=1".to_string()),
-    _ => return Err("input.clickWindowPoint requires --offset-x/--offset-y or --relative-x/--relative-y".to_string()),
-  };
-  let point_value = point.point();
-  if !(0.0..=window.frame.size.width).contains(&point_value.x) || !(0.0..=window.frame.size.height).contains(&point_value.y) {
-    return Err(format!(
-      "input.clickWindowPoint point {},{} is outside target window bounds 0..={},0..={}",
-      point_value.x, point_value.y, window.frame.size.width, window.frame.size.height
-    ));
-  }
-  Ok(point)
 }
 
 fn selected_click_options(input: &crate::InvokeCommandInput) -> Result<auv_driver::ClickOptions, String> {
@@ -589,13 +631,13 @@ fn matched_window_point(window: &auv_driver::Window, matched: &auv_driver::OcrMa
 
 fn selected_window_selector(input: &crate::InvokeCommandInput) -> auv_driver::WindowSelector {
   let app = input
-    .target_application_id
+    .target
     .as_ref()
-    // TODO(cross-platform-application-selector): `--target` currently carries
-    // an application id and therefore maps to bundle/accessibility id. Add an
-    // explicit application-name selector when the CLI contract can distinguish
-    // ids from names; do not guess from punctuation or silently retry.
-    .map(|bundle_id| auv_driver::App::bundle_id(bundle_id.clone()))
+    .and_then(crate::ExecutionTarget::application_id)
+    // TODO(cross-platform-application-selector): Application targets currently
+    // carry bundle/accessibility ids. Add an explicit application-name target
+    // only through an owner-approved target-contract extension.
+    .map(|bundle_id| auv_driver::App::bundle_id(bundle_id.to_string()))
     .unwrap_or_else(auv_driver::App::frontmost);
   let title =
     input.inputs.get("title").filter(|title| !title.trim().is_empty()).map(|title| auv_driver::TextMatcher::Contains(title.clone()));

--- a/crates/auv-cli-invoke/src/runner_test.rs
+++ b/crates/auv-cli-invoke/src/runner_test.rs
@@ -5,7 +5,9 @@ async fn selected_now_playing_rejects_application_target_before_daemon_resolutio
   let error = invoke(
     crate::InvokeCommandInput {
       command_id: "mediaControl.nowPlaying".to_string(),
-      target_application_id: Some("com.example.Player".to_string()),
+      target: Some(crate::ExecutionTarget::Application {
+        id: "com.example.Player".to_string(),
+      }),
       inputs: Default::default(),
       typed_args: None,
       dry_run: false,
@@ -30,7 +32,9 @@ async fn selected_media_commands_reject_application_target_before_daemon_resolut
     let error = invoke(
       crate::InvokeCommandInput {
         command_id: command_id.to_string(),
-        target_application_id: Some("com.example.Player".to_string()),
+        target: Some(crate::ExecutionTarget::Application {
+          id: "com.example.Player".to_string(),
+        }),
         inputs: Default::default(),
         typed_args: None,
         dry_run: false,
@@ -63,7 +67,7 @@ async fn selected_disabled_overlay_validates_without_resolving_a_daemon() {
   .collect::<Vec<_>>();
   let crate::InvokeCliParse::Invoke {
     command_id,
-    target_application_id,
+    target,
     inputs,
     typed_args,
     dry_run,
@@ -75,7 +79,7 @@ async fn selected_disabled_overlay_validates_without_resolving_a_daemon() {
   let output = invoke(
     crate::InvokeCommandInput {
       command_id,
-      target_application_id,
+      target,
       inputs,
       typed_args: Some(typed_args),
       dry_run,
@@ -144,7 +148,9 @@ fn selected_window_selector_keeps_hierarchical_parent_context() {
   inputs.insert("title".to_string(), "Preferences".to_string());
   let selector = selected_window_selector(&crate::InvokeCommandInput {
     command_id: "window.capture".to_string(),
-    target_application_id: Some("com.example.app".to_string()),
+    target: Some(crate::ExecutionTarget::Application {
+      id: "com.example.app".to_string(),
+    }),
     inputs,
     typed_args: None,
     dry_run: false,
@@ -156,36 +162,19 @@ fn selected_window_selector_keeps_hierarchical_parent_context() {
 }
 
 #[test]
-fn selected_window_point_projects_relative_coordinates_and_click_policy() {
+fn selected_click_options_preserve_policy_and_repeated_clicks() {
   let mut inputs = std::collections::BTreeMap::new();
-  inputs.insert("relative-x".to_string(), "0.25".to_string());
-  inputs.insert("relative-y".to_string(), "0.5".to_string());
   inputs.insert("input-policy".to_string(), "background-only".to_string());
   inputs.insert("click-count".to_string(), "2".to_string());
   inputs.insert("click-interval-ms".to_string(), "80".to_string());
   let input = crate::InvokeCommandInput {
-    command_id: "input.clickWindowPoint".to_string(),
-    target_application_id: None,
+    command_id: "input.clickPoint".to_string(),
+    target: None,
     inputs,
     typed_args: None,
     dry_run: false,
     cancellation: Default::default(),
   };
-  let window = auv_driver::Window {
-    reference: auv_driver::WindowRef {
-      id: "window_fixture".to_string(),
-    },
-    title: None,
-    app_name: None,
-    app_bundle_id: None,
-    process_id: None,
-    frame: auv_driver::Rect::new(10.0, 20.0, 400.0, 200.0),
-    coordinate_space: auv_driver::CoordinateSpace::Screen,
-    is_main: true,
-    is_visible: true,
-  };
-
-  assert_eq!(selected_window_point(&input, &window).unwrap(), auv_driver::WindowPoint::new(100.0, 100.0));
   let options = selected_click_options(&input).unwrap();
   assert_eq!(options.policy, auv_driver::InputPolicy::BackgroundOnly);
   assert_eq!(options.click.count(), 2);
@@ -195,8 +184,8 @@ fn selected_window_point_projects_relative_coordinates_and_click_policy() {
 #[test]
 fn selected_screen_point_preserves_logical_coordinates() {
   let input = crate::InvokeCommandInput {
-    command_id: "input.clickScreenPoint".to_string(),
-    target_application_id: None,
+    command_id: "input.clickPoint".to_string(),
+    target: None,
     inputs: std::collections::BTreeMap::from([
       ("x".to_string(), "768".to_string()),
       ("y".to_string(), "1139.5".to_string()),
@@ -206,14 +195,14 @@ fn selected_screen_point_preserves_logical_coordinates() {
     cancellation: Default::default(),
   };
 
-  assert_eq!(selected_screen_point(&input, "input.clickScreenPoint").unwrap(), auv_driver::ScreenPoint::new(768.0, 1139.5));
+  assert_eq!(selected_screen_point(&input, "input.clickPoint").unwrap(), auv_driver::ScreenPoint::new(768.0, 1139.5));
 }
 
 #[test]
 fn selected_screen_text_click_defaults_to_foreground_input() {
   let input = crate::InvokeCommandInput {
     command_id: "screen.clickText".to_string(),
-    target_application_id: None,
+    target: None,
     inputs: std::collections::BTreeMap::new(),
     typed_args: None,
     dry_run: false,
@@ -254,7 +243,7 @@ fn selected_window_text_click_projects_screen_match_and_reuses_click_options() {
   inputs.insert("index".to_string(), "1".to_string());
   let input = crate::InvokeCommandInput {
     command_id: "window.clickText".to_string(),
-    target_application_id: None,
+    target: None,
     inputs,
     typed_args: None,
     dry_run: false,

--- a/crates/auv-cli-invoke/tests/integrated/scan_command_api/cases.rs
+++ b/crates/auv-cli-invoke/tests/integrated/scan_command_api/cases.rs
@@ -37,7 +37,7 @@ fn scan_commands_return_direct_values_and_record_owned_artifacts() {
       let future = root.in_scope(|| {
         command.invoke(InvokeCommandInput {
           command_id: command_id.to_string(),
-          target_application_id: None,
+          target: None,
           inputs: BTreeMap::from([("fixture-dir".to_string(), fixture_dir.to_string_lossy().into_owned())]),
           typed_args: None,
           dry_run: false,

--- a/crates/auv-cli-invoke/tests/invoke_command_macro.rs
+++ b/crates/auv-cli-invoke/tests/invoke_command_macro.rs
@@ -37,7 +37,7 @@ fn invoke_command_macro_expands_for_downstream_crates() {
 
   futures_executor::block_on(command.invoke(auv_cli_invoke::InvokeCommandInput {
     command_id: command.id.to_string(),
-    target_application_id: None,
+    target: None,
     inputs,
     typed_args: None,
     dry_run: false,

--- a/crates/auv-cli/src/commands/invoke.rs
+++ b/crates/auv-cli/src/commands/invoke.rs
@@ -2,7 +2,7 @@ use clap::Args;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use auv_cli_invoke::{ExecutionTarget, InvokeCliParse, InvokeRequest};
+use auv_cli_invoke::{InvokeCliParse, InvokeRequest};
 
 /// Invoke one core computer-use capability and record its run.
 #[derive(Clone, Debug, Args)]
@@ -38,7 +38,7 @@ pub async fn run(args: InvokeArgs, selection: &auv::selection::RootSelection, pr
     }
     InvokeCliParse::Invoke {
       command_id,
-      target_application_id,
+      target,
       inputs,
       typed_args,
       store_root,
@@ -48,9 +48,7 @@ pub async fn run(args: InvokeArgs, selection: &auv::selection::RootSelection, pr
       execute(
         InvokeRequest {
           command_id,
-          target: ExecutionTarget {
-            application_id: target_application_id,
-          },
+          target,
           inputs,
           dry_run,
         },
@@ -87,7 +85,7 @@ async fn execute(
   let remote_context = selected_context.as_ref().map(|resolved| resolved.context.clone());
   let input = auv_cli_invoke::InvokeCommandInput {
     command_id: request.command_id.clone(),
-    target_application_id: request.target.application_id,
+    target: request.target,
     inputs: request.inputs,
     typed_args: Some(typed_args),
     dry_run: request.dry_run,

--- a/crates/auv-cli/src/commands/mcp.rs
+++ b/crates/auv-cli/src/commands/mcp.rs
@@ -41,7 +41,7 @@ mod frontend {
   use serde::Serialize;
   use serde_json::Value;
 
-  use auv_cli_invoke::{InvokeCancellation, InvokeCommand, InvokeCommandInput, InvokeRegistry, default_registry};
+  use auv_cli_invoke::{ExecutionTarget, InvokeCancellation, InvokeCommand, InvokeCommandInput, InvokeRegistry, default_registry};
 
   tokio::task_local! {
     static MCP_REQUEST_CANCELLATION: InvokeCancellation;
@@ -52,7 +52,7 @@ mod frontend {
 
   #[derive(Clone, Debug)]
   pub struct McpInvokeInput {
-    pub target_application_id: Option<String>,
+    pub target: Option<ExecutionTarget>,
     pub inputs: BTreeMap<String, String>,
     pub dry_run: bool,
     pub cancellation: InvokeCancellation,
@@ -242,7 +242,7 @@ mod frontend {
         let output = command
           .invoke(InvokeCommandInput {
             command_id: command_id.to_string(),
-            target_application_id: input.target_application_id,
+            target: input.target,
             inputs,
             typed_args: None,
             dry_run: input.dry_run,
@@ -288,7 +288,7 @@ mod frontend {
       let authority = (self.invoke_dispatch)(req.store_root).map_err(invalid_params)?;
       let cancellation = MCP_REQUEST_CANCELLATION.try_with(Clone::clone).unwrap_or_default();
       let input = McpInvokeInput {
-        target_application_id: req.target.application_id,
+        target: req.target.into_execution_target().map_err(invalid_params)?,
         inputs: req.inputs,
         dry_run: req.dry_run,
         cancellation: cancellation.clone(),
@@ -436,6 +436,33 @@ mod frontend {
   #[serde(deny_unknown_fields)]
   struct McpInvokeTarget {
     application_id: Option<String>,
+    window_id: Option<String>,
+    display_id: Option<String>,
+  }
+
+  impl McpInvokeTarget {
+    fn into_execution_target(self) -> Result<Option<ExecutionTarget>, String> {
+      let targets = [
+        self.application_id.map(|id| ("application_id", ExecutionTarget::Application { id })),
+        self.window_id.map(|id| ("window_id", ExecutionTarget::Window { id })),
+        self.display_id.map(|id| ("display_id", ExecutionTarget::Display { id })),
+      ];
+      let mut targets = targets.into_iter().flatten();
+      let target = targets.next();
+      if targets.next().is_some() {
+        return Err("target must set at most one of application_id, window_id, or display_id".to_string());
+      }
+      let Some((field, target)) = target else {
+        return Ok(None);
+      };
+      let id = match &target {
+        ExecutionTarget::Application { id } | ExecutionTarget::Window { id } | ExecutionTarget::Display { id } => id,
+      };
+      if id.trim().is_empty() {
+        return Err(format!("target.{field} cannot be empty"));
+      }
+      Ok(Some(target))
+    }
   }
 
   #[derive(Debug, Deserialize, Serialize, JsonSchema)]

--- a/crates/auv-cli/src/commands/mcp_test.rs
+++ b/crates/auv-cli/src/commands/mcp_test.rs
@@ -31,7 +31,7 @@ async fn overlay_mcp_adapters_execute_the_shared_dry_run_commands() {
     let adapter = adapters.iter().find(|adapter| adapter.command_id == command_id).unwrap_or_else(|| panic!("missing {command_id} adapter"));
     adapter
       .invoke(McpInvokeInput {
-        target_application_id: None,
+        target: None,
         inputs,
         dry_run: true,
         cancellation: Default::default(),
@@ -53,11 +53,13 @@ async fn mcp_uses_the_same_typed_range_validation_as_cli() {
   // Before the fix, Linux CI observed a platform error instead of the shared
   // validation error. The fix validates command inputs before platform dispatch.
   let adapters = core_invoke_adapters();
-  let adapter = adapters.iter().find(|adapter| adapter.command_id == "input.clickWindowPoint").expect("click-window-point adapter");
+  let adapter = adapters.iter().find(|adapter| adapter.command_id == "input.clickPoint").expect("click-point adapter");
   let error = adapter
     .invoke(McpInvokeInput {
-      target_application_id: None,
-      inputs: pairs(&[("relative-x", "2"), ("relative-y", "0.5")]),
+      target: Some(auv_cli_invoke::ExecutionTarget::Window {
+        id: "window-1".to_string(),
+      }),
+      inputs: pairs(&[("x", "2"), ("y", "0.5"), ("relative-to", "window"), ("normalized", "true")]),
       dry_run: true,
       cancellation: Default::default(),
     })
@@ -65,6 +67,25 @@ async fn mcp_uses_the_same_typed_range_validation_as_cli() {
     .expect_err("out-of-range MCP input must fail typed decoding");
 
   assert!(error.contains("within 0..=1"), "unexpected typed validation error: {error}");
+}
+
+#[tokio::test]
+async fn click_point_mcp_defaults_to_screen_coordinates_without_optional_inputs() {
+  let adapters = core_invoke_adapters();
+  let adapter = adapters.iter().find(|adapter| adapter.command_id == "input.clickPoint").expect("click-point adapter");
+  let success = adapter
+    .invoke(McpInvokeInput {
+      target: None,
+      inputs: pairs(&[("x", "120"), ("y", "80")]),
+      dry_run: true,
+      cancellation: Default::default(),
+    })
+    .await
+    .expect("screen-relative dry run should use typed defaults");
+
+  assert_eq!(success.result["relative_to"], "screen");
+  assert_eq!(success.result["screen_point"]["x"], 120.0);
+  assert!(success.result["action"].is_null());
 }
 
 fn pairs(values: &[(&str, &str)]) -> BTreeMap<String, String> {

--- a/crates/auv-cli/tests/integrated/invoke_cli/cases.rs
+++ b/crates/auv-cli/tests/integrated/invoke_cli/cases.rs
@@ -50,7 +50,7 @@ fn screen_find_text_accepts_a_typed_positional_query() {
   .expect("typed invoke command should parse");
   let InvokeCliParse::Invoke {
     inputs,
-    target_application_id,
+    target,
     dry_run,
     ..
   } = command
@@ -59,7 +59,12 @@ fn screen_find_text_accepts_a_typed_positional_query() {
   };
 
   assert_eq!(inputs.get("query").map(String::as_str), Some("Settings"));
-  assert_eq!(target_application_id.as_deref(), Some("com.apple.TextEdit"));
+  assert_eq!(
+    target,
+    Some(auv_cli_invoke::ExecutionTarget::Application {
+      id: "com.apple.TextEdit".to_string(),
+    })
+  );
   assert!(dry_run);
 }
 
@@ -74,14 +79,17 @@ fn invoke_context_uses_clap_equals_and_end_of_options_semantics() {
   ]))
   .expect("equals syntax should parse");
   let InvokeCliParse::Invoke {
-    target_application_id,
-    dry_run,
-    ..
+    target, dry_run, ..
   } = command
   else {
     panic!("expected invoke command");
   };
-  assert_eq!(target_application_id.as_deref(), Some("com.apple.TextEdit"));
+  assert_eq!(
+    target,
+    Some(auv_cli_invoke::ExecutionTarget::Application {
+      id: "com.apple.TextEdit".to_string(),
+    })
+  );
   assert!(dry_run);
 
   let command =

--- a/crates/auv-cli/tests/root_cli.rs
+++ b/crates/auv-cli/tests/root_cli.rs
@@ -126,6 +126,10 @@ fn invoke_index_presents_registered_operations_as_commands() {
   assert!(help.contains("Usage:\n  auv invoke <COMMAND> [OPTIONS]"), "unexpected invoke help:\n{help}");
   assert!(help.contains("Commands:"), "unexpected invoke help:\n{help}");
   assert!(help.lines().any(|line| line.trim_start().starts_with("display.list ")), "unexpected invoke help:\n{help}");
+  assert!(help.lines().any(|line| line.trim_start().starts_with("input.clickPoint ")), "unexpected invoke help:\n{help}");
+  assert!(!help.contains("input.clickScreenPoint"), "retired command leaked into invoke help:\n{help}");
+  assert!(!help.contains("input.clickWindowPoint"), "retired command leaked into invoke help:\n{help}");
+  assert!(help.contains("--target <TARGET>"), "typed target contract missing from invoke help:\n{help}");
   assert!(help.lines().any(|line| line.trim_start().starts_with("help ")), "unexpected invoke help:\n{help}");
   assert!(help.contains("Options:"), "unexpected invoke help:\n{help}");
   assert!(!help.contains("\nDISPLAY\n"), "invoke operations should not look like internal capability sections:\n{help}");
@@ -863,11 +867,14 @@ fn typed_invoke_values_are_rejected_before_execution() {
 fn typed_invoke_ranges_are_rejected_by_the_handler() {
   let output = run(&[
     "invoke",
-    "input.clickWindowPoint",
-    "--relative-x",
+    "input.clickPoint",
     "2",
-    "--relative-y",
     "0.5",
+    "--target",
+    "window:fixture",
+    "--relative-to",
+    "window",
+    "--normalized",
     "--dry-run",
   ]);
 
@@ -876,10 +883,10 @@ fn typed_invoke_ranges_are_rejected_by_the_handler() {
 }
 
 #[test]
-fn screen_point_click_dry_run_reports_the_validated_coordinate() {
+fn click_point_dry_run_reports_the_validated_coordinate() {
   let output = run(&[
     "invoke",
-    "input.clickScreenPoint",
+    "input.clickPoint",
     "1032.5",
     "1212",
     "--dry-run",
@@ -888,8 +895,8 @@ fn screen_point_click_dry_run_reports_the_validated_coordinate() {
 
   assert!(output.status.success(), "unexpected diagnostic:\n{}", stderr(&output));
   let value: serde_json::Value = serde_json::from_str(&stdout(&output)).expect("JSON output");
-  assert_eq!(value["result"]["point"]["x"], 1032.5);
-  assert_eq!(value["result"]["point"]["y"], 1212.0);
+  assert_eq!(value["result"]["screen_point"]["x"], 1032.5);
+  assert_eq!(value["result"]["screen_point"]["y"], 1212.0);
   assert!(value["result"]["action"].is_null());
 }
 

--- a/crates/auv/src/client/runner.rs
+++ b/crates/auv/src/client/runner.rs
@@ -578,6 +578,21 @@ impl WindowsClient {
       window_ref,
     })
   }
+
+  /// Binds a listed window resource to its stable WindowRef for subsequent
+  /// window-scoped capability calls.
+  pub fn bind(&self, window: auv_driver::Window) -> Result<WindowClient, CapabilityError> {
+    if window.reference.id.trim().is_empty() {
+      return Err(CapabilityError::InvalidResponse("listed Window omitted WindowRef id".to_string()));
+    }
+    Ok(WindowClient {
+      runner: self.runner.clone(),
+      window_ref: proto::WindowRef {
+        window_id: window.reference.id.clone(),
+      },
+      window,
+    })
+  }
 }
 
 /// Capability client bound to one resolved WindowRef.

--- a/docs/TERMS_AND_CONCEPTS.md
+++ b/docs/TERMS_AND_CONCEPTS.md
@@ -726,6 +726,29 @@ and which candidate objects are eligible for selection.
 
 The current scope terms are `screen`, `display`, `window`, and `region`.
 
+## Execution Target
+
+An execution target identifies the resource an invoke operation acts on. The
+shared invoke model distinguishes `Application`, `Window`, and `Display`
+targets instead of carrying an untyped string. The CLI spells these as
+`app:<bundle-id>`, `window:<window-id>`, and `display:<display-id>`. A bare
+`--target` value retains its historical meaning as an application id.
+
+Target identity and coordinate interpretation are separate decisions. For
+`input.clickPoint`, `--relative-to screen|window|display` names the coordinate
+basis. If omitted, the basis follows the target deterministically: no target is
+screen-relative, an application or window target is window-relative, and a
+display target is display-relative. `--normalized` changes window- or
+display-relative values from local logical points to ratios in `0..=1`; it is
+not valid for the logical screen.
+
+`input.clickPoint` is the invoke-level point-click operation. Screen and display
+coordinates use the existing global pointer capability after projection to the
+logical screen. Window coordinates use the existing window-targeted input
+capability and retain its `InputActionResult`, input policy, attempts, fallback
+reason, and disturbance metadata. The driver capabilities remain distinct;
+the unified operation is a frontend and typed-command contract.
+
 ## Screen
 
 A screen is the logical desktop observation surface. It is the user-facing
@@ -778,7 +801,7 @@ A window resolver turns a target application and optional window selector into
 one selected window candidate.
 
 All window-scoped commands should share the same resolver so that
-`captureWindow`, `clickWindowPoint`, OCR window commands, and row window
+`captureWindow`, window-relative `clickPoint`, OCR window commands, and row window
 commands agree about which window they are using. When the resolver cannot make
 a clear choice, it should return an ambiguity error that points users to the
 window-listing API instead of silently selecting an arbitrary candidate.

--- a/docs/ai/references/invoke-cli/2026-09-03-click-point-target-contract-handoff.md
+++ b/docs/ai/references/invoke-cli/2026-09-03-click-point-target-contract-handoff.md
@@ -1,0 +1,53 @@
+# Click point and typed target contract
+
+Status: implemented frontend and typed invoke contract.
+
+## Contract
+
+`auv invoke input.clickPoint X Y` replaces the two invoke command ids
+`input.clickScreenPoint` and `input.clickWindowPoint`.
+
+The shared `ExecutionTarget` is one of:
+
+- `Application { id }`, spelled `--target app:<bundle-id>`;
+- `Window { id }`, spelled `--target window:<window-id>`;
+- `Display { id }`, spelled `--target display:<display-id>`.
+
+Bare target values remain application ids for existing callers. MCP exposes the
+same alternatives as the mutually exclusive `application_id`, `window_id`, and
+`display_id` fields.
+
+`--relative-to screen|window|display` selects the coordinate basis. When it is
+omitted, no target selects `screen`, application/window selects `window`, and
+display selects `display`. `--normalized` is available only for window and
+display coordinates.
+
+The accepted target/basis combinations are:
+
+| Target | Basis | Delivery |
+|---|---|---|
+| none | screen | existing global screen-point click |
+| application | window | resolve the application's window, then existing window click |
+| window | window | bind the listed window id, then existing window click |
+| display | display | project display-local coordinates to screen, then existing global click |
+
+Other combinations fail before input delivery. `--input-policy` is valid only
+for a window-relative click, and `--title` is valid only with an application
+target.
+
+## Ownership
+
+`auv-cli-invoke` owns parsing, combination validation, projection, direct
+results, and local/selected-Runner dispatch. The root CLI and MCP frontend carry
+the same typed target. The `auv` Runner client can bind a window returned by
+`list` so a window-id target retains its `WindowRef` route.
+
+No `auv-driver*` contract or implementation changed. The unified command maps
+to the existing global and window-targeted input capabilities and keeps the
+driver-owned `InputActionResult` unchanged.
+
+## Deferred
+
+Target-aware `input.key`, `input.typeText`, and `input.pasteText` remain a
+separate slice. Their current call sites retain the typed input-target activation
+TODO because this click-point contract does not define a keyboard focus lease.

--- a/docs/ai/references/invoke-cli/INDEX.md
+++ b/docs/ai/references/invoke-cli/INDEX.md
@@ -2,8 +2,9 @@
 
 Invoke routing, CLI handlers, catalog, output contracts
 
-Count: **20**
+Count: **21**
 
+- [`2026-09-03-click-point-target-contract-handoff.md`](2026-09-03-click-point-target-contract-handoff.md)
 - [`2026-08-04-remote-extension-runner-guide.md`](2026-08-04-remote-extension-runner-guide.md)
 - [`2026-08-04-core-cli-command-ownership-design.md`](2026-08-04-core-cli-command-ownership-design.md)
 - [`2026-07-31-kubectl-plugin-context-research.md`](2026-07-31-kubectl-plugin-context-research.md)


### PR DESCRIPTION
## Summary

- replace `input.clickScreenPoint` and `input.clickWindowPoint` with `input.clickPoint X Y --relative-to screen|window|display`
- model invoke targets as typed application, window, or display resources across CLI, MCP, local execution, and selected Runner dispatch
- preserve the existing global and window-targeted driver capabilities and `InputActionResult`; no `auv-driver*` code changes
- update invoke help, regression coverage, shared terminology, and the invoke contract handoff

Bare `--target` values remain application ids for compatibility. Coordinate basis defaults from the target, and `--normalized` is supported for window/display-local points.

## Validation

- `cargo build`
- `cargo fmt --check`
- `cargo check`
- `cargo test`
- `git diff --check`
- `cargo clippy --all-targets --all-features` (passes with existing repository warnings)
- local dry-run resolution for NetEaseMusic `window:5063`
- local dry-run projection for `display:3`

## Deferred

Target-aware keyboard, typeText, and pasteText activation remains a separate slice.